### PR TITLE
chore(supply-chain): Add Dependabot, cargo-deny, and supply chain sec…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,38 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot configuration for barter-rs
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
+      day: "monday"
     rebase-strategy: "disabled"
+    labels:
+      - "dependencies"
+    groups:
+      rust-patch:
+        update-types:
+          - "patch"
+    commit-message:
+      prefix: "deps"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    rebase-strategy: "disabled"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      actions-patch:
+        update-types:
+          - "patch"
+    commit-message:
+      prefix: "ci"

--- a/.github/tier2-dependencies.txt
+++ b/.github/tier2-dependencies.txt
@@ -1,0 +1,15 @@
+# Tier-2 Dependencies - Require Manual Review Before Merge
+#
+# Criteria (any match triggers tier-2):
+# - New direct dependencies (not transitive)
+# - Handles: network/IO, cryptography, unsafe code, financial data
+# - Repo signals: <100 GitHub stars, unmaintained (>1yr), single maintainer
+#
+# Format:
+#   crate           - tier-2, any version change needs review
+#   crate=x.y.z     - PINNED, exact version required
+#
+# Pinned entries include: # review-date | risk-factors
+# The auto-merge workflow reads this file and applies 'tier-2' label.
+
+ibapi=2.11.0  # 2026-04-18 | Financial protocol, community-maintained, no official SDK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,29 @@ jobs:
 
       - name: Run cargo clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious -D clippy::style -W clippy::complexity -D clippy::perf
+
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      # Advisory ignores synced with deny.toml (canonical source for justifications)
+      - name: Run cargo audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ignore: RUSTSEC-2026-0002,RUSTSEC-2026-0097
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Run cargo deny
+        uses: EmbarkStudios/cargo-deny-action@a4d2d701318fdc1c6ae17ba8cea8f329c5110eb2  # v2.0.17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
       # Advisory ignores synced with deny.toml (canonical source for justifications)
       - name: Run cargo audit
         uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,78 @@
+name: "Dependabot Auto-Merge"
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, labeled ]
+    branches:
+      - develop
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch updates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.actor == 'dependabot[bot]'
+    timeout-minutes: 5
+    steps:
+      - name: Checkout for tier-2 config
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: .github/tier2-dependencies.txt
+          sparse-checkout-cone-mode: false
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for tier-2 dependencies
+        id: tier2-check
+        env:
+          DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          # Read tier-2 list: extract crate names only (strip =version and # comments)
+          if [ -f .github/tier2-dependencies.txt ]; then
+            TIER2_DEPS=$(grep -v '^#' .github/tier2-dependencies.txt \
+              | grep -v '^$' \
+              | sed 's/=.*//' \
+              | sed 's/[[:space:]].*//' \
+              | sort -u \
+              | tr '\n' '|' \
+              | sed 's/|$//')
+            # Word-boundary matching: DEP_NAMES is comma-separated from fetch-metadata
+            if [ -n "$TIER2_DEPS" ] && echo "$DEP_NAMES" | grep -qE "(^|, )($TIER2_DEPS)(,|$)"; then
+              echo "match=true" >> $GITHUB_OUTPUT
+              echo "::notice::Tier-2 dependency detected: requires manual review"
+            fi
+          fi
+
+      - name: Add tier-2 label for high-risk dependencies
+        if: steps.tier2-check.outputs.match == 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit "$PR_URL" --add-label "tier-2"
+
+      - name: Disable auto-merge for tier-2 dependencies
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'tier-2') ||
+          steps.tier2-check.outputs.match == 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --disable-auto "$PR_URL" || true
+
+      - name: Auto-merge patch updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          !contains(github.event.pull_request.labels.*.name, 'tier-2') &&
+          steps.tier2-check.outputs.match != 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,56 @@
+# cargo-deny configuration
+# https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+targets = []
+all-features = true
+
+# Advisories - handled by cargo audit job, but deny can also check
+[advisories]
+ignore = [
+    # lru IterMut unsoundness - only affects mutable iteration, we use peek/put only
+    { id = "RUSTSEC-2026-0002", reason = "lru IterMut unsoundness doesn't affect our peek/put usage" },
+    # rand unsoundness requires log feature + custom logger + reseed; log feature not enabled
+    { id = "RUSTSEC-2026-0097", reason = "rand's log feature not enabled in this workspace (required for vulnerability)" },
+]
+
+# Licenses - strict permissive only
+[licenses]
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unlicense",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+]
+exceptions = []
+
+# ring 0.17.x: Cargo.toml declares "Apache-2.0 AND ISC", both allowlisted.
+# No clarify block needed (previous block was stale from ring 0.16.x).
+
+# Bans - minimal, rely on review process instead
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+
+# Known transitive dependencies from upstream crates (not directly controlled)
+[[bans.skip]]
+name = "openssl"
+reason = "binance-sdk 44.0.1 dependency; workspace uses rustls-tls; review on binance-sdk upgrades"
+
+[[bans.skip]]
+name = "openssl-sys"
+reason = "same as openssl"
+
+# Sources - only allow crates.io
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
chore(supply-chain): Add Dependabot, cargo-deny, and supply chain security infrastructure

Implements comprehensive supply chain security controls to protect against vulnerable and untrusted dependencies. Enables automated patch updates for low-risk dependencies and requires manual review for high-risk tier-2 deps (financial protocols, network I/O, cryptography, unsafe code).

- Add enhanced Dependabot configuration targeting develop branch with separate groups for Cargo and GitHub Actions patch updates
- Create tier2-dependencies.txt registry (ibapi=2.11.0 pinned) for crates requiring manual review before merge
- Implement cargo-deny configuration with advisory ignores (lru IterMut, rand log feature) and permissive license allow-list
- Add cargo audit job to CI for regular security advisory scanning
- Add cargo deny job to CI for license and dependency governance checks
- Implement Dependabot auto-merge workflow for patch updates, with tier-2 detection and manual review enforcement