### PR TITLE
feat(ibkr): Differentiate cancelled vs expired order states

### DIFF
--- a/barter-execution/src/client/ibkr/mod.rs
+++ b/barter-execution/src/client/ibkr/mod.rs
@@ -49,7 +49,7 @@ use crate::{
         request::{
             OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, UnindexedOrderResponseCancel,
         },
-        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
+        state::{Cancelled, Expired, Filled, Open, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -65,7 +65,7 @@ use ibapi::{
     accounts::{AccountSummaryResult, types::AccountGroup},
     client::blocking::Client,
 };
-use order::{OrderContext, OrderIdMap, build_ib_order};
+use order::{OrderContext, OrderIdMap, PendingCancels, build_ib_order};
 use parking_lot::Mutex;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -162,6 +162,7 @@ pub struct IbkrClient {
     client: Arc<Client>,
     contracts: ContractRegistry,
     order_ids: OrderIdMap,
+    pending_cancels: PendingCancels,
     execution_buffer: ExecutionBuffer,
     next_order_id: Arc<Mutex<i32>>,
 }
@@ -222,6 +223,7 @@ impl IbkrClient {
             client: Arc::new(client),
             contracts,
             order_ids: OrderIdMap::new(),
+            pending_cancels: PendingCancels::new(),
             execution_buffer: ExecutionBuffer::new(),
             next_order_id: Arc::new(Mutex::new(next_id)),
         })
@@ -287,6 +289,18 @@ impl IbkrClient {
     /// interval is 5-10 minutes with a max_age of 1 hour.
     pub fn clear_stale_order_ids(&self, max_age: std::time::Duration) -> usize {
         self.order_ids.clear_stale(max_age)
+    }
+
+    /// Clear pending cancel entries older than the given duration.
+    ///
+    /// Returns the number of cleared entries.
+    ///
+    /// Pending cancels are tracked to differentiate user-initiated cancellation
+    /// from time-based expiration. If a cancel request is submitted but the order
+    /// never receives terminal status (e.g., network disconnect), the entry would
+    /// remain indefinitely. Call this alongside other stale cleanup methods.
+    pub fn clear_stale_pending_cancels(&self, max_age: std::time::Duration) -> usize {
+        self.pending_cancels.clear_stale(max_age)
     }
 }
 
@@ -465,6 +479,7 @@ impl ExecutionClient for IbkrClient {
 
         let contracts_clone = self.contracts.clone();
         let order_ids_clone = self.order_ids.clone();
+        let pending_cancels_clone = self.pending_cancels.clone();
         let exec_buffer_clone = self.execution_buffer.clone();
 
         let (tx, rx) = mpsc::unbounded_channel();
@@ -493,7 +508,12 @@ impl ExecutionClient for IbkrClient {
                                 };
 
                                 if let Some((client_id, ctx)) = lookup_result {
-                                    let order = make_order_from_status(&status, client_id, &ctx);
+                                    let order = make_order_from_status(
+                                        &status,
+                                        client_id,
+                                        &ctx,
+                                        &pending_cancels_clone,
+                                    );
                                     Some(UnindexedAccountEvent {
                                         exchange: ExchangeId::Ibkr,
                                         kind: AccountEventKind::OrderSnapshot(Snapshot::new(order)),
@@ -604,6 +624,11 @@ impl ExecutionClient for IbkrClient {
 
         match result {
             Ok(Ok(_sub)) => {
+                // Track user-initiated cancel for Cancelled vs Expired differentiation.
+                // Insert only after cancel request succeeded — avoids stale entries if
+                // the future is dropped before reaching this branch.
+                self.pending_cancels.insert(ib_order_id);
+
                 // H-3 fix: Do NOT remove order_ids here. The mapping is needed to
                 // correlate any fill events that arrive between now and when IB
                 // confirms the cancel. Removal happens in account_stream when
@@ -1120,18 +1145,29 @@ impl ExecutionClient for IbkrClient {
 /// | IB Status    | → OrderState          | Rationale                                    |
 /// |--------------|-----------------------|----------------------------------------------|
 /// | "Inactive"   | OpenFailed(Rejected)  | Order blocked by validation/margin/exchange  |
-/// | "Cancelled"  | Cancelled             | User-initiated or exchange cancellation      |
+/// | "Cancelled"  | Cancelled or Expired  | See differentiation logic below              |
 /// | "Filled"     | FullyFilled           | Order fully executed                         |
 /// | Other        | Active(Open)          | Order working on exchange                    |
 ///
-/// Note: IBKR sends both user-cancellation and time-expiration as "Cancelled" status.
-/// Distinguishing Cancelled vs Expired requires correlating with `error` callbacks
-/// (error 202 = user cancel, "expir" in message = expiration). This is a future
-/// enhancement tracked in docs/current_task.md (7.7).
+/// # Cancelled vs Expired Differentiation
+///
+/// IBKR sends `"Cancelled"` status for both user-initiated cancellation and
+/// time-based expiration. We differentiate using:
+///
+/// 1. If order ID is in `pending_cancels` (set by `cancel_order`) → `Cancelled`
+/// 2. Else if `time_in_force == GoodUntilEndOfDay` → `Expired` (DAY order expired)
+/// 3. Else → `Cancelled` (broker-initiated or external cancellation)
+///
+/// # Known Limitation
+///
+/// If the broker cancels a DAY order before market close (e.g., insufficient margin),
+/// it will be misclassified as `Expired`. This is rare and acceptable given the
+/// alternative (forking ibapi to preserve order_id in error callbacks).
 fn make_order_from_status(
     status: &ibapi::orders::OrderStatus,
     client_id: ClientOrderId,
     ctx: &OrderContext,
+    pending_cancels: &PendingCancels,
 ) -> Order<ExchangeId, InstrumentNameExchange, OrderState<AssetNameExchange, InstrumentNameExchange>>
 {
     let ib_id = status.order_id;
@@ -1147,7 +1183,21 @@ fn make_order_from_status(
                 "IB status: Inactive (order blocked by validation/margin/exchange)".into(),
             )))
         }
-        "Cancelled" => OrderState::inactive(Cancelled::new(order_id, Utc::now(), filled_qty)),
+        "Cancelled" => {
+            // Differentiate user-cancel from time-expiration
+            let was_user_cancel = pending_cancels.remove(ib_id);
+
+            if was_user_cancel {
+                // User called cancel_order() — definitely a cancellation
+                OrderState::inactive(Cancelled::new(order_id, Utc::now(), filled_qty))
+            } else if matches!(ctx.time_in_force, TimeInForce::GoodUntilEndOfDay) {
+                // DAY order without pending cancel — expired at market close
+                OrderState::inactive(Expired::new(order_id, Utc::now(), filled_qty))
+            } else {
+                // GTC/IOC/FOK without pending cancel — broker or exchange cancelled
+                OrderState::inactive(Cancelled::new(order_id, Utc::now(), filled_qty))
+            }
+        }
         "Filled" => OrderState::fully_filled(Filled::new(order_id, Utc::now(), filled_qty, None)),
         _ => {
             // "Submitted", "PreSubmitted", "PendingSubmit", "PendingCancel", etc.

--- a/barter-execution/src/client/ibkr/order.rs
+++ b/barter-execution/src/client/ibkr/order.rs
@@ -2,7 +2,7 @@ use crate::order::{OrderKind, TimeInForce, id::ClientOrderId};
 use barter_instrument::{Side, instrument::name::InstrumentNameExchange};
 use fnv::FnvHashMap;
 use ibapi::orders::{Action, Order, TimeInForce as IbTimeInForce, order_builder};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rust_decimal::Decimal;
 use std::{sync::Arc, time::Instant};
 
@@ -155,6 +155,70 @@ impl OrderIdMap {
 }
 
 impl Default for OrderIdMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Tracks IB order IDs with pending cancel requests.
+///
+/// Used to differentiate user-initiated cancellation from time-based expiration.
+/// IBKR sends `"Cancelled"` status for both cases; this map tracks which cancels
+/// were user-initiated via `cancel_order()`.
+#[derive(Debug, Clone)]
+pub struct PendingCancels {
+    inner: Arc<Mutex<FnvHashMap<i32, Instant>>>,
+}
+
+impl PendingCancels {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(FnvHashMap::with_capacity_and_hasher(
+                8,
+                Default::default(),
+            ))),
+        }
+    }
+
+    /// Record a pending cancel request for the given IB order ID.
+    pub fn insert(&self, ib_id: i32) {
+        self.inner.lock().insert(ib_id, Instant::now());
+    }
+
+    /// Check if a cancel was user-initiated and remove from tracking.
+    ///
+    /// Returns `true` if the order ID was in the pending set (user-initiated cancel).
+    #[must_use]
+    pub fn remove(&self, ib_id: i32) -> bool {
+        self.inner.lock().remove(&ib_id).is_some()
+    }
+
+    /// Clear entries older than the given duration.
+    ///
+    /// Returns the number of cleared entries. Call periodically to prevent
+    /// memory leaks from orphaned cancel requests (e.g., network issues).
+    #[must_use]
+    pub fn clear_stale(&self, max_age: std::time::Duration) -> usize {
+        let mut map = self.inner.lock();
+        let before = map.len();
+        map.retain(|_, registered_at| registered_at.elapsed() < max_age);
+        before - map.len()
+    }
+
+    /// Number of pending cancel requests being tracked.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.lock().len()
+    }
+
+    /// Check if there are no pending cancel requests.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().is_empty()
+    }
+}
+
+impl Default for PendingCancels {
     fn default() -> Self {
         Self::new()
     }
@@ -401,5 +465,80 @@ mod tests {
         let cleared = map.clear_stale(Duration::from_secs(3600));
         assert_eq!(cleared, 0);
         assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn test_pending_cancels_insert_remove() {
+        let cancels = PendingCancels::new();
+        assert!(cancels.is_empty());
+
+        // Insert a cancel request
+        cancels.insert(42);
+        assert_eq!(cancels.len(), 1);
+        assert!(!cancels.is_empty());
+
+        // Remove returns true for tracked ID
+        assert!(cancels.remove(42));
+        assert!(cancels.is_empty());
+
+        // Remove returns false for untracked ID
+        assert!(!cancels.remove(42));
+        assert!(!cancels.remove(999));
+    }
+
+    #[test]
+    fn test_pending_cancels_multiple() {
+        let cancels = PendingCancels::new();
+
+        cancels.insert(1);
+        cancels.insert(2);
+        cancels.insert(3);
+        assert_eq!(cancels.len(), 3);
+
+        // Remove middle one
+        assert!(cancels.remove(2));
+        assert_eq!(cancels.len(), 2);
+
+        // Other IDs still tracked
+        assert!(cancels.remove(1));
+        assert!(cancels.remove(3));
+        assert!(cancels.is_empty());
+    }
+
+    #[test]
+    fn test_pending_cancels_clear_stale() {
+        use std::time::Duration;
+
+        let cancels = PendingCancels::new();
+
+        cancels.insert(1);
+        cancels.insert(2);
+
+        // With zero max_age, all entries are stale
+        let cleared = cancels.clear_stale(Duration::ZERO);
+        assert_eq!(cleared, 2);
+        assert!(cancels.is_empty());
+
+        // Insert new ones
+        cancels.insert(10);
+        cancels.insert(20);
+
+        // With large max_age, nothing is stale
+        let cleared = cancels.clear_stale(Duration::from_secs(3600));
+        assert_eq!(cleared, 0);
+        assert_eq!(cancels.len(), 2);
+    }
+
+    #[test]
+    fn test_pending_cancels_duplicate_insert() {
+        let cancels = PendingCancels::new();
+
+        cancels.insert(42);
+        cancels.insert(42);
+
+        // HashMap deduplicates by ID; second insert updates timestamp
+        assert_eq!(cancels.len(), 1);
+        assert!(cancels.remove(42));
+        assert!(cancels.is_empty());
     }
 }

--- a/barter-execution/tests/ibkr_execution.rs
+++ b/barter-execution/tests/ibkr_execution.rs
@@ -24,6 +24,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Integration tests: panics are the correct failure mode
 
 use barter_execution::{
+    AccountEventKind,
     client::{
         ExecutionClient,
         ibkr::{IbkrClient, IbkrConfig, contract::stock_contract},
@@ -32,7 +33,7 @@ use barter_execution::{
         OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::RequestOpen,
-        state::{ActiveOrderState, OrderState},
+        state::{ActiveOrderState, InactiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -500,4 +501,141 @@ async fn test_cancel_nonexistent_order() {
         "Expected rejection for nonexistent order"
     );
     println!("Cancel correctly rejected: {:?}", response.state.err());
+}
+
+// ============================================================================
+// Cancelled vs Expired Differentiation Tests
+// ============================================================================
+
+/// Verifies that user-initiated cancel produces `Cancelled` state, not `Expired`.
+///
+/// This tests the pending_cancels tracking in `make_order_from_status`:
+/// - DAY orders cancelled by user → Cancelled (tracked in pending_cancels)
+/// - DAY orders expired at market close → Expired (not in pending_cancels)
+#[tokio::test]
+#[ignore]
+async fn test_cancel_produces_cancelled_not_expired() {
+    init_logging();
+
+    let config = test_config(11);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let assets: Vec<AssetNameExchange> = vec![];
+    let instruments: Vec<InstrumentNameExchange> = vec![];
+
+    // Start account stream to observe order state changes
+    let mut stream = client
+        .account_stream(&assets, &instruments)
+        .await
+        .expect("account_stream failed");
+
+    // Place a DAY order at $1 (won't fill)
+    let strategy = StrategyId::new("test-cancel-vs-expire");
+    let order_cid = ClientOrderId::new(format!(
+        "cancel-test-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    let request_open = RequestOpen {
+        side: Side::Buy,
+        price: dec!(1.00),
+        quantity: dec!(1),
+        kind: OrderKind::Limit,
+        time_in_force: TimeInForce::GoodUntilEndOfDay, // DAY order - would be Expired if not cancelled
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = barter_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing DAY limit order: BUY 1 AAPL @ $1.00");
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    let exchange_order_id = match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Order placed: {:?}", open_state.id);
+            open_state.id.clone()
+        }
+        other => panic!("Expected Open state, got: {:?}", other),
+    };
+
+    // Brief delay before cancel
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Cancel the order (this adds to pending_cancels)
+    let cancel_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: response.key.strategy.clone(),
+        cid: response.key.cid.clone(),
+    };
+
+    let cancel_request = barter_execution::order::OrderEvent {
+        key: cancel_key,
+        state: barter_execution::order::request::RequestCancel {
+            id: Some(exchange_order_id.clone()),
+        },
+    };
+
+    println!("Cancelling order...");
+    let cancel_response = client.cancel_order(cancel_request).await;
+    assert!(cancel_response.is_some(), "Expected cancel response");
+
+    // Collect stream events and find the final order state
+    println!("Waiting for stream to emit Cancelled state...");
+    let mut found_cancelled = false;
+    let mut found_expired = false;
+
+    let timeout_result = tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(event) = stream.next().await {
+            if let AccountEventKind::OrderSnapshot(snapshot) = &event.kind {
+                let order = snapshot.value();
+                // Match on order ID to find our order
+                if order.key.cid == order_cid {
+                    println!("Order event: {:?}", order.state);
+                    match &order.state {
+                        OrderState::Inactive(InactiveOrderState::Cancelled(_)) => {
+                            found_cancelled = true;
+                            break;
+                        }
+                        OrderState::Inactive(InactiveOrderState::Expired(_)) => {
+                            found_expired = true;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    })
+    .await;
+
+    if timeout_result.is_err() {
+        println!("Timeout waiting for order state (this may happen if stream doesn't emit)");
+    }
+
+    // The key assertion: user cancel should produce Cancelled, not Expired
+    if found_cancelled {
+        println!("SUCCESS: Order state is Cancelled (correct for user-initiated cancel)");
+    } else if found_expired {
+        panic!("FAILURE: Order state is Expired (should be Cancelled for user-initiated cancel)");
+    } else {
+        println!("WARNING: No terminal state observed in stream (cancel_order response was OK)");
+    }
 }


### PR DESCRIPTION
## Summary
- Track pending cancel requests via new `PendingCancels` struct to distinguish user-initiated cancellations from time-based expirations
- IBKR's TWS API sends "Cancelled" status for both cases with no direct way to differentiate
- When mapping order status: check pending_cancels first → then TIF for GoodUntilEndOfDay → default to Cancelled

## Test plan
- [x] Unit tests for `PendingCancels` operations (insert, remove, clear_stale)
- [x] `cargo check` passes
- [x] Manual verification with live IBKR connection