### PR TITLE
Release: Hyperliquid integration, order state improvements, auth error handling

### DIFF
--- a/barter-execution/examples/hyperliquid_execution.rs
+++ b/barter-execution/examples/hyperliquid_execution.rs
@@ -43,6 +43,7 @@ use barter_execution::{
         OrderEvent, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::{RequestCancel, RequestOpen},
+        state::{ActiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -181,7 +182,7 @@ async fn main() {
     match client.open_order(open_request).await {
         Some(response) => {
             match &response.state {
-                Ok(open_state) => {
+                OrderState::Active(ActiveOrderState::Open(open_state)) => {
                     info!("Order placed successfully!");
                     info!("  Client Order ID: {}", response.key.cid);
                     info!("  Exchange Order ID: {}", open_state.id);
@@ -219,12 +220,15 @@ async fn main() {
                         }
                     }
                 }
-                Err(e) => {
+                OrderState::Inactive(e) => {
                     warn!("Order rejected: {e:?}");
                     warn!("This may be due to:");
                     warn!("  - Insufficient margin/balance");
                     warn!("  - Price more than 80% from market");
                     warn!("  - Invalid order parameters");
+                }
+                other => {
+                    info!("Unexpected order state: {other:?}");
                 }
             }
         }

--- a/barter-execution/examples/ibkr_execution.rs
+++ b/barter-execution/examples/ibkr_execution.rs
@@ -38,6 +38,7 @@ use barter_execution::{
         OrderEvent, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::{RequestCancel, RequestOpen},
+        state::{ActiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -150,7 +151,7 @@ async fn main() {
     match client.open_order(open_request).await {
         Some(response) => {
             match &response.state {
-                Ok(open_state) => {
+                OrderState::Active(ActiveOrderState::Open(open_state)) => {
                     info!("Order placed successfully!");
                     info!("  Client Order ID: {}", response.key.cid);
                     info!("  Exchange Order ID: {:?}", open_state.id);
@@ -188,12 +189,15 @@ async fn main() {
                         }
                     }
                 }
-                Err(e) => {
-                    warn!("Order rejected: {e:?}");
+                OrderState::Inactive(inactive) => {
+                    warn!("Order rejected: {inactive:?}");
                     warn!("This may be due to:");
                     warn!("  - 'Read-Only API' is checked in TWS settings");
                     warn!("  - Account not authorized for AAPL trading");
                     warn!("  - Invalid order parameters");
+                }
+                other => {
+                    info!("Unexpected order state: {other:?}");
                 }
             }
         }

--- a/barter-execution/src/client/alpaca/mod.rs
+++ b/barter-execution/src/client/alpaca/mod.rs
@@ -46,9 +46,7 @@ use crate::{
     trade::{AssetFees, Trade, TradeId},
 };
 use barter_instrument::{
-    Side,
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
+    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
     instrument::name::InstrumentNameExchange,
 };
 use barter_integration::protocol::websocket::{WebSocket, WsMessage};
@@ -1152,7 +1150,7 @@ impl ExecutionClient for AlpacaClient {
         &self,
         time_since: DateTime<Utc>,
         instruments: &[InstrumentNameExchange],
-    ) -> Result<Vec<Trade<QuoteAsset, InstrumentNameExchange>>, UnindexedClientError> {
+    ) -> Result<Vec<Trade<AssetNameExchange, InstrumentNameExchange>>, UnindexedClientError> {
         let after_str = time_since.to_rfc3339();
         let base = self.base_url();
         let http = self.http.clone();
@@ -2354,7 +2352,7 @@ fn convert_open_order(
 /// Convert an Alpaca FILL activity into a barter Trade.
 fn convert_activity_to_trade(
     a: &AlpacaActivity,
-) -> Option<Trade<QuoteAsset, InstrumentNameExchange>> {
+) -> Option<Trade<AssetNameExchange, InstrumentNameExchange>> {
     let trade_id = TradeId::new(&a.id);
     let order_id = OrderId(SmolStr::new(&a.order_id));
     let instrument = InstrumentNameExchange::new(&a.symbol);
@@ -2367,8 +2365,9 @@ fn convert_activity_to_trade(
     });
 
     // Alpaca equities and options are commission-free. Crypto trades incur
-    // maker/taker fees (currently 0.15–0.25%); callers should account for this
-    // separately if accurate PnL tracking for crypto is required.
+    // maker/taker fees (currently 0.15–0.25%) charged in the credited asset,
+    // but fee info is not available in trade responses — use Activities API
+    // for end-of-day fee reconciliation.
     Some(Trade::new(
         trade_id,
         order_id,
@@ -2378,7 +2377,11 @@ fn convert_activity_to_trade(
         side,
         price,
         quantity,
-        AssetFees::quote_fees(Decimal::ZERO),
+        AssetFees::new(
+            AssetNameExchange::from("USD"),
+            Decimal::ZERO,
+            Some(Decimal::ZERO),
+        ),
     ))
 }
 
@@ -2447,8 +2450,8 @@ fn convert_trade_update(update: AlpacaTradeUpdate<'_>) -> Option<UnindexedAccoun
             let trade_id = TradeId(format_smolstr!("{}:{}", order.id, cum_qty.normalize()));
 
             // Alpaca equities and options are commission-free. Crypto trades incur
-            // maker/taker fees (currently 0.15–0.25%); callers should account for this
-            // separately if accurate PnL tracking for crypto is required.
+            // maker/taker fees (currently 0.15–0.25%) in the credited asset, but
+            // fee info is not available in WebSocket updates.
             let trade = Trade::new(
                 trade_id,
                 order_id,
@@ -2458,7 +2461,11 @@ fn convert_trade_update(update: AlpacaTradeUpdate<'_>) -> Option<UnindexedAccoun
                 side,
                 price,
                 quantity,
-                AssetFees::quote_fees(Decimal::ZERO),
+                AssetFees::new(
+                    AssetNameExchange::from("USD"),
+                    Decimal::ZERO,
+                    Some(Decimal::ZERO),
+                ),
             );
             Some(UnindexedAccountEvent::new(
                 ExchangeId::Alpaca,

--- a/barter-execution/src/client/alpaca/mod.rs
+++ b/barter-execution/src/client/alpaca/mod.rs
@@ -1728,7 +1728,7 @@ async fn connect_and_subscribe(config: &AlpacaConfig) -> Result<WebSocket, Unind
         }
         Ok(Err(HandshakeError::Auth(e))) => {
             let _ = ws.close(None).await;
-            Err(UnindexedClientError::Internal(e))
+            Err(UnindexedClientError::Api(ApiError::Unauthenticated(e)))
         }
         Err(_) => {
             let _ = ws.close(None).await;
@@ -2673,7 +2673,8 @@ fn parse_api_error(status: reqwest::StatusCode, message: &str) -> crate::error::
         422 if lower.contains("insufficient") => {
             ApiError::BalanceInsufficient(AssetNameExchange::new("usd"), message.to_owned())
         }
-        403 => ApiError::OrderRejected(format!("forbidden (auth/permission): {message}")),
+        401 => ApiError::Unauthenticated(format!("unauthorized: {message}")),
+        403 => ApiError::Unauthenticated(format!("forbidden: {message}")),
         404 => ApiError::OrderRejected(format!("order not found: {message}")),
         _ => ApiError::OrderRejected(message.to_owned()),
     }
@@ -3426,12 +3427,21 @@ mod tests {
 
     // M-1: parse_order_error — pin all status-code branches not covered by existing tests.
     #[test]
-    fn parse_order_error_403_with_insufficient_body_maps_to_order_rejected_not_balance() {
-        // A suspended/forbidden account should NOT route to BalanceInsufficient
-        // (which could trigger a balance-retry loop). Must be OrderRejected.
+    fn parse_order_error_401_maps_to_unauthenticated() {
+        // 401 Unauthorized: invalid/expired API credentials.
         assert!(matches!(
-            parse_order_error(reqwest::StatusCode::FORBIDDEN, "insufficient permissions"),
-            UnindexedOrderError::Rejected(ApiError::OrderRejected(_))
+            parse_order_error(reqwest::StatusCode::UNAUTHORIZED, "bad credentials"),
+            UnindexedOrderError::Rejected(ApiError::Unauthenticated(_))
+        ));
+    }
+
+    #[test]
+    fn parse_order_error_403_maps_to_unauthenticated() {
+        // 403 Forbidden indicates auth/permission failure — use Unauthenticated, not
+        // OrderRejected or BalanceInsufficient (which could trigger incorrect retry logic).
+        assert!(matches!(
+            parse_order_error(reqwest::StatusCode::FORBIDDEN, "account suspended"),
+            UnindexedOrderError::Rejected(ApiError::Unauthenticated(_))
         ));
     }
 

--- a/barter-execution/src/client/alpaca/mod.rs
+++ b/barter-execution/src/client/alpaca/mod.rs
@@ -36,12 +36,12 @@ use crate::{
     UnindexedAccountSnapshot,
     balance::{AssetBalance, Balance},
     client::ExecutionClient,
-    error::{ApiError, ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::{Cancelled, Open, OrderState},
+        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -1045,9 +1045,11 @@ impl ExecutionClient for AlpacaClient {
         match rest_delete_with_retry(&self.rate_limiter, || http.delete(&url)).await {
             Ok(()) => {
                 let exchange_order_id = OrderId(order_id);
+                // REST DELETE returns no response body, so filled_qty unavailable.
+                // Use ZERO; downstream can reconcile via WS events or fetch_open_orders.
                 Some(crate::order::request::OrderResponseCancel {
                     key,
-                    state: Ok(Cancelled::new(exchange_order_id, Utc::now())),
+                    state: Ok(Cancelled::new(exchange_order_id, Utc::now(), Decimal::ZERO)),
                 })
             }
             Err(e) => Some(crate::order::request::OrderResponseCancel { key, state: Err(e) }),
@@ -1077,7 +1079,7 @@ impl ExecutionClient for AlpacaClient {
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let side = request.state.side;
         let reduce_only = request.state.reduce_only;
         self.open_order_inner(request, map_position_intent(side, reduce_only))
@@ -1207,7 +1209,7 @@ impl AlpacaClient {
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
         intent: AlpacaPositionIntent,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         self.open_order_inner(request, intent).await
     }
 
@@ -1215,7 +1217,7 @@ impl AlpacaClient {
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
         intent: AlpacaPositionIntent,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let instrument = request.key.instrument.clone();
         let side = request.state.side;
         let price = request.state.price;
@@ -1242,7 +1244,7 @@ impl AlpacaClient {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Err(UnindexedOrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         msg.to_string(),
                     ))),
                 });
@@ -1288,6 +1290,19 @@ impl AlpacaClient {
                 let time_exchange = parse_timestamp(&resp.created_at).unwrap_or_else(Utc::now);
                 let filled_qty = Decimal::from_str(&resp.filled_qty).unwrap_or(Decimal::ZERO);
 
+                let state = if filled_qty >= quantity {
+                    // Order was fully filled immediately (market order or aggressive limit)
+                    OrderState::fully_filled(Filled::new(
+                        exchange_order_id,
+                        time_exchange,
+                        filled_qty,
+                        None, // Alpaca order response doesn't include avg_price
+                    ))
+                } else {
+                    // Order is resting on the order book (partially filled or unfilled)
+                    OrderState::active(Open::new(exchange_order_id, time_exchange, filled_qty))
+                };
+
                 Some(Order {
                     key: order_key,
                     side,
@@ -1295,13 +1310,13 @@ impl AlpacaClient {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Ok(Open::new(exchange_order_id, time_exchange, filled_qty)),
+                    state,
                 })
             }
             Err(e) => {
                 let order_err = match e {
-                    UnindexedClientError::Connectivity(ce) => UnindexedOrderError::Connectivity(ce),
-                    UnindexedClientError::Api(ae) => UnindexedOrderError::Rejected(ae),
+                    UnindexedClientError::Connectivity(ce) => OrderError::Connectivity(ce),
+                    UnindexedClientError::Api(ae) => OrderError::Rejected(ae),
                     // TaskFailed, Internal, Truncated, and TruncatedSnapshot are not
                     // returned by rest_with_retry (REST-only path for orders), but matching
                     // explicitly ensures any new ClientError variant causes a compile error
@@ -1324,7 +1339,7 @@ impl AlpacaClient {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Err(order_err),
+                    state: OrderState::inactive(order_err),
                 })
             }
         }
@@ -2505,7 +2520,9 @@ fn convert_trade_update(update: AlpacaTradeUpdate<'_>) -> Option<UnindexedAccoun
                 .timestamp
                 .and_then(parse_timestamp)
                 .unwrap_or_else(Utc::now);
-            let cancelled = Cancelled::new(order_id, time_exchange);
+            let filled_qty =
+                Decimal::from_str(order.filled_qty.unwrap_or("0")).unwrap_or(Decimal::ZERO);
+            let cancelled = Cancelled::new(order_id, time_exchange, filled_qty);
             let response = crate::order::request::OrderResponseCancel {
                 key: OrderKey::new(ExchangeId::Alpaca, instrument, StrategyId::unknown(), cid),
                 state: Ok(cancelled),
@@ -3869,7 +3886,7 @@ mod tests {
             assert!(result.is_some(), "open_order should return a result");
             let order = result.unwrap();
             assert!(
-                order.state.is_ok(),
+                order.state.is_accepted(),
                 "order should be accepted: {:?}",
                 order.state
             );
@@ -3955,7 +3972,7 @@ mod tests {
             assert!(result.is_some(), "open_order should return a result");
             let order = result.unwrap();
             assert!(
-                order.state.is_ok(),
+                order.state.is_accepted(),
                 "order should be accepted: {:?}",
                 order.state
             );

--- a/barter-execution/src/client/binance/mod.rs
+++ b/barter-execution/src/client/binance/mod.rs
@@ -42,9 +42,7 @@ use crate::{
     trade::{AssetFees, Trade, TradeId},
 };
 use barter_instrument::{
-    Side,
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
+    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
     instrument::name::InstrumentNameExchange,
 };
 use binance_sdk::{
@@ -1380,7 +1378,7 @@ impl ExecutionClient for BinanceSpot {
         &self,
         time_since: DateTime<Utc>,
         instruments: &[InstrumentNameExchange],
-    ) -> Result<Vec<Trade<QuoteAsset, InstrumentNameExchange>>, UnindexedClientError> {
+    ) -> Result<Vec<Trade<AssetNameExchange, InstrumentNameExchange>>, UnindexedClientError> {
         use futures::StreamExt;
 
         if instruments.is_empty() {
@@ -2010,7 +2008,7 @@ fn convert_open_order(
 fn convert_my_trade(
     t: &binance_sdk::spot::rest_api::MyTradesResponseInner,
     instrument: &InstrumentNameExchange,
-) -> Option<Trade<QuoteAsset, InstrumentNameExchange>> {
+) -> Option<Trade<AssetNameExchange, InstrumentNameExchange>> {
     let trade_id_raw = match t.id {
         Some(id) => id,
         None => {
@@ -2066,17 +2064,16 @@ fn convert_my_trade(
         }
     };
 
-    // known limitation — the trait's Trade<QuoteAsset, _> hardcodes QuoteAsset,
-    // so BNB fee-discount commission cannot be represented. BNB fees are the default
-    // for active traders; debug! avoids log flooding on every REST trade.
-    if let Some(ref comm_asset) = t.commission_asset
-        && comm_asset == "BNB"
-    {
-        debug!(
-            %instrument, commission_asset = %comm_asset,
-            "BinanceSpot REST trade fee paid in BNB (not quote asset) — P&L commission will be misattributed"
-        );
-    }
+    // Use actual commission asset from Binance (e.g., BNB, USDT, BTC).
+    // fees_quote is set to None here; the indexer will compute it if fee is in
+    // quote or base asset. For third-party assets (BNB), downstream must convert.
+    // "UNKNOWN" fallback (rare: API omits commission_asset) will fail indexing.
+    let fee_asset = t
+        .commission_asset
+        .as_deref()
+        .map(AssetNameExchange::from)
+        .unwrap_or_else(|| AssetNameExchange::from("UNKNOWN"));
+
     Some(Trade::new(
         trade_id,
         order_id,
@@ -2086,7 +2083,7 @@ fn convert_my_trade(
         side,
         price,
         quantity,
-        AssetFees::quote_fees(commission),
+        AssetFees::new(fee_asset, commission, None),
     ))
 }
 
@@ -2242,17 +2239,15 @@ fn convert_execution_report(
                 }
             };
 
-            // known limitation — the trait's Trade<QuoteAsset, _> hardcodes
-            // QuoteAsset, so BNB fee-discount commission cannot be represented.
-            // BNB fees are the default for active traders; see module-level FORK comment.
-            if let Some(ref comm_asset) = report.n_uppercase
-                && comm_asset == "BNB"
-            {
-                debug!(
-                    %symbol, commission_asset = %comm_asset,
-                    "BinanceSpot WS TRADE fee paid in BNB (not quote asset) — P&L commission will be misattributed"
-                );
-            }
+            // Use actual commission asset from Binance (N field: e.g., BNB, USDT, BTC).
+            // fees_quote is None here; indexer computes if fee is in quote/base asset.
+            // "UNKNOWN" fallback (rare: API omits N field) will fail indexing.
+            let fee_asset = report
+                .n_uppercase
+                .as_deref()
+                .map(AssetNameExchange::from)
+                .unwrap_or_else(|| AssetNameExchange::from("UNKNOWN"));
+
             let trade = Trade::new(
                 trade_id,
                 order_id,
@@ -2262,7 +2257,7 @@ fn convert_execution_report(
                 side,
                 last_price,
                 last_qty,
-                AssetFees::quote_fees(commission),
+                AssetFees::new(fee_asset, commission, None),
             );
 
             Some(UnindexedAccountEvent::new(
@@ -3038,12 +3033,11 @@ mod tests {
         use crate::order::id::{OrderId, StrategyId};
         use crate::trade::{AssetFees, Trade, TradeId};
         use barter_instrument::Side;
-        use barter_instrument::asset::QuoteAsset;
         use chrono::Utc;
         use rust_decimal::Decimal;
 
         let instrument = InstrumentNameExchange::new("BTCUSDT");
-        let trade = Trade::<QuoteAsset, InstrumentNameExchange>::new(
+        let trade = Trade::<AssetNameExchange, InstrumentNameExchange>::new(
             TradeId::new("9001"),
             OrderId::new("4242"),
             instrument.clone(),
@@ -3052,7 +3046,11 @@ mod tests {
             Side::Buy,
             Decimal::ZERO,
             Decimal::ZERO,
-            AssetFees::quote_fees(Decimal::ZERO),
+            AssetFees::new(
+                AssetNameExchange::from("USDT"),
+                Decimal::ZERO,
+                Some(Decimal::ZERO),
+            ),
         );
         let event =
             UnindexedAccountEvent::new(ExchangeId::BinanceSpot, AccountEventKind::Trade(trade));
@@ -3068,7 +3066,7 @@ mod tests {
 
         // Same trade ID on a different instrument must produce a different key (cross-symbol collision prevention)
         let instrument2 = InstrumentNameExchange::new("ETHUSDT");
-        let trade2 = Trade::<QuoteAsset, InstrumentNameExchange>::new(
+        let trade2 = Trade::<AssetNameExchange, InstrumentNameExchange>::new(
             TradeId::new("9001"),
             OrderId::new("7777"),
             instrument2,
@@ -3077,7 +3075,11 @@ mod tests {
             Side::Buy,
             Decimal::ZERO,
             Decimal::ZERO,
-            AssetFees::quote_fees(Decimal::ZERO),
+            AssetFees::new(
+                AssetNameExchange::from("USDT"),
+                Decimal::ZERO,
+                Some(Decimal::ZERO),
+            ),
         );
         let event2 =
             UnindexedAccountEvent::new(ExchangeId::BinanceSpot, AccountEventKind::Trade(trade2));

--- a/barter-execution/src/client/binance/mod.rs
+++ b/barter-execution/src/client/binance/mod.rs
@@ -2533,6 +2533,14 @@ fn convert_order_kind_tif(
     }
 }
 
+/// Case-insensitive substring search that avoids the `to_lowercase` allocation.
+fn contains_ignore_case(haystack: &str, needle: &str) -> bool {
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .any(|w| w.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
 /// Returns true if `msg` contains `code` as a standalone numeric token:
 /// not immediately preceded or followed by another ASCII digit.
 /// Prevents "-2013" from matching "-20130" (suffix guard) or "1-2013" (prefix guard).
@@ -2564,6 +2572,12 @@ fn parse_binance_api_error(
     instrument: &InstrumentNameExchange,
 ) -> ApiError<AssetNameExchange, InstrumentNameExchange> {
     // Match on Binance error codes first — these are stable numeric identifiers
+    if contains_error_code(&error_msg, "-1002") || contains_error_code(&error_msg, "-2015") {
+        // -1002: "You are not authorized to execute this request"
+        // -2015: "Invalid API-key, IP, or permissions for action"
+        // Auth failures must not be retried as order rejections.
+        return ApiError::Unauthenticated(error_msg);
+    }
     if contains_error_code(&error_msg, "-1003") || contains_error_code(&error_msg, "-1015") {
         // -1003: too many requests; -1015: IP rate-limit ban. Both are transient throttles.
         return ApiError::RateLimit;
@@ -2591,12 +2605,6 @@ fn parse_binance_api_error(
     }
 
     // Fall back to case-insensitive message text heuristics (avoid to_lowercase allocation)
-    fn contains_ignore_case(haystack: &str, needle: &str) -> bool {
-        haystack
-            .as_bytes()
-            .windows(needle.len())
-            .any(|w| w.eq_ignore_ascii_case(needle.as_bytes()))
-    }
     if contains_ignore_case(&error_msg, "insufficient")
         || contains_ignore_case(&error_msg, "not enough")
     {
@@ -2626,13 +2634,21 @@ fn parse_binance_api_error(
 }
 
 fn connectivity_error(e: anyhow::Error) -> UnindexedClientError {
-    // use alternate display {:#} to preserve the full anyhow error chain.
-    // Known limitation: all SDK errors (auth failures, HTTP 5xx, malformed responses,
-    // network errors) are uniformly classified as ConnectivityError::Socket. The SDK
-    // uses anyhow::Error, making it impractical to distinguish error categories without
-    // parsing the string — callers cannot distinguish "network unavailable" from
-    // "auth rejected" without inspecting the error message.
-    UnindexedClientError::Connectivity(ConnectivityError::Socket(format!("{e:#}")))
+    let msg = format!("{e:#}");
+
+    // Check for auth failures before falling back to generic connectivity error.
+    // -1002: "You are not authorized to execute this request"
+    // -2015: "Invalid API-key, IP, or permissions for action"
+    if contains_error_code(&msg, "-1002")
+        || contains_error_code(&msg, "-2015")
+        || contains_ignore_case(&msg, "invalid api-key")
+        || contains_ignore_case(&msg, "invalid signature")
+        || contains_ignore_case(&msg, "signature for this request is not valid")
+    {
+        return UnindexedClientError::Api(ApiError::Unauthenticated(msg));
+    }
+
+    UnindexedClientError::Connectivity(ConnectivityError::Socket(msg))
 }
 
 #[cfg(test)]
@@ -2935,6 +2951,54 @@ mod tests {
         assert!(
             !is_api_rejection_error(&rate_limit),
             "rate-limit string error should not be detected as API rejection"
+        );
+    }
+
+    #[test]
+    fn test_connectivity_error_detects_auth_failures() {
+        // -1002: "You are not authorized to execute this request"
+        let err = connectivity_error(anyhow::anyhow!("Error -1002: unauthorized"));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for -1002, got {err:?}"
+        );
+
+        // -2015: "Invalid API-key, IP, or permissions for action"
+        // Use a code-only body (no auth text keyword) to isolate the numeric-code branch.
+        let err = connectivity_error(anyhow::anyhow!("Error -2015: permission denied for action"));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for -2015, got {err:?}"
+        );
+
+        // Text-based detection: "invalid signature"
+        let err = connectivity_error(anyhow::anyhow!("invalid signature provided"));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for 'invalid signature', got {err:?}"
+        );
+
+        // Text-based detection: "signature for this request is not valid"
+        let err = connectivity_error(anyhow::anyhow!(
+            "The signature for this request is not valid."
+        ));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for 'signature for this request is not valid', got {err:?}"
+        );
+
+        // Text-based detection: "invalid api-key"
+        let err = connectivity_error(anyhow::anyhow!("Invalid API-key format"));
+        assert!(
+            matches!(err, UnindexedClientError::Api(ApiError::Unauthenticated(_))),
+            "expected Unauthenticated for 'invalid api-key', got {err:?}"
+        );
+
+        // Non-auth errors should remain as Connectivity
+        let err = connectivity_error(anyhow::anyhow!("connection timeout"));
+        assert!(
+            matches!(err, UnindexedClientError::Connectivity(_)),
+            "expected Connectivity for timeout, got {err:?}"
         );
     }
 

--- a/barter-execution/src/client/binance/mod.rs
+++ b/barter-execution/src/client/binance/mod.rs
@@ -32,12 +32,12 @@ use crate::{
     UnindexedAccountSnapshot,
     balance::{AssetBalance, Balance},
     client::ExecutionClient,
-    error::{ApiError, ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::{Cancelled, Open, OrderState},
+        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -1055,9 +1055,15 @@ impl ExecutionClient for BinanceSpot {
                         }
                     };
 
+                    let filled_qty = data
+                        .executed_qty
+                        .as_deref()
+                        .and_then(|q| Decimal::from_str(q).ok())
+                        .unwrap_or(Decimal::ZERO);
+
                     Some(UnindexedOrderResponseCancel {
                         key,
-                        state: Ok(Cancelled::new(exchange_order_id, time_exchange)),
+                        state: Ok(Cancelled::new(exchange_order_id, time_exchange, filled_qty)),
                     })
                 }
                 Err(e) => {
@@ -1113,7 +1119,7 @@ impl ExecutionClient for BinanceSpot {
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let instrument = request.key.instrument.clone();
         let side = request.state.side;
         let price = request.state.price;
@@ -1139,7 +1145,7 @@ impl ExecutionClient for BinanceSpot {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Err(UnindexedOrderError::Connectivity(
+                    state: OrderState::inactive(OrderError::Connectivity(
                         ConnectivityError::Socket(format!("{e:#}")),
                     )),
                 });
@@ -1184,7 +1190,7 @@ impl ExecutionClient for BinanceSpot {
                     quantity,
                     kind,
                     time_in_force,
-                    state: Err(UnindexedOrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         e.to_string(),
                     ))),
                 });
@@ -1210,9 +1216,11 @@ impl ExecutionClient for BinanceSpot {
                                 quantity,
                                 kind,
                                 time_in_force,
-                                state: Err(UnindexedOrderError::Rejected(ApiError::OrderRejected(
-                                    "open_order response missing orderId".into(),
-                                ))),
+                                state: OrderState::inactive(OrderError::Rejected(
+                                    ApiError::OrderRejected(
+                                        "open_order response missing orderId".into(),
+                                    ),
+                                )),
                             });
                         }
                     };
@@ -1223,6 +1231,19 @@ impl ExecutionClient for BinanceSpot {
                         .and_then(|q| Decimal::from_str(q).ok())
                         .unwrap_or(Decimal::ZERO);
 
+                    let state = if filled_qty >= quantity {
+                        // Order was fully filled immediately
+                        OrderState::fully_filled(Filled::new(
+                            exchange_order_id,
+                            time_exchange,
+                            filled_qty,
+                            None, // Binance SDK response doesn't expose avg_price directly
+                        ))
+                    } else {
+                        // Order is resting on the order book
+                        OrderState::active(Open::new(exchange_order_id, time_exchange, filled_qty))
+                    };
+
                     Some(Order {
                         key: order_key,
                         side,
@@ -1230,7 +1251,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Ok(Open::new(exchange_order_id, time_exchange, filled_qty)),
+                        state,
                     })
                 }
                 Err(e) => {
@@ -1242,7 +1263,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Err(UnindexedOrderError::Rejected(ApiError::OrderRejected(
+                        state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                             e.to_string(),
                         ))),
                     })
@@ -1269,7 +1290,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Err(UnindexedOrderError::from(api_err)),
+                        state: OrderState::inactive(OrderError::from(api_err)),
                     })
                 } else if is_rate_limit_error(&e) {
                     // WS-level 429 — update the shared rate limiter so REST calls also back off.
@@ -1281,7 +1302,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Err(UnindexedOrderError::from(ApiError::RateLimit)),
+                        state: OrderState::inactive(OrderError::from(ApiError::RateLimit)),
                     })
                 } else {
                     // Transport-level error — clear cached session so next call reconnects.
@@ -1294,7 +1315,7 @@ impl ExecutionClient for BinanceSpot {
                         quantity,
                         kind,
                         time_in_force,
-                        state: Err(UnindexedOrderError::Connectivity(
+                        state: OrderState::inactive(OrderError::Connectivity(
                             ConnectivityError::Socket(format!("{e:#}")),
                         )),
                     })
@@ -2250,7 +2271,12 @@ fn convert_execution_report(
             ))
         }
         "CANCELED" | "EXPIRED" | "EXPIRED_IN_MATCH" => {
-            let cancelled = Cancelled::new(order_id, time_exchange);
+            let filled_qty = report
+                .z
+                .as_deref()
+                .and_then(|s| Decimal::from_str(s).ok())
+                .unwrap_or(Decimal::ZERO);
+            let cancelled = Cancelled::new(order_id, time_exchange, filled_qty);
             let response = UnindexedOrderResponseCancel {
                 key: OrderKey::new(
                     ExchangeId::BinanceSpot,
@@ -2294,7 +2320,12 @@ fn convert_execution_report(
             // The replacement order arrives as a subsequent NEW execution report with
             // its own order ID. We emit OrderCancelled for the original order so the
             // engine removes it from its open-order book.
-            let cancelled = Cancelled::new(order_id, time_exchange);
+            let filled_qty = report
+                .z
+                .as_deref()
+                .and_then(|s| Decimal::from_str(s).ok())
+                .unwrap_or(Decimal::ZERO);
+            let cancelled = Cancelled::new(order_id, time_exchange, filled_qty);
             let response = UnindexedOrderResponseCancel {
                 key: OrderKey::new(ExchangeId::BinanceSpot, symbol, StrategyId::unknown(), cid),
                 state: Ok(cancelled),
@@ -3832,12 +3863,17 @@ mod tests {
             AccountEventKind::OrderSnapshot(Snapshot(Order::new(
                 key,
                 Side::Buy,
-                Decimal::ZERO,
-                Decimal::ZERO,
+                Decimal::ONE,
+                Decimal::ONE,
                 OrderKind::Market,
                 TimeInForce::ImmediateOrCancel,
                 OrderState::<AssetNameExchange, InstrumentNameExchange>::Inactive(
-                    InactiveOrderState::FullyFilled,
+                    InactiveOrderState::FullyFilled(crate::order::state::Filled::new(
+                        OrderId::new("123"),
+                        Utc::now(),
+                        Decimal::ONE, // FullyFilled must have non-zero filled_quantity
+                        None,
+                    )),
                 ),
             ))),
         );

--- a/barter-execution/src/client/hyperliquid/mod.rs
+++ b/barter-execution/src/client/hyperliquid/mod.rs
@@ -29,12 +29,12 @@ use crate::{
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::{AssetBalance, Balance},
     client::ExecutionClient,
-    error::{ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::Open,
+        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
     },
     position::Position,
     trade::{AssetFees, Trade, TradeId},
@@ -706,10 +706,11 @@ impl ExecutionClient for HyperliquidClient {
                         strategy: request.key.strategy.clone(),
                         cid: request.key.cid.clone(),
                     },
-                    state: Ok(Cancelled {
-                        id: order_id.clone(),
-                        time_exchange: Utc::now(),
-                    }),
+                    state: Ok(Cancelled::new(
+                        order_id.clone(),
+                        Utc::now(),
+                        Decimal::ZERO, // Cancel response doesn't include filled quantity
+                    )),
                 })
             }
             ExchangeResponseStatus::Err(msg) => {
@@ -732,7 +733,7 @@ impl ExecutionClient for HyperliquidClient {
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         use hyperliquid_rust_sdk::{
             ClientLimit, ClientOrder, ClientOrderRequest, ExchangeDataStatus,
             ExchangeResponseStatus,
@@ -783,7 +784,7 @@ impl ExecutionClient for HyperliquidClient {
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
-                    state: Err(error::map_order_error(e, request.key.instrument)),
+                    state: OrderState::inactive(error::map_order_error(e, request.key.instrument)),
                 });
             }
         };
@@ -799,7 +800,7 @@ impl ExecutionClient for HyperliquidClient {
                 match status {
                     Some(ExchangeDataStatus::Resting(resting)) => {
                         debug!(oid = resting.oid, "Order resting");
-                        Ok(Open {
+                        OrderState::active(Open {
                             id: OrderId(format_smolstr!("{}", resting.oid)),
                             time_exchange: Utc::now(),
                             filled_quantity: Decimal::ZERO,
@@ -807,16 +808,19 @@ impl ExecutionClient for HyperliquidClient {
                     }
                     Some(ExchangeDataStatus::Filled(filled)) => {
                         debug!(oid = filled.oid, avg_px = %filled.avg_px, "Order filled");
-                        Ok(Open {
-                            id: OrderId(format_smolstr!("{}", filled.oid)),
-                            time_exchange: Utc::now(),
-                            filled_quantity: parse_decimal(&filled.total_sz, "total_sz")
+                        // Hyperliquid provides avg_px for filled orders
+                        let avg_price = parse_decimal(&filled.avg_px, "avg_px");
+                        OrderState::fully_filled(Filled::new(
+                            OrderId(format_smolstr!("{}", filled.oid)),
+                            Utc::now(),
+                            parse_decimal(&filled.total_sz, "total_sz")
                                 .unwrap_or(request.state.quantity),
-                        })
+                            avg_price,
+                        ))
                     }
                     Some(ExchangeDataStatus::Error(msg)) => {
                         warn!(%msg, "Order rejected by exchange");
-                        Err(UnindexedOrderError::Rejected(
+                        OrderState::inactive(OrderError::Rejected(
                             crate::error::ApiError::OrderRejected(msg),
                         ))
                     }
@@ -825,7 +829,7 @@ impl ExecutionClient for HyperliquidClient {
                         // Trigger/conditional orders return no usable order ID.
                         // Reject since we can't track or cancel these orders.
                         warn!("Trigger/conditional orders not supported");
-                        Err(UnindexedOrderError::Rejected(
+                        OrderState::inactive(OrderError::Rejected(
                             crate::error::ApiError::OrderRejected(
                                 "trigger/conditional orders not supported".to_string(),
                             ),
@@ -835,7 +839,7 @@ impl ExecutionClient for HyperliquidClient {
                         // Generic success without order ID — SDK didn't return structured data.
                         // This shouldn't happen for limit orders; reject to avoid silent failures.
                         warn!("Order accepted but no order ID returned");
-                        Err(UnindexedOrderError::Rejected(
+                        OrderState::inactive(OrderError::Rejected(
                             crate::error::ApiError::OrderRejected(
                                 "no order ID in response".to_string(),
                             ),
@@ -845,9 +849,9 @@ impl ExecutionClient for HyperliquidClient {
             }
             ExchangeResponseStatus::Err(msg) => {
                 warn!(%msg, "Order rejected");
-                Err(UnindexedOrderError::Rejected(
-                    crate::error::ApiError::OrderRejected(msg),
-                ))
+                OrderState::inactive(OrderError::Rejected(crate::error::ApiError::OrderRejected(
+                    msg,
+                )))
             }
         };
 
@@ -1100,7 +1104,7 @@ fn order_update_to_account_event(
         .map(|c| ClientOrderId::new(SmolStr::new(c)))
         .unwrap_or_else(|| ClientOrderId::new(order_id_smol.clone()));
 
-    // Determine order state from status — parse current_sz only when needed for filled_quantity
+    // Determine order state from status
     let state = match update.status.as_str() {
         "open" | "resting" => {
             let current_sz = parse_decimal(&order.sz, "order.sz")?;
@@ -1111,12 +1115,20 @@ fn order_update_to_account_event(
                 filled_quantity,
             })
         }
-        "filled" => crate::order::state::OrderState::fully_filled(),
+        "filled" => crate::order::state::OrderState::fully_filled(Filled::new(
+            OrderId(order_id_smol),
+            time_exchange,
+            orig_sz, // Fully filled means filled_quantity == orig_sz
+            None,    // OrderUpdate doesn't include avg_price
+        )),
         "canceled" | "cancelled" => {
-            crate::order::state::OrderState::inactive(crate::order::state::Cancelled {
-                id: OrderId(order_id_smol),
+            let current_sz = parse_decimal(&order.sz, "order.sz")?;
+            let filled_quantity = (orig_sz - current_sz).max(Decimal::ZERO);
+            crate::order::state::OrderState::inactive(Cancelled::new(
+                OrderId(order_id_smol),
                 time_exchange,
-            })
+                filled_quantity,
+            ))
         }
         status => {
             warn!(%status, "Unknown order status");
@@ -1368,7 +1380,7 @@ mod tests {
                 assert!(matches!(
                     order.state,
                     crate::order::state::OrderState::Inactive(
-                        crate::order::state::InactiveOrderState::FullyFilled
+                        crate::order::state::InactiveOrderState::FullyFilled(_)
                     )
                 ));
             }

--- a/barter-execution/src/client/hyperliquid/mod.rs
+++ b/barter-execution/src/client/hyperliquid/mod.rs
@@ -40,9 +40,7 @@ use crate::{
     trade::{AssetFees, Trade, TradeId},
 };
 use barter_instrument::{
-    Side,
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
+    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
     instrument::name::InstrumentNameExchange,
 };
 use barter_integration::collection::snapshot::Snapshot;
@@ -981,7 +979,7 @@ impl ExecutionClient for HyperliquidClient {
         &self,
         time_since: DateTime<Utc>,
         instruments: &[InstrumentNameExchange],
-    ) -> Result<Vec<Trade<QuoteAsset, InstrumentNameExchange>>, UnindexedClientError> {
+    ) -> Result<Vec<Trade<AssetNameExchange, InstrumentNameExchange>>, UnindexedClientError> {
         let address = self.wallet_h160();
 
         let fills = self
@@ -1044,8 +1042,9 @@ impl ExecutionClient for HyperliquidClient {
                 price,
                 quantity,
                 fees: AssetFees {
-                    asset: QuoteAsset,
+                    asset: AssetNameExchange::from("USDC"),
                     fees: fee,
+                    fees_quote: Some(fee),
                 },
             });
         }
@@ -1074,8 +1073,9 @@ fn fill_to_account_event(fill: &hyperliquid_rust_sdk::TradeInfo) -> Option<Unind
         price,
         quantity,
         fees: AssetFees {
-            asset: QuoteAsset,
+            asset: AssetNameExchange::from("USDC"),
             fees: fee,
+            fees_quote: Some(fee),
         },
     };
 

--- a/barter-execution/src/client/ibkr/execution.rs
+++ b/barter-execution/src/client/ibkr/execution.rs
@@ -2,7 +2,9 @@ use crate::{
     order::id::{ClientOrderId, StrategyId},
     trade::{AssetFees, Trade, TradeId},
 };
-use barter_instrument::{Side, asset::QuoteAsset, instrument::name::InstrumentNameExchange};
+use barter_instrument::{
+    Side, asset::name::AssetNameExchange, instrument::name::InstrumentNameExchange,
+};
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Tz;
 use fnv::FnvHashMap;
@@ -87,7 +89,7 @@ impl ExecutionBuffer {
     pub fn complete_with_commission(
         &self,
         report: &CommissionReport,
-    ) -> Option<Trade<QuoteAsset, InstrumentNameExchange>> {
+    ) -> Option<Trade<AssetNameExchange, InstrumentNameExchange>> {
         let pending = {
             let mut inner = self.inner.lock();
             inner.pending.remove(&report.execution_id)?
@@ -142,7 +144,7 @@ impl Default for ExecutionBuffer {
 fn build_trade(
     pending: PendingExecution,
     commission: &CommissionReport,
-) -> Option<Trade<QuoteAsset, InstrumentNameExchange>> {
+) -> Option<Trade<AssetNameExchange, InstrumentNameExchange>> {
     let exec = &pending.execution.execution;
 
     let side = match parse_ib_side(&exec.side) {
@@ -173,8 +175,9 @@ fn build_trade(
         price,
         quantity,
         fees: AssetFees {
-            asset: QuoteAsset,
+            asset: AssetNameExchange::from(commission.currency.as_str()),
             fees: commission_amount,
+            fees_quote: None, // Indexer computes based on fee asset vs instrument quote
         },
     })
 }

--- a/barter-execution/src/client/ibkr/mod.rs
+++ b/barter-execution/src/client/ibkr/mod.rs
@@ -42,14 +42,14 @@ use crate::{
     UnindexedAccountSnapshot,
     balance::AssetBalance,
     client::ExecutionClient,
-    error::{ApiError, ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError},
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{
             OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, UnindexedOrderResponseCancel,
         },
-        state::{Cancelled, Open, OrderState},
+        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -496,12 +496,7 @@ impl ExecutionClient for IbkrClient {
                                 };
 
                                 if let Some((client_id, ctx)) = lookup_result {
-                                    let order = make_order_from_status(
-                                        &status,
-                                        client_id,
-                                        &ctx,
-                                        is_terminal,
-                                    );
+                                    let order = make_order_from_status(&status, client_id, &ctx);
                                     Some(UnindexedAccountEvent {
                                         exchange: ExchangeId::Ibkr,
                                         kind: AccountEventKind::OrderSnapshot(Snapshot::new(order)),
@@ -616,11 +611,14 @@ impl ExecutionClient for IbkrClient {
                 // correlate any fill events that arrive between now and when IB
                 // confirms the cancel. Removal happens in account_stream when
                 // OrderStatus::Cancelled is received.
+                // IBKR cancel_order returns no filled qty; use ZERO and let
+                // subsequent OrderStatus events provide accurate fill info.
                 Some(OrderResponseCancel {
                     key,
                     state: Ok(Cancelled::new(
                         OrderId::new(format_smolstr!("{}", ib_order_id)),
                         Utc::now(),
+                        Decimal::ZERO,
                     )),
                 })
             }
@@ -662,7 +660,7 @@ impl ExecutionClient for IbkrClient {
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let key = OrderKey {
             exchange: ExchangeId::Ibkr,
             instrument: request.key.instrument.clone(),
@@ -680,12 +678,10 @@ impl ExecutionClient for IbkrClient {
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
-                    state: Err(crate::error::OrderError::Rejected(
-                        ApiError::InstrumentInvalid(
-                            request.key.instrument.clone(),
-                            "contract not registered".to_string(),
-                        ),
-                    )),
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::InstrumentInvalid(
+                        request.key.instrument.clone(),
+                        "contract not registered".to_string(),
+                    ))),
                 });
             }
         };
@@ -700,7 +696,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
-                    state: Err(crate::error::OrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         format!("quantity {} exceeds f64 range", request.state.quantity),
                     ))),
                 });
@@ -723,7 +719,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
-                    state: Err(crate::error::OrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         e.to_string(),
                     ))),
                 });
@@ -787,19 +783,23 @@ impl ExecutionClient for IbkrClient {
         .await;
 
         match result {
-            Ok(Ok(Some((order_id, filled)))) => Some(Order {
-                key,
-                side,
-                price,
-                quantity: req_quantity,
-                kind,
-                time_in_force: tif,
-                state: Ok(Open::new(
-                    OrderId::new(format_smolstr!("{}", order_id)),
-                    Utc::now(),
-                    filled,
-                )),
-            }),
+            Ok(Ok(Some((order_id, filled)))) => {
+                // IB always returns order status via subscription - never immediate fills.
+                // The filled quantity here is from the OrderStatus event, not a complete fill.
+                Some(Order {
+                    key,
+                    side,
+                    price,
+                    quantity: req_quantity,
+                    kind,
+                    time_in_force: tif,
+                    state: OrderState::active(Open::new(
+                        OrderId::new(format_smolstr!("{}", order_id)),
+                        Utc::now(),
+                        filled,
+                    )),
+                })
+            }
             Ok(Ok(None)) => {
                 // Subscription exhausted without terminal status. The order WAS submitted
                 // (we have an IB order ID), but we lost tracking. Return Open with zero
@@ -815,7 +815,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: req_quantity,
                     kind,
                     time_in_force: tif,
-                    state: Ok(Open::new(
+                    state: OrderState::active(Open::new(
                         OrderId::new(format_smolstr!("{}", ib_order_id)),
                         Utc::now(),
                         Decimal::ZERO,
@@ -832,7 +832,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: req_quantity,
                     kind,
                     time_in_force: tif,
-                    state: Err(crate::error::OrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         status,
                     ))),
                 })
@@ -846,7 +846,7 @@ impl ExecutionClient for IbkrClient {
                     quantity: req_quantity,
                     kind,
                     time_in_force: tif,
-                    state: Err(crate::error::OrderError::Rejected(ApiError::OrderRejected(
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
                         e.to_string(),
                     ))),
                 })
@@ -1116,28 +1116,44 @@ impl ExecutionClient for IbkrClient {
 
 /// Build an Order from IB OrderStatus using stored OrderContext.
 ///
-/// `is_terminal` indicates Cancelled/Inactive status (caller determines this before
-/// choosing the lookup method, so we take it as a parameter to avoid re-matching).
+/// # IBKR Status Mapping
+///
+/// | IB Status    | → OrderState          | Rationale                                    |
+/// |--------------|-----------------------|----------------------------------------------|
+/// | "Inactive"   | OpenFailed(Rejected)  | Order blocked by validation/margin/exchange  |
+/// | "Cancelled"  | Cancelled             | User-initiated or exchange cancellation      |
+/// | "Filled"     | FullyFilled           | Order fully executed                         |
+/// | Other        | Active(Open)          | Order working on exchange                    |
+///
+/// Note: IBKR sends both user-cancellation and time-expiration as "Cancelled" status.
+/// Distinguishing Cancelled vs Expired requires correlating with `error` callbacks
+/// (error 202 = user cancel, "expir" in message = expiration). This is a future
+/// enhancement tracked in docs/current_task.md (7.7).
 fn make_order_from_status(
     status: &ibapi::orders::OrderStatus,
     client_id: ClientOrderId,
     ctx: &OrderContext,
-    is_terminal: bool,
 ) -> Order<ExchangeId, InstrumentNameExchange, OrderState<AssetNameExchange, InstrumentNameExchange>>
 {
     let ib_id = status.order_id;
     let order_id = OrderId::new(format_smolstr!("{}", ib_id));
 
-    let state = if is_terminal {
-        OrderState::inactive(Cancelled::new(order_id, Utc::now()))
-    } else if status.status.as_str() == "Filled" {
-        OrderState::fully_filled()
-    } else {
-        OrderState::active(Open::new(
-            order_id,
-            Utc::now(),
-            parse_decimal_or_warn(status.filled, "status.filled"),
-        ))
+    let filled_qty = parse_decimal_or_warn(status.filled, "status.filled");
+    let state = match status.status.as_str() {
+        "Inactive" => {
+            // "Inactive" means the order was accepted by IB but is not working:
+            // validation failure, margin issue, exchange closed, share location hold.
+            // This is a placement failure, not a cancellation.
+            OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
+                "IB status: Inactive (order blocked by validation/margin/exchange)".into(),
+            )))
+        }
+        "Cancelled" => OrderState::inactive(Cancelled::new(order_id, Utc::now(), filled_qty)),
+        "Filled" => OrderState::fully_filled(Filled::new(order_id, Utc::now(), filled_qty, None)),
+        _ => {
+            // "Submitted", "PreSubmitted", "PendingSubmit", "PendingCancel", etc.
+            OrderState::active(Open::new(order_id, Utc::now(), filled_qty))
+        }
     };
 
     Order {

--- a/barter-execution/src/client/ibkr/mod.rs
+++ b/barter-execution/src/client/ibkr/mod.rs
@@ -49,7 +49,7 @@ use crate::{
         request::{
             OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, UnindexedOrderResponseCancel,
         },
-        state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
+        state::{Cancelled, Expired, Filled, Open, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -65,7 +65,7 @@ use ibapi::{
     accounts::{AccountSummaryResult, types::AccountGroup},
     client::blocking::Client,
 };
-use order::{OrderContext, OrderIdMap, build_ib_order};
+use order::{OrderContext, OrderIdMap, PendingCancels, build_ib_order};
 use parking_lot::Mutex;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -162,6 +162,7 @@ pub struct IbkrClient {
     client: Arc<Client>,
     contracts: ContractRegistry,
     order_ids: OrderIdMap,
+    pending_cancels: PendingCancels,
     execution_buffer: ExecutionBuffer,
     next_order_id: Arc<Mutex<i32>>,
 }
@@ -222,6 +223,7 @@ impl IbkrClient {
             client: Arc::new(client),
             contracts,
             order_ids: OrderIdMap::new(),
+            pending_cancels: PendingCancels::new(),
             execution_buffer: ExecutionBuffer::new(),
             next_order_id: Arc::new(Mutex::new(next_id)),
         })
@@ -287,6 +289,18 @@ impl IbkrClient {
     /// interval is 5-10 minutes with a max_age of 1 hour.
     pub fn clear_stale_order_ids(&self, max_age: std::time::Duration) -> usize {
         self.order_ids.clear_stale(max_age)
+    }
+
+    /// Clear pending cancel entries older than the given duration.
+    ///
+    /// Returns the number of cleared entries.
+    ///
+    /// Pending cancels are tracked to differentiate user-initiated cancellation
+    /// from time-based expiration. If a cancel request is submitted but the order
+    /// never receives terminal status (e.g., network disconnect), the entry would
+    /// remain indefinitely. Call this alongside other stale cleanup methods.
+    pub fn clear_stale_pending_cancels(&self, max_age: std::time::Duration) -> usize {
+        self.pending_cancels.clear_stale(max_age)
     }
 }
 
@@ -465,6 +479,7 @@ impl ExecutionClient for IbkrClient {
 
         let contracts_clone = self.contracts.clone();
         let order_ids_clone = self.order_ids.clone();
+        let pending_cancels_clone = self.pending_cancels.clone();
         let exec_buffer_clone = self.execution_buffer.clone();
 
         let (tx, rx) = mpsc::unbounded_channel();
@@ -493,7 +508,12 @@ impl ExecutionClient for IbkrClient {
                                 };
 
                                 if let Some((client_id, ctx)) = lookup_result {
-                                    let order = make_order_from_status(&status, client_id, &ctx);
+                                    let order = make_order_from_status(
+                                        &status,
+                                        client_id,
+                                        &ctx,
+                                        &pending_cancels_clone,
+                                    );
                                     Some(UnindexedAccountEvent {
                                         exchange: ExchangeId::Ibkr,
                                         kind: AccountEventKind::OrderSnapshot(Snapshot::new(order)),
@@ -604,6 +624,11 @@ impl ExecutionClient for IbkrClient {
 
         match result {
             Ok(Ok(_sub)) => {
+                // Track user-initiated cancel for Cancelled vs Expired differentiation.
+                // Insert only after cancel request succeeded — avoids stale entries if
+                // the future is dropped before reaching this branch.
+                self.pending_cancels.insert(ib_order_id);
+
                 // H-3 fix: Do NOT remove order_ids here. The mapping is needed to
                 // correlate any fill events that arrive between now and when IB
                 // confirms the cancel. Removal happens in account_stream when
@@ -1120,18 +1145,29 @@ impl ExecutionClient for IbkrClient {
 /// | IB Status    | → OrderState          | Rationale                                    |
 /// |--------------|-----------------------|----------------------------------------------|
 /// | "Inactive"   | OpenFailed(Rejected)  | Order blocked by validation/margin/exchange  |
-/// | "Cancelled"  | Cancelled             | User-initiated or exchange cancellation      |
+/// | "Cancelled"  | Cancelled or Expired  | See differentiation logic below              |
 /// | "Filled"     | FullyFilled           | Order fully executed                         |
 /// | Other        | Active(Open)          | Order working on exchange                    |
 ///
-/// Note: IBKR sends both user-cancellation and time-expiration as "Cancelled" status.
-/// Distinguishing Cancelled vs Expired requires correlating with `error` callbacks
-/// (error 202 = user cancel, "expir" in message = expiration). This is a future
-/// enhancement tracked in docs/current_task.md (7.7).
+/// # Cancelled vs Expired Differentiation
+///
+/// IBKR sends `"Cancelled"` status for both user-initiated cancellation and
+/// time-based expiration. We differentiate using:
+///
+/// 1. If order ID is in `pending_cancels` (set by `cancel_order`) → `Cancelled`
+/// 2. Else if `time_in_force == GoodUntilEndOfDay` → `Expired` (DAY order expired)
+/// 3. Else → `Cancelled` (broker-initiated or external cancellation)
+///
+/// # Known Limitation
+///
+/// If the broker cancels a DAY order before market close (e.g., insufficient margin),
+/// it will be misclassified as `Expired`. This is rare and acceptable given the
+/// alternative (forking ibapi to preserve order_id in error callbacks).
 fn make_order_from_status(
     status: &ibapi::orders::OrderStatus,
     client_id: ClientOrderId,
     ctx: &OrderContext,
+    pending_cancels: &PendingCancels,
 ) -> Order<ExchangeId, InstrumentNameExchange, OrderState<AssetNameExchange, InstrumentNameExchange>>
 {
     let ib_id = status.order_id;
@@ -1147,7 +1183,21 @@ fn make_order_from_status(
                 "IB status: Inactive (order blocked by validation/margin/exchange)".into(),
             )))
         }
-        "Cancelled" => OrderState::inactive(Cancelled::new(order_id, Utc::now(), filled_qty)),
+        "Cancelled" => {
+            // Differentiate user-cancel from time-expiration
+            let was_user_cancel = pending_cancels.remove(ib_id);
+
+            if was_user_cancel {
+                // User called cancel_order() — definitely a cancellation
+                OrderState::inactive(Cancelled::new(order_id, Utc::now(), filled_qty))
+            } else if matches!(ctx.time_in_force, TimeInForce::GoodUntilEndOfDay) {
+                // DAY order without pending cancel — expired at market close
+                OrderState::inactive(Expired::new(order_id, Utc::now(), filled_qty))
+            } else {
+                // GTC/IOC/FOK without pending cancel — broker or exchange cancelled
+                OrderState::inactive(Cancelled::new(order_id, Utc::now(), filled_qty))
+            }
+        }
         "Filled" => OrderState::fully_filled(Filled::new(order_id, Utc::now(), filled_qty, None)),
         _ => {
             // "Submitted", "PreSubmitted", "PendingSubmit", "PendingCancel", etc.

--- a/barter-execution/src/client/ibkr/mod.rs
+++ b/barter-execution/src/client/ibkr/mod.rs
@@ -55,10 +55,7 @@ use crate::{
 };
 use account::BalanceAggregator;
 use barter_instrument::{
-    Side,
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
-    ibkr::ContractRegistry,
+    Side, asset::name::AssetNameExchange, exchange::ExchangeId, ibkr::ContractRegistry,
     instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
@@ -1022,7 +1019,7 @@ impl ExecutionClient for IbkrClient {
         &self,
         time_since: DateTime<Utc>,
         instruments: &[InstrumentNameExchange],
-    ) -> Result<Vec<Trade<QuoteAsset, InstrumentNameExchange>>, UnindexedClientError> {
+    ) -> Result<Vec<Trade<AssetNameExchange, InstrumentNameExchange>>, UnindexedClientError> {
         let client = self.client.clone();
         let contracts = self.contracts.clone();
         let order_ids = self.order_ids.clone();
@@ -1103,7 +1100,9 @@ impl ExecutionClient for IbkrClient {
                     side,
                     price: parse_decimal_or_warn(exec.price, "exec.price"),
                     quantity: parse_decimal_or_warn(exec.shares, "exec.shares"),
-                    fees: AssetFees::default(),
+                    // IBKR executions API lacks commission data (available via CommissionReport callback).
+                    // "UNKNOWN" placeholder will fail indexing - use unindexed or correlate with WS.
+                    fees: AssetFees::new(AssetNameExchange::from("UNKNOWN"), Decimal::ZERO, None),
                 });
             }
 

--- a/barter-execution/src/client/ibkr/order.rs
+++ b/barter-execution/src/client/ibkr/order.rs
@@ -2,7 +2,7 @@ use crate::order::{OrderKind, TimeInForce, id::ClientOrderId};
 use barter_instrument::{Side, instrument::name::InstrumentNameExchange};
 use fnv::FnvHashMap;
 use ibapi::orders::{Action, Order, TimeInForce as IbTimeInForce, order_builder};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rust_decimal::Decimal;
 use std::{sync::Arc, time::Instant};
 
@@ -155,6 +155,70 @@ impl OrderIdMap {
 }
 
 impl Default for OrderIdMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Tracks IB order IDs with pending cancel requests.
+///
+/// Used to differentiate user-initiated cancellation from time-based expiration.
+/// IBKR sends `"Cancelled"` status for both cases; this map tracks which cancels
+/// were user-initiated via `cancel_order()`.
+#[derive(Debug, Clone)]
+pub struct PendingCancels {
+    inner: Arc<Mutex<FnvHashMap<i32, Instant>>>,
+}
+
+impl PendingCancels {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(FnvHashMap::with_capacity_and_hasher(
+                8,
+                Default::default(),
+            ))),
+        }
+    }
+
+    /// Record a pending cancel request for the given IB order ID.
+    pub fn insert(&self, ib_id: i32) {
+        self.inner.lock().insert(ib_id, Instant::now());
+    }
+
+    /// Check if a cancel was user-initiated and remove from tracking.
+    ///
+    /// Returns `true` if the order ID was in the pending set (user-initiated cancel).
+    #[must_use]
+    pub fn remove(&self, ib_id: i32) -> bool {
+        self.inner.lock().remove(&ib_id).is_some()
+    }
+
+    /// Clear entries older than the given duration.
+    ///
+    /// Returns the number of cleared entries. Call periodically to prevent
+    /// memory leaks from orphaned cancel requests (e.g., network issues).
+    #[must_use]
+    pub fn clear_stale(&self, max_age: std::time::Duration) -> usize {
+        let mut map = self.inner.lock();
+        let before = map.len();
+        map.retain(|_, registered_at| registered_at.elapsed() < max_age);
+        before - map.len()
+    }
+
+    /// Number of pending cancel requests being tracked.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.lock().len()
+    }
+
+    /// Check if there are no pending cancel requests.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().is_empty()
+    }
+}
+
+impl Default for PendingCancels {
     fn default() -> Self {
         Self::new()
     }
@@ -401,5 +465,80 @@ mod tests {
         let cleared = map.clear_stale(Duration::from_secs(3600));
         assert_eq!(cleared, 0);
         assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn test_pending_cancels_insert_remove() {
+        let cancels = PendingCancels::new();
+        assert!(cancels.is_empty());
+
+        // Insert a cancel request
+        cancels.insert(42);
+        assert_eq!(cancels.len(), 1);
+        assert!(!cancels.is_empty());
+
+        // Remove returns true for tracked ID
+        assert!(cancels.remove(42));
+        assert!(cancels.is_empty());
+
+        // Remove returns false for untracked ID
+        assert!(!cancels.remove(42));
+        assert!(!cancels.remove(999));
+    }
+
+    #[test]
+    fn test_pending_cancels_multiple() {
+        let cancels = PendingCancels::new();
+
+        cancels.insert(1);
+        cancels.insert(2);
+        cancels.insert(3);
+        assert_eq!(cancels.len(), 3);
+
+        // Remove middle one
+        assert!(cancels.remove(2));
+        assert_eq!(cancels.len(), 2);
+
+        // Other IDs still tracked
+        assert!(cancels.remove(1));
+        assert!(cancels.remove(3));
+        assert!(cancels.is_empty());
+    }
+
+    #[test]
+    fn test_pending_cancels_clear_stale() {
+        use std::time::Duration;
+
+        let cancels = PendingCancels::new();
+
+        cancels.insert(1);
+        cancels.insert(2);
+
+        // With zero max_age, all entries are stale
+        let cleared = cancels.clear_stale(Duration::ZERO);
+        assert_eq!(cleared, 2);
+        assert!(cancels.is_empty());
+
+        // Insert new ones
+        cancels.insert(10);
+        cancels.insert(20);
+
+        // With large max_age, nothing is stale
+        let cleared = cancels.clear_stale(Duration::from_secs(3600));
+        assert_eq!(cleared, 0);
+        assert_eq!(cancels.len(), 2);
+    }
+
+    #[test]
+    fn test_pending_cancels_duplicate_insert() {
+        let cancels = PendingCancels::new();
+
+        cancels.insert(42);
+        cancels.insert(42);
+
+        // HashMap deduplicates by ID; second insert updates timestamp
+        assert_eq!(cancels.len(), 1);
+        assert!(cancels.remove(42));
+        assert!(cancels.is_empty());
     }
 }

--- a/barter-execution/src/client/mock/mod.rs
+++ b/barter-execution/src/client/mock/mod.rs
@@ -2,14 +2,14 @@ use crate::{
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::AssetBalance,
     client::ExecutionClient,
-    error::{ConnectivityError, UnindexedClientError, UnindexedOrderError},
+    error::{ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     exchange::mock::request::{MarketPrices, MockExchangeRequest},
     fee::FeeModelConfig,
     fill::SimFillConfig,
     order::{
         Order, OrderEvent, OrderKey,
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::Open,
+        state::{Open, OrderState, UnindexedOrderState},
     },
     trade::Trade,
 };
@@ -208,7 +208,7 @@ where
     async fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>> {
+    ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         let (response_tx, response_rx) = oneshot::channel();
 
         let request = into_owned_request(request);
@@ -230,7 +230,7 @@ where
                 quantity: request.state.quantity,
                 kind: request.state.kind,
                 time_in_force: request.state.time_in_force,
-                state: Err(UnindexedOrderError::Connectivity(
+                state: OrderState::inactive(OrderError::Connectivity(
                     ConnectivityError::ExchangeOffline(self.mocked_exchange),
                 )),
             });
@@ -245,7 +245,7 @@ where
                 quantity: request.state.quantity,
                 kind: request.state.kind,
                 time_in_force: request.state.time_in_force,
-                state: Err(UnindexedOrderError::Connectivity(
+                state: OrderState::inactive(OrderError::Connectivity(
                     ConnectivityError::ExchangeOffline(self.mocked_exchange),
                 )),
             },

--- a/barter-execution/src/client/mock/mod.rs
+++ b/barter-execution/src/client/mock/mod.rs
@@ -14,9 +14,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
 use derive_more::Constructor;
@@ -307,7 +305,7 @@ where
         time_since: DateTime<Utc>,
         // MockExchange fetch_trades doesn't filter by instrument
         _instruments: &[InstrumentNameExchange],
-    ) -> Result<Vec<Trade<QuoteAsset, InstrumentNameExchange>>, UnindexedClientError> {
+    ) -> Result<Vec<Trade<AssetNameExchange, InstrumentNameExchange>>, UnindexedClientError> {
         let (response_tx, response_rx) = oneshot::channel();
 
         self.request_tx

--- a/barter-execution/src/client/mod.rs
+++ b/barter-execution/src/client/mod.rs
@@ -1,11 +1,11 @@
 use crate::{
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::AssetBalance,
-    error::{UnindexedClientError, UnindexedOrderError},
+    error::UnindexedClientError,
     order::{
         Order,
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::Open,
+        state::{Open, UnindexedOrderState},
     },
     trade::Trade,
 };
@@ -98,22 +98,29 @@ where
         )
     }
 
+    /// Place an order on the exchange.
+    ///
+    /// # Return value
+    ///
+    /// Returns `OrderState` directly rather than `Result<Open, OrderError>`:
+    /// - `OrderState::Active(Open)` - order is resting on the order book
+    /// - `OrderState::Inactive(FullyFilled)` - order was immediately filled (includes `avg_price` when available)
+    /// - `OrderState::Inactive(OpenFailed)` - order placement failed (API error, connectivity, etc.)
+    ///
+    /// This design allows immediate fills to carry metadata (e.g., `avg_price`) that
+    /// would be lost if we had to infer terminal state from `Open::filled_quantity`.
     fn open_order(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
-    ) -> impl Future<
-        Output = Option<
-            Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
-        >,
-    > + Send;
+    ) -> impl Future<Output = Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>>>
+    + Send;
 
     // `+ Send` on default method return types for multi-threaded Tokio runtime
     fn open_orders<'a>(
         &self,
         requests: impl IntoIterator<Item = OrderRequestOpen<ExchangeId, &'a InstrumentNameExchange>>,
-    ) -> impl Stream<
-        Item = Option<Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>>,
-    > + Send {
+    ) -> impl Stream<Item = Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>>> + Send
+    {
         futures::stream::FuturesUnordered::from_iter(
             requests.into_iter().map(|request| self.open_order(request)),
         )

--- a/barter-execution/src/client/mod.rs
+++ b/barter-execution/src/client/mod.rs
@@ -10,9 +10,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
 use futures::Stream;
@@ -153,12 +151,18 @@ where
     /// return trades across all instruments. When non-empty, only trades for the listed
     /// instruments are returned.
     ///
+    /// The fee asset (`AssetNameExchange`) may be quote, base, or third-party (e.g., BNB).
+    /// Use `fees.fees_quote` for quote-equivalent value when available.
+    ///
     /// Note: `MockExecution` currently ignores `instruments` and always returns all trades.
     fn fetch_trades(
         &self,
         time_since: DateTime<Utc>,
         instruments: &[InstrumentNameExchange],
     ) -> impl Future<
-        Output = Result<Vec<Trade<QuoteAsset, InstrumentNameExchange>>, UnindexedClientError>,
+        Output = Result<
+            Vec<Trade<AssetNameExchange, InstrumentNameExchange>>,
+            UnindexedClientError,
+        >,
     > + Send;
 }

--- a/barter-execution/src/exchange/mock/account.rs
+++ b/barter-execution/src/exchange/mock/account.rs
@@ -9,9 +9,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
 use derive_more::Constructor;
@@ -23,7 +21,7 @@ pub struct AccountState {
     orders_open: FnvHashMap<ClientOrderId, Order<ExchangeId, InstrumentNameExchange, Open>>,
     orders_cancelled:
         FnvHashMap<ClientOrderId, Order<ExchangeId, InstrumentNameExchange, Cancelled>>,
-    trades: Vec<Trade<QuoteAsset, InstrumentNameExchange>>,
+    trades: Vec<Trade<AssetNameExchange, InstrumentNameExchange>>,
 }
 
 impl AccountState {
@@ -56,7 +54,7 @@ impl AccountState {
     pub fn trades(
         &self,
         time_since: DateTime<Utc>,
-    ) -> impl Iterator<Item = &Trade<QuoteAsset, InstrumentNameExchange>> + '_ {
+    ) -> impl Iterator<Item = &Trade<AssetNameExchange, InstrumentNameExchange>> + '_ {
         self.trades
             .iter()
             .filter(move |trade| trade.time_exchange >= time_since)
@@ -69,7 +67,7 @@ impl AccountState {
         self.balances.get_mut(asset)
     }
 
-    pub fn ack_trade(&mut self, trade: Trade<QuoteAsset, InstrumentNameExchange>) {
+    pub fn ack_trade(&mut self, trade: Trade<AssetNameExchange, InstrumentNameExchange>) {
         self.trades.push(trade);
     }
 }

--- a/barter-execution/src/exchange/mock/mod.rs
+++ b/barter-execution/src/exchange/mock/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         Order, OrderKey, OrderKind, UnindexedOrder,
         id::OrderId,
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::{Cancelled, Open},
+        state::{Cancelled, Filled, InactiveOrderState, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -296,7 +296,7 @@ impl MockExchange {
         request: OrderRequestOpen<ExchangeId, InstrumentNameExchange>,
         market_prices: MarketPrices,
     ) -> (
-        Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
+        Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
         Option<OpenOrderNotifications>,
     ) {
         if let Err(error) = self.validate_order_kind_supported(request.state.kind) {
@@ -440,11 +440,12 @@ impl MockExchange {
             quantity: request.state.quantity,
             kind: request.state.kind,
             time_in_force: request.state.time_in_force,
-            state: Ok(Open {
-                id: order_id.clone(),
-                time_exchange: self.time_exchange(),
-                filled_quantity: request.state.quantity,
-            }),
+            state: OrderState::fully_filled(Filled::new(
+                order_id.clone(),
+                self.time_exchange(),
+                request.state.quantity,
+                Some(fill_price),
+            )),
         };
 
         let notifications = OpenOrderNotifications {
@@ -510,7 +511,7 @@ impl MockExchange {
 fn build_open_order_err_response<E>(
     request: OrderRequestOpen<ExchangeId, InstrumentNameExchange>,
     error: E,
-) -> Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>
+) -> Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>
 where
     E: Into<UnindexedOrderError>,
 {
@@ -521,7 +522,7 @@ where
         quantity: request.state.quantity,
         kind: request.state.kind,
         time_in_force: request.state.time_in_force,
-        state: Err(error.into()),
+        state: OrderState::inactive(error.into()),
     }
 }
 
@@ -538,7 +539,7 @@ mod tests {
     use crate::{
         UnindexedAccountSnapshot,
         balance::{AssetBalance, Balance},
-        error::{ApiError, UnindexedOrderError},
+        error::ApiError,
         exchange::mock::request::MarketPrices,
         fee::{FeeModelConfig, PercentageFeeModel},
         fill::{BidAskFillModel, SimFillConfig},
@@ -699,7 +700,7 @@ mod tests {
             exchange.open_order(sell_request("0.5", "50000"), MarketPrices::default());
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "sell should succeed: {:?}",
             response.state
         );
@@ -741,15 +742,16 @@ mod tests {
             "failed order must produce no notifications"
         );
         match response.state {
-            Err(UnindexedOrderError::Rejected(ApiError::BalanceInsufficient(ref asset, _))) => {
+            OrderState::Inactive(InactiveOrderState::OpenFailed(
+                crate::error::OrderError::Rejected(ApiError::BalanceInsufficient(ref asset, _)),
+            )) => {
                 assert_eq!(
                     *asset,
                     base(),
                     "BalanceInsufficient must name the base asset (BTC), not the quote (USDT)"
                 );
             }
-            Err(other) => panic!("expected BalanceInsufficient, got: {other:?}"),
-            Ok(_) => panic!("expected error for oversized sell, got Ok"),
+            other => panic!("expected BalanceInsufficient, got: {other:?}"),
         }
     }
 
@@ -769,7 +771,7 @@ mod tests {
         let (response, notifications) = exchange.open_order(buy_request("1", "100"), market_prices);
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "buy should succeed: {:?}",
             response.state
         );
@@ -805,7 +807,7 @@ mod tests {
             exchange.open_order(buy_request("10", "100"), MarketPrices::default());
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "buy should succeed: {:?}",
             response.state
         );
@@ -838,7 +840,7 @@ mod tests {
             exchange.open_order(sell_request("1", "100"), MarketPrices::default());
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "sell should succeed: {:?}",
             response.state
         );
@@ -873,7 +875,7 @@ mod tests {
             exchange.open_order(sell_request("1", "0"), MarketPrices::default());
 
         assert!(
-            response.state.is_ok(),
+            response.state.is_accepted(),
             "sell at zero price should succeed: {:?}",
             response.state
         );

--- a/barter-execution/src/exchange/mock/mod.rs
+++ b/barter-execution/src/exchange/mock/mod.rs
@@ -13,13 +13,13 @@ use crate::{
         Order, OrderKey, OrderKind, UnindexedOrder,
         id::OrderId,
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::{Cancelled, Filled, InactiveOrderState, OrderState, UnindexedOrderState},
+        state::{Cancelled, Filled, OrderState, UnindexedOrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
 use barter_instrument::{
     Side,
-    asset::{QuoteAsset, name::AssetNameExchange},
+    asset::name::AssetNameExchange,
     exchange::ExchangeId,
     instrument::{Instrument, name::InstrumentNameExchange},
 };
@@ -262,7 +262,7 @@ impl MockExchange {
             if tx.send(trade).is_err() {
                 error!(
                     %exchange,
-                    kind = "Trade<QuoteAsset, InstrumentNameExchange>",
+                    kind = "Trade<AssetNameExchange, InstrumentNameExchange>",
                     "MockExchange failed to send AccountEvent notification to client"
                 );
             }
@@ -367,10 +367,17 @@ impl MockExchange {
                     current.balance.total = maybe_new_balance;
                     current.time_exchange = time_exchange;
 
-                    Ok((current.clone(), AssetFees::quote_fees(order_fees_quote)))
+                    Ok((
+                        current.clone(),
+                        AssetFees::new(
+                            underlying.quote.clone(),
+                            order_fees_quote,
+                            Some(order_fees_quote),
+                        ),
+                    ))
                 } else {
                     Err(ApiError::BalanceInsufficient(
-                        underlying.quote,
+                        underlying.quote.clone(),
                         format!(
                             "Available Balance: {}, Required Balance inc. fees: {}",
                             current.balance.free, quote_required
@@ -412,7 +419,14 @@ impl MockExchange {
                     current.balance.total = maybe_new_balance;
                     current.time_exchange = time_exchange;
 
-                    Ok((current.clone(), AssetFees::quote_fees(order_fees_quote)))
+                    Ok((
+                        current.clone(),
+                        AssetFees::new(
+                            underlying.quote.clone(),
+                            order_fees_quote,
+                            Some(order_fees_quote),
+                        ),
+                    ))
                 } else {
                     Err(ApiError::BalanceInsufficient(
                         underlying.base,
@@ -529,7 +543,7 @@ where
 #[derive(Debug)]
 pub struct OpenOrderNotifications {
     pub balance: Snapshot<AssetBalance<AssetNameExchange>>,
-    pub trade: Trade<QuoteAsset, InstrumentNameExchange>,
+    pub trade: Trade<AssetNameExchange, InstrumentNameExchange>,
 }
 
 #[cfg(test)]
@@ -547,6 +561,7 @@ mod tests {
             OrderEvent, OrderKey, OrderKind, TimeInForce,
             id::{ClientOrderId, StrategyId},
             request::RequestOpen,
+            state::InactiveOrderState,
         },
     };
     use barter_instrument::{

--- a/barter-execution/src/exchange/mock/request.rs
+++ b/barter-execution/src/exchange/mock/request.rs
@@ -1,11 +1,10 @@
 use crate::{
     UnindexedAccountSnapshot,
     balance::AssetBalance,
-    error::UnindexedOrderError,
     order::{
         Order,
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
-        state::Open,
+        state::{Open, UnindexedOrderState},
     },
     trade::Trade,
 };
@@ -117,7 +116,7 @@ impl MockExchangeRequest {
     pub fn open_order(
         time_request: DateTime<Utc>,
         response_tx: oneshot::Sender<
-            Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
+            Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
         >,
         request: OrderRequestOpen<ExchangeId, InstrumentNameExchange>,
         market_prices: MarketPrices,
@@ -155,9 +154,8 @@ pub enum MockExchangeRequestKind {
         request: OrderRequestCancel<ExchangeId, InstrumentNameExchange>,
     },
     OpenOrder {
-        response_tx: oneshot::Sender<
-            Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
-        >,
+        response_tx:
+            oneshot::Sender<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>>,
         request: OrderRequestOpen<ExchangeId, InstrumentNameExchange>,
         market_prices: MarketPrices,
     },

--- a/barter-execution/src/exchange/mock/request.rs
+++ b/barter-execution/src/exchange/mock/request.rs
@@ -9,9 +9,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{QuoteAsset, name::AssetNameExchange},
-    exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
 };
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
@@ -87,7 +85,7 @@ impl MockExchangeRequest {
 
     pub fn fetch_trades(
         time_request: DateTime<Utc>,
-        response_tx: oneshot::Sender<Vec<Trade<QuoteAsset, InstrumentNameExchange>>>,
+        response_tx: oneshot::Sender<Vec<Trade<AssetNameExchange, InstrumentNameExchange>>>,
         time_since: DateTime<Utc>,
     ) -> Self {
         Self::new(
@@ -146,7 +144,7 @@ pub enum MockExchangeRequestKind {
         response_tx: oneshot::Sender<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>>,
     },
     FetchTrades {
-        response_tx: oneshot::Sender<Vec<Trade<QuoteAsset, InstrumentNameExchange>>>,
+        response_tx: oneshot::Sender<Vec<Trade<AssetNameExchange, InstrumentNameExchange>>>,
         time_since: DateTime<Utc>,
     },
     CancelOrder {

--- a/barter-execution/src/indexer.rs
+++ b/barter-execution/src/indexer.rs
@@ -12,10 +12,10 @@ use crate::{
         request::OrderResponseCancel,
         state::{InactiveOrderState, OrderState, UnindexedOrderState},
     },
-    trade::Trade,
+    trade::{AssetFees, Trade},
 };
 use barter_instrument::{
-    asset::{AssetIndex, QuoteAsset, name::AssetNameExchange},
+    asset::{AssetIndex, name::AssetNameExchange},
     exchange::{ExchangeId, ExchangeIndex},
     index::error::IndexError,
     instrument::{InstrumentIndex, name::InstrumentNameExchange},
@@ -287,10 +287,21 @@ impl AccountEventIndexer {
         })
     }
 
+    /// Index a trade, converting fee asset and computing `fees_quote`.
+    ///
+    /// Computes `fees_quote` based on fee asset relationship to instrument:
+    /// - Fee in quote asset: `fees_quote = Some(fees)`
+    /// - Fee in base asset: `fees_quote = Some(fees * price)`
+    /// - Fee in third-party asset (e.g., BNB): `fees_quote = None`
+    ///
+    /// # Errors
+    /// Returns `IndexError` if fee asset is not in the map. Some integrations use
+    /// "UNKNOWN" as a placeholder when fee data is unavailable (e.g., IBKR `fetch_trades`,
+    /// Binance when API omits `commission_asset`). These trades will fail indexing.
     pub fn trade(
         &self,
-        trade: Trade<QuoteAsset, InstrumentNameExchange>,
-    ) -> Result<Trade<QuoteAsset, InstrumentIndex>, IndexError> {
+        trade: Trade<AssetNameExchange, InstrumentNameExchange>,
+    ) -> Result<Trade<AssetIndex, InstrumentIndex>, IndexError> {
         let Trade {
             id,
             order_id,
@@ -298,12 +309,31 @@ impl AccountEventIndexer {
             strategy,
             time_exchange,
             side,
-            price,
+            price: trade_price,
             quantity,
             fees,
         } = trade;
 
         let instrument_index = self.map.find_instrument_index(&instrument)?;
+        let fee_asset_index = self.map.find_asset_index(&fees.asset)?;
+
+        // Compute fees_quote based on fee asset relationship to instrument
+        let fees_quote = self
+            .map
+            .instruments
+            .get_index(instrument_index.index())
+            .and_then(|instr| {
+                if fee_asset_index == instr.underlying.quote {
+                    // Fee is in quote asset — no conversion needed
+                    Some(fees.fees)
+                } else if fee_asset_index == instr.underlying.base {
+                    // Fee is in base asset — convert using trade price
+                    Some(fees.fees * trade_price)
+                } else {
+                    // Fee is in third-party asset (e.g., BNB) — needs external price
+                    None
+                }
+            });
 
         Ok(Trade {
             id,
@@ -312,9 +342,13 @@ impl AccountEventIndexer {
             strategy,
             time_exchange,
             side,
-            price,
+            price: trade_price,
             quantity,
-            fees,
+            fees: AssetFees {
+                asset: fee_asset_index,
+                fees: fees.fees,
+                fees_quote,
+            },
         })
     }
 }

--- a/barter-execution/src/indexer.rs
+++ b/barter-execution/src/indexer.rs
@@ -150,23 +150,7 @@ impl AccountEventIndexer {
         } = order;
 
         let key = self.order_key(key)?;
-
-        let state = match state {
-            UnindexedOrderState::Active(active) => OrderState::Active(active),
-            UnindexedOrderState::Inactive(inactive) => match inactive {
-                InactiveOrderState::OpenFailed(failed) => match failed {
-                    OrderError::Rejected(rejected) => {
-                        OrderState::inactive(OrderError::Rejected(self.api_error(rejected)?))
-                    }
-                    OrderError::Connectivity(error) => {
-                        OrderState::inactive(OrderError::Connectivity(error))
-                    }
-                },
-                InactiveOrderState::Cancelled(cancelled) => OrderState::inactive(cancelled),
-                InactiveOrderState::FullyFilled => OrderState::fully_filled(),
-                InactiveOrderState::Expired => OrderState::expired(),
-            },
-        };
+        let state = self.order_state(state)?;
 
         Ok(Order {
             key,
@@ -207,6 +191,28 @@ impl AccountEventIndexer {
             instrument: self.map.find_instrument_index(&instrument)?,
             strategy,
             cid,
+        })
+    }
+
+    /// Index an [`UnindexedOrderState`] to an [`OrderState`].
+    ///
+    /// Used by [`ExecutionManager`] to index `open_order` responses.
+    pub fn order_state(&self, state: UnindexedOrderState) -> Result<OrderState, IndexError> {
+        Ok(match state {
+            UnindexedOrderState::Active(active) => OrderState::Active(active),
+            UnindexedOrderState::Inactive(inactive) => match inactive {
+                InactiveOrderState::OpenFailed(failed) => match failed {
+                    OrderError::Rejected(rejected) => {
+                        OrderState::inactive(OrderError::Rejected(self.api_error(rejected)?))
+                    }
+                    OrderError::Connectivity(error) => {
+                        OrderState::inactive(OrderError::Connectivity(error))
+                    }
+                },
+                InactiveOrderState::Cancelled(cancelled) => OrderState::inactive(cancelled),
+                InactiveOrderState::FullyFilled(filled) => OrderState::fully_filled(filled),
+                InactiveOrderState::Expired(expired) => OrderState::expired(expired),
+            },
         })
     }
 

--- a/barter-execution/src/lib.rs
+++ b/barter-execution/src/lib.rs
@@ -41,7 +41,7 @@ use crate::{
     trade::Trade,
 };
 use barter_instrument::{
-    asset::{AssetIndex, QuoteAsset, name::AssetNameExchange},
+    asset::{AssetIndex, name::AssetNameExchange},
     exchange::{ExchangeId, ExchangeIndex},
     instrument::{InstrumentIndex, name::InstrumentNameExchange},
 };
@@ -115,7 +115,11 @@ pub enum AccountEventKind<ExchangeKey, AssetKey, InstrumentKey> {
     OrderCancelled(OrderResponseCancel<ExchangeKey, AssetKey, InstrumentKey>),
 
     /// [`Order<ExchangeKey, InstrumentKey, Open>`] partial or full-fill.
-    Trade(Trade<QuoteAsset, InstrumentKey>),
+    ///
+    /// The fee asset (`AssetKey`) may be the quote asset, base asset, or a third-party
+    /// asset (e.g., BNB on Binance). Use `fees.fees_quote` for quote-equivalent value
+    /// when available.
+    Trade(Trade<AssetKey, InstrumentKey>),
 
     /// WebSocket-level error from exchange. Connection may have dropped.
     ///

--- a/barter-execution/src/order/state.rs
+++ b/barter-execution/src/order/state.rs
@@ -33,12 +33,12 @@ impl<AssetKey, InstrumentKey> OrderState<AssetKey, InstrumentKey> {
         OrderState::Inactive(state.into())
     }
 
-    pub fn fully_filled() -> Self {
-        Self::Inactive(InactiveOrderState::FullyFilled)
+    pub fn fully_filled(filled: Filled) -> Self {
+        Self::Inactive(InactiveOrderState::FullyFilled(filled))
     }
 
-    pub fn expired() -> Self {
-        Self::Inactive(InactiveOrderState::Expired)
+    pub fn expired(expired: Expired) -> Self {
+        Self::Inactive(InactiveOrderState::Expired(expired))
     }
 
     pub fn time_exchange(&self) -> Option<DateTime<Utc>> {
@@ -52,9 +52,29 @@ impl<AssetKey, InstrumentKey> OrderState<AssetKey, InstrumentKey> {
             },
             Self::Inactive(inactive) => match inactive {
                 InactiveOrderState::Cancelled(state) => Some(state.time_exchange),
-                _ => None,
+                InactiveOrderState::FullyFilled(state) => Some(state.time_exchange),
+                InactiveOrderState::Expired(state) => Some(state.time_exchange),
+                InactiveOrderState::OpenFailed(_) => None,
             },
         }
+    }
+
+    /// Returns `true` if the order was not rejected at placement.
+    ///
+    /// Returns `true` for all states except `Inactive(OpenFailed(_))`:
+    /// - `Active(_)` — order is working on the exchange
+    /// - `Inactive(FullyFilled(_))` — order completed successfully
+    /// - `Inactive(Cancelled(_))` — order was accepted then cancelled
+    /// - `Inactive(Expired(_))` — order was accepted then expired
+    ///
+    /// This is the opposite of [`is_failed()`](Self::is_failed).
+    pub fn is_accepted(&self) -> bool {
+        !self.is_failed()
+    }
+
+    /// Returns `true` if the order failed to open.
+    pub fn is_failed(&self) -> bool {
+        matches!(self, Self::Inactive(InactiveOrderState::OpenFailed(_)))
     }
 }
 
@@ -93,6 +113,24 @@ impl Open {
     }
 }
 
+/// Metadata for a fully filled order.
+///
+/// Unlike [`Open`], this represents an order that has completed execution
+/// and is no longer active on the exchange.
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
+)]
+pub struct Filled {
+    pub id: OrderId,
+    pub time_exchange: DateTime<Utc>,
+    pub filled_quantity: Decimal,
+    /// Volume-weighted average execution price across all fills.
+    ///
+    /// `Some` when the exchange provides it in the response, `None` otherwise.
+    /// When `None`, downstream consumers should compute from individual fill events.
+    pub avg_price: Option<Decimal>,
+}
+
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize, Constructor,
 )]
@@ -103,15 +141,38 @@ pub struct CancelInFlight {
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, From)]
 pub enum InactiveOrderState<AssetKey, InstrumentKey> {
     Cancelled(Cancelled),
-    FullyFilled,
+    FullyFilled(Filled),
     OpenFailed(OrderError<AssetKey, InstrumentKey>),
-    Expired,
+    Expired(Expired),
 }
 
+/// Metadata for a cancelled order.
+///
+/// Includes `filled_quantity` to handle IOC (Immediate-Or-Cancel) orders
+/// that partially fill before the remainder is cancelled.
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
 )]
 pub struct Cancelled {
     pub id: OrderId,
     pub time_exchange: DateTime<Utc>,
+    /// Quantity filled before the order was cancelled.
+    ///
+    /// Zero for orders cancelled with no fills (e.g., GTC limit order cancelled by user).
+    /// Non-zero for IOC orders that partially filled before cancellation.
+    pub filled_quantity: Decimal,
+}
+
+/// Metadata for an expired order.
+///
+/// Includes `filled_quantity` to handle GTD (Good-Till-Date) orders
+/// that partially fill before expiration.
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
+)]
+pub struct Expired {
+    pub id: OrderId,
+    pub time_exchange: DateTime<Utc>,
+    /// Quantity filled before the order expired.
+    pub filled_quantity: Decimal,
 }

--- a/barter-execution/src/trade.rs
+++ b/barter-execution/src/trade.rs
@@ -51,19 +51,36 @@ where
     }
 }
 
-#[derive(
-    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
-)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 pub struct AssetFees<AssetKey> {
     pub asset: AssetKey,
     pub fees: Decimal,
+    /// Fee value in quote currency when computable.
+    /// - `Some(fees)` if fee asset == quote asset
+    /// - `Some(fees * price)` if fee asset == base asset (computed by indexer)
+    /// - `None` if fee asset is third-party (e.g., BNB) — requires external price data
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fees_quote: Option<Decimal>,
+}
+
+impl<AssetKey> AssetFees<AssetKey> {
+    pub fn new(asset: AssetKey, fees: Decimal, fees_quote: Option<Decimal>) -> Self {
+        Self {
+            asset,
+            fees,
+            fees_quote,
+        }
+    }
 }
 
 impl AssetFees<QuoteAsset> {
+    /// Construct fees already denominated in quote asset.
+    /// Sets `fees_quote = Some(fees)` since no conversion needed.
     pub fn quote_fees(fees: Decimal) -> Self {
         Self {
             asset: QuoteAsset,
             fees,
+            fees_quote: Some(fees),
         }
     }
 }
@@ -73,6 +90,7 @@ impl Default for AssetFees<QuoteAsset> {
         Self {
             asset: QuoteAsset,
             fees: Decimal::ZERO,
+            fees_quote: Some(Decimal::ZERO),
         }
     }
 }
@@ -82,6 +100,7 @@ impl<AssetKey> Default for AssetFees<Option<AssetKey>> {
         Self {
             asset: None,
             fees: Decimal::ZERO,
+            fees_quote: None,
         }
     }
 }

--- a/barter-execution/tests/hyperliquid_execution.rs
+++ b/barter-execution/tests/hyperliquid_execution.rs
@@ -41,6 +41,7 @@ use barter_execution::{
         OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::RequestOpen,
+        state::{ActiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -364,7 +365,7 @@ async fn test_place_and_cancel_limit_order() {
     let response = response.unwrap();
 
     match &response.state {
-        Ok(open_state) => {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
             println!("Order placed successfully!");
             println!("  Client Order ID: {}", response.key.cid);
             println!("  Exchange Order ID: {}", open_state.id);
@@ -403,8 +404,11 @@ async fn test_place_and_cancel_limit_order() {
                 }
             }
         }
-        Err(e) => {
+        OrderState::Inactive(e) => {
             panic!("Order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
         }
     }
 }
@@ -522,12 +526,12 @@ async fn test_account_stream_with_order() {
     let response = response.unwrap();
 
     let order_id = match &response.state {
-        Ok(open_state) => {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
             println!("Order placed: {}", open_state.id);
             Some(open_state.id.clone())
         }
-        Err(e) => {
-            println!("Order failed (may still get stream events): {:?}", e);
+        other => {
+            println!("Order failed (may still get stream events): {:?}", other);
             None
         }
     };

--- a/barter-execution/tests/ibkr_execution.rs
+++ b/barter-execution/tests/ibkr_execution.rs
@@ -24,6 +24,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Integration tests: panics are the correct failure mode
 
 use barter_execution::{
+    AccountEventKind,
     client::{
         ExecutionClient,
         ibkr::{IbkrClient, IbkrConfig, contract::stock_contract},
@@ -32,7 +33,7 @@ use barter_execution::{
         OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::RequestOpen,
-        state::{ActiveOrderState, OrderState},
+        state::{ActiveOrderState, InactiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -500,4 +501,141 @@ async fn test_cancel_nonexistent_order() {
         "Expected rejection for nonexistent order"
     );
     println!("Cancel correctly rejected: {:?}", response.state.err());
+}
+
+// ============================================================================
+// Cancelled vs Expired Differentiation Tests
+// ============================================================================
+
+/// Verifies that user-initiated cancel produces `Cancelled` state, not `Expired`.
+///
+/// This tests the pending_cancels tracking in `make_order_from_status`:
+/// - DAY orders cancelled by user → Cancelled (tracked in pending_cancels)
+/// - DAY orders expired at market close → Expired (not in pending_cancels)
+#[tokio::test]
+#[ignore]
+async fn test_cancel_produces_cancelled_not_expired() {
+    init_logging();
+
+    let config = test_config(11);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let assets: Vec<AssetNameExchange> = vec![];
+    let instruments: Vec<InstrumentNameExchange> = vec![];
+
+    // Start account stream to observe order state changes
+    let mut stream = client
+        .account_stream(&assets, &instruments)
+        .await
+        .expect("account_stream failed");
+
+    // Place a DAY order at $1 (won't fill)
+    let strategy = StrategyId::new("test-cancel-vs-expire");
+    let order_cid = ClientOrderId::new(format!(
+        "cancel-test-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    let request_open = RequestOpen {
+        side: Side::Buy,
+        price: dec!(1.00),
+        quantity: dec!(1),
+        kind: OrderKind::Limit,
+        time_in_force: TimeInForce::GoodUntilEndOfDay, // DAY order - would be Expired if not cancelled
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = barter_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing DAY limit order: BUY 1 AAPL @ $1.00");
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    let exchange_order_id = match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Order placed: {:?}", open_state.id);
+            open_state.id.clone()
+        }
+        other => panic!("Expected Open state, got: {:?}", other),
+    };
+
+    // Brief delay before cancel
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Cancel the order (this adds to pending_cancels)
+    let cancel_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: response.key.strategy.clone(),
+        cid: response.key.cid.clone(),
+    };
+
+    let cancel_request = barter_execution::order::OrderEvent {
+        key: cancel_key,
+        state: barter_execution::order::request::RequestCancel {
+            id: Some(exchange_order_id.clone()),
+        },
+    };
+
+    println!("Cancelling order...");
+    let cancel_response = client.cancel_order(cancel_request).await;
+    assert!(cancel_response.is_some(), "Expected cancel response");
+
+    // Collect stream events and find the final order state
+    println!("Waiting for stream to emit Cancelled state...");
+    let mut found_cancelled = false;
+    let mut found_expired = false;
+
+    let timeout_result = tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(event) = stream.next().await {
+            if let AccountEventKind::OrderSnapshot(snapshot) = &event.kind {
+                let order = snapshot.value();
+                // Match on order ID to find our order
+                if order.key.cid == order_cid {
+                    println!("Order event: {:?}", order.state);
+                    match &order.state {
+                        OrderState::Inactive(InactiveOrderState::Cancelled(_)) => {
+                            found_cancelled = true;
+                            break;
+                        }
+                        OrderState::Inactive(InactiveOrderState::Expired(_)) => {
+                            found_expired = true;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    })
+    .await;
+
+    if timeout_result.is_err() {
+        println!("Timeout waiting for order state (this may happen if stream doesn't emit)");
+    }
+
+    // The key assertion: user cancel should produce Cancelled, not Expired
+    if found_cancelled {
+        println!("SUCCESS: Order state is Cancelled (correct for user-initiated cancel)");
+    } else if found_expired {
+        panic!("FAILURE: Order state is Expired (should be Cancelled for user-initiated cancel)");
+    } else {
+        println!("WARNING: No terminal state observed in stream (cancel_order response was OK)");
+    }
 }

--- a/barter-execution/tests/ibkr_execution.rs
+++ b/barter-execution/tests/ibkr_execution.rs
@@ -32,6 +32,7 @@ use barter_execution::{
         OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, StrategyId},
         request::RequestOpen,
+        state::{ActiveOrderState, OrderState},
     },
 };
 use barter_instrument::{
@@ -264,7 +265,7 @@ async fn test_place_and_cancel_limit_order() {
     let response = response.unwrap();
 
     match &response.state {
-        Ok(open_state) => {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
             println!("Order placed successfully!");
             println!("  Client Order ID: {}", response.key.cid);
             println!("  Exchange Order ID: {:?}", open_state.id);
@@ -302,8 +303,11 @@ async fn test_place_and_cancel_limit_order() {
                 }
             }
         }
-        Err(e) => {
+        OrderState::Inactive(e) => {
             panic!("Order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
         }
     }
 }
@@ -456,10 +460,10 @@ async fn test_order_without_registered_contract() {
     let response = response.unwrap();
 
     assert!(
-        response.state.is_err(),
+        response.state.is_failed(),
         "Expected rejection for unregistered contract"
     );
-    println!("Order correctly rejected: {:?}", response.state.err());
+    println!("Order correctly rejected: {:?}", response.state);
 }
 
 #[tokio::test]

--- a/barter/examples/statistical_trading_summary.rs
+++ b/barter/examples/statistical_trading_summary.rs
@@ -144,10 +144,12 @@ fn generate_synthetic_updates(base_time: DateTime<Utc>) -> Vec<ContrivedEvents> 
             fees_enter: AssetFees {
                 asset: QuoteAsset,
                 fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
             },
             fees_exit: AssetFees {
                 asset: QuoteAsset,
                 fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
             },
             time_enter: base_time.checked_add_days(Days::new(1)).unwrap(),
             time_exit: base_time.checked_add_days(Days::new(2)).unwrap(),

--- a/barter/src/engine/mod.rs
+++ b/barter/src/engine/mod.rs
@@ -37,7 +37,7 @@ use barter_execution::{
 };
 use barter_instrument::{
     Side,
-    asset::QuoteAsset,
+    asset::AssetIndex,
     exchange::ExchangeIndex,
     instrument::{InstrumentIndex, kind::option::OptionKind},
 };
@@ -385,7 +385,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     pub fn process_contract_expiry(
         &mut self,
         key: &InstrumentIndex,
-    ) -> Vec<PositionExited<QuoteAsset, InstrumentIndex>>
+    ) -> Vec<PositionExited<AssetIndex, InstrumentIndex>>
     where
         Clock: EngineClock,
         InstrumentData: InstrumentDataState + InFlightRequestRecorder,
@@ -553,6 +553,8 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                 pos_id,
                 engine_time.timestamp_micros()
             );
+            // Use the instrument's quote asset for fee tracking (amount is zero)
+            let quote_asset = instrument_state.instrument.underlying.quote;
             let settlement_trade = Trade {
                 id: TradeId::new(&trade_tag),
                 order_id: barter_execution::order::id::OrderId::new(&trade_tag),
@@ -563,8 +565,9 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                 price: settlement_price,
                 quantity: closing_quantity,
                 fees: AssetFees {
-                    asset: QuoteAsset,
+                    asset: quote_asset,
                     fees: Decimal::ZERO,
+                    fees_quote: Some(Decimal::ZERO),
                 },
             };
 
@@ -664,7 +667,7 @@ pub enum EngineOutput<
     Commanded(ActionOutput<ExchangeKey, InstrumentKey>),
     OnTradingDisabled(OnTradingDisabled),
     AccountDisconnect(OnDisconnect),
-    PositionExit(PositionExited<QuoteAsset, InstrumentKey>),
+    PositionExit(PositionExited<AssetIndex, InstrumentKey>),
     MarketDisconnect(OnDisconnect),
     AlgoOrders(GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>),
 }
@@ -680,10 +683,11 @@ pub enum UpdateTradingStateOutput<OnTradingDisabled> {
 /// Output produced by the [`Engine`] updating from an [`AccountStreamEvent`], used to construct
 /// an `Engine` [`EngineAudit`].
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)] // PositionExit is rare; avoiding Box keeps API simple
 pub enum UpdateFromAccountOutput<OnDisconnect, InstrumentKey = InstrumentIndex> {
     None,
     OnDisconnect(OnDisconnect),
-    PositionExit(PositionExited<QuoteAsset, InstrumentKey>),
+    PositionExit(PositionExited<AssetIndex, InstrumentKey>),
 }
 
 /// Output produced by the [`Engine`] updating from an [`MarketStreamEvent`], used to construct
@@ -704,10 +708,10 @@ impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
 }
 
 impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
-    From<PositionExited<QuoteAsset, InstrumentKey>>
+    From<PositionExited<AssetIndex, InstrumentKey>>
     for EngineOutput<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
 {
-    fn from(value: PositionExited<QuoteAsset, InstrumentKey>) -> Self {
+    fn from(value: PositionExited<AssetIndex, InstrumentKey>) -> Self {
         Self::PositionExit(value)
     }
 }

--- a/barter/src/engine/state/instrument/mod.rs
+++ b/barter/src/engine/state/instrument/mod.rs
@@ -19,7 +19,7 @@ use barter_execution::{
 };
 use barter_instrument::{
     Keyed,
-    asset::{AssetIndex, QuoteAsset, name::AssetNameExchange},
+    asset::{AssetIndex, name::AssetNameExchange},
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
     instrument::{
@@ -262,7 +262,7 @@ pub struct InstrumentState<
     pub tear_sheet: TearSheetGenerator,
 
     /// Current `PositionManager`.
-    pub position: PositionManager<InstrumentKey>,
+    pub position: PositionManager<AssetKey, InstrumentKey>,
 
     /// Active orders and associated order management.
     pub orders: Orders<ExchangeKey, InstrumentKey>,
@@ -321,7 +321,7 @@ pub struct InstrumentState<
     /// In `OmsMode::Netting` this field is always empty (netting positions use a fixed key;
     /// fill-before-ack does not cause split slots).
     #[serde(default = "Vec::new")]
-    pub pending_fills: Vec<Trade<QuoteAsset, InstrumentKey>>,
+    pub pending_fills: Vec<Trade<AssetKey, InstrumentKey>>,
 
     /// Reverse index: exchange `OrderId` → `ClientOrderId` for O(1) fill routing in
     /// `OmsMode::Hedging`.
@@ -412,7 +412,7 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
     pub fn update_from_order_snapshot(
         &mut self,
         order: Snapshot<&Order<ExchangeKey, InstrumentKey, OrderState<AssetKey, InstrumentKey>>>,
-    ) -> Option<PositionExited<QuoteAsset, InstrumentKey>>
+    ) -> Option<PositionExited<AssetKey, InstrumentKey>>
     where
         ExchangeKey: Debug + Clone,
         AssetKey: Debug + Clone,
@@ -478,7 +478,7 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
             if !self.pending_fills.is_empty() {
                 // Collect matching fills first to avoid borrow-checker conflict
                 // between pending_fills drain and update_from_trade's &mut self.
-                let deferred: Vec<Trade<QuoteAsset, InstrumentKey>> = self
+                let deferred: Vec<Trade<AssetKey, InstrumentKey>> = self
                     .pending_fills
                     .iter()
                     .filter(|f| f.order_id == exchange_id)
@@ -594,9 +594,10 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
     /// positions explicitly rather than rely on flip semantics.
     pub fn update_from_trade(
         &mut self,
-        trade: &Trade<QuoteAsset, InstrumentKey>,
-    ) -> Option<PositionExited<QuoteAsset, InstrumentKey>>
+        trade: &Trade<AssetKey, InstrumentKey>,
+    ) -> Option<PositionExited<AssetKey, InstrumentKey>>
     where
+        AssetKey: Debug + Clone,
         InstrumentKey: Debug + Clone + PartialEq,
     {
         // Step 1: Resolve PositionId.
@@ -719,6 +720,8 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
                 fees: barter_execution::trade::AssetFees {
                     asset: trade.fees.asset.clone(),
                     fees: trade.fees.fees + computed_fee,
+                    // computed_fee is in quote terms; add to fees_quote if available
+                    fees_quote: trade.fees.fees_quote.map(|fq| fq + computed_fee),
                 },
                 ..trade.clone()
             };

--- a/barter/src/engine/state/mod.rs
+++ b/barter/src/engine/state/mod.rs
@@ -18,7 +18,7 @@ use barter_execution::{
 };
 use barter_instrument::{
     Keyed,
-    asset::{AssetIndex, QuoteAsset},
+    asset::AssetIndex,
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
     instrument::{Instrument, InstrumentIndex},
@@ -104,7 +104,7 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
     pub fn update_from_account(
         &mut self,
         event: &AccountEvent,
-    ) -> Option<PositionExited<QuoteAsset>>
+    ) -> Option<PositionExited<AssetIndex>>
     where
         GlobalData: for<'a> Processor<&'a AccountEvent>,
         InstrumentData: for<'a> Processor<&'a AccountEvent>,

--- a/barter/src/engine/state/order/mod.rs
+++ b/barter/src/engine/state/order/mod.rs
@@ -414,7 +414,9 @@ mod tests {
             Order, OrderKey, OrderKind, TimeInForce,
             id::{ClientOrderId, OrderId, StrategyId},
             request::{RequestCancel, RequestOpen},
-            state::{ActiveOrderState, CancelInFlight, Cancelled, Open, OpenInFlight},
+            state::{
+                ActiveOrderState, CancelInFlight, Cancelled, Expired, Filled, Open, OpenInFlight,
+            },
         },
     };
     use barter_instrument::{Side, exchange::ExchangeId};
@@ -475,6 +477,7 @@ mod tests {
             state: OrderState::inactive(Cancelled {
                 id: OrderId(SmolStr::default()),
                 time_exchange: Default::default(),
+                filled_quantity: Default::default(),
             }),
         })
     }
@@ -494,7 +497,12 @@ mod tests {
             quantity: Default::default(),
             kind: OrderKind::Market,
             time_in_force: TimeInForce::GoodUntilEndOfDay,
-            state: OrderState::fully_filled(),
+            state: OrderState::fully_filled(Filled::new(
+                OrderId(SmolStr::default()),
+                DateTime::<Utc>::MIN_UTC,
+                Default::default(),
+                None,
+            )),
         })
     }
 
@@ -532,7 +540,11 @@ mod tests {
             quantity: Default::default(),
             kind: OrderKind::Market,
             time_in_force: TimeInForce::GoodUntilEndOfDay,
-            state: OrderState::expired(),
+            state: OrderState::expired(Expired::new(
+                OrderId(SmolStr::default()),
+                DateTime::<Utc>::MIN_UTC,
+                Default::default(),
+            )),
         })
     }
 
@@ -616,6 +628,7 @@ mod tests {
             state: Ok(Cancelled {
                 id: OrderId(SmolStr::default()),
                 time_exchange: DateTime::<Utc>::MIN_UTC,
+                filled_quantity: Default::default(),
             }),
         }
     }

--- a/barter/src/engine/state/position.rs
+++ b/barter/src/engine/state/position.rs
@@ -1,10 +1,6 @@
 pub use barter_execution::order::id::PositionId;
 use barter_execution::trade::{AssetFees, Trade, TradeId};
-use barter_instrument::{
-    Side,
-    asset::{AssetIndex, QuoteAsset},
-    instrument::InstrumentIndex,
-};
+use barter_instrument::{Side, asset::AssetIndex, instrument::InstrumentIndex};
 use chrono::{DateTime, Utc};
 use derive_more::Constructor;
 use indexmap::IndexMap;
@@ -36,19 +32,19 @@ pub enum OmsMode {
 /// - `Netting` (default): at most one entry; same flip/close logic as before.
 /// - `Hedging`: multiple concurrent entries, keyed by `PositionId`.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct PositionManager<InstrumentKey = InstrumentIndex> {
+pub struct PositionManager<AssetKey = AssetIndex, InstrumentKey = InstrumentIndex> {
     pub mode: OmsMode,
     /// All currently open positions keyed by `PositionId`.
-    pub positions: IndexMap<PositionId, Position<QuoteAsset, InstrumentKey>>,
+    pub positions: IndexMap<PositionId, Position<AssetKey, InstrumentKey>>,
 }
 
-impl<InstrumentKey> Default for PositionManager<InstrumentKey> {
+impl<AssetKey, InstrumentKey> Default for PositionManager<AssetKey, InstrumentKey> {
     fn default() -> Self {
         Self::new(OmsMode::Netting)
     }
 }
 
-impl<InstrumentKey> PositionManager<InstrumentKey> {
+impl<AssetKey, InstrumentKey> PositionManager<AssetKey, InstrumentKey> {
     /// Construct a new `PositionManager` with the given OMS mode and no open positions.
     pub fn new(mode: OmsMode) -> Self {
         // Pre-allocate capacity for 1 entry in Netting mode (the common case).
@@ -61,7 +57,7 @@ impl<InstrumentKey> PositionManager<InstrumentKey> {
     }
 }
 
-impl<InstrumentKey> PositionManager<InstrumentKey> {
+impl<AssetKey: Debug + Clone, InstrumentKey> PositionManager<AssetKey, InstrumentKey> {
     /// Updates the current position state based on a new trade.
     ///
     /// This method handles:
@@ -88,9 +84,9 @@ impl<InstrumentKey> PositionManager<InstrumentKey> {
     /// * `contract_size` - Contract multiplier for derivatives (1 for spot, 100 for standard options)
     pub fn update_from_trade(
         &mut self,
-        trade: &Trade<QuoteAsset, InstrumentKey>,
+        trade: &Trade<AssetKey, InstrumentKey>,
         contract_size: Decimal,
-    ) -> Option<PositionExited<QuoteAsset, InstrumentKey>>
+    ) -> Option<PositionExited<AssetKey, InstrumentKey>>
     where
         InstrumentKey: Debug + Clone + PartialEq,
     {
@@ -121,10 +117,10 @@ impl<InstrumentKey> PositionManager<InstrumentKey> {
     /// settlement commission, if any, is not modelled and must be tracked separately).
     pub fn update_from_trade_with_id(
         &mut self,
-        trade: &Trade<QuoteAsset, InstrumentKey>,
+        trade: &Trade<AssetKey, InstrumentKey>,
         position_id: &PositionId,
         contract_size: Decimal,
-    ) -> Option<PositionExited<QuoteAsset, InstrumentKey>>
+    ) -> Option<PositionExited<AssetKey, InstrumentKey>>
     where
         InstrumentKey: Debug + Clone + PartialEq,
     {
@@ -355,7 +351,7 @@ fn default_contract_size() -> Decimal {
     Decimal::ONE
 }
 
-impl<InstrumentKey> Position<QuoteAsset, InstrumentKey> {
+impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// Updates the [`Position`] state based on a new [`Trade`].
     ///
     /// This method handles various scenarios:
@@ -373,12 +369,13 @@ impl<InstrumentKey> Position<QuoteAsset, InstrumentKey> {
     /// - `Option<PositionExited>`: The closed [`PositionExited`], if the [`Position`] was closed.
     pub fn update_from_trade(
         mut self,
-        trade: &Trade<QuoteAsset, InstrumentKey>,
+        trade: &Trade<AssetKey, InstrumentKey>,
     ) -> (
         Option<Self>,
-        Option<PositionExited<QuoteAsset, InstrumentKey>>,
+        Option<PositionExited<AssetKey, InstrumentKey>>,
     )
     where
+        AssetKey: Debug + Clone,
         InstrumentKey: Debug + Clone + PartialEq,
     {
         // Sanity check
@@ -403,8 +400,18 @@ impl<InstrumentKey> Position<QuoteAsset, InstrumentKey> {
                 if self.quantity_abs > self.quantity_abs_max {
                     self.quantity_abs_max = self.quantity_abs;
                 }
-                self.pnl_realised -= trade.fees.fees;
+                // Use fees_quote when computable; falls back to raw fees.fees only for
+                // third-party fee assets (e.g., BNB) where the indexer cannot derive a
+                // quote-equivalent. Downstream is responsible for applying a converted
+                // fee impact when accurate quote-denominated P&L is required for those
+                // assets (see `AssetFees::fees_quote` doc).
+                self.pnl_realised -= trade.fees.fees_quote.unwrap_or(trade.fees.fees);
                 self.fees_enter.fees += trade.fees.fees;
+                self.fees_enter.fees_quote =
+                    match (self.fees_enter.fees_quote, trade.fees.fees_quote) {
+                        (Some(a), Some(b)) => Some(a + b),
+                        _ => None,
+                    };
                 self.time_exchange_update = trade.time_exchange;
                 self.update_pnl_unrealised(trade.price);
 
@@ -412,12 +419,19 @@ impl<InstrumentKey> Position<QuoteAsset, InstrumentKey> {
             }
             // Reduce LONG/SHORT Position
             (Buy, Sell) | (Sell, Buy) if self.quantity_abs > trade.quantity.abs() => {
-                // Update pnl_realised
-                self.update_pnl_realised(trade.quantity, trade.price, trade.fees.fees);
+                // Use quote-equivalent fee for P&L; fall back to raw fees.fees for
+                // third-party fee assets (caller must layer their own conversion).
+                let closed_fee_quote = trade.fees.fees_quote.unwrap_or(trade.fees.fees);
+                self.update_pnl_realised(trade.quantity, trade.price, closed_fee_quote);
 
                 // Update remaining Position state
                 self.quantity_abs -= trade.quantity.abs();
                 self.fees_exit.fees += trade.fees.fees;
+                self.fees_exit.fees_quote = match (self.fees_exit.fees_quote, trade.fees.fees_quote)
+                {
+                    (Some(a), Some(b)) => Some(a + b),
+                    _ => None,
+                };
                 self.time_exchange_update = trade.time_exchange;
 
                 // Update pnl_unrealised for remaining Position
@@ -429,8 +443,14 @@ impl<InstrumentKey> Position<QuoteAsset, InstrumentKey> {
             (Buy, Sell) | (Sell, Buy) if self.quantity_abs == trade.quantity.abs() => {
                 self.quantity_abs -= trade.quantity.abs();
                 self.fees_exit.fees += trade.fees.fees;
+                self.fees_exit.fees_quote = match (self.fees_exit.fees_quote, trade.fees.fees_quote)
+                {
+                    (Some(a), Some(b)) => Some(a + b),
+                    _ => None,
+                };
                 self.time_exchange_update = trade.time_exchange;
-                self.update_pnl_realised(trade.quantity, trade.price, trade.fees.fees);
+                let closed_fee_quote = trade.fees.fees_quote.unwrap_or(trade.fees.fees);
+                self.update_pnl_realised(trade.quantity, trade.price, closed_fee_quote);
                 self.update_pnl_unrealised(trade.price);
 
                 (None, Some(PositionExited::from(self)))
@@ -454,14 +474,30 @@ impl<InstrumentKey> Position<QuoteAsset, InstrumentKey> {
                     fees: AssetFees {
                         asset: trade.fees.asset.clone(),
                         fees: next_position_fee_enter,
+                        fees_quote: trade
+                            .fees
+                            .fees_quote
+                            .map(|fq| fq * (next_position_quantity / trade.quantity.abs())),
                     },
                 };
 
                 // Update closing Position with appropriate ratio of fees for theoretical quantity
                 let fee_exit = trade.fees.fees * (self.quantity_abs / trade.quantity.abs());
+                let fee_exit_quote = trade
+                    .fees
+                    .fees_quote
+                    .map(|fq| fq * (self.quantity_abs / trade.quantity.abs()));
                 self.fees_exit.fees += fee_exit;
+                self.fees_exit.fees_quote = match (self.fees_exit.fees_quote, fee_exit_quote) {
+                    (Some(a), Some(b)) => Some(a + b),
+                    _ => None,
+                };
                 self.time_exchange_update = trade.time_exchange;
-                self.update_pnl_realised(self.quantity_abs, trade.price, fee_exit);
+                self.update_pnl_realised(
+                    self.quantity_abs,
+                    trade.price,
+                    fee_exit_quote.unwrap_or(fee_exit),
+                );
                 self.quantity_abs = Decimal::ZERO;
                 self.update_pnl_unrealised(trade.price);
 
@@ -478,7 +514,7 @@ impl<InstrumentKey> Position<QuoteAsset, InstrumentKey> {
     /// Updates the volume-weighted average entry price of the [`Position`].
     ///
     /// Internally uses the logic defined in [`calculate_price_entry_average`].
-    fn update_price_entry_average(&mut self, trade: &Trade<QuoteAsset, InstrumentKey>) {
+    fn update_price_entry_average(&mut self, trade: &Trade<AssetKey, InstrumentKey>) {
         self.price_entry_average = calculate_price_entry_average(
             self.price_entry_average,
             self.quantity_abs,
@@ -523,11 +559,13 @@ impl<InstrumentKey> Position<QuoteAsset, InstrumentKey> {
     }
 }
 
-impl<InstrumentKey> From<&Trade<QuoteAsset, InstrumentKey>> for Position<QuoteAsset, InstrumentKey>
+impl<AssetKey, InstrumentKey> From<&Trade<AssetKey, InstrumentKey>>
+    for Position<AssetKey, InstrumentKey>
 where
+    AssetKey: Clone,
     InstrumentKey: Clone,
 {
-    fn from(trade: &Trade<QuoteAsset, InstrumentKey>) -> Self {
+    fn from(trade: &Trade<AssetKey, InstrumentKey>) -> Self {
         let mut trades = Vec::with_capacity(2);
         trades.push(trade.id.clone());
         Self {
@@ -537,9 +575,9 @@ where
             quantity_abs: trade.quantity.abs(),
             quantity_abs_max: trade.quantity.abs(),
             pnl_unrealised: Decimal::ZERO,
-            pnl_realised: -trade.fees.fees,
+            pnl_realised: -trade.fees.fees_quote.unwrap_or(trade.fees.fees),
             fees_enter: trade.fees.clone(),
-            fees_exit: AssetFees::default(),
+            fees_exit: AssetFees::new(trade.fees.asset.clone(), Decimal::ZERO, Some(Decimal::ZERO)),
             time_enter: trade.time_exchange,
             time_exchange_update: trade.time_exchange,
             trades,
@@ -736,7 +774,7 @@ pub fn calculate_pnl_return(
 mod tests {
     use super::*;
     use crate::test_utils::{time_plus_days, trade};
-    use barter_instrument::instrument::name::InstrumentNameInternal;
+    use barter_instrument::{asset::QuoteAsset, instrument::name::InstrumentNameInternal};
     use rust_decimal_macros::dec;
 
     #[test]
@@ -766,10 +804,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(20.0),
+                        fees_quote: Some(dec!(20.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(0.0),
+                        fees_quote: Some(dec!(0.0)),
                     },
                     time_enter: base_time,
                     time_exchange_update: time_plus_days(base_time, 1),
@@ -793,10 +833,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(5.0),
+                        fees_quote: Some(dec!(5.0)),
                     },
                     time_enter: base_time,
                     time_exchange_update: time_plus_days(base_time, 1),
@@ -820,10 +862,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     time_enter: base_time,
                     time_exit: time_plus_days(base_time, 1),
@@ -845,10 +889,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(0.0),
+                        fees_quote: Some(dec!(0.0)),
                     },
                     time_enter: time_plus_days(base_time, 1),
                     time_exchange_update: time_plus_days(base_time, 1),
@@ -865,10 +911,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     time_enter: base_time,
                     time_exit: time_plus_days(base_time, 1),
@@ -890,10 +938,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(20.0),
+                        fees_quote: Some(dec!(20.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(0.0),
+                        fees_quote: Some(dec!(0.0)),
                     },
                     time_enter: base_time,
                     time_exchange_update: base_time,
@@ -917,10 +967,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(5.0),
+                        fees_quote: Some(dec!(5.0)),
                     },
                     time_enter: base_time,
                     time_exchange_update: base_time,
@@ -944,10 +996,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     time_enter: base_time,
                     time_exit: base_time,
@@ -969,10 +1023,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(0.0),
+                        fees_quote: Some(dec!(0.0)),
                     },
                     time_enter: base_time,
                     time_exchange_update: base_time,
@@ -989,10 +1045,12 @@ mod tests {
                     fees_enter: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     fees_exit: AssetFees {
                         asset: QuoteAsset,
                         fees: dec!(10.0),
+                        fees_quote: Some(dec!(10.0)),
                     },
                     time_enter: base_time,
                     time_exit: base_time,

--- a/barter/src/execution/manager.rs
+++ b/barter/src/execution/manager.rs
@@ -10,7 +10,7 @@ use barter_data::streams::{
 use barter_execution::{
     AccountEvent, AccountEventKind,
     client::ExecutionClient,
-    error::{ConnectivityError, OrderError, UnindexedOrderError},
+    error::{ConnectivityError, OrderError},
     indexer::{AccountEventIndexer, IndexedAccountStream},
     map::ExecutionInstrumentMap,
     order::{
@@ -18,7 +18,7 @@ use barter_execution::{
         request::{
             OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, UnindexedOrderResponseCancel,
         },
-        state::{Open, OrderState},
+        state::{OrderState, UnindexedOrderState},
     },
 };
 use barter_instrument::{
@@ -375,7 +375,7 @@ where
 
     fn process_open_response(
         &self,
-        order: Order<ExchangeId, InstrumentNameExchange, Result<Open, UnindexedOrderError>>,
+        order: Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
     ) -> Result<AccountStreamEvent, IndexError> {
         let Order {
             key,
@@ -388,12 +388,7 @@ where
         } = order;
 
         let key = self.indexer.order_key(key)?;
-
-        let state = match state {
-            Ok(open) if open.quantity_remaining(quantity).is_zero() => OrderState::fully_filled(),
-            Ok(open) => OrderState::active(open),
-            Err(error) => OrderState::inactive(self.indexer.order_error(error)?),
-        };
+        let state = self.indexer.order_state(state)?;
 
         Ok(AccountStreamEvent::Item(AccountEvent {
             exchange: key.exchange,

--- a/barter/src/lib.rs
+++ b/barter/src/lib.rs
@@ -274,6 +274,7 @@ pub mod test_utils {
             fees: AssetFees {
                 asset: QuoteAsset,
                 fees: fees.try_into().unwrap(),
+                fees_quote: Some(fees.try_into().unwrap()),
             },
         }
     }

--- a/barter/tests/test_engine_process_engine_event_with_audit.rs
+++ b/barter/tests/test_engine_process_engine_event_with_audit.rs
@@ -96,6 +96,24 @@ const STARTING_BALANCE_ETH: Balance = Balance {
 };
 const QUOTE_FEES_PERCENT: f64 = 0.1; // 10%
 
+// Asset indices after alphabetical sorting: btc(0), eth(1), usdt(2)
+// For BTCUSDT (instrument 0): quote = usdt = AssetIndex(2)
+// For ETHBTC (instrument 1): quote = btc = AssetIndex(0)
+fn quote_asset_index(instrument: usize) -> AssetIndex {
+    match instrument {
+        0 => AssetIndex(2), // BTCUSDT → usdt
+        1 => AssetIndex(0), // ETHBTC → btc
+        other => panic!(
+            "quote_asset_index: unknown instrument index {other}; update test setup if a new instrument is added"
+        ),
+    }
+}
+
+/// Create AssetFees with proper AssetIndex (simulates quote-denominated fees)
+fn asset_fees(instrument: usize, amount: Decimal) -> AssetFees<AssetIndex> {
+    AssetFees::new(quote_asset_index(instrument), amount, Some(amount))
+}
+
 // Type alias to avoid clippy::type_complexity warnings in test helper functions
 type TestEngine = Engine<
     HistoricalClock,
@@ -468,8 +486,8 @@ fn test_engine_process_engine_event_with_audit() {
                 price_entry_average: dec!(10_000.0),
                 quantity_abs_max: dec!(1.0),
                 pnl_realised: dec!(7000.0), // (-10k entry - 1k fees)+(20k exit - 2k fees) = 7k
-                fees_enter: AssetFees::quote_fees(dec!(1_000.0)),
-                fees_exit: AssetFees::quote_fees(dec!(2_000.0)),
+                fees_enter: asset_fees(0, dec!(1_000.0)),
+                fees_exit: asset_fees(0, dec!(2_000.0)),
                 time_enter: time_plus_days(STARTING_TIMESTAMP, 2),
                 time_exit: time_plus_days(STARTING_TIMESTAMP, 3),
                 trades: vec![gen_trade_id(0), gen_trade_id(0)],
@@ -656,8 +674,8 @@ fn test_engine_process_engine_event_with_audit() {
                 price_entry_average: dec!(0.1),
                 quantity_abs_max: dec!(1.0),
                 pnl_realised: dec!(-0.065), // 0.05 - 0.01 - 0.01 entry fees - 0.005 exit fees
-                fees_enter: AssetFees::quote_fees(dec!(0.01)), // 0.01 btc
-                fees_exit: AssetFees::quote_fees(dec!(0.005)), // 0.005 btc
+                fees_enter: asset_fees(1, dec!(0.01)), // 0.01 btc
+                fees_exit: asset_fees(1, dec!(0.005)), // 0.005 btc
                 time_enter: time_plus_days(STARTING_TIMESTAMP, 2),
                 time_exit: time_plus_days(STARTING_TIMESTAMP, 5),
                 trades: vec![gen_trade_id(1), gen_trade_id(1)],
@@ -1034,7 +1052,8 @@ fn account_event_trade(
             side,
             price: Decimal::try_from(price).unwrap(),
             quantity: Decimal::try_from(quantity).unwrap(),
-            fees: AssetFees::quote_fees(
+            fees: asset_fees(
+                instrument,
                 Decimal::try_from(price * quantity * QUOTE_FEES_PERCENT).unwrap(),
             ),
         }),
@@ -1138,7 +1157,8 @@ fn open_option_position(engine: &mut TestEngine, quantity: f64, price: f64) {
             side: Side::Buy,
             price: Decimal::try_from(price).unwrap(),
             quantity: Decimal::try_from(quantity).unwrap(),
-            fees: AssetFees::quote_fees(Decimal::ZERO),
+            // Option instrument quote is USD = AssetIndex(1) in option engine
+            fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
         }),
     }));
     engine.process(event);
@@ -1464,7 +1484,8 @@ fn open_option_position_side(engine: &mut TestEngine, side: Side, quantity: f64,
             side,
             price: Decimal::try_from(price).unwrap(),
             quantity: Decimal::try_from(quantity).unwrap(),
-            fees: AssetFees::quote_fees(Decimal::ZERO),
+            // Put option instrument quote is USD = AssetIndex(1)
+            fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
         }),
     }));
     engine.process(event);
@@ -1706,7 +1727,8 @@ fn send_fill(
             side,
             price,
             quantity: dec!(1),
-            fees: AssetFees::quote_fees(Decimal::ZERO),
+            // Hedging option engine: quote is USD = AssetIndex(1)
+            fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
         }),
     }));
     engine.process(event);
@@ -1991,7 +2013,8 @@ fn test_fee_model_per_contract_augments_trade_fees() {
             side: Side::Buy,
             price: dec!(1_000),
             quantity: dec!(1),
-            fees: AssetFees::quote_fees(Decimal::ZERO), // Exchange reports zero commission
+            // Option engine: quote is USD = AssetIndex(1). Exchange reports zero commission.
+            fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
         }),
     }));
     engine.process(event);

--- a/barter/tests/test_engine_process_engine_event_with_audit.rs
+++ b/barter/tests/test_engine_process_engine_event_with_audit.rs
@@ -50,7 +50,7 @@ use barter_execution::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, PositionId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, OrderResponseCancel, RequestOpen},
-        state::{ActiveOrderState, Cancelled, Open, OrderState},
+        state::{ActiveOrderState, Cancelled, Filled, Open, OrderState},
     },
     trade::{AssetFees, Trade, TradeId},
 };
@@ -620,7 +620,12 @@ fn test_engine_process_engine_event_with_audit() {
             quantity: dec!(1),
             kind: OrderKind::Limit,
             time_in_force: TimeInForce::GoodUntilCancelled { post_only: true },
-            state: OrderState::fully_filled(),
+            state: OrderState::fully_filled(Filled::new(
+                OrderId::new("eth_btc_sell_order"),
+                time_plus_days(STARTING_TIMESTAMP, 4),
+                dec!(1),
+                None,
+            )),
         })),
     }));
     let audit = process_with_audit(&mut engine, event.clone());
@@ -1729,7 +1734,12 @@ fn send_fully_filled_snapshot(engine: &mut HedgingTestEngine, cid: ClientOrderId
             quantity: dec!(1),
             kind: OrderKind::Limit,
             time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
-            state: OrderState::fully_filled(),
+            state: OrderState::fully_filled(Filled::new(
+                OrderId::new("test_order"),
+                time_plus_days(STARTING_TIMESTAMP, 2),
+                dec!(1),
+                None,
+            )),
         })),
     }));
     engine.process(event);
@@ -2039,6 +2049,7 @@ fn send_cancel_ack(engine: &mut HedgingTestEngine, cid: ClientOrderId, exchange_
             state: Ok(Cancelled {
                 id: exchange_order_id,
                 time_exchange: time_plus_days(STARTING_TIMESTAMP, 1),
+                filled_quantity: dec!(0),
             }),
         }),
     }));


### PR DESCRIPTION
## Summary

- **Hyperliquid perpetuals integration**: Full market data (barter-data) and execution (barter-execution) support including WebSocket streaming, order management, and historical data
- **Order state metadata**: Terminal states now include `filled_quantity` and `avg_price` for proper position tracking
- **Authentication error detection**: `ExecutionError::Unauthenticated` variant for Alpaca, Binance, and Hyperliquid
- **Non-quote fee assets**: Track fees paid in non-quote assets with quote-equivalent values
- **IBKR improvements**: Differentiate cancelled vs expired order states

## Test plan

- [x] All existing tests pass
- [x] Integration tests for Hyperliquid data and execution (require API credentials)
- [x] IBKR order state tests updated