### PR TITLE
feat(execution): Use Unauthenticated error variant for auth failures

### DIFF
--- a/barter-execution/src/client/alpaca/mod.rs
+++ b/barter-execution/src/client/alpaca/mod.rs
@@ -1728,7 +1728,7 @@ async fn connect_and_subscribe(config: &AlpacaConfig) -> Result<WebSocket, Unind
         }
         Ok(Err(HandshakeError::Auth(e))) => {
             let _ = ws.close(None).await;
-            Err(UnindexedClientError::Internal(e))
+            Err(UnindexedClientError::Api(ApiError::Unauthenticated(e)))
         }
         Err(_) => {
             let _ = ws.close(None).await;
@@ -2673,7 +2673,8 @@ fn parse_api_error(status: reqwest::StatusCode, message: &str) -> crate::error::
         422 if lower.contains("insufficient") => {
             ApiError::BalanceInsufficient(AssetNameExchange::new("usd"), message.to_owned())
         }
-        403 => ApiError::OrderRejected(format!("forbidden (auth/permission): {message}")),
+        401 => ApiError::Unauthenticated(format!("unauthorized: {message}")),
+        403 => ApiError::Unauthenticated(format!("forbidden: {message}")),
         404 => ApiError::OrderRejected(format!("order not found: {message}")),
         _ => ApiError::OrderRejected(message.to_owned()),
     }
@@ -3426,12 +3427,21 @@ mod tests {
 
     // M-1: parse_order_error — pin all status-code branches not covered by existing tests.
     #[test]
-    fn parse_order_error_403_with_insufficient_body_maps_to_order_rejected_not_balance() {
-        // A suspended/forbidden account should NOT route to BalanceInsufficient
-        // (which could trigger a balance-retry loop). Must be OrderRejected.
+    fn parse_order_error_401_maps_to_unauthenticated() {
+        // 401 Unauthorized: invalid/expired API credentials.
         assert!(matches!(
-            parse_order_error(reqwest::StatusCode::FORBIDDEN, "insufficient permissions"),
-            UnindexedOrderError::Rejected(ApiError::OrderRejected(_))
+            parse_order_error(reqwest::StatusCode::UNAUTHORIZED, "bad credentials"),
+            UnindexedOrderError::Rejected(ApiError::Unauthenticated(_))
+        ));
+    }
+
+    #[test]
+    fn parse_order_error_403_maps_to_unauthenticated() {
+        // 403 Forbidden indicates auth/permission failure — use Unauthenticated, not
+        // OrderRejected or BalanceInsufficient (which could trigger incorrect retry logic).
+        assert!(matches!(
+            parse_order_error(reqwest::StatusCode::FORBIDDEN, "account suspended"),
+            UnindexedOrderError::Rejected(ApiError::Unauthenticated(_))
         ));
     }
 

--- a/barter-execution/src/client/binance/mod.rs
+++ b/barter-execution/src/client/binance/mod.rs
@@ -2533,6 +2533,14 @@ fn convert_order_kind_tif(
     }
 }
 
+/// Case-insensitive substring search that avoids the `to_lowercase` allocation.
+fn contains_ignore_case(haystack: &str, needle: &str) -> bool {
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .any(|w| w.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
 /// Returns true if `msg` contains `code` as a standalone numeric token:
 /// not immediately preceded or followed by another ASCII digit.
 /// Prevents "-2013" from matching "-20130" (suffix guard) or "1-2013" (prefix guard).
@@ -2564,6 +2572,12 @@ fn parse_binance_api_error(
     instrument: &InstrumentNameExchange,
 ) -> ApiError<AssetNameExchange, InstrumentNameExchange> {
     // Match on Binance error codes first — these are stable numeric identifiers
+    if contains_error_code(&error_msg, "-1002") || contains_error_code(&error_msg, "-2015") {
+        // -1002: "You are not authorized to execute this request"
+        // -2015: "Invalid API-key, IP, or permissions for action"
+        // Auth failures must not be retried as order rejections.
+        return ApiError::Unauthenticated(error_msg);
+    }
     if contains_error_code(&error_msg, "-1003") || contains_error_code(&error_msg, "-1015") {
         // -1003: too many requests; -1015: IP rate-limit ban. Both are transient throttles.
         return ApiError::RateLimit;
@@ -2591,12 +2605,6 @@ fn parse_binance_api_error(
     }
 
     // Fall back to case-insensitive message text heuristics (avoid to_lowercase allocation)
-    fn contains_ignore_case(haystack: &str, needle: &str) -> bool {
-        haystack
-            .as_bytes()
-            .windows(needle.len())
-            .any(|w| w.eq_ignore_ascii_case(needle.as_bytes()))
-    }
     if contains_ignore_case(&error_msg, "insufficient")
         || contains_ignore_case(&error_msg, "not enough")
     {
@@ -2626,13 +2634,21 @@ fn parse_binance_api_error(
 }
 
 fn connectivity_error(e: anyhow::Error) -> UnindexedClientError {
-    // use alternate display {:#} to preserve the full anyhow error chain.
-    // Known limitation: all SDK errors (auth failures, HTTP 5xx, malformed responses,
-    // network errors) are uniformly classified as ConnectivityError::Socket. The SDK
-    // uses anyhow::Error, making it impractical to distinguish error categories without
-    // parsing the string — callers cannot distinguish "network unavailable" from
-    // "auth rejected" without inspecting the error message.
-    UnindexedClientError::Connectivity(ConnectivityError::Socket(format!("{e:#}")))
+    let msg = format!("{e:#}");
+
+    // Check for auth failures before falling back to generic connectivity error.
+    // -1002: "You are not authorized to execute this request"
+    // -2015: "Invalid API-key, IP, or permissions for action"
+    if contains_error_code(&msg, "-1002")
+        || contains_error_code(&msg, "-2015")
+        || contains_ignore_case(&msg, "invalid api-key")
+        || contains_ignore_case(&msg, "invalid signature")
+        || contains_ignore_case(&msg, "signature for this request is not valid")
+    {
+        return UnindexedClientError::Api(ApiError::Unauthenticated(msg));
+    }
+
+    UnindexedClientError::Connectivity(ConnectivityError::Socket(msg))
 }
 
 #[cfg(test)]
@@ -2935,6 +2951,54 @@ mod tests {
         assert!(
             !is_api_rejection_error(&rate_limit),
             "rate-limit string error should not be detected as API rejection"
+        );
+    }
+
+    #[test]
+    fn test_connectivity_error_detects_auth_failures() {
+        // -1002: "You are not authorized to execute this request"
+        let err = connectivity_error(anyhow::anyhow!("Error -1002: unauthorized"));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for -1002, got {err:?}"
+        );
+
+        // -2015: "Invalid API-key, IP, or permissions for action"
+        // Use a code-only body (no auth text keyword) to isolate the numeric-code branch.
+        let err = connectivity_error(anyhow::anyhow!("Error -2015: permission denied for action"));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for -2015, got {err:?}"
+        );
+
+        // Text-based detection: "invalid signature"
+        let err = connectivity_error(anyhow::anyhow!("invalid signature provided"));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for 'invalid signature', got {err:?}"
+        );
+
+        // Text-based detection: "signature for this request is not valid"
+        let err = connectivity_error(anyhow::anyhow!(
+            "The signature for this request is not valid."
+        ));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for 'signature for this request is not valid', got {err:?}"
+        );
+
+        // Text-based detection: "invalid api-key"
+        let err = connectivity_error(anyhow::anyhow!("Invalid API-key format"));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for 'invalid api-key', got {err:?}"
+        );
+
+        // Non-auth errors should remain as Connectivity
+        let err = connectivity_error(anyhow::anyhow!("connection timeout"));
+        assert!(
+            matches!(err, UnindexedClientError::Connectivity(_)),
+            "expected Connectivity for timeout, got {err:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Map Alpaca HTTP 403 and WebSocket `HandshakeError::Auth` to `ApiError::Unauthenticated`
- Detect Binance auth failures (error codes -1002, -2015, "invalid api-key", "invalid signature") and map to `Unauthenticated`
- IBKR reviewed — auth happens at TWS/Gateway level before client connects, no changes needed

This completes the rollout of the `Unauthenticated` variant added in TG6 across all exchange integrations.

## Migration note

`ApiError` and `OrderError` are now `#[non_exhaustive]`. Match statements require a wildcard arm:

```rust
match err {
    ApiError::Unauthenticated(msg) => { /* handle */ }
    ApiError::RateLimited => { /* handle */ }
    // ...
    _ => { /* forward compatibility */ }
}
```

## Test plan

- [x] `cargo test --lib alpaca` — includes `parse_order_error_403_maps_to_unauthenticated`
- [x] `cargo test --lib binance` — includes `test_connectivity_error_detects_auth_failures`
- [x] `cargo clippy --workspace`