### PR TITLE
feat(order-state): Add terminal order state metadata

### DIFF
--- a/barter-execution/examples/hyperliquid_execution.rs
+++ b/barter-execution/examples/hyperliquid_execution.rs
@@ -43,6 +43,7 @@ use barter_execution::{
         OrderEvent, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::{RequestCancel, RequestOpen},
+        state::{ActiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -181,7 +182,7 @@ async fn main() {
     match client.open_order(open_request).await {
         Some(response) => {
             match &response.state {
-                Ok(open_state) => {
+                OrderState::Active(ActiveOrderState::Open(open_state)) => {
                     info!("Order placed successfully!");
                     info!("  Client Order ID: {}", response.key.cid);
                     info!("  Exchange Order ID: {}", open_state.id);
@@ -219,12 +220,15 @@ async fn main() {
                         }
                     }
                 }
-                Err(e) => {
+                OrderState::Inactive(e) => {
                     warn!("Order rejected: {e:?}");
                     warn!("This may be due to:");
                     warn!("  - Insufficient margin/balance");
                     warn!("  - Price more than 80% from market");
                     warn!("  - Invalid order parameters");
+                }
+                other => {
+                    info!("Unexpected order state: {other:?}");
                 }
             }
         }

--- a/barter-execution/examples/ibkr_execution.rs
+++ b/barter-execution/examples/ibkr_execution.rs
@@ -38,6 +38,7 @@ use barter_execution::{
         OrderEvent, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::{RequestCancel, RequestOpen},
+        state::{ActiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -150,7 +151,7 @@ async fn main() {
     match client.open_order(open_request).await {
         Some(response) => {
             match &response.state {
-                Ok(open_state) => {
+                OrderState::Active(ActiveOrderState::Open(open_state)) => {
                     info!("Order placed successfully!");
                     info!("  Client Order ID: {}", response.key.cid);
                     info!("  Exchange Order ID: {:?}", open_state.id);
@@ -188,12 +189,15 @@ async fn main() {
                         }
                     }
                 }
-                Err(e) => {
-                    warn!("Order rejected: {e:?}");
+                OrderState::Inactive(inactive) => {
+                    warn!("Order rejected: {inactive:?}");
                     warn!("This may be due to:");
                     warn!("  - 'Read-Only API' is checked in TWS settings");
                     warn!("  - Account not authorized for AAPL trading");
                     warn!("  - Invalid order parameters");
+                }
+                other => {
+                    info!("Unexpected order state: {other:?}");
                 }
             }
         }

--- a/barter-execution/src/client/alpaca/mod.rs
+++ b/barter-execution/src/client/alpaca/mod.rs
@@ -36,12 +36,12 @@ use crate::{
     UnindexedAccountSnapshot,
     balance::{AssetBalance, Balance},
     client::ExecutionClient,
-    error::{ApiError, ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::{Cancelled, Open, OrderState},
+        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -1045,9 +1045,11 @@ impl ExecutionClient for AlpacaClient {
         match rest_delete_with_retry(&self.rate_limiter, || http.delete(&url)).await {
             Ok(()) => {
                 let exchange_order_id = OrderId(order_id);
+                // REST DELETE returns no response body, so filled_qty unavailable.
+                // Use ZERO; downstream can reconcile via WS events or fetch_open_orders.
                 Some(crate::order::request::OrderResponseCancel {
                     key,
-                    state: Ok(Cancelled::new(exchange_order_id, Utc::now())),
+                    state: Ok(Cancelled::new(exchange_order_id, Utc::now(), Decimal::ZERO)),
                 })
             }
             Err(e) => Some(crate::order::request::OrderResponseCancel { key, state: Err(e) }),
@@ -1077,7 +1079,7 @@ impl ExecutionClient for AlpacaClient {
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let side = request.state.side;
         let reduce_only = request.state.reduce_only;
         self.open_order_inner(request, map_position_intent(side, reduce_only))
@@ -1207,7 +1209,7 @@ impl AlpacaClient {
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
         intent: AlpacaPositionIntent,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         self.open_order_inner(request, intent).await
     }
 
@@ -1215,7 +1217,7 @@ impl AlpacaClient {
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
         intent: AlpacaPositionIntent,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let instrument = request.key.instrument.clone();
         let side = request.state.side;
         let price = request.state.price;
@@ -1242,7 +1244,7 @@ impl AlpacaClient {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Err(UnindexedOrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         msg.to_string(),
                     ))),
                 });
@@ -1288,6 +1290,19 @@ impl AlpacaClient {
                 let time_exchange = parse_timestamp(&resp.created_at).unwrap_or_else(Utc::now);
                 let filled_qty = Decimal::from_str(&resp.filled_qty).unwrap_or(Decimal::ZERO);
 
+                let state = if filled_qty >= quantity {
+                    // Order was fully filled immediately (market order or aggressive limit)
+                    OrderState::fully_filled(Filled::new(
+                        exchange_order_id,
+                        time_exchange,
+                        filled_qty,
+                        None, // Alpaca order response doesn't include avg_price
+                    ))
+                } else {
+                    // Order is resting on the order book (partially filled or unfilled)
+                    OrderState::active(Open::new(exchange_order_id, time_exchange, filled_qty))
+                };
+
                 Some(Order {
                     key: order_key,
                     side,
@@ -1295,13 +1310,13 @@ impl AlpacaClient {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Ok(Open::new(exchange_order_id, time_exchange, filled_qty)),
+                    state,
                 })
             }
             Err(e) => {
                 let order_err = match e {
-                    UnindexedClientError::Connectivity(ce) => UnindexedOrderError::Connectivity(ce),
-                    UnindexedClientError::Api(ae) => UnindexedOrderError::Rejected(ae),
+                    UnindexedClientError::Connectivity(ce) => OrderError::Connectivity(ce),
+                    UnindexedClientError::Api(ae) => OrderError::Rejected(ae),
                     // TaskFailed, Internal, Truncated, and TruncatedSnapshot are not
                     // returned by rest_with_retry (REST-only path for orders), but matching
                     // explicitly ensures any new ClientError variant causes a compile error
@@ -1324,7 +1339,7 @@ impl AlpacaClient {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Err(order_err),
+                    state: OrderState::inactive(order_err),
                 })
             }
         }
@@ -2505,7 +2520,9 @@ fn convert_trade_update(update: AlpacaTradeUpdate<'_>) -> Option<UnindexedAccoun
                 .timestamp
                 .and_then(parse_timestamp)
                 .unwrap_or_else(Utc::now);
-            let cancelled = Cancelled::new(order_id, time_exchange);
+            let filled_qty =
+                Decimal::from_str(order.filled_qty.unwrap_or("0")).unwrap_or(Decimal::ZERO);
+            let cancelled = Cancelled::new(order_id, time_exchange, filled_qty);
             let response = crate::order::request::OrderResponseCancel {
                 key: OrderKey::new(ExchangeId::Alpaca, instrument, StrategyId::unknown(), cid),
                 state: Ok(cancelled),
@@ -3869,7 +3886,7 @@ mod tests {
             assert!(result.is_some(), "open_order should return a result");
             let order = result.unwrap();
             assert!(
-                order.state.is_ok(),
+                order.state.is_accepted(),
                 "order should be accepted: {:?}",
                 order.state
             );
@@ -3955,7 +3972,7 @@ mod tests {
             assert!(result.is_some(), "open_order should return a result");
             let order = result.unwrap();
             assert!(
-                order.state.is_ok(),
+                order.state.is_accepted(),
                 "order should be accepted: {:?}",
                 order.state
             );

--- a/barter-execution/src/client/binance/mod.rs
+++ b/barter-execution/src/client/binance/mod.rs
@@ -32,12 +32,12 @@ use crate::{
     UnindexedAccountSnapshot,
     balance::{AssetBalance, Balance},
     client::ExecutionClient,
-    error::{ApiError, ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::{Cancelled, Open, OrderState},
+        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -1055,9 +1055,15 @@ impl ExecutionClient for BinanceSpot {
                         }
                     };
 
+                    let filled_qty = data
+                        .executed_qty
+                        .as_deref()
+                        .and_then(|q| Decimal::from_str(q).ok())
+                        .unwrap_or(Decimal::ZERO);
+
                     Some(UnindexedOrderResponseCancel {
                         key,
-                        state: Ok(Cancelled::new(exchange_order_id, time_exchange)),
+                        state: Ok(Cancelled::new(exchange_order_id, time_exchange, filled_qty)),
                     })
                 }
                 Err(e) => {
@@ -1113,7 +1119,7 @@ impl ExecutionClient for BinanceSpot {
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let instrument = request.key.instrument.clone();
         let side = request.state.side;
         let price = request.state.price;
@@ -1139,7 +1145,7 @@ impl ExecutionClient for BinanceSpot {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Err(UnindexedOrderError::Connectivity(
+                    state: OrderState::inactive(OrderError::Connectivity(
                         ConnectivityError::Socket(format!("{e:#}")),
                     )),
                 });
@@ -1184,7 +1190,7 @@ impl ExecutionClient for BinanceSpot {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Err(UnindexedOrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         e.to_string(),
                     ))),
                 });
@@ -1210,9 +1216,11 @@ impl ExecutionClient for BinanceSpot {
                                 quantity,
                                 kind,
                                 time_in_force,
-                                state: Err(UnindexedOrderError::Rejected(ApiError::OrderRejected(
-                                    "open_order response missing orderId".into(),
-                                ))),
+                                state: OrderState::inactive(OrderError::Rejected(
+                                    ApiError::OrderRejected(
+                                        "open_order response missing orderId".into(),
+                                    ),
+                                )),
                             });
                         }
                     };
@@ -1223,6 +1231,19 @@ impl ExecutionClient for BinanceSpot {
                         .and_then(|q| Decimal::from_str(q).ok())
                         .unwrap_or(Decimal::ZERO);
 
+                    let state = if filled_qty >= quantity {
+                        // Order was fully filled immediately
+                        OrderState::fully_filled(Filled::new(
+                            exchange_order_id,
+                            time_exchange,
+                            filled_qty,
+                            None, // Binance SDK response doesn't expose avg_price directly
+                        ))
+                    } else {
+                        // Order is resting on the order book
+                        OrderState::active(Open::new(exchange_order_id, time_exchange, filled_qty))
+                    };
+
                     Some(Order {
                         key: order_key,
                         side,
@@ -1230,7 +1251,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Ok(Open::new(exchange_order_id, time_exchange, filled_qty)),
+                        state,
                     })
                 }
                 Err(e) => {
@@ -1242,7 +1263,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Err(UnindexedOrderError::Rejected(ApiError::OrderRejected(
+                        state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                             e.to_string(),
                         ))),
                     })
@@ -1269,7 +1290,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Err(UnindexedOrderError::from(api_err)),
+                        state: OrderState::inactive(OrderError::from(api_err)),
                     })
                 } else if is_rate_limit_error(&e) {
                     // WS-level 429 — update the shared rate limiter so REST calls also back off.
@@ -1281,7 +1302,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Err(UnindexedOrderError::from(ApiError::RateLimit)),
+                        state: OrderState::inactive(OrderError::from(ApiError::RateLimit)),
                     })
                 } else {
                     // Transport-level error — clear cached session so next call reconnects.
@@ -1294,7 +1315,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Err(UnindexedOrderError::Connectivity(
+                        state: OrderState::inactive(OrderError::Connectivity(
                             ConnectivityError::Socket(format!("{e:#}")),
                         )),
                     })
@@ -2250,7 +2271,12 @@ fn convert_execution_report(
             ))
         }
         "CANCELED" | "EXPIRED" | "EXPIRED_IN_MATCH" => {
-            let cancelled = Cancelled::new(order_id, time_exchange);
+            let filled_qty = report
+                .z
+                .as_deref()
+                .and_then(|s| Decimal::from_str(s).ok())
+                .unwrap_or(Decimal::ZERO);
+            let cancelled = Cancelled::new(order_id, time_exchange, filled_qty);
             let response = UnindexedOrderResponseCancel {
                 key: OrderKey::new(
                     ExchangeId::BinanceSpot,
@@ -2294,7 +2320,12 @@ fn convert_execution_report(
             // The replacement order arrives as a subsequent NEW execution report with
             // its own order ID. We emit OrderCancelled for the original order so the
             // engine removes it from its open-order book.
-            let cancelled = Cancelled::new(order_id, time_exchange);
+            let filled_qty = report
+                .z
+                .as_deref()
+                .and_then(|s| Decimal::from_str(s).ok())
+                .unwrap_or(Decimal::ZERO);
+            let cancelled = Cancelled::new(order_id, time_exchange, filled_qty);
             let response = UnindexedOrderResponseCancel {
                 key: OrderKey::new(ExchangeId::BinanceSpot, symbol, StrategyId::unknown(), cid),
                 state: Ok(cancelled),
@@ -3832,12 +3863,17 @@ mod tests {
             AccountEventKind::OrderSnapshot(Snapshot(Order::new(
                 key,
                 Side::Buy,
-                Decimal::ZERO,
-                Decimal::ZERO,
+                Decimal::ONE,
+                Decimal::ONE,
                 OrderKind::Market,
                 TimeInForce::ImmediateOrCancel,
                 OrderState::<AssetNameExchange, InstrumentNameExchange>::Inactive(
-                    InactiveOrderState::FullyFilled,
+                    InactiveOrderState::FullyFilled(crate::order::state::Filled::new(
+                        OrderId::new("123"),
+                        Utc::now(),
+                        Decimal::ONE, // FullyFilled must have non-zero filled_quantity
+                        None,
+                    )),
                 ),
             ))),
         );

--- a/barter-execution/src/client/hyperliquid/mod.rs
+++ b/barter-execution/src/client/hyperliquid/mod.rs
@@ -29,12 +29,12 @@ use crate::{
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::{AssetBalance, Balance},
     client::ExecutionClient,
-    error::{ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::Open,
+        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
     },
     position::Position,
     trade::{AssetFees, Trade, TradeId},
@@ -706,10 +706,11 @@ impl ExecutionClient for HyperliquidClient {
                         strategy: request.key.strategy.clone(),
                         cid: request.key.cid.clone(),
                     },
-                    state: Ok(Cancelled {
-                        id: order_id.clone(),
-                        time_exchange: Utc::now(),
-                    }),
+                    state: Ok(Cancelled::new(
+                        order_id.clone(),
+                        Utc::now(),
+                        Decimal::ZERO, // Cancel response doesn't include filled quantity
+                    )),
                 })
             }
             ExchangeResponseStatus::Err(msg) => {
@@ -732,7 +733,7 @@ impl ExecutionClient for HyperliquidClient {
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         use hyperliquid_rust_sdk::{
             ClientLimit, ClientOrder, ClientOrderRequest, ExchangeDataStatus,
             ExchangeResponseStatus,
@@ -783,7 +784,7 @@ impl ExecutionClient for HyperliquidClient {
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
-                    state: Err(error::map_order_error(e, request.key.instrument)),
+                    state: OrderState::inactive(error::map_order_error(e, request.key.instrument)),
                 });
             }
         };
@@ -799,7 +800,7 @@ impl ExecutionClient for HyperliquidClient {
                 match status {
                     Some(ExchangeDataStatus::Resting(resting)) => {
                         debug!(oid = resting.oid, "Order resting");
-                        Ok(Open {
+                        OrderState::active(Open {
                             id: OrderId(format_smolstr!("{}", resting.oid)),
                             time_exchange: Utc::now(),
                             filled_quantity: Decimal::ZERO,
@@ -807,16 +808,19 @@ impl ExecutionClient for HyperliquidClient {
                     }
                     Some(ExchangeDataStatus::Filled(filled)) => {
                         debug!(oid = filled.oid, avg_px = %filled.avg_px, "Order filled");
-                        Ok(Open {
-                            id: OrderId(format_smolstr!("{}", filled.oid)),
-                            time_exchange: Utc::now(),
-                            filled_quantity: parse_decimal(&filled.total_sz, "total_sz")
+                        // Hyperliquid provides avg_px for filled orders
+                        let avg_price = parse_decimal(&filled.avg_px, "avg_px");
+                        OrderState::fully_filled(Filled::new(
+                            OrderId(format_smolstr!("{}", filled.oid)),
+                            Utc::now(),
+                            parse_decimal(&filled.total_sz, "total_sz")
                                 .unwrap_or(request.state.quantity),
-                        })
+                            avg_price,
+                        ))
                     }
                     Some(ExchangeDataStatus::Error(msg)) => {
                         warn!(%msg, "Order rejected by exchange");
-                        Err(UnindexedOrderError::Rejected(
+                        OrderState::inactive(OrderError::Rejected(
                             crate::error::ApiError::OrderRejected(msg),
                         ))
                     }
@@ -825,7 +829,7 @@ impl ExecutionClient for HyperliquidClient {
                         // Trigger/conditional orders return no usable order ID.
                         // Reject since we can't track or cancel these orders.
                         warn!("Trigger/conditional orders not supported");
-                        Err(UnindexedOrderError::Rejected(
+                        OrderState::inactive(OrderError::Rejected(
                             crate::error::ApiError::OrderRejected(
                                 "trigger/conditional orders not supported".to_string(),
                             ),
@@ -835,7 +839,7 @@ impl ExecutionClient for HyperliquidClient {
                         // Generic success without order ID — SDK didn't return structured data.
                         // This shouldn't happen for limit orders; reject to avoid silent failures.
                         warn!("Order accepted but no order ID returned");
-                        Err(UnindexedOrderError::Rejected(
+                        OrderState::inactive(OrderError::Rejected(
                             crate::error::ApiError::OrderRejected(
                                 "no order ID in response".to_string(),
                             ),
@@ -845,9 +849,9 @@ impl ExecutionClient for HyperliquidClient {
             }
             ExchangeResponseStatus::Err(msg) => {
                 warn!(%msg, "Order rejected");
-                Err(UnindexedOrderError::Rejected(
-                    crate::error::ApiError::OrderRejected(msg),
-                ))
+                OrderState::inactive(OrderError::Rejected(crate::error::ApiError::OrderRejected(
+                    msg,
+                )))
             }
         };
 
@@ -1100,7 +1104,7 @@ fn order_update_to_account_event(
         .map(|c| ClientOrderId::new(SmolStr::new(c)))
         .unwrap_or_else(|| ClientOrderId::new(order_id_smol.clone()));
 
-    // Determine order state from status — parse current_sz only when needed for filled_quantity
+    // Determine order state from status
     let state = match update.status.as_str() {
         "open" | "resting" => {
             let current_sz = parse_decimal(&order.sz, "order.sz")?;
@@ -1111,12 +1115,20 @@ fn order_update_to_account_event(
                 filled_quantity,
             })
         }
-        "filled" => crate::order::state::OrderState::fully_filled(),
+        "filled" => crate::order::state::OrderState::fully_filled(Filled::new(
+            OrderId(order_id_smol),
+            time_exchange,
+            orig_sz, // Fully filled means filled_quantity == orig_sz
+            None,    // OrderUpdate doesn't include avg_price
+        )),
         "canceled" | "cancelled" => {
-            crate::order::state::OrderState::inactive(crate::order::state::Cancelled {
-                id: OrderId(order_id_smol),
+            let current_sz = parse_decimal(&order.sz, "order.sz")?;
+            let filled_quantity = (orig_sz - current_sz).max(Decimal::ZERO);
+            crate::order::state::OrderState::inactive(Cancelled::new(
+                OrderId(order_id_smol),
                 time_exchange,
-            })
+                filled_quantity,
+            ))
         }
         status => {
             warn!(%status, "Unknown order status");
@@ -1368,7 +1380,7 @@ mod tests {
                 assert!(matches!(
                     order.state,
                     crate::order::state::OrderState::Inactive(
-                        crate::order::state::InactiveOrderState::FullyFilled
+                        crate::order::state::InactiveOrderState::FullyFilled(_)
                     )
                 ));
             }

--- a/barter-execution/src/client/ibkr/mod.rs
+++ b/barter-execution/src/client/ibkr/mod.rs
@@ -42,14 +42,14 @@ use crate::{
     UnindexedAccountSnapshot,
     balance::AssetBalance,
     client::ExecutionClient,
-    error::{ApiError, ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError},
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{
             OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, UnindexedOrderResponseCancel,
         },
-        state::{Cancelled, Open, OrderState},
+        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -496,12 +496,7 @@ impl ExecutionClient for IbkrClient {
                                 };
 
                                 if let Some((client_id, ctx)) = lookup_result {
-                                    let order = make_order_from_status(
-                                        &status,
-                                        client_id,
-                                        &ctx,
-                                        is_terminal,
-                                    );
+                                    let order = make_order_from_status(&status, client_id, &ctx);
                                     Some(UnindexedAccountEvent {
                                         exchange: ExchangeId::Ibkr,
                                         kind: AccountEventKind::OrderSnapshot(Snapshot::new(order)),
@@ -616,11 +611,14 @@ impl ExecutionClient for IbkrClient {
                 // correlate any fill events that arrive between now and when IB
                 // confirms the cancel. Removal happens in account_stream when
                 // OrderStatus::Cancelled is received.
+                // IBKR cancel_order returns no filled qty; use ZERO and let
+                // subsequent OrderStatus events provide accurate fill info.
                 Some(OrderResponseCancel {
                     key,
                     state: Ok(Cancelled::new(
                         OrderId::new(format_smolstr!("{}", ib_order_id)),
                         Utc::now(),
+                        Decimal::ZERO,
                     )),
                 })
             }
@@ -662,7 +660,7 @@ impl ExecutionClient for IbkrClient {
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let key = OrderKey {
             exchange: ExchangeId::Ibkr,
             instrument: request.key.instrument.clone(),
@@ -680,12 +678,10 @@ impl ExecutionClient for IbkrClient {
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
-                    state: Err(crate::error::OrderError::Rejected(
-                        ApiError::InstrumentInvalid(
-                            request.key.instrument.clone(),
-                            "contract not registered".to_string(),
-                        ),
-                    )),
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::InstrumentInvalid(
+                        request.key.instrument.clone(),
+                        "contract not registered".to_string(),
+                    ))),
                 });
             }
         };
@@ -700,7 +696,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
-                    state: Err(crate::error::OrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         format!("quantity {} exceeds f64 range", request.state.quantity),
                     ))),
                 });
@@ -723,7 +719,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
-                    state: Err(crate::error::OrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         e.to_string(),
                     ))),
                 });
@@ -787,19 +783,23 @@ impl ExecutionClient for IbkrClient {
         .await;
 
         match result {
-            Ok(Ok(Some((order_id, filled)))) => Some(Order {
-                key,
-                side,
-                price,
-                quantity: req_quantity,
-                kind,
-                time_in_force: tif,
-                state: Ok(Open::new(
-                    OrderId::new(format_smolstr!("{}", order_id)),
-                    Utc::now(),
-                    filled,
-                )),
-            }),
+            Ok(Ok(Some((order_id, filled)))) => {
+                // IB always returns order status via subscription - never immediate fills.
+                // The filled quantity here is from the OrderStatus event, not a complete fill.
+                Some(Order {
+                    key,
+                    side,
+                    price,
+                    quantity: req_quantity,
+                    kind,
+                    time_in_force: tif,
+                    state: OrderState::active(Open::new(
+                        OrderId::new(format_smolstr!("{}", order_id)),
+                        Utc::now(),
+                        filled,
+                    )),
+                })
+            }
             Ok(Ok(None)) => {
                 // Subscription exhausted without terminal status. The order WAS submitted
                 // (we have an IB order ID), but we lost tracking. Return Open with zero
@@ -815,7 +815,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: req_quantity,
                     kind,
                     time_in_force: tif,
-                    state: Ok(Open::new(
+                    state: OrderState::active(Open::new(
                         OrderId::new(format_smolstr!("{}", ib_order_id)),
                         Utc::now(),
                         Decimal::ZERO,
@@ -832,7 +832,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: req_quantity,
                     kind,
                     time_in_force: tif,
-                    state: Err(crate::error::OrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         status,
                     ))),
                 })
@@ -846,7 +846,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: req_quantity,
                     kind,
                     time_in_force: tif,
-                    state: Err(crate::error::OrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         e.to_string(),
                     ))),
                 })
@@ -1116,28 +1116,44 @@ impl ExecutionClient for IbkrClient {
 
 /// Build an Order from IB OrderStatus using stored OrderContext.
 ///
-/// `is_terminal` indicates Cancelled/Inactive status (caller determines this before
-/// choosing the lookup method, so we take it as a parameter to avoid re-matching).
+/// # IBKR Status Mapping
+///
+/// | IB Status    | → OrderState          | Rationale                                    |
+/// |--------------|-----------------------|----------------------------------------------|
+/// | "Inactive"   | OpenFailed(Rejected)  | Order blocked by validation/margin/exchange  |
+/// | "Cancelled"  | Cancelled             | User-initiated or exchange cancellation      |
+/// | "Filled"     | FullyFilled           | Order fully executed                         |
+/// | Other        | Active(Open)          | Order working on exchange                    |
+///
+/// Note: IBKR sends both user-cancellation and time-expiration as "Cancelled" status.
+/// Distinguishing Cancelled vs Expired requires correlating with `error` callbacks
+/// (error 202 = user cancel, "expir" in message = expiration). This is a future
+/// enhancement tracked in docs/current_task.md (7.7).
 fn make_order_from_status(
     status: &ibapi::orders::OrderStatus,
     client_id: ClientOrderId,
     ctx: &OrderContext,
-    is_terminal: bool,
 ) -> Order<ExchangeId, InstrumentNameExchange, OrderState<AssetNameExchange, InstrumentNameExchange>>
 {
     let ib_id = status.order_id;
     let order_id = OrderId::new(format_smolstr!("{}", ib_id));
 
-    let state = if is_terminal {
-        OrderState::inactive(Cancelled::new(order_id, Utc::now()))
-    } else if status.status.as_str() == "Filled" {
-        OrderState::fully_filled()
-    } else {
-        OrderState::active(Open::new(
-            order_id,
-            Utc::now(),
-            parse_decimal_or_warn(status.filled, "status.filled"),
-        ))
+    let filled_qty = parse_decimal_or_warn(status.filled, "status.filled");
+    let state = match status.status.as_str() {
+        "Inactive" => {
+            // "Inactive" means the order was accepted by IB but is not working:
+            // validation failure, margin issue, exchange closed, share location hold.
+            // This is a placement failure, not a cancellation.
+            OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
+                "IB status: Inactive (order blocked by validation/margin/exchange)".into(),
+            )))
+        }
+        "Cancelled" => OrderState::inactive(Cancelled::new(order_id, Utc::now(), filled_qty)),
+        "Filled" => OrderState::fully_filled(Filled::new(order_id, Utc::now(), filled_qty, None)),
+        _ => {
+            // "Submitted", "PreSubmitted", "PendingSubmit", "PendingCancel", etc.
+            OrderState::active(Open::new(order_id, Utc::now(), filled_qty))
+        }
     };
 
     Order {

--- a/barter-execution/src/client/mock/mod.rs
+++ b/barter-execution/src/client/mock/mod.rs
@@ -2,14 +2,14 @@ use crate::{
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::AssetBalance,
     client::ExecutionClient,
-    error::{ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     exchange::mock::request::{MarketPrices, MockExchangeRequest},
     fee::FeeModelConfig,
     fill::SimFillConfig,
     order::{
         Order, OrderEvent, OrderKey,
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::Open,
+        state::{Open, OrderState, UnindexedOrderState},
     },
     trade::Trade,
 };
@@ -208,7 +208,7 @@ where
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let (response_tx, response_rx) = oneshot::channel();
 
         let request = into_owned_request(request);
@@ -230,7 +230,7 @@ where
                 quantity: request.state.quantity,
                 kind: request.state.kind,
                 time_in_force: request.state.time_in_force,
-                state: Err(UnindexedOrderError::Connectivity(
+                state: OrderState::inactive(OrderError::Connectivity(
                     ConnectivityError::ExchangeOffline(self.mocked_exchange),
                 )),
             });
@@ -245,7 +245,7 @@ where
                 quantity: request.state.quantity,
                 kind: request.state.kind,
                 time_in_force: request.state.time_in_force,
-                state: Err(UnindexedOrderError::Connectivity(
+                state: OrderState::inactive(OrderError::Connectivity(
                     ConnectivityError::ExchangeOffline(self.mocked_exchange),
                 )),
             },

--- a/barter-execution/src/client/mod.rs
+++ b/barter-execution/src/client/mod.rs
@@ -1,11 +1,11 @@
 use crate::{
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::AssetBalance,
-    error::{UnindexedClientError, UnindexedOrderError},
+    error::UnindexedClientError,
     order::{
         Order,
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::Open,
+        state::{Open, UnindexedOrderState},
     },
     trade::Trade,
 };
@@ -98,22 +98,29 @@ where
         )
     }
 
+    /// Place an order on the exchange.
+    ///
+    /// # Return value
+    ///
+    /// Returns `OrderState` directly rather than `Result<Open, OrderError>`:
+    /// - `OrderState::Active(Open)` - order is resting on the order book
+    /// - `OrderState::Inactive(FullyFilled)` - order was immediately filled (includes `avg_price` when available)
+    /// - `OrderState::Inactive(OpenFailed)` - order placement failed (API error, connectivity, etc.)
+    ///
+    /// This design allows immediate fills to carry metadata (e.g., `avg_price`) that
+    /// would be lost if we had to infer terminal state from `Open::filled_quantity`.
     fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> impl Future<
-        Output = Option<
-            Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
-        >,
-    > + Send;
+    ) -> impl Future<Output = Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>>>
+    + Send;
 
     // `+ Send` on default method return types for multi-threaded Tokio runtime
     fn open_orders<'a>(
         &self,
         requests: impl IntoIterator<Item = OrderRequestOpen<ExchangeId, &'a InstrumentNameExchange>>,
-    ) -> impl Stream<
-        Item = Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>>,
-    > + Send {
+    ) -> impl Stream<Item = Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>>> + Send
+    {
         futures::stream::FuturesUnordered::from_iter(
             requests.into_iter().map(|request| self.open_order(request)),
         )

--- a/barter-execution/src/exchange/mock/mod.rs
+++ b/barter-execution/src/exchange/mock/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         Order, OrderKey, OrderKind, UnindexedOrder,
         id::OrderId,
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::{Cancelled, Open},
+        state::{Cancelled, Filled, InactiveOrderState, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -296,7 +296,7 @@ impl MockExchange {
         request: OrderRequestOpen<ExchangeId, InstrumentNameExchange>,
         market_prices: MarketPrices,
     ) -> (
-        Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
+        Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
         Option<OpenOrderNotifications>,
     ) {
         if let Err(error) = self.validate_order_kind_supported(request.state.kind) {
@@ -440,11 +440,12 @@ impl MockExchange {
             quantity: request.state.quantity,
             kind: request.state.kind,
             time_in_force: request.state.time_in_force,
-            state: Ok(Open {
-                id: order_id.clone(),
-                time_exchange: self.time_exchange(),
-                filled_quantity: request.state.quantity,
-            }),
+            state: OrderState::fully_filled(Filled::new(
+                order_id.clone(),
+                self.time_exchange(),
+                request.state.quantity,
+                Some(fill_price),
+            )),
         };
 
         let notifications = OpenOrderNotifications {
@@ -510,7 +511,7 @@ impl MockExchange {
 fn build_open_order_err_response<E>(
     request: OrderRequestOpen<ExchangeId, InstrumentNameExchange>,
     error: E,
-) -> Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>
+) -> Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>
 where
     E: Into<UnindexedOrderError>,
 {
@@ -521,7 +522,7 @@ where
         quantity: request.state.quantity,
         kind: request.state.kind,
         time_in_force: request.state.time_in_force,
-        state: Err(error.into()),
+        state: OrderState::inactive(error.into()),
     }
 }
 
@@ -538,7 +539,7 @@ mod tests {
     use crate::{
         UnindexedAccountSnapshot,
         balance::{AssetBalance, Balance},
-        error::{ApiError, UnindexedOrderError},
+        error::ApiError,
         exchange::mock::request::MarketPrices,
         fee::{FeeModelConfig, PercentageFeeModel},
         fill::{BidAskFillModel, SimFillConfig},
@@ -699,7 +700,7 @@ mod tests {
             exchange.open_order(sell_request("0.5", "50000"), MarketPrices::default());
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "sell should succeed: {:?}",
             response.state
         );
@@ -741,15 +742,16 @@ mod tests {
             "failed order must produce no notifications"
         );
         match response.state {
-            Err(UnindexedOrderError::Rejected(ApiError::BalanceInsufficient(ref asset, _))) => {
+            OrderState::Inactive(InactiveOrderState::OpenFailed(
+                crate::error::OrderError::Rejected(ApiError::BalanceInsufficient(ref asset, _)),
+            )) => {
                 assert_eq!(
                     *asset,
                     base(),
                     "BalanceInsufficient must name the base asset (BTC), not the quote (USDT)"
                 );
             }
-            Err(other) => panic!("expected BalanceInsufficient, got: {other:?}"),
-            Ok(_) => panic!("expected error for oversized sell, got Ok"),
+            other => panic!("expected BalanceInsufficient, got: {other:?}"),
         }
     }
 
@@ -769,7 +771,7 @@ mod tests {
         let (response, notifications) = exchange.open_order(buy_request("1", "100"), market_prices);
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "buy should succeed: {:?}",
             response.state
         );
@@ -805,7 +807,7 @@ mod tests {
             exchange.open_order(buy_request("10", "100"), MarketPrices::default());
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "buy should succeed: {:?}",
             response.state
         );
@@ -838,7 +840,7 @@ mod tests {
             exchange.open_order(sell_request("1", "100"), MarketPrices::default());
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "sell should succeed: {:?}",
             response.state
         );
@@ -873,7 +875,7 @@ mod tests {
             exchange.open_order(sell_request("1", "0"), MarketPrices::default());
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "sell at zero price should succeed: {:?}",
             response.state
         );

--- a/barter-execution/src/exchange/mock/request.rs
+++ b/barter-execution/src/exchange/mock/request.rs
@@ -1,11 +1,10 @@
 use crate::{
     UnindexedAccountSnapshot,
     balance::AssetBalance,
-    error::UnindexedOrderError,
     order::{
         Order,
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::Open,
+        state::{Open, UnindexedOrderState},
     },
     trade::Trade,
 };
@@ -117,7 +116,7 @@ impl MockExchangeRequest {
     pub fn open_order(
         time_request: DateTime<Utc>,
         response_tx: oneshot::Sender<
-            Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
+            Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
         >,
         request: OrderRequestOpen<ExchangeId, InstrumentNameExchange>,
         market_prices: MarketPrices,
@@ -155,9 +154,8 @@ pub enum MockExchangeRequestKind {
         request: OrderRequestCancel<ExchangeId, InstrumentNameExchange>,
     },
     OpenOrder {
-        response_tx: oneshot::Sender<
-            Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
-        >,
+        response_tx:
+            oneshot::Sender<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>>,
         request: OrderRequestOpen<ExchangeId, InstrumentNameExchange>,
         market_prices: MarketPrices,
     },

--- a/barter-execution/src/indexer.rs
+++ b/barter-execution/src/indexer.rs
@@ -150,23 +150,7 @@ impl AccountEventIndexer {
         } = order;
 
         let key = self.order_key(key)?;
-
-        let state = match state {
-            UnindexedOrderState::Active(active) => OrderState::Active(active),
-            UnindexedOrderState::Inactive(inactive) => match inactive {
-                InactiveOrderState::OpenFailed(failed) => match failed {
-                    OrderError::Rejected(rejected) => {
-                        OrderState::inactive(OrderError::Rejected(self.api_error(rejected)?))
-                    }
-                    OrderError::Connectivity(error) => {
-                        OrderState::inactive(OrderError::Connectivity(error))
-                    }
-                },
-                InactiveOrderState::Cancelled(cancelled) => OrderState::inactive(cancelled),
-                InactiveOrderState::FullyFilled => OrderState::fully_filled(),
-                InactiveOrderState::Expired => OrderState::expired(),
-            },
-        };
+        let state = self.order_state(state)?;
 
         Ok(Order {
             key,
@@ -207,6 +191,28 @@ impl AccountEventIndexer {
             instrument: self.map.find_instrument_index(&instrument)?,
             strategy,
             cid,
+        })
+    }
+
+    /// Index an [`UnindexedOrderState`] to an [`OrderState`].
+    ///
+    /// Used by [`ExecutionManager`] to index `open_order` responses.
+    pub fn order_state(&self, state: UnindexedOrderState) -> Result<OrderState, IndexError> {
+        Ok(match state {
+            UnindexedOrderState::Active(active) => OrderState::Active(active),
+            UnindexedOrderState::Inactive(inactive) => match inactive {
+                InactiveOrderState::OpenFailed(failed) => match failed {
+                    OrderError::Rejected(rejected) => {
+                        OrderState::inactive(OrderError::Rejected(self.api_error(rejected)?))
+                    }
+                    OrderError::Connectivity(error) => {
+                        OrderState::inactive(OrderError::Connectivity(error))
+                    }
+                },
+                InactiveOrderState::Cancelled(cancelled) => OrderState::inactive(cancelled),
+                InactiveOrderState::FullyFilled(filled) => OrderState::fully_filled(filled),
+                InactiveOrderState::Expired(expired) => OrderState::expired(expired),
+            },
         })
     }
 

--- a/barter-execution/src/order/state.rs
+++ b/barter-execution/src/order/state.rs
@@ -33,12 +33,12 @@ impl<AssetKey, InstrumentKey> OrderState<AssetKey, InstrumentKey> {
         OrderState::Inactive(state.into())
     }
 
-    pub fn fully_filled() -> Self {
-        Self::Inactive(InactiveOrderState::FullyFilled)
+    pub fn fully_filled(filled: Filled) -> Self {
+        Self::Inactive(InactiveOrderState::FullyFilled(filled))
     }
 
-    pub fn expired() -> Self {
-        Self::Inactive(InactiveOrderState::Expired)
+    pub fn expired(expired: Expired) -> Self {
+        Self::Inactive(InactiveOrderState::Expired(expired))
     }
 
     pub fn time_exchange(&self) -> Option<DateTime<Utc>> {
@@ -52,9 +52,29 @@ impl<AssetKey, InstrumentKey> OrderState<AssetKey, InstrumentKey> {
             },
             Self::Inactive(inactive) => match inactive {
                 InactiveOrderState::Cancelled(state) => Some(state.time_exchange),
-                _ => None,
+                InactiveOrderState::FullyFilled(state) => Some(state.time_exchange),
+                InactiveOrderState::Expired(state) => Some(state.time_exchange),
+                InactiveOrderState::OpenFailed(_) => None,
             },
         }
+    }
+
+    /// Returns `true` if the order was not rejected at placement.
+    ///
+    /// Returns `true` for all states except `Inactive(OpenFailed(_))`:
+    /// - `Active(_)` — order is working on the exchange
+    /// - `Inactive(FullyFilled(_))` — order completed successfully
+    /// - `Inactive(Cancelled(_))` — order was accepted then cancelled
+    /// - `Inactive(Expired(_))` — order was accepted then expired
+    ///
+    /// This is the opposite of [`is_failed()`](Self::is_failed).
+    pub fn is_accepted(&self) -> bool {
+        !self.is_failed()
+    }
+
+    /// Returns `true` if the order failed to open.
+    pub fn is_failed(&self) -> bool {
+        matches!(self, Self::Inactive(InactiveOrderState::OpenFailed(_)))
     }
 }
 
@@ -93,6 +113,24 @@ impl Open {
     }
 }
 
+/// Metadata for a fully filled order.
+///
+/// Unlike [`Open`], this represents an order that has completed execution
+/// and is no longer active on the exchange.
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
+)]
+pub struct Filled {
+    pub id: OrderId,
+    pub time_exchange: DateTime<Utc>,
+    pub filled_quantity: Decimal,
+    /// Volume-weighted average execution price across all fills.
+    ///
+    /// `Some` when the exchange provides it in the response, `None` otherwise.
+    /// When `None`, downstream consumers should compute from individual fill events.
+    pub avg_price: Option<Decimal>,
+}
+
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize, Constructor,
 )]
@@ -103,15 +141,38 @@ pub struct CancelInFlight {
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, From)]
 pub enum InactiveOrderState<AssetKey, InstrumentKey> {
     Cancelled(Cancelled),
-    FullyFilled,
+    FullyFilled(Filled),
     OpenFailed(OrderError<AssetKey, InstrumentKey>),
-    Expired,
+    Expired(Expired),
 }
 
+/// Metadata for a cancelled order.
+///
+/// Includes `filled_quantity` to handle IOC (Immediate-Or-Cancel) orders
+/// that partially fill before the remainder is cancelled.
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
 )]
 pub struct Cancelled {
     pub id: OrderId,
     pub time_exchange: DateTime<Utc>,
+    /// Quantity filled before the order was cancelled.
+    ///
+    /// Zero for orders cancelled with no fills (e.g., GTC limit order cancelled by user).
+    /// Non-zero for IOC orders that partially filled before cancellation.
+    pub filled_quantity: Decimal,
+}
+
+/// Metadata for an expired order.
+///
+/// Includes `filled_quantity` to handle GTD (Good-Till-Date) orders
+/// that partially fill before expiration.
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
+)]
+pub struct Expired {
+    pub id: OrderId,
+    pub time_exchange: DateTime<Utc>,
+    /// Quantity filled before the order expired.
+    pub filled_quantity: Decimal,
 }

--- a/barter-execution/tests/hyperliquid_execution.rs
+++ b/barter-execution/tests/hyperliquid_execution.rs
@@ -41,6 +41,7 @@ use barter_execution::{
         OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::RequestOpen,
+        state::{ActiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -364,7 +365,7 @@ async fn test_place_and_cancel_limit_order() {
     let response = response.unwrap();
 
     match &response.state {
-        Ok(open_state) => {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
             println!("Order placed successfully!");
             println!("  Client Order ID: {}", response.key.cid);
             println!("  Exchange Order ID: {}", open_state.id);
@@ -403,8 +404,11 @@ async fn test_place_and_cancel_limit_order() {
                 }
             }
         }
-        Err(e) => {
+        OrderState::Inactive(e) => {
             panic!("Order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
         }
     }
 }
@@ -522,12 +526,12 @@ async fn test_account_stream_with_order() {
     let response = response.unwrap();
 
     let order_id = match &response.state {
-        Ok(open_state) => {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
             println!("Order placed: {}", open_state.id);
             Some(open_state.id.clone())
         }
-        Err(e) => {
-            println!("Order failed (may still get stream events): {:?}", e);
+        other => {
+            println!("Order failed (may still get stream events): {:?}", other);
             None
         }
     };

--- a/barter-execution/tests/ibkr_execution.rs
+++ b/barter-execution/tests/ibkr_execution.rs
@@ -32,6 +32,7 @@ use barter_execution::{
         OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::RequestOpen,
+        state::{ActiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -264,7 +265,7 @@ async fn test_place_and_cancel_limit_order() {
     let response = response.unwrap();
 
     match &response.state {
-        Ok(open_state) => {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
             println!("Order placed successfully!");
             println!("  Client Order ID: {}", response.key.cid);
             println!("  Exchange Order ID: {:?}", open_state.id);
@@ -302,8 +303,11 @@ async fn test_place_and_cancel_limit_order() {
                 }
             }
         }
-        Err(e) => {
+        OrderState::Inactive(e) => {
             panic!("Order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
         }
     }
 }
@@ -456,10 +460,10 @@ async fn test_order_without_registered_contract() {
     let response = response.unwrap();
 
     assert!(
-        response.state.is_err(),
+        response.state.is_failed(),
         "Expected rejection for unregistered contract"
     );
-    println!("Order correctly rejected: {:?}", response.state.err());
+    println!("Order correctly rejected: {:?}", response.state);
 }
 
 #[tokio::test]

--- a/barter/src/engine/state/order/mod.rs
+++ b/barter/src/engine/state/order/mod.rs
@@ -414,7 +414,9 @@ mod tests {
             Order, OrderKey, OrderKind, TimeInForce,
             id::{ClientOrderId, OrderId, StrategyId},
             request::{RequestCancel, RequestOpen},
-            state::{ActiveOrderState, CancelInFlight, Cancelled, Open, OpenInFlight},
+            state::{
+                ActiveOrderState, CancelInFlight, Cancelled, Expired, Filled, Open, OpenInFlight,
+            },
         },
     };
     use barter_instrument::{Side, exchange::ExchangeId};
@@ -475,6 +477,7 @@ mod tests {
             state: OrderState::inactive(Cancelled {
                 id: OrderId(SmolStr::default()),
                 time_exchange: Default::default(),
+                filled_quantity: Default::default(),
             }),
         })
     }
@@ -494,7 +497,12 @@ mod tests {
             quantity: Default::default(),
             kind: OrderKind::Market,
             time_in_force: TimeInForce::GoodUntilEndOfDay,
-            state: OrderState::fully_filled(),
+            state: OrderState::fully_filled(Filled::new(
+                OrderId(SmolStr::default()),
+                DateTime::<Utc>::MIN_UTC,
+                Default::default(),
+                None,
+            )),
         })
     }
 
@@ -532,7 +540,11 @@ mod tests {
             quantity: Default::default(),
             kind: OrderKind::Market,
             time_in_force: TimeInForce::GoodUntilEndOfDay,
-            state: OrderState::expired(),
+            state: OrderState::expired(Expired::new(
+                OrderId(SmolStr::default()),
+                DateTime::<Utc>::MIN_UTC,
+                Default::default(),
+            )),
         })
     }
 
@@ -616,6 +628,7 @@ mod tests {
             state: Ok(Cancelled {
                 id: OrderId(SmolStr::default()),
                 time_exchange: DateTime::<Utc>::MIN_UTC,
+                filled_quantity: Default::default(),
             }),
         }
     }

--- a/barter/src/execution/manager.rs
+++ b/barter/src/execution/manager.rs
@@ -10,7 +10,7 @@ use barter_data::streams::{
 use barter_execution::{
     AccountEvent, AccountEventKind,
     client::ExecutionClient,
-    error::{ConnectivityError, OrderError, UnindexedOrderError},
+    error::{ConnectivityError, OrderError},
     indexer::{AccountEventIndexer, IndexedAccountStream},
     map::ExecutionInstrumentMap,
     order::{
@@ -18,7 +18,7 @@ use barter_execution::{
         request::{
             OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, UnindexedOrderResponseCancel,
         },
-        state::{Open, OrderState},
+        state::{OrderState, UnindexedOrderState},
     },
 };
 use barter_instrument::{
@@ -375,7 +375,7 @@ where
 
     fn process_open_response(
         &self,
-        order: Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
+        order: Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
     ) -> Result<AccountStreamEvent, IndexError> {
         let Order {
             key,
@@ -388,12 +388,7 @@ where
         } = order;
 
         let key = self.indexer.order_key(key)?;
-
-        let state = match state {
-            Ok(open) if open.quantity_remaining(quantity).is_zero() => OrderState::fully_filled(),
-            Ok(open) => OrderState::active(open),
-            Err(error) => OrderState::inactive(self.indexer.order_error(error)?),
-        };
+        let state = self.indexer.order_state(state)?;
 
         Ok(AccountStreamEvent::Item(AccountEvent {
             exchange: key.exchange,

--- a/barter/tests/test_engine_process_engine_event_with_audit.rs
+++ b/barter/tests/test_engine_process_engine_event_with_audit.rs
@@ -50,7 +50,7 @@ use barter_execution::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, PositionId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, RequestOpen},
-        state::{ActiveOrderState, Cancelled, Open, OrderState},
+        state::{ActiveOrderState, Cancelled, Filled, Open, OrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -620,7 +620,12 @@ fn test_engine_process_engine_event_with_audit() {
             quantity: dec!(1),
             kind: OrderKind::Limit,
             time_in_force: TimeInForce::GoodUntilCancelled { post_only: true },
-            state: OrderState::fully_filled(),
+            state: OrderState::fully_filled(Filled::new(
+                OrderId::new("eth_btc_sell_order"),
+                time_plus_days(STARTING_TIMESTAMP, 4),
+                dec!(1),
+                None,
+            )),
         })),
     }));
     let audit = process_with_audit(&mut engine, event.clone());
@@ -1729,7 +1734,12 @@ fn send_fully_filled_snapshot(engine: &mut HedgingTestEngine, cid: ClientOrderId
             quantity: dec!(1),
             kind: OrderKind::Limit,
             time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
-            state: OrderState::fully_filled(),
+            state: OrderState::fully_filled(Filled::new(
+                OrderId::new("test_order"),
+                time_plus_days(STARTING_TIMESTAMP, 2),
+                dec!(1),
+                None,
+            )),
         })),
     }));
     engine.process(event);
@@ -2039,6 +2049,7 @@ fn send_cancel_ack(engine: &mut HedgingTestEngine, cid: ClientOrderId, exchange_
             state: Ok(Cancelled {
                 id: exchange_order_id,
                 time_exchange: time_plus_days(STARTING_TIMESTAMP, 1),
+                filled_quantity: dec!(0),
             }),
         }),
     }));


### PR DESCRIPTION
## Summary

- Add `Filled` struct with `filled_quantity` and `avg_price` for fully filled orders
- Add `filled_quantity` field to `Cancelled` and `Expired` structs for partial fill tracking
- Change `ExecutionClient::open_order` return type from `Result<Open, OrderError>` to `OrderState`
- Add `is_accepted()` and `is_failed()` helper methods to `OrderState`

This enables accurate position reconciliation without relying on fill events, and preserves metadata that was previously lost when orders transitioned to terminal states.

## Breaking Changes

### 1. `ExecutionClient::open_order` return type changed

**Before:**
```rust
fn open_order(&self, request: ...) -> impl Future<Output = Option<Order<..., Result<Open, UnindexedOrderError>>>>;
```

**After:**
```rust
fn open_order(&self, request: ...) -> impl Future<Output = Option<Order<..., UnindexedOrderState>>>;
```

**Migration:** Match on `OrderState` variants instead of `Result`:
```rust
// Before
match order.state {
    Ok(open) => { /* resting order */ }
    Err(error) => { /* placement failed */ }
}

// After
match order.state {
    OrderState::Active(open) => { /* resting order */ }
    OrderState::Inactive(InactiveOrderState::FullyFilled(filled)) => {
        // Immediate fill - use filled.avg_price if available
    }
    OrderState::Inactive(InactiveOrderState::OpenFailed(error)) => { /* placement failed */ }
    _ => unreachable!("open_order only returns Active, FullyFilled, or OpenFailed"),
}
```

### 2. `InactiveOrderState::FullyFilled` now carries data

**Before:** `FullyFilled` (unit variant)  
**After:** `FullyFilled(Filled)` where `Filled` contains `id`, `time_exchange`, `filled_quantity`, `avg_price: Option<Decimal>`

### 3. `InactiveOrderState::Expired` now carries data

**Before:** `Expired` (unit variant)  
**After:** `Expired(Expired)` where `Expired` contains `id`, `time_exchange`, `filled_quantity`

### 4. `Cancelled` struct has new required field

**Before:** `Cancelled { id, time_exchange }`  
**After:** `Cancelled { id, time_exchange, filled_quantity }`

### 5. `OrderState::fully_filled()` and `expired()` signatures changed

**Before:**
```rust
OrderState::fully_filled()
OrderState::expired()
```

**After:**
```rust
OrderState::fully_filled(Filled { id, time_exchange, filled_quantity, avg_price })
OrderState::expired(Expired { id, time_exchange, filled_quantity })
```

## Test plan

- [x] `cargo test --lib order` — order state unit tests
- [x] `cargo test --lib engine` — engine state management tests
- [x] `cargo test --test hyperliquid_execution` — Hyperliquid integration
- [x] `cargo test --test ibkr_execution` — IBKR integration
- [x] `cargo clippy --workspace --all-targets --all-features`