### PR TITLE
Feature/Code Quality Lints

### DIFF
--- a/barter-data/examples/dynamic_multi_stream_multi_exchange.rs
+++ b/barter-data/examples/dynamic_multi_stream_multi_exchange.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_data::{
     event::DataKind,
     streams::{

--- a/barter-data/examples/indexed_market_stream.rs
+++ b/barter-data/examples/indexed_market_stream.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_data::{
     streams::builder::dynamic::indexed::init_indexed_multi_exchange_market_stream,
     subscription::SubKind,

--- a/barter-data/examples/multi_stream_multi_exchange.rs
+++ b/barter-data/examples/multi_stream_multi_exchange.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_data::{
     event::DataKind,
     exchange::{

--- a/barter-data/examples/order_books_l1_streams.rs
+++ b/barter-data/examples/order_books_l1_streams.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_data::{
     exchange::binance::spot::BinanceSpot,
     streams::{Streams, reconnect::stream::ReconnectingStream},

--- a/barter-data/examples/order_books_l1_streams_multi_exchange.rs
+++ b/barter-data/examples/order_books_l1_streams_multi_exchange.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_data::{
     exchange::binance::{futures::BinanceFuturesUsd, spot::BinanceSpot},
     streams::{Streams, reconnect::stream::ReconnectingStream},

--- a/barter-data/examples/order_books_l2_manager.rs
+++ b/barter-data/examples/order_books_l2_manager.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_data::{
     books::{manager::init_multi_order_book_l2_manager, map::OrderBookMap},
     exchange::binance::spot::BinanceSpot,

--- a/barter-data/examples/order_books_l2_streams.rs
+++ b/barter-data/examples/order_books_l2_streams.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_data::{
     exchange::binance::spot::BinanceSpot,
     streams::{Streams, reconnect::stream::ReconnectingStream},

--- a/barter-data/examples/public_trades_streams.rs
+++ b/barter-data/examples/public_trades_streams.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_data::{
     exchange::binance::futures::BinanceFuturesUsd,
     streams::{Streams, reconnect::stream::ReconnectingStream},

--- a/barter-data/examples/public_trades_streams_multi_exchange.rs
+++ b/barter-data/examples/public_trades_streams_multi_exchange.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_data::{
     exchange::{
         binance::{futures::BinanceFuturesUsd, spot::BinanceSpot},

--- a/barter-data/src/books/mod.rs
+++ b/barter-data/src/books/mod.rs
@@ -179,7 +179,7 @@ impl OrderBookSide<Asks> {
         L: Into<Level>,
     {
         let mut levels = levels.into_iter().map(L::into).collect::<Vec<_>>();
-        levels.sort_unstable_by(|a, b| a.price.cmp(&b.price));
+        levels.sort_unstable_by_key(|a| a.price);
 
         Self { side: Asks, levels }
     }

--- a/barter-data/src/exchange/binance/book/l1.rs
+++ b/barter-data/src/exchange/binance/book/l1.rs
@@ -109,6 +109,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-data/src/exchange/binance/book/l2.rs
+++ b/barter-data/src/exchange/binance/book/l2.rs
@@ -105,6 +105,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-data/src/exchange/binance/book/mod.rs
+++ b/barter-data/src/exchange/binance/book/mod.rs
@@ -33,6 +33,7 @@ impl From<BinanceLevel> for Level {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-data/src/exchange/binance/futures/l2.rs
+++ b/barter-data/src/exchange/binance/futures/l2.rs
@@ -363,6 +363,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BinanceFuturesOrderBookL2Up
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::books::Level;

--- a/barter-data/src/exchange/binance/futures/liquidation.rs
+++ b/barter-data/src/exchange/binance/futures/liquidation.rs
@@ -122,6 +122,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-data/src/exchange/binance/spot/l2.rs
+++ b/barter-data/src/exchange/binance/spot/l2.rs
@@ -347,6 +347,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BinanceSpotOrderBookL2Updat
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::books::Level;

--- a/barter-data/src/exchange/bitfinex/subscription.rs
+++ b/barter-data/src/exchange/bitfinex/subscription.rs
@@ -180,7 +180,7 @@ impl<'de> Deserialize<'de> for Status {
     {
         #[derive(Deserialize)]
         struct Outer {
-            #[serde(deserialize_with = "de_status_from_u8")]
+            #[serde(deserialize_with = "de_status_from_integer")]
             status: Status,
         }
 
@@ -191,12 +191,12 @@ impl<'de> Deserialize<'de> for Status {
     }
 }
 
-/// Deserialize a `u8` as a `Bitfinex` platform [`Status`].
+/// Deserialize an integer as a `Bitfinex` platform [`Status`].
 ///
-/// 0u8 => [`Status::Maintenance`](Status), <br>
-/// 1u8 => [`Status::Operative`](Status), <br>
+/// 0 => [`Status::Maintenance`](Status), <br>
+/// 1 => [`Status::Operative`](Status), <br>
 /// other => [`de::Error`]
-fn de_status_from_u8<'de, D>(deserializer: D) -> Result<Status, D::Error>
+fn de_status_from_integer<'de, D>(deserializer: D) -> Result<Status, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
@@ -204,7 +204,7 @@ where
         0 => Ok(Status::Maintenance),
         1 => Ok(Status::Operative),
         other => Err(serde::de::Error::invalid_value(
-            serde::de::Unexpected::Unsigned(other as u64),
+            serde::de::Unexpected::Signed(other),
             &"0 or 1",
         )),
     }

--- a/barter-data/src/exchange/bybit/book/mod.rs
+++ b/barter-data/src/exchange/bybit/book/mod.rs
@@ -88,6 +88,7 @@ impl From<BybitLevel> for Level {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-data/src/exchange/coinbase/trade.rs
+++ b/barter-data/src/exchange/coinbase/trade.rs
@@ -82,6 +82,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use barter_integration::error::SocketError;

--- a/barter-data/src/exchange/gateio/perpetual/trade.rs
+++ b/barter-data/src/exchange/gateio/perpetual/trade.rs
@@ -99,6 +99,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, GateioFuturesTrades)
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-data/src/exchange/gateio/spot/trade.rs
+++ b/barter-data/src/exchange/gateio/spot/trade.rs
@@ -79,6 +79,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, GateioSpotTrade)>
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-data/src/lib.rs
+++ b/barter-data/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![deny(clippy::unwrap_used, clippy::expect_used)]
 #![warn(
     unused,
     clippy::cognitive_complexity,

--- a/barter-data/src/lib.rs
+++ b/barter-data/src/lib.rs
@@ -1,5 +1,10 @@
 #![forbid(unsafe_code)]
-#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 #![warn(
     unused,
     clippy::cognitive_complexity,

--- a/barter-data/src/streams/builder/dynamic/mod.rs
+++ b/barter-data/src/streams/builder/dynamic/mod.rs
@@ -72,6 +72,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
     /// ## Examples
     /// Please see barter-data-rs/examples/dynamic_multi_stream_multi_exchange.rs for a
     /// comprehensive example of how to use this market data stream initialiser.
+    #[allow(clippy::unwrap_used)] // Invariant: Channels::try_from creates entries for all exchanges in batches; lookups iterate over the same exchanges
     pub async fn init<SubBatchIter, SubIter, Sub, Instrument>(
         subscription_batches: SubBatchIter,
     ) -> Result<Self, DataError>

--- a/barter-data/src/streams/builder/multi.rs
+++ b/barter-data/src/streams/builder/multi.rs
@@ -79,6 +79,8 @@ impl<Output> MultiStreamBuilder<Output> {
                 .for_each(|(exchange, exchange_rx)| {
                     // Remove exchange_tx<Output> from HashMap that's associated with this tuple:
                     // (ExchangeId, exchange_rx<MarketStreamResult<InstrumentKey, SubscriptionKind::Event>>)
+                    #[allow(clippy::expect_used)]
+                    // Invariant: exchange_txs created with same keys as builder.streams produces
                     let exchange_tx = exchange_txs
                         .remove(&exchange)
                         .expect("all exchange_txs should be present here");

--- a/barter-data/src/subscription/mod.rs
+++ b/barter-data/src/subscription/mod.rs
@@ -334,6 +334,7 @@ impl<T> Map<T> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-execution/src/client/alpaca/mod.rs
+++ b/barter-execution/src/client/alpaca/mod.rs
@@ -198,10 +198,10 @@ impl RateLimitTracker {
                         // Deadline was expired and cleared above; no sleep needed.
                         return;
                     }
-                    debug!(
-                        delay_ms = (until - now).as_millis() as u64,
-                        "Alpaca REST rate-limited, waiting before request"
-                    );
+                    // as_millis() returns u128; truncation impossible (u64::MAX ms ≈ 584M years)
+                    #[allow(clippy::cast_possible_truncation)]
+                    let delay_ms = (until - now).as_millis() as u64;
+                    debug!(delay_ms, "Alpaca REST rate-limited, waiting before request");
                     tokio::time::sleep_until(until).await;
                 }
             }

--- a/barter-execution/src/client/alpaca/mod.rs
+++ b/barter-execution/src/client/alpaca/mod.rs
@@ -615,6 +615,7 @@ impl AlpacaClient {
     ///
     /// Panics if the API key or secret contains characters that are invalid
     /// in an HTTP header value (non-ASCII or control characters).
+    #[allow(clippy::expect_used)] // Documented panic: invalid credentials detected at startup
     fn build_http(config: &AlpacaConfig) -> reqwest::Client {
         use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
         let mut headers = HeaderMap::new();
@@ -2652,6 +2653,7 @@ fn connectivity_err(msg: impl Into<String>) -> UnindexedClientError {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-execution/src/client/binance/mod.rs
+++ b/barter-execution/src/client/binance/mod.rs
@@ -319,8 +319,11 @@ impl RateLimitTracker {
                     // debug! not warn! — on_rate_limited already logs the event;
                     // multiple concurrent callers all hitting wait_if_blocked during
                     // recover_fills would otherwise flood the log with identical lines.
+                    // as_millis() returns u128; truncation impossible (u64::MAX ms ≈ 584M years)
+                    #[allow(clippy::cast_possible_truncation)]
+                    let delay_ms = (until - now).as_millis() as u64;
                     debug!(
-                        delay_ms = (until - now).as_millis() as u64,
+                        delay_ms,
                         "BinanceSpot REST rate-limited, waiting before request"
                     );
                     tokio::time::sleep_until(until).await;
@@ -721,6 +724,8 @@ async fn paginate_my_trades(
             let sym = symbol_str.clone();
             let stm = start_time_ms;
             Box::pin(async move {
+                // const_assert! above guarantees BINANCE_MAX_TRADES fits in i32
+                #[allow(clippy::cast_possible_truncation)]
                 let builder = MyTradesParams::builder(sym).limit(BINANCE_MAX_TRADES as i32);
                 let params = if let Some(id) = fid {
                     builder.from_id(id).build()?

--- a/barter-execution/src/client/binance/mod.rs
+++ b/barter-execution/src/client/binance/mod.rs
@@ -517,6 +517,7 @@ impl std::fmt::Debug for BinanceSpot {
 impl BinanceSpot {
     /// # Panics
     /// Panics if the binance-sdk configuration builder fails (invalid credentials format).
+    #[allow(clippy::expect_used)] // Documented panic: invalid credentials detected at startup
     fn build_rest(config: &BinanceSpotConfig) -> Arc<RestApi> {
         let rest_config = ConfigurationRestApi::builder()
             .api_key(config.api_key.clone())
@@ -533,6 +534,7 @@ impl BinanceSpot {
 
     /// # Panics
     /// Panics if the binance-sdk configuration builder fails (invalid credentials format).
+    #[allow(clippy::expect_used)] // Documented panic: invalid credentials detected at startup
     fn build_ws_handle(config: &BinanceSpotConfig) -> WebsocketApiHandle {
         let ws_config = ConfigurationWebsocketApi::builder()
             .api_key(config.api_key.clone())
@@ -2628,6 +2630,7 @@ fn connectivity_error(e: anyhow::Error) -> UnindexedClientError {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-execution/src/exchange/mock/mod.rs
+++ b/barter-execution/src/exchange/mock/mod.rs
@@ -346,6 +346,8 @@ impl MockExchange {
         let balance_change_result = match request.state.side {
             Side::Buy => {
                 // Buying Instrument requires sufficient QuoteAsset Balance
+                #[allow(clippy::expect_used)]
+                // Invariant: MockExchange - balances exist for all configured instruments
                 let current = self
                     .account
                     .balance_mut(&underlying.quote)
@@ -377,6 +379,8 @@ impl MockExchange {
             }
             Side::Sell => {
                 // Selling Instrument requires sufficient BaseAsset Balance
+                #[allow(clippy::expect_used)]
+                // Invariant: MockExchange - balances exist for all configured instruments
                 let current = self
                     .account
                     .balance_mut(&underlying.base)
@@ -527,6 +531,7 @@ pub struct OpenOrderNotifications {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::{

--- a/barter-execution/src/fee.rs
+++ b/barter-execution/src/fee.rs
@@ -106,6 +106,7 @@ impl FeeModel for FeeModelConfig {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-execution/src/fill.rs
+++ b/barter-execution/src/fill.rs
@@ -183,6 +183,7 @@ impl FillModel for SimFillConfig {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-execution/src/lib.rs
+++ b/barter-execution/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![deny(clippy::unwrap_used, clippy::expect_used)]
 #![warn(
     unused,
     clippy::cognitive_complexity,

--- a/barter-execution/src/lib.rs
+++ b/barter-execution/src/lib.rs
@@ -1,5 +1,10 @@
 #![forbid(unsafe_code)]
-#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 #![warn(
     unused,
     clippy::cognitive_complexity,

--- a/barter-execution/src/map.rs
+++ b/barter-execution/src/map.rs
@@ -177,6 +177,7 @@ pub fn generate_execution_instrument_map(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use barter_instrument::{exchange::ExchangeId, test_utils};

--- a/barter-execution/src/order/id.rs
+++ b/barter-execution/src/order/id.rs
@@ -30,6 +30,7 @@ impl ClientOrderId<SmolStr> {
 
         let mut thread_rng = rand::rng();
 
+        #[allow(clippy::expect_used)] // Invariant: URL_SAFE_SYMBOLS is a const 64-element array
         let random_utf8: [u8; LEN_NON_ALLOCATING_CID] = std::array::from_fn(|_| {
             let symbol = URL_SAFE_SYMBOLS
                 .choose(&mut thread_rng)
@@ -38,6 +39,7 @@ impl ClientOrderId<SmolStr> {
             *symbol as u8
         });
 
+        #[allow(clippy::expect_used)] // Invariant: all URL_SAFE_SYMBOLS chars are ASCII
         let random_utf8_str =
             std::str::from_utf8(&random_utf8).expect("URL_SAFE_SYMBOLS are valid utf8");
 

--- a/barter-instrument/src/exchange.rs
+++ b/barter-instrument/src/exchange.rs
@@ -129,6 +129,7 @@ impl ExchangeId {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-instrument/src/index/builder.rs
+++ b/barter-instrument/src/index/builder.rs
@@ -91,11 +91,15 @@ impl IndexedInstrumentsBuilder {
             .enumerate()
             .map(|(index, instrument)| {
                 let exchange_id = instrument.exchange;
+                #[allow(clippy::expect_used)]
+                // Invariant: add_instrument populates exchanges alongside each instrument
                 let exchange_key = find_exchange_by_exchange_id(&exchanges, &exchange_id)
                     .expect("every exchange related to every instrument has been added");
 
                 let instrument = instrument.map_exchange_key(Keyed::new(exchange_key, exchange_id));
 
+                #[allow(clippy::expect_used)]
+                // Invariant: add_instrument populates assets alongside each instrument
                 let instrument = instrument
                     .map_asset_key_with_lookup(|asset: &Asset| {
                         find_asset_by_exchange_and_name_internal(
@@ -119,6 +123,7 @@ impl IndexedInstrumentsBuilder {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::{

--- a/barter-instrument/src/index/mod.rs
+++ b/barter-instrument/src/index/mod.rs
@@ -212,6 +212,7 @@ fn find_asset_by_exchange_and_name_internal(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-instrument/src/instrument/market_data/mod.rs
+++ b/barter-instrument/src/instrument/market_data/mod.rs
@@ -52,6 +52,7 @@ impl MarketDataInstrument {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use crate::instrument::{
         kind::option::{OptionExercise, OptionKind},

--- a/barter-instrument/src/lib.rs
+++ b/barter-instrument/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![deny(clippy::unwrap_used, clippy::expect_used)]
 #![warn(
     unused,
     clippy::cognitive_complexity,

--- a/barter-instrument/src/lib.rs
+++ b/barter-instrument/src/lib.rs
@@ -1,5 +1,10 @@
 #![forbid(unsafe_code)]
-#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 #![warn(
     unused,
     clippy::cognitive_complexity,

--- a/barter-integration/examples/signed_get_request.rs
+++ b/barter-integration/examples/signed_get_request.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_instrument::asset::name::AssetNameInternal;
 use barter_integration::{
     error::SocketError,

--- a/barter-integration/examples/simple_websocket_integration.rs
+++ b/barter-integration/examples/simple_websocket_integration.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter_integration::{
     Transformer,
     error::SocketError,

--- a/barter-integration/src/collection/none_one_or_many.rs
+++ b/barter-integration/src/collection/none_one_or_many.rs
@@ -150,10 +150,10 @@ impl<T> From<Option<T>> for NoneOneOrMany<T> {
 
 // Convert from Vec into NoneOneOrMany
 impl<T> From<Vec<T>> for NoneOneOrMany<T> {
-    fn from(items: Vec<T>) -> Self {
+    fn from(mut items: Vec<T>) -> Self {
         match items.len() {
             0 => NoneOneOrMany::None,
-            1 => NoneOneOrMany::One(items.into_iter().next().unwrap()),
+            1 => NoneOneOrMany::One(items.swap_remove(0)),
             _ => NoneOneOrMany::Many(items),
         }
     }

--- a/barter-integration/src/collection/snapshot.rs
+++ b/barter-integration/src/collection/snapshot.rs
@@ -45,6 +45,7 @@ pub struct SnapUpdates<Snapshot, Updates> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-integration/src/lib.rs
+++ b/barter-integration/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![deny(clippy::unwrap_used, clippy::expect_used)]
 #![warn(
     unused,
     clippy::cognitive_complexity,

--- a/barter-integration/src/lib.rs
+++ b/barter-integration/src/lib.rs
@@ -1,5 +1,10 @@
 #![forbid(unsafe_code)]
-#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 #![warn(
     unused,
     clippy::cognitive_complexity,

--- a/barter-integration/src/protocol/http/rest/client.rs
+++ b/barter-integration/src/protocol/http/rest/client.rs
@@ -98,9 +98,12 @@ where
         Request: RestRequest,
     {
         // Construct Http request duration Metric
+        // timestamps are post-1970 (positive)
+        #[allow(clippy::cast_sign_loss)]
+        let time = Utc::now().timestamp_millis() as u64;
         let mut latency = Metric {
             name: "http_request_duration",
-            time: Utc::now().timestamp_millis() as u64,
+            time,
             tags: vec![
                 Tag::new("http_method", Request::method().as_str()),
                 Tag::new("base_url", self.base_url.as_ref()),
@@ -112,6 +115,8 @@ where
         // Measure the HTTP request round trip duration
         let start = std::time::Instant::now();
         let response = self.http_client.execute(request).await?;
+        // as_millis() returns u128; truncation impossible (u64::MAX ms ≈ 584M years)
+        #[allow(clippy::cast_possible_truncation)]
         let duration = start.elapsed().as_millis() as u64;
 
         // Update Metric with response status and request duration

--- a/barter-integration/src/protocol/websocket/mod.rs
+++ b/barter-integration/src/protocol/websocket/mod.rs
@@ -223,6 +223,7 @@ pub fn is_websocket_disconnected(error: &WsError) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;

--- a/barter-integration/src/serde/de/mod.rs
+++ b/barter-integration/src/serde/de/mod.rs
@@ -121,6 +121,7 @@ impl DeProtobuf {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-integration/src/serde/de/util.rs
+++ b/barter-integration/src/serde/de/util.rs
@@ -41,14 +41,24 @@ where
 }
 
 /// Deserialise a &str "f64" milliseconds value as `DateTime<Utc>`.
+// cast_sign_loss: guard below ensures epoch_ms >= 0.0
+// cast_possible_truncation: f64 as u64 saturates per Rust 1.45+; sub-ms precision discarded intentionally
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn de_str_f64_epoch_ms_as_datetime_utc<'de, D>(
     deserializer: D,
 ) -> Result<chrono::DateTime<chrono::Utc>, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
-    de_str(deserializer).map(|epoch_ms: f64| {
-        datetime_utc_from_epoch_duration(std::time::Duration::from_millis(epoch_ms as u64))
+    de_str(deserializer).and_then(|epoch_ms: f64| {
+        if !epoch_ms.is_finite() || epoch_ms < 0.0 {
+            return Err(serde::de::Error::custom(format!(
+                "invalid epoch_ms: {epoch_ms}"
+            )));
+        }
+        Ok(datetime_utc_from_epoch_duration(
+            std::time::Duration::from_millis(epoch_ms as u64),
+        ))
     })
 }
 
@@ -59,8 +69,15 @@ pub fn de_str_f64_epoch_s_as_datetime_utc<'de, D>(
 where
     D: serde::de::Deserializer<'de>,
 {
-    de_str(deserializer).map(|epoch_s: f64| {
-        datetime_utc_from_epoch_duration(std::time::Duration::from_secs_f64(epoch_s))
+    de_str(deserializer).and_then(|epoch_s: f64| {
+        if !epoch_s.is_finite() || epoch_s < 0.0 {
+            return Err(serde::de::Error::custom(format!(
+                "invalid epoch_s: {epoch_s}"
+            )));
+        }
+        Ok(datetime_utc_from_epoch_duration(
+            std::time::Duration::from_secs_f64(epoch_s),
+        ))
     })
 }
 

--- a/barter-integration/src/serde/se/mod.rs
+++ b/barter-integration/src/serde/se/mod.rs
@@ -105,6 +105,7 @@ impl SeJsonBytes {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-integration/src/socket/backoff.rs
+++ b/barter-integration/src/socket/backoff.rs
@@ -30,6 +30,7 @@ impl ReconnectBackoff for DefaultBackoff {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use std::time::Duration;

--- a/barter-integration/src/socket/on_connect_err.rs
+++ b/barter-integration/src/socket/on_connect_err.rs
@@ -126,6 +126,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::socket::ReconnectingSocket;

--- a/barter-integration/src/socket/on_stream_err.rs
+++ b/barter-integration/src/socket/on_stream_err.rs
@@ -100,6 +100,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use futures::StreamExt;

--- a/barter-integration/src/socket/on_stream_err_filter.rs
+++ b/barter-integration/src/socket/on_stream_err_filter.rs
@@ -75,6 +75,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::socket::on_stream_err::StreamErrorAction;

--- a/barter-integration/src/stream/data.rs
+++ b/barter-integration/src/stream/data.rs
@@ -87,6 +87,7 @@ pub struct Historical {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 

--- a/barter-integration/src/stream/ext/forward_by.rs
+++ b/barter-integration/src/stream/ext/forward_by.rs
@@ -83,6 +83,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::stream::ext::BarterStreamExt;

--- a/barter-integration/src/stream/ext/forward_clone_by.rs
+++ b/barter-integration/src/stream/ext/forward_clone_by.rs
@@ -75,6 +75,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::stream::ext::BarterStreamExt;

--- a/barter-integration/src/stream/ext/indexed.rs
+++ b/barter-integration/src/stream/ext/indexed.rs
@@ -47,6 +47,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::stream::ext::BarterStreamExt;

--- a/barter-integration/src/stream/util/merge.rs
+++ b/barter-integration/src/stream/util/merge.rs
@@ -20,6 +20,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use futures::StreamExt;

--- a/barter-macro/src/lib.rs
+++ b/barter-macro/src/lib.rs
@@ -1,4 +1,9 @@
-#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 
 extern crate proc_macro;
 

--- a/barter-macro/src/lib.rs
+++ b/barter-macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::unwrap_used, clippy::expect_used)]
+
 extern crate proc_macro;
 
 use convert_case::{Boundary, Case, Casing};
@@ -8,6 +10,7 @@ use syn::DeriveInput;
 #[proc_macro_derive(DeExchange)]
 pub fn de_exchange_derive(input: TokenStream) -> TokenStream {
     // Parse Rust code abstract syntax tree with Syn from TokenStream -> DeriveInput
+    #[allow(clippy::expect_used)] // Proc-macro: panic produces compile error (idiomatic)
     let ast: DeriveInput =
         syn::parse(input).expect("de_exchange_derive() failed to parse input TokenStream");
 
@@ -42,6 +45,7 @@ pub fn de_exchange_derive(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(SerExchange)]
 pub fn ser_exchange_derive(input: TokenStream) -> TokenStream {
     // Parse Rust code abstract syntax tree with Syn from TokenStream -> DeriveInput
+    #[allow(clippy::expect_used)] // Proc-macro: panic produces compile error (idiomatic)
     let ast: DeriveInput =
         syn::parse(input).expect("ser_exchange_derive() failed to parse input TokenStream");
 
@@ -65,6 +69,7 @@ pub fn ser_exchange_derive(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(DeSubKind)]
 pub fn de_sub_kind_derive(input: TokenStream) -> TokenStream {
     // Parse Rust code abstract syntax tree with Syn from TokenStream -> DeriveInput
+    #[allow(clippy::expect_used)] // Proc-macro: panic produces compile error (idiomatic)
     let ast: DeriveInput =
         syn::parse(input).expect("de_sub_kind_derive() failed to parse input TokenStream");
 
@@ -103,6 +108,7 @@ pub fn de_sub_kind_derive(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(SerSubKind)]
 pub fn ser_sub_kind_derive(input: TokenStream) -> TokenStream {
     // Parse Rust code abstract syntax tree with Syn from TokenStream -> DeriveInput
+    #[allow(clippy::expect_used)] // Proc-macro: panic produces compile error (idiomatic)
     let ast: DeriveInput =
         syn::parse(input).expect("ser_sub_kind_derive() failed to parse input TokenStream");
 

--- a/barter/benches/backtest/mod.rs
+++ b/barter/benches/backtest/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Benchmark code: panics acceptable
+
 use barter::{
     backtest,
     backtest::{BacktestArgsConstant, BacktestArgsDynamic, market_data::MarketDataInMemory},

--- a/barter/examples/backtests_concurrent.rs
+++ b/barter/examples/backtests_concurrent.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter::{
     backtest::{
         BacktestArgsConstant, BacktestArgsDynamic,

--- a/barter/examples/engine_async_with_historic_market_data_and_mock_execution.rs
+++ b/barter/examples/engine_async_with_historic_market_data_and_mock_execution.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter::{
     EngineEvent,
     engine::{

--- a/barter/examples/engine_sync_with_audit_replica_engine_state.rs
+++ b/barter/examples/engine_sync_with_audit_replica_engine_state.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter::{
     EngineEvent,
     engine::{

--- a/barter/examples/engine_sync_with_live_market_data_and_mock_execution_and_audit.rs
+++ b/barter/examples/engine_sync_with_live_market_data_and_mock_execution_and_audit.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter::{
     engine::{
         clock::LiveClock,

--- a/barter/examples/engine_sync_with_multiple_strategies.rs
+++ b/barter/examples/engine_sync_with_multiple_strategies.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter::{
     EngineEvent,
     engine::{

--- a/barter/examples/engine_sync_with_risk_manager_open_order_checks.rs
+++ b/barter/examples/engine_sync_with_risk_manager_open_order_checks.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter::{
     EngineEvent,
     engine::{

--- a/barter/examples/statistical_trading_summary.rs
+++ b/barter/examples/statistical_trading_summary.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
 use barter::{
     engine::state::{
         EngineState, global::DefaultGlobalData, instrument::data::DefaultInstrumentMarketData,

--- a/barter/src/backtest/market_data.rs
+++ b/barter/src/backtest/market_data.rs
@@ -60,6 +60,10 @@ where
 
 impl<Kind> MarketDataInMemory<Kind> {
     /// Create a new in-memory market data source from a vector of market events.
+    ///
+    /// # Panics
+    /// Panics if `events` contains no `MarketStreamEvent::Item` variant.
+    #[allow(clippy::expect_used)] // Caller contract: events must contain at least one MarketStreamEvent::Item variant
     pub fn new(events: Arc<Vec<MarketStreamEvent<InstrumentIndex, Kind>>>) -> Self {
         let time_first_event = events
             .iter()

--- a/barter/src/engine/clock.rs
+++ b/barter/src/engine/clock.rs
@@ -165,6 +165,7 @@ impl<MarketEventKind: Debug> TimeExchange for EngineEvent<MarketEventKind> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use barter_data::event::MarketEvent;

--- a/barter/src/engine/state/asset/mod.rs
+++ b/barter/src/engine/state/asset/mod.rs
@@ -174,6 +174,7 @@ pub fn generate_empty_indexed_asset_states(instruments: &IndexedInstruments) -> 
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::test_utils::asset_state;

--- a/barter/src/engine/state/instrument/data.rs
+++ b/barter/src/engine/state/instrument/data.rs
@@ -93,10 +93,8 @@ impl<InstrumentKey> Processor<&MarketEvent<InstrumentKey, DataKind>>
                         .replace(Timed::new(price, event.time_exchange));
                 }
             }
-            DataKind::OrderBookL1(l1) => {
-                if self.l1.last_update_time < event.time_exchange {
-                    self.l1 = l1.clone()
-                }
+            DataKind::OrderBookL1(l1) if self.l1.last_update_time < event.time_exchange => {
+                self.l1 = l1.clone()
             }
             _ => {}
         }

--- a/barter/src/execution/builder.rs
+++ b/barter/src/execution/builder.rs
@@ -386,6 +386,7 @@ impl IntoIterator for ExecutionHandles {
     }
 }
 
+#[allow(clippy::unwrap_used)] // Invariant: IndexedInstruments - all referenced assets exist; panics for unsupported InstrumentKind
 fn generate_mock_exchange_instruments(
     instruments: &IndexedInstruments,
     exchange: ExchangeId,

--- a/barter/src/lib.rs
+++ b/barter/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![deny(clippy::unwrap_used, clippy::expect_used)]
 #![warn(
     unused,
     clippy::cognitive_complexity,
@@ -199,6 +200,7 @@ impl Sequence {
 }
 
 /// Barter core test utilities.
+#[allow(clippy::unwrap_used)] // Test utilities: callers provide valid inputs
 pub mod test_utils {
     use crate::{
         Timed, engine::state::asset::AssetState, statistic::summary::asset::TearSheetAssetGenerator,

--- a/barter/src/lib.rs
+++ b/barter/src/lib.rs
@@ -1,5 +1,10 @@
 #![forbid(unsafe_code)]
-#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 #![warn(
     unused,
     clippy::cognitive_complexity,

--- a/barter/src/statistic/algorithm.rs
+++ b/barter/src/statistic/algorithm.rs
@@ -44,6 +44,7 @@ pub mod welford_online {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use rust_decimal::Decimal;
@@ -194,7 +195,7 @@ mod tests {
             dec!(16200000000.0),
         ];
 
-        for (index, (input, expected)) in inputs.iter().zip(expected.into_iter()).enumerate() {
+        for (index, (input, expected)) in inputs.iter().zip(expected).enumerate() {
             let actual_m = welford_online::calculate_recurrence_relation_m(
                 input.prev_m,
                 input.prev_mean,
@@ -223,7 +224,7 @@ mod tests {
             dec!(4.3045929964271878093926219276),
         ];
 
-        for ((input_m, input_count), expected) in inputs.iter().zip(expected.into_iter()) {
+        for ((input_m, input_count), expected) in inputs.iter().zip(expected) {
             let actual_variance = welford_online::calculate_sample_variance(*input_m, *input_count);
             assert_eq!(actual_variance, expected);
         }
@@ -246,7 +247,7 @@ mod tests {
             dec!(4.3044077091942148760330578512),
         ];
 
-        for (index, (input, expected)) in inputs.iter().zip(expected.into_iter()).enumerate() {
+        for (index, (input, expected)) in inputs.iter().zip(expected).enumerate() {
             let actual_variance =
                 welford_online::calculate_population_variance(input.0, input.1.into());
             assert_eq!(actual_variance, expected, "TC{index} failed");

--- a/barter/src/statistic/metric/calmar.rs
+++ b/barter/src/statistic/metric/calmar.rs
@@ -41,6 +41,7 @@ where
             }
         } else {
             let excess_returns = mean_return - risk_free_return;
+            #[allow(clippy::unwrap_used)] // Invariant: else branch guarantees max_drawdown != 0
             let ratio = excess_returns.checked_div(max_drawdown.abs()).unwrap();
             Self {
                 value: ratio,
@@ -62,12 +63,14 @@ where
         let target_secs = Decimal::from(target.interval().num_seconds());
         let current_secs = Decimal::from(self.interval.interval().num_seconds());
 
+        #[allow(clippy::expect_used)]
+        // Zero-duration intervals yield Decimal::MAX (via unwrap_or); abs() ensures valid sqrt() input
         let scale = target_secs
             .abs()
             .checked_div(current_secs.abs())
             .unwrap_or(Decimal::MAX)
             .sqrt()
-            .expect("ensured seconds are Positive");
+            .expect("abs() ensures non-negative input");
 
         CalmarRatio {
             value: self.value.checked_mul(scale).unwrap_or(Decimal::MAX),
@@ -77,6 +80,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::statistic::time::{Annual252, Daily};

--- a/barter/src/statistic/metric/drawdown/mod.rs
+++ b/barter/src/statistic/metric/drawdown/mod.rs
@@ -106,6 +106,7 @@ impl DrawdownGenerator {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::test_utils::time_plus_days;

--- a/barter/src/statistic/metric/profit_factor.rs
+++ b/barter/src/statistic/metric/profit_factor.rs
@@ -38,6 +38,7 @@ impl ProfitFactor {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;

--- a/barter/src/statistic/metric/sharpe.rs
+++ b/barter/src/statistic/metric/sharpe.rs
@@ -32,6 +32,7 @@ where
             }
         } else {
             let excess_returns = mean_return - risk_free_return;
+            #[allow(clippy::unwrap_used)] // Invariant: else branch guarantees std_dev_returns != 0
             let ratio = excess_returns.checked_div(std_dev_returns).unwrap();
             Self {
                 value: ratio,
@@ -51,12 +52,14 @@ where
         let target_secs = Decimal::from(target.interval().num_seconds());
         let current_secs = Decimal::from(self.interval.interval().num_seconds());
 
+        #[allow(clippy::expect_used)]
+        // Zero-duration intervals yield Decimal::MAX (via unwrap_or); abs() ensures valid sqrt() input
         let scale = target_secs
             .abs()
             .checked_div(current_secs.abs())
             .unwrap_or(Decimal::MAX)
             .sqrt()
-            .expect("ensured seconds are Positive");
+            .expect("abs() ensures non-negative input");
 
         SharpeRatio {
             value: self.value.checked_mul(scale).unwrap_or(Decimal::MAX),
@@ -66,6 +69,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::statistic::time::{Annual252, Daily};

--- a/barter/src/statistic/metric/sortino.rs
+++ b/barter/src/statistic/metric/sortino.rs
@@ -39,6 +39,8 @@ where
             }
         } else {
             let excess_returns = mean_return - risk_free_return;
+            #[allow(clippy::unwrap_used)]
+            // Invariant: else branch guarantees std_dev_loss_returns != 0
             let ratio = excess_returns.checked_div(std_dev_loss_returns).unwrap();
             Self {
                 value: ratio,
@@ -59,12 +61,14 @@ where
         let target_secs = Decimal::from(target.interval().num_seconds());
         let current_secs = Decimal::from(self.interval.interval().num_seconds());
 
+        #[allow(clippy::expect_used)]
+        // Zero-duration intervals yield Decimal::MAX (via unwrap_or); abs() ensures valid sqrt() input
         let scale = target_secs
             .abs()
             .checked_div(current_secs.abs())
             .unwrap_or(Decimal::MAX)
             .sqrt()
-            .expect("ensured seconds are Positive");
+            .expect("abs() ensures non-negative input");
 
         SortinoRatio {
             value: self.value.checked_mul(scale).unwrap_or(Decimal::MAX),
@@ -74,6 +78,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::statistic::time::{Annual252, Daily};

--- a/barter/src/statistic/metric/win_rate.rs
+++ b/barter/src/statistic/metric/win_rate.rs
@@ -26,6 +26,7 @@ impl WinRate {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;

--- a/barter/src/statistic/summary/dataset/dispersion.rs
+++ b/barter/src/statistic/summary/dataset/dispersion.rs
@@ -37,11 +37,15 @@ impl Dispersion {
             welford_online::calculate_population_variance(self.recurrence_relation_m, value_count);
 
         // Update Standard Deviation
-        self.std_dev = self
-            .variance
-            .abs()
-            .sqrt()
-            .expect("variance cannot be negative");
+        // Welford variance can be slightly negative due to Decimal rounding; abs() guards sqrt input
+        #[allow(clippy::expect_used)]
+        {
+            self.std_dev = self
+                .variance
+                .abs()
+                .sqrt()
+                .expect("abs() ensures non-negative input");
+        }
     }
 }
 
@@ -88,6 +92,7 @@ impl Range {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;
@@ -199,7 +204,7 @@ mod tests {
 
         let outputs = vec![output_1, output_2, output_3, output_4, output_5];
 
-        for (input, out) in inputs.into_iter().zip(outputs.into_iter()) {
+        for (input, out) in inputs.into_iter().zip(outputs) {
             dispersion.update(
                 input.prev_mean,
                 input.new_mean,

--- a/barter/src/statistic/summary/dataset/mod.rs
+++ b/barter/src/statistic/summary/dataset/mod.rs
@@ -76,6 +76,7 @@ impl DataSetSummary {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::statistic::summary::dataset::dispersion::Range;

--- a/barter/src/statistic/summary/display.rs
+++ b/barter/src/statistic/summary/display.rs
@@ -110,13 +110,7 @@ where
         // Add metric rows
         self.add_instrument_metric_row(&mut table, "PnL", |ts| format!("{:.2}", ts.pnl));
         self.add_instrument_metric_row(&mut table, &format!("Return {interval}"), |ts| {
-            format!(
-                "{:.2}%",
-                ts.pnl_return
-                    .value
-                    .checked_mul(Decimal::ONE_HUNDRED)
-                    .unwrap()
-            )
+            format_percentage(ts.pnl_return.value, 2)
         });
         self.add_instrument_metric_row(&mut table, &format!("Sharpe {interval}"), |ts| {
             format_ratio(ts.sharpe_ratio.value)
@@ -129,47 +123,28 @@ where
         });
         self.add_instrument_metric_row(&mut table, "PnL Drawdown", |ts| {
             if let Some(drawdown) = &ts.pnl_drawdown {
-                format!(
-                    "{:.2}%",
-                    drawdown.value.checked_mul(Decimal::ONE_HUNDRED).unwrap()
-                )
+                format_percentage(drawdown.value, 2)
             } else {
                 "N/A".to_string()
             }
         });
         self.add_instrument_metric_row(&mut table, "PnL Drawdown Avg", |ts| {
             if let Some(mean_drawdown) = &ts.pnl_drawdown_mean {
-                format!(
-                    "{:.2}%",
-                    mean_drawdown
-                        .mean_drawdown
-                        .checked_mul(Decimal::ONE_HUNDRED)
-                        .unwrap()
-                )
+                format_percentage(mean_drawdown.mean_drawdown, 2)
             } else {
                 "N/A".to_string()
             }
         });
         self.add_instrument_metric_row(&mut table, "PnL Drawdown Max", |ts| {
             if let Some(max_drawdown) = &ts.pnl_drawdown_max {
-                format!(
-                    "{:.2}%",
-                    max_drawdown
-                        .0
-                        .value
-                        .checked_mul(Decimal::ONE_HUNDRED)
-                        .unwrap()
-                )
+                format_percentage(max_drawdown.0.value, 2)
             } else {
                 "N/A".to_string()
             }
         });
         self.add_instrument_metric_row(&mut table, "Win Rate", |ts| {
             if let Some(win_rate) = &ts.win_rate {
-                format!(
-                    "{:.1}%",
-                    win_rate.value.checked_mul(Decimal::ONE_HUNDRED).unwrap()
-                )
+                format_percentage(win_rate.value, 1)
             } else {
                 "N/A".to_string()
             }
@@ -231,37 +206,21 @@ where
         });
         self.add_asset_metric_row(&mut table, "Drawdown", |ts| {
             if let Some(drawdown) = &ts.drawdown {
-                format!(
-                    "{:.2}%",
-                    drawdown.value.checked_mul(Decimal::ONE_HUNDRED).unwrap()
-                )
+                format_percentage(drawdown.value, 2)
             } else {
                 "N/A".to_string()
             }
         });
         self.add_asset_metric_row(&mut table, "Drawdown Avg", |ts| {
             if let Some(mean_drawdown) = &ts.drawdown_mean {
-                format!(
-                    "{:.2}%",
-                    mean_drawdown
-                        .mean_drawdown
-                        .checked_mul(Decimal::ONE_HUNDRED)
-                        .unwrap()
-                )
+                format_percentage(mean_drawdown.mean_drawdown, 2)
             } else {
                 "N/A".to_string()
             }
         });
         self.add_asset_metric_row(&mut table, "Drawdown Max", |ts| {
             if let Some(max_drawdown) = &ts.drawdown_max {
-                format!(
-                    "{:.2}%",
-                    max_drawdown
-                        .0
-                        .value
-                        .checked_mul(Decimal::ONE_HUNDRED)
-                        .unwrap()
-                )
+                format_percentage(max_drawdown.0.value, 2)
             } else {
                 "N/A".to_string()
             }
@@ -289,5 +248,12 @@ fn format_ratio(value: Decimal) -> String {
         "-∞".to_string()
     } else {
         format!("{value:.4}")
+    }
+}
+
+fn format_percentage(value: Decimal, precision: usize) -> String {
+    match value.checked_mul(Decimal::ONE_HUNDRED) {
+        Some(pct) => format!("{pct:.precision$}%"),
+        None => "∞%".to_string(),
     }
 }

--- a/barter/src/system/mod.rs
+++ b/barter/src/system/mod.rs
@@ -91,6 +91,9 @@ where
     ///
     /// **Note that for live & paper-trading this market stream will never end, so use
     /// System::shutdown() for that use case**.
+    ///
+    /// # Panics
+    /// Panics if the Engine task has already dropped its receiver (i.e., panicked).
     pub async fn shutdown_after_backtest(self) -> Result<(Engine, Engine::Audit), JoinError>
     where
         Event: From<Shutdown>,
@@ -110,6 +113,7 @@ where
         // Wait for MarketStream to finish forwarding to Engine before initiating Shutdown
         market_to_engine.await?;
 
+        #[allow(clippy::expect_used)] // Critical invariant: Engine must be alive during shutdown
         feed_tx
             .send(Shutdown)
             .expect("Engine cannot drop Feed receiver");
@@ -179,6 +183,7 @@ where
     }
 
     /// Send an `Event` to the `Engine`.
+    #[allow(clippy::expect_used)] // Critical invariant: Engine must be alive to receive events
     fn send<T>(&self, event: T)
     where
         T: Into<Event>,

--- a/barter/tests/test_engine_process_engine_event_with_audit.rs
+++ b/barter/tests/test_engine_process_engine_event_with_audit.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics acceptable
+
 use barter::{
     EngineEvent, Sequence, Timed,
     engine::{


### PR DESCRIPTION
**Code Quality Lints**

- Enabled strict clippy lints across all 6 crates to prevent panics and numeric overflow bugs in production code.
- Added `clippy::unwrap_used` and `clippy::expect_used` denies using `#[allow]` with explanatory comments distinguishing test code, proc-macros, and safety-proven production code.
- Added `clippy::cast_possible_truncation` and `clippy::cast_sign_loss` denies with 8 targeted exemptions for legitimate casts like HTTP latency timestamps and API response conversions.