### PR TITLE
feat(hyperliquid): Add spot trading support to execution and market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Barter
 
 > **This is a public fork of [barter-rs/barter-rs](https://github.com/barter-rs/barter-rs).**
-> It adds execution clients for **Binance**, **Alpaca**, and **Hyperliquid**.
+> It adds execution clients for **Binance**, **Alpaca**, **Hyperliquid**, and **IBKR**.
 > For questions or discussion, please use [GitHub Discussions](https://github.com/Niqnil/barter-rs/discussions).
 
 Barter is an algorithmic trading ecosystem of Rust libraries for building high-performance live-trading, paper-trading
@@ -26,13 +26,13 @@ and back-testing systems. It is made up of several easy-to-use, extensible crate
 * **Barter**: Algorithmic trading Engine with feature rich state management system.
 * **Barter-Instrument**: Exchange, Instrument and Asset data structures and utilities.
 * **Barter-Data**: Stream public market data from financial venues. Easily extensible via the MarketStream interface.
-* **Barter-Execution**: Stream private account data and execute orders. Includes live clients for **Binance** (spot), **Alpaca** (equities, options, crypto), and **Hyperliquid** (perpetuals). Easily extensible via the ExecutionClient interface.
+* **Barter-Execution**: Stream private account data and execute orders. Includes live clients for **Binance** (spot), **Alpaca** (equities, options, crypto), **Hyperliquid** (spot, perpetuals), and **IBKR** (equities, futures, options, forex). Easily extensible via the ExecutionClient interface.
 * **Barter-Integration**: Low-level frameworks for flexible REST/WebSocket integrations.
 
 ## Notable Features
 - Stream public market data from financial venues via the [`Barter-Data`] library.
 - Stream private account data, execute orders (live or mock) via the [`Barter-Execution`] library.
-- Live execution clients for Binance (spot), Alpaca, and Hyperliquid (perpetuals).
+- Live execution clients for Binance (spot), Alpaca, Hyperliquid (spot, perpetuals), and IBKR.
 - Plug and play Strategy and RiskManager components that facilitate most trading strategies.
 - Backtest utilities for efficiently running thousands of concurrent backtests.
 - Flexible Engine that facilitates trading strategies that execute on many exchanges simultaneously.

--- a/barter-data/README.md
+++ b/barter-data/README.md
@@ -22,5 +22,7 @@ WebSocket integration library for streaming public market data from exchanges.
 | **Kraken** | `Kraken` | Spot | PublicTrades, OrderBooksL1 |
 | **Okx** | `Okx` | Spot, Future, Perpetual, Option | PublicTrades |
 | **Hyperliquid** | `Hyperliquid::default()` | Perpetual | PublicTrades, OrderBooksL2 |
+| **HyperliquidSpot** | `HyperliquidSpot::default()` | Spot | PublicTrades, OrderBooksL2 |
+| **IBKR** | `IbkrMarketStream::connect()` | Spot, Future, Option | PublicTrades, OrderBooksL1, OrderBooksL2, Candles |
 
 See the [workspace README](../README.md) for documentation, examples, and contributing guidelines.

--- a/barter-data/examples/hyperliquid_spot_market_data.rs
+++ b/barter-data/examples/hyperliquid_spot_market_data.rs
@@ -1,0 +1,114 @@
+//! Hyperliquid spot market data streaming example.
+//!
+//! Demonstrates how to subscribe to public trades and L2 order book snapshots
+//! from Hyperliquid spot markets. Exits after receiving a few events.
+//!
+//! Run with: `cargo run --example hyperliquid_spot_market_data --features hyperliquid`
+//!
+//! # Spot Market Subscriptions
+//!
+//! Hyperliquid spot uses `@{index}` format for WebSocket subscriptions.
+//! Use [`resolve_spot_pair`] to convert pair names to the required format:
+//!
+//! ```ignore
+//! let coin = resolve_spot_pair("hype", "usdc").await?; // "@107"
+//! ```
+
+// Example binary: panics are acceptable for demonstration code.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use barter_data::{
+    exchange::hyperliquid::{HyperliquidSpot, resolve_spot_pair},
+    streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscription::{book::OrderBooksL2, trade::PublicTrades},
+};
+use barter_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
+use futures_util::StreamExt;
+use tracing::{info, warn};
+
+const MAX_EVENTS: usize = 10;
+
+#[tokio::main]
+async fn main() {
+    init_logging();
+
+    info!("Subscribing to Hyperliquid SPOT market data...");
+
+    // Resolve pair name to @index format (fetches spotMeta on first call)
+    let hype_usdc = resolve_spot_pair("hype", "usdc")
+        .await
+        .expect("Failed to resolve HYPE/USDC spot pair");
+    info!("Resolved HYPE/USDC -> {}", hype_usdc);
+
+    // Subscribe to HYPE/USDC spot trades
+    let trades = Streams::<PublicTrades>::builder()
+        .subscribe([(
+            HyperliquidSpot,
+            hype_usdc.as_str(),
+            "usdc",
+            MarketDataInstrumentKind::Spot,
+            PublicTrades,
+        )])
+        .init()
+        .await
+        .unwrap();
+
+    // Subscribe to HYPE/USDC spot L2 order book
+    let books = Streams::<OrderBooksL2>::builder()
+        .subscribe([(
+            HyperliquidSpot,
+            hype_usdc.as_str(),
+            "usdc",
+            MarketDataInstrumentKind::Spot,
+            OrderBooksL2,
+        )])
+        .init()
+        .await
+        .unwrap();
+
+    // Merge all streams
+    let mut trades_stream = trades
+        .select_all()
+        .with_error_handler(|error| warn!(?error, "Trade stream error"));
+
+    let mut books_stream = books
+        .select_all()
+        .with_error_handler(|error| warn!(?error, "Book stream error"));
+
+    info!(
+        "Subscribed to Hyperliquid {} (HYPE/USDC) spot trades + L2 books",
+        hype_usdc
+    );
+    info!("Receiving {} events then exiting...", MAX_EVENTS);
+
+    let mut event_count = 0;
+
+    // Process both streams concurrently, exit after MAX_EVENTS
+    while event_count < MAX_EVENTS {
+        tokio::select! {
+            Some(trade) = trades_stream.next() => {
+                info!("Spot Trade: {:?}", trade);
+                event_count += 1;
+            }
+            Some(book) = books_stream.next() => {
+                info!("Spot Book: {:?}", book);
+                event_count += 1;
+            }
+            else => break,
+        }
+    }
+
+    info!("Received {} events, exiting", event_count);
+}
+
+fn init_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::filter::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_ansi(cfg!(debug_assertions))
+        .json()
+        .init()
+}

--- a/barter-data/src/exchange/hyperliquid/channel.rs
+++ b/barter-data/src/exchange/hyperliquid/channel.rs
@@ -1,4 +1,4 @@
-use super::Hyperliquid;
+use super::{Hyperliquid, HyperliquidSpot};
 use crate::{
     Identifier,
     subscription::{Subscription, book::OrderBooksL2, trade::PublicTrades},
@@ -46,6 +46,22 @@ impl<Instrument> Identifier<HyperliquidChannel>
 
 impl<Instrument> Identifier<HyperliquidChannel>
     for Subscription<Hyperliquid, Instrument, OrderBooksL2>
+{
+    fn id(&self) -> HyperliquidChannel {
+        HyperliquidChannel::L2Book
+    }
+}
+
+impl<Instrument> Identifier<HyperliquidChannel>
+    for Subscription<HyperliquidSpot, Instrument, PublicTrades>
+{
+    fn id(&self) -> HyperliquidChannel {
+        HyperliquidChannel::Trades
+    }
+}
+
+impl<Instrument> Identifier<HyperliquidChannel>
+    for Subscription<HyperliquidSpot, Instrument, OrderBooksL2>
 {
     fn id(&self) -> HyperliquidChannel {
         HyperliquidChannel::L2Book

--- a/barter-data/src/exchange/hyperliquid/market.rs
+++ b/barter-data/src/exchange/hyperliquid/market.rs
@@ -1,15 +1,15 @@
-use super::Hyperliquid;
+use super::{Hyperliquid, HyperliquidSpot};
 use crate::{Identifier, instrument::MarketInstrumentData, subscription::Subscription};
 use barter_instrument::{
     Keyed, asset::name::AssetNameInternal, instrument::market_data::MarketDataInstrument,
 };
 use serde::{Deserialize, Serialize};
-use smol_str::{SmolStr, StrExt};
+use smol_str::{SmolStr, StrExt, format_smolstr};
 
 /// Hyperliquid market identifier.
 ///
 /// For perpetuals, this is just the base asset in uppercase (e.g., "BTC", "ETH").
-/// Hyperliquid perps are quoted in USDC, so the quote asset is implicit.
+/// For spot, this is the pair format (e.g., "PURR/USDC", "HYPE/USDC").
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct HyperliquidMarket(pub SmolStr);
 
@@ -42,5 +42,55 @@ impl<InstrumentKey, Kind> Identifier<HyperliquidMarket>
 impl AsRef<str> for HyperliquidMarket {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+// HyperliquidSpot implementations
+
+impl<Kind> Identifier<HyperliquidMarket>
+    for Subscription<HyperliquidSpot, MarketDataInstrument, Kind>
+{
+    fn id(&self) -> HyperliquidMarket {
+        hyperliquid_spot_market(&self.instrument.base, &self.instrument.quote)
+    }
+}
+
+impl<InstrumentKey, Kind> Identifier<HyperliquidMarket>
+    for Subscription<HyperliquidSpot, Keyed<InstrumentKey, MarketDataInstrument>, Kind>
+{
+    fn id(&self) -> HyperliquidMarket {
+        hyperliquid_spot_market(&self.instrument.value.base, &self.instrument.value.quote)
+    }
+}
+
+fn hyperliquid_spot_market(
+    base: &AssetNameInternal,
+    quote: &AssetNameInternal,
+) -> HyperliquidMarket {
+    let base_name = base.name();
+    // Hyperliquid spot WebSocket uses "@index" format for all spot markets
+    // (e.g., "@0" for PURR, "@107" for HYPE). Use SpotMetaResolver to map
+    // token names to indices. If base already starts with "@", use it directly.
+    if base_name.starts_with('@') {
+        HyperliquidMarket(SmolStr::new(base_name))
+    } else {
+        // WARNING: This fallback produces "BASE/QUOTE" literal strings, which only
+        // work for PURR/USDC (the sole exception that uses literal pair name).
+        // All other spot pairs must be resolved via SpotMetaResolver to "@{index}"
+        // format before calling — otherwise the subscription will silently receive
+        // no data.
+        HyperliquidMarket(format_smolstr!(
+            "{}/{}",
+            base_name.to_uppercase_smolstr(),
+            quote.name().to_uppercase_smolstr()
+        ))
+    }
+}
+
+impl<InstrumentKey, Kind> Identifier<HyperliquidMarket>
+    for Subscription<HyperliquidSpot, MarketInstrumentData<InstrumentKey>, Kind>
+{
+    fn id(&self) -> HyperliquidMarket {
+        HyperliquidMarket(self.instrument.name_exchange.name().clone())
     }
 }

--- a/barter-data/src/exchange/hyperliquid/mod.rs
+++ b/barter-data/src/exchange/hyperliquid/mod.rs
@@ -1,15 +1,41 @@
-//! Hyperliquid perpetual futures market data connector.
+//! Hyperliquid market data connectors for perpetual futures and spot trading.
 //!
 //! Uses raw WebSocket connection to `wss://api.hyperliquid.xyz/ws` for market data streams.
 //! Reuses `hyperliquid_rust_sdk` types for deserialization.
+//!
+//! # Connectors
+//!
+//! - [`Hyperliquid`]: Perpetual futures market data
+//! - [`HyperliquidSpot`]: Spot trading market data
 //!
 //! # Supported Streams
 //! - [`PublicTrades`](crate::subscription::trade::PublicTrades): Real-time trade feed
 //! - [`OrderBooksL2`](crate::subscription::book::OrderBooksL2): L2 order book snapshots
 //!
+//! # Spot Market Subscriptions
+//!
+//! Hyperliquid spot uses `@{index}` format for WebSocket subscriptions.
+//! Use [`SpotMetaResolver`] to convert pair names to indices:
+//!
+//! ```ignore
+//! use barter_data::exchange::hyperliquid::{HyperliquidSpot, resolve_spot_pair};
+//!
+//! // Resolve pair name to @index format
+//! let coin = resolve_spot_pair("hype", "usdc").await?; // "@107"
+//!
+//! // Subscribe using resolved index
+//! let streams = Streams::<PublicTrades>::builder()
+//!     .subscribe([(HyperliquidSpot, &coin, "usdc", MarketDataInstrumentKind::Spot, PublicTrades)])
+//!     .init()
+//!     .await?;
+//! ```
+//!
+//! Or use `@index` directly if you already know the spot pair index.
+//!
 //! # Notes
 //! - Market data streams are unauthenticated (public data)
 //! - Execution client uses SDK's WebSocket separately for user data
+//! - Spot and perps use the same WebSocket endpoint and protocol
 
 use self::{
     book::HyperliquidL2Book, channel::HyperliquidChannel, market::HyperliquidMarket,
@@ -35,8 +61,11 @@ pub mod book;
 pub mod channel;
 pub mod historical;
 pub mod market;
+pub mod spot_meta;
 pub mod subscription;
 pub mod trade;
+
+pub use spot_meta::{SpotMetaResolver, resolve_spot_pair};
 
 /// Hyperliquid mainnet WebSocket URL.
 pub const BASE_URL_HYPERLIQUID: &str = "wss://api.hyperliquid.xyz/ws";
@@ -46,6 +75,24 @@ const PING_INTERVAL_SECS: u64 = 50;
 
 /// Type alias for Hyperliquid WebSocket stream.
 pub type HyperliquidWsStream<Transformer> = ExchangeWsStream<WebSocketSerdeParser, Transformer>;
+
+/// Build WebSocket subscription messages for Hyperliquid channels.
+fn build_subscribe_messages(
+    exchange_subs: Vec<ExchangeSub<HyperliquidChannel, HyperliquidMarket>>,
+) -> Vec<WsMessage> {
+    exchange_subs
+        .into_iter()
+        .map(|ExchangeSub { channel, market }| {
+            WsMessage::text(
+                json!({
+                    "method": "subscribe",
+                    "subscription": channel.subscription_payload(market.as_ref())
+                })
+                .to_string(),
+            )
+        })
+        .collect()
+}
 
 /// Hyperliquid perpetual futures exchange connector.
 #[derive(
@@ -84,18 +131,7 @@ impl Connector for Hyperliquid {
     }
 
     fn requests(exchange_subs: Vec<ExchangeSub<Self::Channel, Self::Market>>) -> Vec<WsMessage> {
-        exchange_subs
-            .into_iter()
-            .map(|ExchangeSub { channel, market }| {
-                WsMessage::text(
-                    json!({
-                        "method": "subscribe",
-                        "subscription": channel.subscription_payload(market.as_ref())
-                    })
-                    .to_string(),
-                )
-            })
-            .collect()
+        build_subscribe_messages(exchange_subs)
     }
 }
 
@@ -110,6 +146,77 @@ where
 }
 
 impl<Instrument> StreamSelector<Instrument, OrderBooksL2> for Hyperliquid
+where
+    Instrument: InstrumentData,
+{
+    type SnapFetcher = NoInitialSnapshots;
+    type Stream = HyperliquidWsStream<
+        StatelessTransformer<Self, Instrument::Key, OrderBooksL2, HyperliquidL2Book>,
+    >;
+}
+
+/// Hyperliquid spot trading exchange connector.
+///
+/// Uses the same WebSocket endpoint and protocol as perpetuals, but with a different
+/// `ExchangeId` for routing.
+///
+/// # Market Format
+///
+/// Spot markets use `@{index}` format for WebSocket subscriptions (e.g., `"@107"` for HYPE).
+/// Get the spot index from the `spotMeta` API. Exception: PURR uses `"PURR/USDC"` literally.
+///
+/// Perpetuals use symbol-only format: `"BTC"`, `"ETH"`
+#[derive(
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Default,
+    Display,
+    DeExchange,
+    SerExchange,
+)]
+pub struct HyperliquidSpot;
+
+impl Connector for HyperliquidSpot {
+    const ID: ExchangeId = ExchangeId::HyperliquidSpot;
+    type Channel = HyperliquidChannel;
+    type Market = HyperliquidMarket;
+    type Subscriber = WebSocketSubscriber;
+    type SubValidator = WebSocketSubValidator;
+    type SubResponse = HyperliquidSubResponse;
+
+    fn url() -> Result<Url, url::ParseError> {
+        Url::parse(BASE_URL_HYPERLIQUID)
+    }
+
+    fn ping_interval() -> Option<PingInterval> {
+        Some(PingInterval {
+            interval: tokio::time::interval(Duration::from_secs(PING_INTERVAL_SECS)),
+            ping: || WsMessage::text(r#"{"method":"ping"}"#),
+        })
+    }
+
+    fn requests(exchange_subs: Vec<ExchangeSub<Self::Channel, Self::Market>>) -> Vec<WsMessage> {
+        build_subscribe_messages(exchange_subs)
+    }
+}
+
+impl<Instrument> StreamSelector<Instrument, PublicTrades> for HyperliquidSpot
+where
+    Instrument: InstrumentData,
+{
+    type SnapFetcher = NoInitialSnapshots;
+    type Stream = HyperliquidWsStream<
+        StatelessTransformer<Self, Instrument::Key, PublicTrades, HyperliquidTrade>,
+    >;
+}
+
+impl<Instrument> StreamSelector<Instrument, OrderBooksL2> for HyperliquidSpot
 where
     Instrument: InstrumentData,
 {

--- a/barter-data/src/exchange/hyperliquid/spot_meta.rs
+++ b/barter-data/src/exchange/hyperliquid/spot_meta.rs
@@ -1,0 +1,302 @@
+//! Hyperliquid spot metadata resolution.
+//!
+//! Fetches and caches the `spotMeta` endpoint to resolve human-readable pair names
+//! (e.g., "HYPE/USDC") to the `@{index}` format required by WebSocket subscriptions.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use barter_data::exchange::hyperliquid::spot_meta::SpotMetaResolver;
+//!
+//! // Create resolver (fetches spotMeta on first resolution)
+//! let resolver = SpotMetaResolver::mainnet();
+//!
+//! // Resolve pair name to @index format
+//! let coin = resolver.resolve("hype", "usdc").await?; // Returns "@107"
+//! ```
+//!
+//! # Caching
+//!
+//! The resolver caches the spotMeta response at first resolution. The cache is
+//! immutable after initialization — newly-listed spot pairs require a process
+//! restart to be picked up.
+
+use reqwest::Client;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+use tracing::debug;
+
+/// Hyperliquid mainnet info endpoint.
+const INFO_URL: &str = "https://api.hyperliquid.xyz/info";
+
+/// Hyperliquid testnet info endpoint.
+const INFO_URL_TESTNET: &str = "https://api.hyperliquid-testnet.xyz/info";
+
+/// Error type for spot metadata resolution.
+#[derive(Debug, thiserror::Error)]
+pub enum SpotMetaError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("Token not found: {0}")]
+    TokenNotFound(String),
+
+    #[error("Pair not found: {0}/{1}")]
+    PairNotFound(String, String),
+}
+
+/// Response from the spotMeta endpoint.
+#[derive(Debug, Deserialize)]
+struct SpotMetaResponse {
+    tokens: Vec<TokenInfo>,
+    universe: Vec<UniverseEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenInfo {
+    name: String,
+    index: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct UniverseEntry {
+    // Required for serde deserialization of spotMeta universe entries; not read after construction.
+    #[allow(dead_code)]
+    name: String,
+    index: u32,
+    tokens: Vec<u32>,
+}
+
+/// Cached spot metadata for resolution.
+#[derive(Debug, Clone)]
+struct SpotMetaCache {
+    /// Map from uppercase token name to token index
+    token_indices: HashMap<String, u32>,
+    /// Map from (base_token_idx, quote_token_idx) to spot pair index
+    pair_indices: HashMap<(u32, u32), u32>,
+}
+
+impl SpotMetaCache {
+    fn from_response(response: SpotMetaResponse) -> Self {
+        let token_indices: HashMap<String, u32> = response
+            .tokens
+            .into_iter()
+            .map(|t| (t.name.to_uppercase(), t.index))
+            .collect();
+
+        let pair_indices: HashMap<(u32, u32), u32> = response
+            .universe
+            .into_iter()
+            .filter_map(|u| {
+                if u.tokens.len() == 2 {
+                    Some(((u.tokens[0], u.tokens[1]), u.index))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        Self {
+            token_indices,
+            pair_indices,
+        }
+    }
+
+    fn resolve(&self, base: &str, quote: &str) -> Result<String, SpotMetaError> {
+        let base_upper = base.to_uppercase();
+        let quote_upper = quote.to_uppercase();
+
+        let base_idx = self
+            .token_indices
+            .get(&base_upper)
+            .ok_or_else(|| SpotMetaError::TokenNotFound(base_upper.clone()))?;
+
+        let quote_idx = self
+            .token_indices
+            .get(&quote_upper)
+            .ok_or_else(|| SpotMetaError::TokenNotFound(quote_upper.clone()))?;
+
+        // Try both orderings: empirically all SDK examples show [base, quote], but the API
+        // docs don't formally guarantee this ordering. The defensive fallback lookup adds
+        // minimal overhead (one extra HashMap lookup on miss) and prevents silent resolution
+        // failures if the API ever deviates from the assumed ordering.
+        let pair_idx = self
+            .pair_indices
+            .get(&(*base_idx, *quote_idx))
+            .or_else(|| self.pair_indices.get(&(*quote_idx, *base_idx)))
+            .ok_or_else(|| SpotMetaError::PairNotFound(base_upper, quote_upper))?;
+
+        Ok(format!("@{}", pair_idx))
+    }
+}
+
+/// Resolver for Hyperliquid spot pair names to `@{index}` format.
+///
+/// Fetches and caches the `spotMeta` endpoint. Thread-safe and cloneable.
+/// Uses `OnceCell` for lock-free reads after the first initialization.
+///
+/// # Cache Lifetime
+///
+/// The cache is immutable after first initialization. Newly-listed spot pairs
+/// will not be resolved until the process is restarted.
+#[derive(Debug, Clone)]
+pub struct SpotMetaResolver {
+    client: Client,
+    /// OnceCell ensures exactly one HTTP fetch; reads are lock-free after init.
+    cache: Arc<OnceCell<Arc<SpotMetaCache>>>,
+    testnet: bool,
+}
+
+impl Default for SpotMetaResolver {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}
+
+impl SpotMetaResolver {
+    fn new(testnet: bool) -> Self {
+        Self {
+            client: Client::new(),
+            cache: Arc::new(OnceCell::new()),
+            testnet,
+        }
+    }
+
+    /// Create a resolver for mainnet.
+    pub fn mainnet() -> Self {
+        Self::new(false)
+    }
+
+    /// Create a resolver for testnet.
+    pub fn testnet() -> Self {
+        Self::new(true)
+    }
+
+    fn info_url(&self) -> &'static str {
+        if self.testnet {
+            INFO_URL_TESTNET
+        } else {
+            INFO_URL
+        }
+    }
+
+    /// Fetch spotMeta from the network.
+    async fn fetch(&self) -> Result<Arc<SpotMetaCache>, SpotMetaError> {
+        let response: SpotMetaResponse = self
+            .client
+            .post(self.info_url())
+            .json(&serde_json::json!({"type": "spotMeta"}))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        let cache = SpotMetaCache::from_response(response);
+        debug!(
+            tokens = cache.token_indices.len(),
+            pairs = cache.pair_indices.len(),
+            "Fetched spot metadata"
+        );
+
+        Ok(Arc::new(cache))
+    }
+
+    /// Resolve a pair name to `@{index}` format.
+    ///
+    /// Fetches spotMeta on first call if not already cached. Concurrent callers
+    /// during first init will race to populate the cache; `OnceCell` ensures
+    /// exactly one wins. Subsequent calls are lock-free reads.
+    ///
+    /// # Arguments
+    /// * `base` - Base token name (e.g., "hype", "HYPE")
+    /// * `quote` - Quote token name (e.g., "usdc", "USDC")
+    ///
+    /// # Returns
+    /// The spot index in `@{index}` format (e.g., "@107")
+    ///
+    /// # Cache Lifetime
+    ///
+    /// The cache is immutable after first initialization. Newly-listed spot pairs
+    /// require a process restart to be resolved.
+    pub async fn resolve(&self, base: &str, quote: &str) -> Result<String, SpotMetaError> {
+        let cache = self.cache.get_or_try_init(|| self.fetch()).await?;
+        cache.resolve(base, quote)
+    }
+
+    /// Check if a pair exists in the cache.
+    ///
+    /// Returns `None` if the cache hasn't been populated yet.
+    pub fn pair_exists(&self, base: &str, quote: &str) -> Option<bool> {
+        self.cache
+            .get()
+            .map(|cache| cache.resolve(base, quote).is_ok())
+    }
+}
+
+/// Global spot metadata resolver instance.
+///
+/// Use this for convenience when you don't need separate testnet/mainnet resolvers.
+static MAINNET_RESOLVER: std::sync::OnceLock<SpotMetaResolver> = std::sync::OnceLock::new();
+
+/// Get the global mainnet spot metadata resolver.
+pub fn mainnet_resolver() -> &'static SpotMetaResolver {
+    MAINNET_RESOLVER.get_or_init(SpotMetaResolver::mainnet)
+}
+
+/// Resolve a spot pair name to `@{index}` format using the global mainnet resolver.
+///
+/// This is a convenience function for common use cases.
+///
+/// # Example
+/// ```ignore
+/// let coin = resolve_spot_pair("hype", "usdc").await?; // "@107"
+/// ```
+pub async fn resolve_spot_pair(base: &str, quote: &str) -> Result<String, SpotMetaError> {
+    mainnet_resolver().resolve(base, quote).await
+}
+
+#[cfg(test)]
+// Test code: panics on bad input are acceptable
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore] // Requires network
+    async fn test_resolve_hype_usdc() {
+        let resolver = SpotMetaResolver::mainnet();
+        let result = resolver.resolve("hype", "usdc").await.unwrap();
+        assert_eq!(result, "@107");
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires network
+    async fn test_resolve_purr_usdc() {
+        let resolver = SpotMetaResolver::mainnet();
+        let result = resolver.resolve("purr", "usdc").await.unwrap();
+        assert_eq!(result, "@0");
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires network
+    async fn test_resolve_case_insensitive() {
+        let resolver = SpotMetaResolver::mainnet();
+        let r1 = resolver.resolve("HYPE", "USDC").await.unwrap();
+        let r2 = resolver.resolve("hype", "usdc").await.unwrap();
+        let r3 = resolver.resolve("Hype", "Usdc").await.unwrap();
+        // Verify all variants resolve to the correct index
+        assert_eq!(r1, "@107");
+        assert_eq!(r2, "@107");
+        assert_eq!(r3, "@107");
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires network
+    async fn test_resolve_invalid_token() {
+        let resolver = SpotMetaResolver::mainnet();
+        let result = resolver.resolve("NOTAREAL", "usdc").await;
+        assert!(matches!(result, Err(SpotMetaError::TokenNotFound(_))));
+    }
+}

--- a/barter-data/src/exchange/mod.rs
+++ b/barter-data/src/exchange/mod.rs
@@ -36,7 +36,7 @@ pub mod kraken;
 /// `Okx` [`Connector`] and [`StreamSelector`] implementations.
 pub mod okx;
 
-/// `Hyperliquid` [`Connector`] and [`StreamSelector`] implementations (behind `hyperliquid` feature).
+/// `Hyperliquid` and `HyperliquidSpot` [`Connector`] and [`StreamSelector`] implementations (behind `hyperliquid` feature).
 #[cfg(feature = "hyperliquid")]
 pub mod hyperliquid;
 

--- a/barter-data/tests/hyperliquid_spot_data.rs
+++ b/barter-data/tests/hyperliquid_spot_data.rs
@@ -1,0 +1,298 @@
+//! Hyperliquid Spot Market Data Integration Tests
+//!
+//! These tests verify connectivity and data reception from Hyperliquid spot markets.
+//!
+//! # Running
+//!
+//! ```bash
+//! # Run all Hyperliquid spot integration tests
+//! cargo test --test hyperliquid_spot_data --features hyperliquid -- --ignored
+//!
+//! # Run specific test
+//! cargo test --test hyperliquid_spot_data --features hyperliquid test_spot_trade_stream_connection -- --ignored
+//! ```
+//!
+//! Tests are marked `#[ignore]` to avoid CI failures and rate limiting.
+//!
+//! # Spot vs Perpetuals
+//!
+//! - Uses `HyperliquidSpot` connector instead of `Hyperliquid`
+//! - Market format: `@{index}` where index is from `spotMeta` API (e.g., "@107" for HYPE)
+//!   - Exception: PURR uses literal "PURR/USDC"
+//!   - Get indices via: `curl -X POST https://api.hyperliquid.xyz/info -d '{"type":"spotMeta"}'`
+//! - Same WebSocket protocol as perpetuals
+
+#![cfg(feature = "hyperliquid")]
+// Integration test: panics on bad input are acceptable.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use barter_data::{
+    exchange::hyperliquid::HyperliquidSpot,
+    streams::{
+        Streams,
+        reconnect::{Event, stream::ReconnectingStream},
+    },
+    subscription::{book::OrderBooksL2, trade::PublicTrades},
+};
+use barter_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
+use futures_util::StreamExt;
+use std::time::Duration as StdDuration;
+use tracing_subscriber::{EnvFilter, fmt};
+
+fn init_logging() {
+    let _ = fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(tracing::Level::DEBUG.into())
+                .from_env_lossy(),
+        )
+        .try_init();
+}
+
+// ============================================================================
+// WebSocket Stream Tests - Trades
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_trade_stream_connection() {
+    init_logging();
+
+    let streams = Streams::<PublicTrades>::builder()
+        .subscribe([(
+            HyperliquidSpot,
+            "@107",
+            "usdc",
+            MarketDataInstrumentKind::Spot,
+            PublicTrades,
+        )])
+        .init()
+        .await;
+
+    assert!(
+        streams.is_ok(),
+        "Failed to init spot trade stream: {:?}",
+        streams.err()
+    );
+    tracing::info!("Spot trade stream connected");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_trade_stream_receives_data() {
+    init_logging();
+
+    let streams = Streams::<PublicTrades>::builder()
+        .subscribe([(
+            HyperliquidSpot,
+            "@107",
+            "usdc",
+            MarketDataInstrumentKind::Spot,
+            PublicTrades,
+        )])
+        .init()
+        .await
+        .expect("Failed to init stream");
+
+    let mut stream = streams
+        .select_all()
+        .with_error_handler(|e| tracing::warn!(?e, "Stream error"));
+
+    let deadline = tokio::time::Instant::now() + StdDuration::from_secs(60);
+
+    tracing::info!("Waiting for spot trade data (60 second timeout)...");
+    tracing::info!("Note: Spot markets may have lower volume than perps");
+
+    while tokio::time::Instant::now() < deadline {
+        let timeout = tokio::time::timeout(StdDuration::from_secs(30), stream.next()).await;
+
+        match timeout {
+            Ok(Some(Event::Item(trade))) => {
+                tracing::info!(?trade, "Received spot trade");
+                assert!(trade.kind.price > 0.0, "Invalid trade price");
+                assert!(trade.kind.amount > 0.0, "Invalid trade amount");
+                return;
+            }
+            Ok(Some(Event::Reconnecting(info))) => {
+                tracing::warn!(?info, "Stream reconnecting");
+            }
+            Ok(None) => {
+                panic!("Stream ended without data");
+            }
+            Err(_) => {
+                tracing::warn!("Timeout waiting for trade, retrying...");
+            }
+        }
+    }
+
+    panic!("No spot trade events received within timeout (spot markets may have low volume)");
+}
+
+// ============================================================================
+// WebSocket Stream Tests - L2 Order Book
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_l2_book_stream_connection() {
+    init_logging();
+
+    let streams = Streams::<OrderBooksL2>::builder()
+        .subscribe([(
+            HyperliquidSpot,
+            "@107",
+            "usdc",
+            MarketDataInstrumentKind::Spot,
+            OrderBooksL2,
+        )])
+        .init()
+        .await;
+
+    assert!(
+        streams.is_ok(),
+        "Failed to init spot L2 book stream: {:?}",
+        streams.err()
+    );
+    tracing::info!("Spot L2 book stream connected");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_l2_book_stream_receives_data() {
+    init_logging();
+
+    let streams = Streams::<OrderBooksL2>::builder()
+        .subscribe([(
+            HyperliquidSpot,
+            "@107",
+            "usdc",
+            MarketDataInstrumentKind::Spot,
+            OrderBooksL2,
+        )])
+        .init()
+        .await
+        .expect("Failed to init stream");
+
+    let mut stream = streams
+        .select_all()
+        .with_error_handler(|e| tracing::warn!(?e, "Stream error"));
+
+    let timeout = tokio::time::timeout(StdDuration::from_secs(30), stream.next()).await;
+
+    let event = timeout.expect("Timeout waiting for spot L2 book data");
+    let book_event = event.expect("Stream ended without data");
+    tracing::info!(?book_event, "Received spot L2 book");
+}
+
+// ============================================================================
+// Multiple Streams
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_combined_streams() {
+    init_logging();
+
+    // Subscribe to both trades and books for BTC/USDC spot
+    let trades = Streams::<PublicTrades>::builder()
+        .subscribe([(
+            HyperliquidSpot,
+            "@107",
+            "usdc",
+            MarketDataInstrumentKind::Spot,
+            PublicTrades,
+        )])
+        .init()
+        .await
+        .expect("Failed to init trade stream");
+
+    let books = Streams::<OrderBooksL2>::builder()
+        .subscribe([(
+            HyperliquidSpot,
+            "@107",
+            "usdc",
+            MarketDataInstrumentKind::Spot,
+            OrderBooksL2,
+        )])
+        .init()
+        .await
+        .expect("Failed to init book stream");
+
+    let mut trades_stream = trades
+        .select_all()
+        .with_error_handler(|e| tracing::warn!(?e, "Trade stream error"));
+
+    let mut books_stream = books
+        .select_all()
+        .with_error_handler(|e| tracing::warn!(?e, "Book stream error"));
+
+    let mut trade_seen = false;
+    let mut book_seen = false;
+    let deadline = tokio::time::Instant::now() + StdDuration::from_secs(60);
+
+    tracing::info!("Waiting for both @107 (HYPE/USDC) spot trade and book data...");
+
+    while !(trade_seen && book_seen) && tokio::time::Instant::now() < deadline {
+        tokio::select! {
+            Some(Event::Item(_)) = trades_stream.next() => {
+                trade_seen = true;
+                tracing::info!("Received spot trade");
+            }
+            Some(Event::Item(_)) = books_stream.next() => {
+                book_seen = true;
+                tracing::info!("Received spot book update");
+            }
+            else => break,
+        }
+    }
+
+    // Book updates are more frequent, trades may be sparse
+    assert!(book_seen, "No spot book updates received within timeout");
+    if !trade_seen {
+        tracing::warn!("No spot trades received (low volume is normal for spot)");
+    }
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_invalid_pair_handling() {
+    init_logging();
+
+    // Try to subscribe to a non-existent spot pair
+    let result = Streams::<PublicTrades>::builder()
+        .subscribe([(
+            HyperliquidSpot,
+            "invalidcoin",
+            "usdc",
+            MarketDataInstrumentKind::Spot,
+            PublicTrades,
+        )])
+        .init()
+        .await;
+
+    // Should either fail to connect or receive no data
+    // Hyperliquid may accept the subscription but send no data
+    match result {
+        Ok(streams) => {
+            let mut stream = streams
+                .select_all()
+                .with_error_handler(|e| tracing::info!(?e, "Expected stream error"));
+
+            let timeout = tokio::time::timeout(StdDuration::from_secs(5), stream.next()).await;
+
+            // Should timeout with no data for invalid pair
+            assert!(
+                timeout.is_err() || matches!(timeout, Ok(None)),
+                "Expected no data for invalid spot pair"
+            );
+            tracing::info!("Invalid pair correctly produced no data");
+        }
+        Err(e) => {
+            tracing::info!(?e, "Invalid pair correctly rejected at subscribe time");
+        }
+    }
+}

--- a/barter-execution/README.md
+++ b/barter-execution/README.md
@@ -2,4 +2,14 @@
 
 Execution client library for streaming private account data and executing orders (live or mock).
 
+## Supported Exchanges
+
+| Exchange | Constructor | InstrumentKinds | Features |
+|:--------:|:-----------:|:---------------:|:--------:|
+| **Binance** | `BinanceClient::connect()` | Spot | Orders, Balances, Positions |
+| **Alpaca** | `AlpacaClient::connect()` | Spot (Equities, Crypto) | Orders, Balances, Positions |
+| **Hyperliquid** | `HyperliquidClient::connect()` | Perpetual | Orders, Balances, Positions |
+| **HyperliquidSpot** | `HyperliquidSpotClient::connect()` | Spot | Orders, Balances, Positions |
+| **IBKR** | `IbkrClient::connect()` | Spot, Future, Option | Orders, Balances, Positions |
+
 See the [workspace README](../README.md) for documentation, examples, and contributing guidelines.

--- a/barter-execution/examples/hyperliquid_spot_execution.rs
+++ b/barter-execution/examples/hyperliquid_spot_execution.rs
@@ -1,0 +1,279 @@
+//! Hyperliquid Spot Execution Example
+//!
+//! Demonstrates order execution with Hyperliquid spot trading:
+//! - Connecting to Hyperliquid (testnet or mainnet)
+//! - Fetching spot token balances
+//! - Placing a limit order
+//! - Canceling an order
+//! - Streaming account events
+//!
+//! # Prerequisites
+//!
+//! 1. Hyperliquid account with funds (testnet recommended)
+//! 2. Wallet private key (EVM-compatible)
+//! 3. Environment variables:
+//!    - `HYPERLIQUID_PRIVATE_KEY`: Hex-encoded private key (with or without 0x prefix)
+//!    - `HYPERLIQUID_TESTNET`: Set to "true" for testnet (recommended)
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Using testnet (recommended)
+//! HYPERLIQUID_PRIVATE_KEY=0x... HYPERLIQUID_TESTNET=true \
+//!     cargo run --example hyperliquid_spot_execution --features hyperliquid
+//!
+//! # Or source from .env file
+//! source .env && cargo run --example hyperliquid_spot_execution --features hyperliquid
+//! ```
+//!
+//! # Safety Note
+//!
+//! This example places a LIMIT order far from market price that should NOT fill.
+//! Always use TESTNET for testing to avoid risking real funds.
+//!
+//! # Spot vs Perpetuals
+//!
+//! - Spot uses pair format: "BTC/USDC" -> instrument "BTC-USDC-SPOT"
+//! - No leverage or margin concepts
+//! - $10 minimum order notional value
+//! - Balances from `user_token_balances()` instead of margin summary
+
+// Examples use unwrap/expect for brevity — not production code
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use barter_execution::{
+    client::{
+        ExecutionClient,
+        hyperliquid::{config::HyperliquidConfig, spot::HyperliquidSpotClient},
+    },
+    order::{
+        OrderEvent, OrderKey, OrderKind, TimeInForce,
+        id::{ClientOrderId, StrategyId},
+        request::{RequestCancel, RequestOpen},
+        state::{ActiveOrderState, OrderState},
+    },
+};
+use barter_instrument::{
+    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
+    instrument::name::InstrumentNameExchange,
+};
+use rust_decimal_macros::dec;
+use std::time::Duration;
+use tokio_stream::StreamExt;
+use tracing::{info, warn};
+
+#[tokio::main]
+async fn main() {
+    init_logging();
+
+    // Load configuration from environment
+    let config = match HyperliquidConfig::from_env() {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Configuration error: {e}");
+            warn!("Set HYPERLIQUID_PRIVATE_KEY and optionally HYPERLIQUID_TESTNET=true");
+            return;
+        }
+    };
+
+    let network = if config.testnet { "TESTNET" } else { "MAINNET" };
+    info!("Connecting to Hyperliquid {network} (SPOT)...");
+    info!("Wallet: {}", config.wallet_address_hex());
+
+    if !config.testnet {
+        warn!("WARNING: Running on MAINNET - real funds at risk!");
+        warn!("Set HYPERLIQUID_TESTNET=true for safe testing");
+    }
+
+    // Connect to Hyperliquid Spot
+    let client = match HyperliquidSpotClient::connect(config).await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Failed to connect: {e}");
+            return;
+        }
+    };
+
+    info!("Connected!");
+
+    // Fetch account snapshot (spot balances)
+    info!("");
+    info!("=== Account Snapshot (Spot) ===");
+
+    let assets: Vec<AssetNameExchange> = vec![];
+    let instruments: Vec<InstrumentNameExchange> = vec![];
+
+    match client.account_snapshot(&assets, &instruments).await {
+        Ok(snapshot) => {
+            info!("Spot Token Balances:");
+            if snapshot.balances.is_empty() {
+                info!("  (no spot balances)");
+            }
+            for balance in &snapshot.balances {
+                info!(
+                    "  {}: total={}, free={}",
+                    balance.asset, balance.balance.total, balance.balance.free
+                );
+            }
+
+            info!("Open Spot Orders:");
+            let total_orders: usize = snapshot.instruments.iter().map(|i| i.orders.len()).sum();
+            if total_orders == 0 {
+                info!("  (no open orders)");
+            }
+            for inst in &snapshot.instruments {
+                for order in &inst.orders {
+                    info!(
+                        "  {} {:?} {} @ {}",
+                        inst.instrument, order.side, order.quantity, order.price
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            warn!("Failed to get account snapshot: {e}");
+        }
+    }
+
+    // Place a limit order (far from market to avoid filling)
+    info!("");
+    info!("=== Placing Spot Limit Order ===");
+
+    // Spot instrument format: "BTC-USDC-SPOT" (converts to "BTC/USDC" for API)
+    let btc_spot: InstrumentNameExchange = "BTC-USDC-SPOT".into();
+    let order_cid = ClientOrderId::new(format!(
+        "spot-example-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+    let strategy = StrategyId::new("demo-spot-strategy");
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::HyperliquidSpot,
+        instrument: &btc_spot,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Price must be reasonable - BTC ~$95k, so $50k is well below market
+    // Quantity 0.001 BTC @ $50k = $50 notional (above $10 minimum)
+    let request_open = RequestOpen {
+        side: Side::Buy,
+        price: dec!(50000.0),
+        quantity: dec!(0.001),
+        kind: OrderKind::Limit,
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    info!("Placing BUY 0.001 BTC-USDC-SPOT @ $50,000 (won't fill - below market)");
+
+    match client.open_order(open_request).await {
+        Some(response) => {
+            match &response.state {
+                OrderState::Active(ActiveOrderState::Open(open_state)) => {
+                    info!("Order placed successfully!");
+                    info!("  Client Order ID: {}", response.key.cid);
+                    info!("  Exchange Order ID: {}", open_state.id);
+
+                    // Wait a moment then cancel
+                    info!("");
+                    info!("=== Canceling Order ===");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+
+                    let cancel_key = OrderKey {
+                        exchange: ExchangeId::HyperliquidSpot,
+                        instrument: &btc_spot,
+                        strategy: response.key.strategy.clone(),
+                        cid: response.key.cid.clone(),
+                    };
+
+                    let cancel_request = OrderEvent {
+                        key: cancel_key,
+                        state: RequestCancel {
+                            id: Some(open_state.id.clone()),
+                        },
+                    };
+
+                    match client.cancel_order(cancel_request).await {
+                        Some(cancel_response) => match &cancel_response.state {
+                            Ok(_cancelled) => {
+                                info!("Order canceled successfully!");
+                            }
+                            Err(e) => {
+                                warn!("Cancel rejected: {e:?}");
+                            }
+                        },
+                        None => {
+                            info!("Cancel request sent (no immediate response)");
+                        }
+                    }
+                }
+                OrderState::Inactive(e) => {
+                    warn!("Order rejected: {e:?}");
+                    warn!("This may be due to:");
+                    warn!("  - Insufficient spot balance");
+                    warn!("  - Order below $10 minimum notional");
+                    warn!("  - Invalid order parameters");
+                }
+                other => {
+                    info!("Unexpected order state: {other:?}");
+                }
+            }
+        }
+        None => {
+            info!("Order request sent (no immediate response)");
+        }
+    }
+
+    // Demonstrate account stream (optional - brief listen)
+    info!("");
+    info!("=== Account Stream (5 seconds) ===");
+
+    match client.account_stream(&[], &[]).await {
+        Ok(mut stream) => {
+            info!("Listening for spot account events...");
+            info!("(Note: receives both spot AND perp events - we filter to spot only)");
+
+            let timeout = tokio::time::timeout(Duration::from_secs(5), async {
+                let mut count = 0;
+                while let Some(event) = stream.next().await {
+                    info!("  Event: {:?}", event.kind);
+                    count += 1;
+                    if count >= 5 {
+                        break;
+                    }
+                }
+                count
+            })
+            .await;
+
+            match timeout {
+                Ok(count) => info!("Received {count} events"),
+                Err(_) => info!("Timeout (no events - this is normal if no activity)"),
+            }
+        }
+        Err(e) => {
+            warn!("Failed to start account stream: {e}");
+        }
+    }
+
+    info!("");
+    info!("Example complete");
+}
+
+fn init_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::filter::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_ansi(cfg!(debug_assertions))
+        .init()
+}

--- a/barter-execution/src/client/hyperliquid/common.rs
+++ b/barter-execution/src/client/hyperliquid/common.rs
@@ -1,0 +1,336 @@
+//! Shared utilities for Hyperliquid execution clients (perps and spot).
+//!
+//! Contains parsing helpers and stream wrappers used by both
+//! `HyperliquidClient` (perps) and `HyperliquidSpotClient`.
+//!
+//! Error mapping is in the `error` module.
+
+use crate::order::{TimeInForce, id::ClientOrderId};
+use barter_instrument::{Side, instrument::name::InstrumentNameExchange};
+use chrono::{DateTime, TimeZone, Utc};
+use futures::Stream;
+use rust_decimal::Decimal;
+use smol_str::format_smolstr;
+use std::pin::Pin;
+use std::str::FromStr;
+use std::task::{Context, Poll};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+/// Stream wrapper that cancels background tasks when dropped.
+///
+/// Ensures spawned WebSocket processing tasks are cleaned up when the consumer
+/// drops the account stream, preventing task leaks.
+#[derive(Debug)]
+pub struct CancelOnDropStream<S> {
+    inner: S,
+    cancel_token: CancellationToken,
+}
+
+impl<S> CancelOnDropStream<S> {
+    /// Create a new cancel-on-drop stream wrapper.
+    pub(crate) fn new(inner: S, cancel_token: CancellationToken) -> Self {
+        Self {
+            inner,
+            cancel_token,
+        }
+    }
+}
+
+impl<S: Stream + Unpin> Stream for CancelOnDropStream<S> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl<S> Drop for CancelOnDropStream<S> {
+    fn drop(&mut self) {
+        self.cancel_token.cancel();
+    }
+}
+
+/// Parse a decimal string from SDK response, logging warnings on failure.
+pub fn parse_decimal(value: &str, field: &str) -> Option<Decimal> {
+    Decimal::from_str(value)
+        .map_err(|e| warn!(%field, %value, %e, "Failed to parse decimal"))
+        .ok()
+}
+
+/// Parse SDK side string to barter Side.
+///
+/// Hyperliquid API returns "B" for buy/long and "A" for sell/short (ask-side).
+/// Extra variants included for defensive parsing of potential future API changes.
+pub fn parse_side(side: &str) -> Option<Side> {
+    match side {
+        "B" | "b" | "BUY" | "Buy" | "buy" => Some(Side::Buy),
+        "A" | "a" | "S" | "s" | "SELL" | "Sell" | "sell" => Some(Side::Sell),
+        _ => {
+            warn!(%side, "Unknown side string");
+            None
+        }
+    }
+}
+
+/// Convert milliseconds timestamp to DateTime<Utc>.
+///
+/// Returns `None` for timestamps outside the representable range (year 292M+).
+pub fn millis_to_datetime(millis: u64) -> Option<DateTime<Utc>> {
+    Utc.timestamp_millis_opt(i64::try_from(millis).ok()?)
+        .single()
+}
+
+/// Round a price to 5 significant figures (Hyperliquid requirement).
+///
+/// Performs rounding using `Decimal` arithmetic to avoid floating-point precision
+/// errors. The final `f64` conversion happens only at the SDK interface boundary.
+pub fn round_to_5_sig_figs(value: Decimal) -> f64 {
+    use rust_decimal::prelude::ToPrimitive;
+
+    if value.is_zero() {
+        return 0.0;
+    }
+
+    // Use f64 only for computing magnitude (acceptable precision for this purpose;
+    // we only need to know which power of 10 the number is close to).
+    let abs_f = value.abs().to_f64().unwrap_or(0.0);
+    if abs_f == 0.0 {
+        return 0.0;
+    }
+
+    // Clamp magnitude to prevent overflow when computing scale factor
+    #[allow(clippy::cast_possible_truncation)]
+    let magnitude = abs_f.log10().floor().clamp(-30.0, 30.0) as i32;
+
+    // Round using Decimal arithmetic to preserve precision
+    let rounded = if magnitude >= 4 {
+        // Large numbers (e.g., 123456): scale down, round integer, scale back up
+        // Safety: magnitude >= 4 guarantees (magnitude - 4) is non-negative
+        #[allow(clippy::cast_sign_loss)]
+        let factor = Decimal::from(10i64.pow((magnitude - 4) as u32));
+        (value / factor).round() * factor
+    } else {
+        // Small/medium numbers: round to appropriate decimal places
+        #[allow(clippy::cast_sign_loss)]
+        let dp = (4 - magnitude) as u32;
+        value.round_dp(dp)
+    };
+
+    // SDK requires f64 — convert only at the interface boundary
+    rounded.to_f64().unwrap_or(0.0)
+}
+
+/// Map barter TimeInForce to Hyperliquid TIF string.
+pub fn map_tif(tif: &TimeInForce) -> &'static str {
+    match tif {
+        TimeInForce::GoodUntilCancelled { post_only: true } => "Alo",
+        TimeInForce::GoodUntilCancelled { post_only: false } => "Gtc",
+        TimeInForce::ImmediateOrCancel => "Ioc",
+        TimeInForce::FillOrKill => "Ioc", // Hyperliquid doesn't have FOK, use IOC
+        TimeInForce::GoodUntilEndOfDay => "Gtc", // No EOD on Hyperliquid
+    }
+}
+
+/// Convert a ClientOrderId to SDK cloid format (UUID) if valid.
+///
+/// Returns `Some(Uuid)` if the cid is a valid UUID, `None` otherwise.
+/// Non-UUID CIDs are logged at debug level since they're common in tests/examples.
+pub fn cid_to_cloid(cid: &ClientOrderId) -> Option<Uuid> {
+    match Uuid::parse_str(cid.0.as_str()) {
+        Ok(uuid) => Some(uuid),
+        Err(_) => {
+            debug!(cid = %cid.0, "CID is not a valid UUID, cloid will be None");
+            None
+        }
+    }
+}
+
+/// Build perp instrument name from Hyperliquid coin name (e.g., "BTC" -> "BTC-USD-PERP").
+pub fn perp_coin_to_instrument(coin: &str) -> InstrumentNameExchange {
+    InstrumentNameExchange::from(format_smolstr!("{}-USD-PERP", coin))
+}
+
+/// Extract coin name from perp instrument (e.g., "BTC-USD-PERP" -> "BTC").
+///
+/// Returns `String` because Hyperliquid SDK requires `String` for asset fields.
+pub fn instrument_to_perp_coin(instrument: &InstrumentNameExchange) -> String {
+    let s = instrument.as_ref();
+    // Expected format: "COIN-USD-PERP" or just "COIN"
+    match s.split_once('-') {
+        Some((coin, _)) => coin.to_string(),
+        None => s.to_string(),
+    }
+}
+
+/// Build spot instrument name from Hyperliquid coin pair (e.g., "PURR/USDC" -> "PURR-USDC-SPOT").
+///
+/// # Panics (debug builds only)
+///
+/// Debug-asserts if `coin` does not contain '/' — callers must verify `is_spot_coin()`
+/// before calling. The fallback path produces a malformed instrument name.
+pub fn spot_coin_to_instrument(coin: &str) -> InstrumentNameExchange {
+    match coin.split_once('/') {
+        Some((base, quote)) => {
+            InstrumentNameExchange::from(format_smolstr!("{}-{}-SPOT", base, quote))
+        }
+        None => {
+            debug_assert!(
+                false,
+                "spot_coin_to_instrument called with non-spot coin: {coin}"
+            );
+            InstrumentNameExchange::from(format_smolstr!("{}-SPOT", coin))
+        }
+    }
+}
+
+/// Extract coin pair from spot instrument (e.g., "PURR-USDC-SPOT" -> "PURR/USDC").
+///
+/// Returns `Option<String>` — `None` if the instrument doesn't match expected
+/// `BASE-QUOTE-SPOT` format. Callers should fail fast on `None` rather than
+/// send a malformed asset to the exchange.
+pub fn instrument_to_spot_coin(instrument: &InstrumentNameExchange) -> Option<String> {
+    let s = instrument.as_ref();
+    // Expected format: "BASE-QUOTE-SPOT" -> "BASE/QUOTE"
+    let without_suffix = s.strip_suffix("-SPOT")?;
+    let (base, quote) = without_suffix.split_once('-')?;
+    Some(format!("{}/{}", base, quote))
+}
+
+/// Check if a Hyperliquid coin name is a spot pair (contains '/').
+///
+/// Hyperliquid API uses pair format `"BASE/QUOTE"` (e.g., `"PURR/USDC"`) for spot coins
+/// and single symbols (e.g., `"BTC"`) for perpetuals. This naming convention is observed
+/// across all SDK examples and test fixtures. The invariant is validated by our spot
+/// fixture tests in `hyperliquid_spot_execution.rs`.
+pub fn is_spot_coin(coin: &str) -> bool {
+    coin.contains('/')
+}
+
+#[cfg(test)]
+// Test code: panics on bad input are acceptable
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_parse_decimal_valid() {
+        assert_eq!(parse_decimal("123.456", "test"), Some(dec!(123.456)));
+        assert_eq!(parse_decimal("0", "test"), Some(dec!(0)));
+        assert_eq!(parse_decimal("-50.5", "test"), Some(dec!(-50.5)));
+    }
+
+    #[test]
+    fn test_parse_decimal_invalid() {
+        assert_eq!(parse_decimal("", "test"), None);
+        assert_eq!(parse_decimal("abc", "test"), None);
+        assert_eq!(parse_decimal("12.34.56", "test"), None);
+    }
+
+    #[test]
+    fn test_parse_side() {
+        assert_eq!(parse_side("B"), Some(Side::Buy));
+        assert_eq!(parse_side("BUY"), Some(Side::Buy));
+        assert_eq!(parse_side("buy"), Some(Side::Buy));
+        assert_eq!(parse_side("A"), Some(Side::Sell));
+        assert_eq!(parse_side("S"), Some(Side::Sell));
+        assert_eq!(parse_side("SELL"), Some(Side::Sell));
+        assert_eq!(parse_side("sell"), Some(Side::Sell));
+        assert_eq!(parse_side("X"), None);
+        assert_eq!(parse_side(""), None);
+    }
+
+    #[test]
+    fn test_perp_coin_to_instrument() {
+        let inst = perp_coin_to_instrument("BTC");
+        assert_eq!(inst.as_ref(), "BTC-USD-PERP");
+
+        let inst = perp_coin_to_instrument("ETH");
+        assert_eq!(inst.as_ref(), "ETH-USD-PERP");
+    }
+
+    #[test]
+    fn test_instrument_to_perp_coin() {
+        let coin = instrument_to_perp_coin(&InstrumentNameExchange::from("BTC-USD-PERP"));
+        assert_eq!(coin, "BTC");
+
+        let coin = instrument_to_perp_coin(&InstrumentNameExchange::from("ETH-USD-PERP"));
+        assert_eq!(coin, "ETH");
+
+        // Just coin name without suffix
+        let coin = instrument_to_perp_coin(&InstrumentNameExchange::from("SOL"));
+        assert_eq!(coin, "SOL");
+    }
+
+    #[test]
+    fn test_spot_coin_to_instrument() {
+        let inst = spot_coin_to_instrument("PURR/USDC");
+        assert_eq!(inst.as_ref(), "PURR-USDC-SPOT");
+
+        let inst = spot_coin_to_instrument("HYPE/USDC");
+        assert_eq!(inst.as_ref(), "HYPE-USDC-SPOT");
+    }
+
+    #[test]
+    fn test_instrument_to_spot_coin() {
+        let coin = instrument_to_spot_coin(&InstrumentNameExchange::from("PURR-USDC-SPOT"));
+        assert_eq!(coin, Some("PURR/USDC".to_string()));
+
+        let coin = instrument_to_spot_coin(&InstrumentNameExchange::from("HYPE-USDC-SPOT"));
+        assert_eq!(coin, Some("HYPE/USDC".to_string()));
+
+        // Malformed instruments return None
+        assert_eq!(
+            instrument_to_spot_coin(&InstrumentNameExchange::from("BTC-USD-PERP")),
+            None
+        );
+        assert_eq!(
+            instrument_to_spot_coin(&InstrumentNameExchange::from("INVALID")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_is_spot_coin() {
+        assert!(is_spot_coin("PURR/USDC"));
+        assert!(is_spot_coin("HYPE/USDC"));
+        assert!(!is_spot_coin("BTC"));
+        assert!(!is_spot_coin("ETH"));
+    }
+
+    #[test]
+    fn test_round_to_5_sig_figs() {
+        assert_eq!(round_to_5_sig_figs(dec!(0)), 0.0);
+        assert_eq!(round_to_5_sig_figs(dec!(12345)), 12345.0);
+        assert_eq!(round_to_5_sig_figs(dec!(123456)), 123460.0);
+        assert_eq!(round_to_5_sig_figs(dec!(0.00012345)), 0.00012345);
+        assert_eq!(round_to_5_sig_figs(dec!(0.000123456)), 0.00012346);
+        assert_eq!(round_to_5_sig_figs(dec!(1.23456789)), 1.2346);
+    }
+
+    #[test]
+    fn test_map_tif() {
+        assert_eq!(
+            map_tif(&TimeInForce::GoodUntilCancelled { post_only: false }),
+            "Gtc"
+        );
+        assert_eq!(
+            map_tif(&TimeInForce::GoodUntilCancelled { post_only: true }),
+            "Alo"
+        );
+        assert_eq!(map_tif(&TimeInForce::ImmediateOrCancel), "Ioc");
+        assert_eq!(map_tif(&TimeInForce::FillOrKill), "Ioc");
+        assert_eq!(map_tif(&TimeInForce::GoodUntilEndOfDay), "Gtc");
+    }
+
+    #[test]
+    fn test_millis_to_datetime() {
+        let dt = millis_to_datetime(1714100000000).unwrap();
+        assert_eq!(dt.timestamp_millis(), 1714100000000);
+
+        // Zero timestamp (Unix epoch) is valid
+        assert!(millis_to_datetime(0).is_some());
+    }
+}

--- a/barter-execution/src/client/hyperliquid/spot.rs
+++ b/barter-execution/src/client/hyperliquid/spot.rs
@@ -1,35 +1,39 @@
-//! Hyperliquid ExecutionClient implementations for perpetual futures and spot trading.
+//! Hyperliquid spot trading ExecutionClient implementation.
 //!
-//! Uses the official `hyperliquid_rust_sdk` crate for REST and WebSocket API access.
-//! Gated behind the "hyperliquid" feature flag.
+//! Uses the same `hyperliquid_rust_sdk` clients as the perpetuals client, but with
+//! spot-specific endpoints and data handling.
 //!
-//! # Modules
+//! # Differences from Perpetuals
 //!
-//! - [`HyperliquidClient`]: Perpetual futures client
-//! - [`spot::HyperliquidSpotClient`]: Spot trading client
+//! - **Coin naming**: Spot uses pair format `"PURR/USDC"` vs symbol-only `"BTC"` for perps
+//! - **Asset indices**: Spot uses 10000+ (vs 0-9999 for perps)
+//! - **Balances**: Uses `user_token_balances()` instead of `user_state()` margin summary
+//! - **No positions**: Spot has no margin/leverage concepts
+//! - **$10 minimum**: Spot orders require minimum $10 notional value
 //!
-//! # Authentication
+//! # Unified Account Model
 //!
-//! Hyperliquid uses EVM-based authentication (Ethereum private key + EIP-712 signatures)
-//! instead of traditional API key/secret. The SDK handles all signing internally.
+//! Hyperliquid uses a unified account model:
+//! - Spot balances count as perpetual collateral
+//! - Separate wallets within the unified account (explicit transfer required)
+//! - Perpetual liquidation cannot sweep spot holdings
 //!
-//! # Architecture
+//! # WebSocket Events
 //!
-//! - REST (`InfoClient`): account_snapshot, fetch_balances, fetch_open_orders, fetch_trades
-//! - REST (`ExchangeClient`): open_order, cancel_order
-//! - WebSocket (`InfoClient` with `with_reconnect`): account_stream via UserFills + OrderUpdates subscriptions
+//! `UserFills` and `OrderUpdates` subscriptions deliver **both** spot and perp events,
+//! intermingled in the same stream. Events are filtered by coin name format:
+//! - Spot coins contain `/` (e.g., `"PURR/USDC"`)
+//! - Perp coins are single symbols (e.g., `"BTC"`)
 //!
-//! # Limitations
-//!
-//! - **SDK-managed reconnect**: WebSocket streams use `InfoClient::with_reconnect()` for automatic
-//!   reconnection. REST clients (`InfoClient::new()`, `ExchangeClient::new()`) do not auto-reconnect.
-//! - **Price precision**: Hyperliquid requires 5 significant figures for prices
+//! If a user has both perp and spot clients for the same wallet, events will be
+//! duplicated. Consumers should use one client type per account, or deduplicate externally.
 
-pub mod common;
-pub mod config;
-pub mod error;
-pub mod spot;
-
+use super::common::{
+    CancelOnDropStream, cid_to_cloid, instrument_to_spot_coin, is_spot_coin, map_tif,
+    millis_to_datetime, parse_decimal, parse_side, round_to_5_sig_figs, spot_coin_to_instrument,
+};
+use super::config::HyperliquidConfig;
+use super::error::{map_order_error, map_sdk_error};
 use crate::{
     AccountEvent, AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot,
     UnindexedAccountEvent, UnindexedAccountSnapshot,
@@ -42,7 +46,6 @@ use crate::{
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
         state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
     },
-    position::Position,
     trade::{AssetFees, Trade, TradeId},
 };
 use barter_instrument::{
@@ -51,12 +54,6 @@ use barter_instrument::{
 };
 use barter_integration::collection::snapshot::Snapshot;
 use chrono::{DateTime, Utc};
-use common::{
-    CancelOnDropStream, cid_to_cloid, instrument_to_perp_coin, map_tif, millis_to_datetime,
-    parse_decimal, parse_side, perp_coin_to_instrument, round_to_5_sig_figs,
-};
-use config::HyperliquidConfig;
-use error::{map_order_error, map_sdk_error};
 use ethers::signers::Signer;
 use futures::{StreamExt, stream::BoxStream};
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, InfoClient, Message, Subscription};
@@ -67,22 +64,19 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-/// USDC asset name on Hyperliquid (the only collateral asset for perps).
-const USDC_ASSET: &str = "USDC";
-
-/// Hyperliquid perpetual futures execution client.
+/// Hyperliquid spot trading execution client.
 ///
-/// Wraps the official `hyperliquid_rust_sdk` to implement the `ExecutionClient` trait.
-/// Supports perpetual futures trading on Hyperliquid DEX.
+/// Wraps the official `hyperliquid_rust_sdk` to implement the `ExecutionClient` trait
+/// for spot trading on Hyperliquid DEX.
 #[derive(Debug, Clone)]
-pub struct HyperliquidClient {
+pub struct HyperliquidSpotClient {
     config: HyperliquidConfig,
     info_client: Arc<InfoClient>,
     exchange_client: Arc<ExchangeClient>,
 }
 
-impl HyperliquidClient {
-    /// Create a new client asynchronously.
+impl HyperliquidSpotClient {
+    /// Create a new spot client asynchronously.
     ///
     /// Use this when calling from an async context (e.g., tokio tests).
     /// For sync contexts, use `ExecutionClient::new()`.
@@ -105,7 +99,7 @@ impl HyperliquidClient {
         info!(
             testnet = config.testnet,
             wallet = %config.wallet_address_hex(),
-            "Created HyperliquidClient"
+            "Created HyperliquidSpotClient"
         );
 
         Ok(Self {
@@ -135,13 +129,13 @@ impl HyperliquidClient {
     }
 }
 
-impl ExecutionClient for HyperliquidClient {
-    const EXCHANGE: ExchangeId = ExchangeId::HyperliquidPerp;
+impl ExecutionClient for HyperliquidSpotClient {
+    const EXCHANGE: ExchangeId = ExchangeId::HyperliquidSpot;
 
     type Config = HyperliquidConfig;
     type AccountStream = BoxStream<'static, UnindexedAccountEvent>;
 
-    /// Creates a new Hyperliquid client synchronously.
+    /// Creates a new Hyperliquid spot client synchronously.
     ///
     /// # Panics
     ///
@@ -151,7 +145,7 @@ impl ExecutionClient for HyperliquidClient {
     ///
     /// # Recommended Usage
     ///
-    /// Use [`HyperliquidClient::connect`] instead — it's async-safe and returns `Result`.
+    /// Use [`HyperliquidSpotClient::connect`] instead — it's async-safe and returns `Result`.
     /// This method exists only for trait compliance; prefer `connect()` in all new code.
     fn new(config: Self::Config) -> Self {
         let base_url = if config.testnet {
@@ -160,8 +154,6 @@ impl ExecutionClient for HyperliquidClient {
             BaseUrl::Mainnet
         };
 
-        // SDK initialization is async; block on it since ExecutionClient::new is sync.
-        // WARNING: This will panic if called from within an async context.
         let handle = tokio::runtime::Handle::current();
 
         let info_client = handle.block_on(async {
@@ -180,7 +172,7 @@ impl ExecutionClient for HyperliquidClient {
         info!(
             testnet = config.testnet,
             wallet = %config.wallet_address_hex(),
-            "Created HyperliquidClient"
+            "Created HyperliquidSpotClient"
         );
 
         Self {
@@ -197,11 +189,11 @@ impl ExecutionClient for HyperliquidClient {
     ) -> Result<UnindexedAccountSnapshot, UnindexedClientError> {
         let address = self.wallet_h160();
 
-        // Fetch user state (balances + positions) and open orders concurrently
-        let (user_state, open_orders) = tokio::try_join!(
+        // Fetch spot token balances and open orders concurrently
+        let (token_balances, open_orders) = tokio::try_join!(
             async {
                 self.info_client
-                    .user_state(address)
+                    .user_token_balances(address)
                     .await
                     .map_err(map_sdk_error)
             },
@@ -214,25 +206,7 @@ impl ExecutionClient for HyperliquidClient {
         )?;
 
         let now = Utc::now();
-
-        // Build balance from margin summary (USDC is the only collateral)
-        let account_value =
-            parse_decimal(&user_state.margin_summary.account_value, "account_value")
-                .unwrap_or(Decimal::ZERO);
-        let margin_used = parse_decimal(
-            &user_state.margin_summary.total_margin_used,
-            "total_margin_used",
-        )
-        .unwrap_or(Decimal::ZERO);
-
-        // Free balance can go negative during liquidation (margin_used > account_value).
-        // Clamp to zero since negative free balance has no meaningful interpretation.
-        let free_balance = (account_value - margin_used).max(Decimal::ZERO);
-        let balances = vec![AssetBalance::new(
-            AssetNameExchange::from(USDC_ASSET),
-            Balance::new(account_value, free_balance),
-            now,
-        )];
+        let balances = parse_token_balances(&token_balances.balances, now);
 
         // Build instrument filter if provided
         let instrument_filter: Option<HashSet<_>> = if instruments.is_empty() {
@@ -243,12 +217,17 @@ impl ExecutionClient for HyperliquidClient {
             Some(set)
         };
 
-        // Group open orders by instrument
+        // Group open orders by instrument (filter to spot orders only)
         let mut orders_by_instrument: std::collections::HashMap<InstrumentNameExchange, Vec<_>> =
-            std::collections::HashMap::with_capacity(open_orders.len());
+            std::collections::HashMap::new();
 
         for order in &open_orders {
-            let instrument = perp_coin_to_instrument(&order.coin);
+            // Filter: only spot coins (contain '/')
+            if !is_spot_coin(&order.coin) {
+                continue;
+            }
+
+            let instrument = spot_coin_to_instrument(&order.coin);
             if instrument_filter
                 .as_ref()
                 .is_some_and(|f| !f.contains(&instrument))
@@ -277,7 +256,7 @@ impl ExecutionClient for HyperliquidClient {
             let order_id = format_smolstr!("{}", order.oid);
             let order_snapshot = Order {
                 key: OrderKey {
-                    exchange: ExchangeId::HyperliquidPerp,
+                    exchange: ExchangeId::HyperliquidSpot,
                     instrument: instrument.clone(),
                     strategy: StrategyId::unknown(),
                     cid: ClientOrderId::new(order_id.clone()),
@@ -300,85 +279,35 @@ impl ExecutionClient for HyperliquidClient {
                 .push(order_snapshot);
         }
 
-        // Build positions from asset_positions
-        let mut instrument_snapshots = Vec::new();
-        for asset_pos in user_state.asset_positions {
-            let pos = &asset_pos.position;
-            let instrument = perp_coin_to_instrument(&pos.coin);
-
-            if instrument_filter
-                .as_ref()
-                .is_some_and(|f| !f.contains(&instrument))
-            {
-                continue;
-            }
-
-            let quantity = parse_decimal(&pos.szi, "szi").unwrap_or(Decimal::ZERO);
-            let entry_price = pos
-                .entry_px
-                .as_ref()
-                .and_then(|p| parse_decimal(p, "entry_px"));
-            let unrealized_pnl = parse_decimal(&pos.unrealized_pnl, "unrealized_pnl");
-            let margin_used = parse_decimal(&pos.margin_used, "margin_used");
-            let liquidation_price = pos
-                .liquidation_px
-                .as_ref()
-                .and_then(|p| parse_decimal(p, "liquidation_px"));
-            let leverage = Some(Decimal::from(pos.leverage.value));
-
-            let position = if quantity.is_zero() {
-                None
-            } else {
-                Some(Position::new(
-                    quantity,
-                    entry_price,
-                    unrealized_pnl,
-                    margin_used,
-                    liquidation_price,
-                    leverage,
-                    now,
-                ))
-            };
-
-            let orders = orders_by_instrument.remove(&instrument).unwrap_or_default();
-
-            instrument_snapshots.push(InstrumentAccountSnapshot {
+        // Build instrument snapshots from orders (spot has no positions)
+        let instrument_snapshots: Vec<_> = orders_by_instrument
+            .into_iter()
+            .map(|(instrument, orders)| InstrumentAccountSnapshot {
                 instrument,
                 orders,
-                position,
-            });
-        }
-
-        // Add any instruments that have orders but no position
-        for (instrument, orders) in orders_by_instrument {
-            instrument_snapshots.push(InstrumentAccountSnapshot {
-                instrument,
-                orders,
-                position: None,
-            });
-        }
+                position: None, // Spot has no positions
+            })
+            .collect();
 
         Ok(AccountSnapshot {
-            exchange: ExchangeId::HyperliquidPerp,
+            exchange: ExchangeId::HyperliquidSpot,
             balances,
             instruments: instrument_snapshots,
         })
     }
 
-    /// Returns a live stream of account events (fills, order updates).
+    /// Returns a live stream of account events (fills, order updates) for spot orders.
     ///
     /// # Instrument filtering
     ///
     /// The `instruments` parameter is **ignored** — Hyperliquid's WebSocket API does not
     /// support per-instrument subscriptions for user events. All fills and order updates
-    /// across all instruments are delivered. Consumers requiring instrument filtering
-    /// must filter client-side.
+    /// are delivered, but we filter client-side to only emit spot events (coins with '/').
     ///
     /// # Task lifecycle
     ///
     /// Spawns two background tasks (fills, orders) that are automatically cancelled
-    /// when the returned stream is dropped. The `ws_client` is held by the orders task;
-    /// when cancelled, both tasks exit and the WebSocket connection closes.
+    /// when the returned stream is dropped.
     async fn account_stream(
         &self,
         _assets: &[AssetNameExchange],
@@ -387,37 +316,29 @@ impl ExecutionClient for HyperliquidClient {
         let user = self.wallet_h160();
         let base_url = self.base_url();
 
-        // Create a dedicated InfoClient for WebSocket streaming.
-        // Using with_reconnect() enables SDK-managed reconnection.
         let mut ws_client = InfoClient::with_reconnect(None, Some(base_url))
             .await
             .map_err(|e| ConnectivityError::Socket(e.to_string()))?;
 
-        // Create channels for subscriptions
         let (fills_tx, mut fills_rx) = mpsc::unbounded_channel::<Message>();
         let (orders_tx, mut orders_rx) = mpsc::unbounded_channel::<Message>();
 
-        // Subscribe to user fills
         ws_client
             .subscribe(Subscription::UserFills { user }, fills_tx)
             .await
             .map_err(|e| ConnectivityError::Socket(format!("UserFills subscribe: {e}")))?;
 
-        // Subscribe to order updates
         ws_client
             .subscribe(Subscription::OrderUpdates { user }, orders_tx)
             .await
             .map_err(|e| ConnectivityError::Socket(format!("OrderUpdates subscribe: {e}")))?;
 
-        info!(%user, "Subscribed to Hyperliquid account stream");
+        info!(%user, "Subscribed to Hyperliquid spot account stream");
 
-        // Create output channel for merged events
         let (event_tx, event_rx) = mpsc::unbounded_channel::<UnindexedAccountEvent>();
-
-        // CancellationToken ensures tasks exit when stream is dropped
         let cancel_token = CancellationToken::new();
 
-        // Spawn task to process fills
+        // Spawn task to process fills (filtered to spot only)
         let fills_event_tx = event_tx.clone();
         let fills_cancel = cancel_token.clone();
         tokio::spawn(async move {
@@ -425,32 +346,36 @@ impl ExecutionClient for HyperliquidClient {
                 tokio::select! {
                     biased;
                     () = fills_cancel.cancelled() => {
-                        debug!("Fills task cancelled");
+                        debug!("Spot fills task cancelled");
                         return;
                     }
                     msg = fills_rx.recv() => {
                         let Some(msg) = msg else {
-                            debug!("Fills receiver closed");
+                            debug!("Spot fills receiver closed");
                             return;
                         };
                         match msg {
                             Message::UserFills(fills) => {
                                 for fill in fills.data.fills {
+                                    // Filter: only spot coins
+                                    if !is_spot_coin(&fill.coin) {
+                                        continue;
+                                    }
                                     if let Some(event) = fill_to_account_event(&fill)
                                         && fills_event_tx.send(event).is_err()
                                     {
-                                        debug!("Fills event channel closed");
+                                        debug!("Spot fills event channel closed");
                                         return;
                                     }
                                 }
                             }
                             Message::NoData => {
-                                warn!("UserFills WebSocket disconnected");
+                                warn!("Spot UserFills WebSocket disconnected");
                             }
                             Message::HyperliquidError(e) => {
-                                error!(%e, "UserFills WebSocket error");
+                                error!(%e, "Spot UserFills WebSocket error");
                                 let _ = fills_event_tx.send(AccountEvent::new(
-                                    ExchangeId::HyperliquidPerp,
+                                    ExchangeId::HyperliquidSpot,
                                     AccountEventKind::StreamError(e),
                                 ));
                             }
@@ -461,7 +386,7 @@ impl ExecutionClient for HyperliquidClient {
             }
         });
 
-        // Spawn task to process order updates
+        // Spawn task to process order updates (filtered to spot only)
         // NOTE: ws_client is moved here to keep the WebSocket alive. When this task
         // exits (via cancellation or channel close), the WebSocket connection closes,
         // which causes fills_rx to also close.
@@ -474,32 +399,36 @@ impl ExecutionClient for HyperliquidClient {
                 tokio::select! {
                     biased;
                     () = orders_cancel.cancelled() => {
-                        debug!("Orders task cancelled");
+                        debug!("Spot orders task cancelled");
                         return;
                     }
                     msg = orders_rx.recv() => {
                         let Some(msg) = msg else {
-                            debug!("Orders receiver closed");
+                            debug!("Spot orders receiver closed");
                             return;
                         };
                         match msg {
                             Message::OrderUpdates(updates) => {
                                 for update in updates.data {
+                                    // Filter: only spot coins
+                                    if !is_spot_coin(&update.order.coin) {
+                                        continue;
+                                    }
                                     if let Some(event) = order_update_to_account_event(&update)
                                         && orders_event_tx.send(event).is_err()
                                     {
-                                        debug!("Orders event channel closed");
+                                        debug!("Spot orders event channel closed");
                                         return;
                                     }
                                 }
                             }
                             Message::NoData => {
-                                warn!("OrderUpdates WebSocket disconnected");
+                                warn!("Spot OrderUpdates WebSocket disconnected");
                             }
                             Message::HyperliquidError(e) => {
-                                error!(%e, "OrderUpdates WebSocket error");
+                                error!(%e, "Spot OrderUpdates WebSocket error");
                                 let _ = orders_event_tx.send(AccountEvent::new(
-                                    ExchangeId::HyperliquidPerp,
+                                    ExchangeId::HyperliquidSpot,
                                     AccountEventKind::StreamError(e),
                                 ));
                             }
@@ -510,7 +439,6 @@ impl ExecutionClient for HyperliquidClient {
             }
         });
 
-        // Wrap stream with drop guard that cancels tasks
         let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(event_rx);
         let guarded_stream = CancelOnDropStream::new(stream, cancel_token);
         Ok(guarded_stream.boxed())
@@ -523,16 +451,37 @@ impl ExecutionClient for HyperliquidClient {
         use crate::order::{request::OrderResponseCancel, state::Cancelled};
         use hyperliquid_rust_sdk::ClientCancelRequest;
 
-        let coin = instrument_to_perp_coin(request.key.instrument);
+        let coin = match instrument_to_spot_coin(request.key.instrument) {
+            Some(c) => c,
+            None => {
+                warn!(
+                    instrument = %request.key.instrument,
+                    "Invalid spot instrument format (expected BASE-QUOTE-SPOT)"
+                );
+                return Some(OrderResponseCancel {
+                    key: OrderKey {
+                        exchange: ExchangeId::HyperliquidSpot,
+                        instrument: request.key.instrument.clone(),
+                        strategy: request.key.strategy.clone(),
+                        cid: request.key.cid.clone(),
+                    },
+                    state: Err(UnindexedOrderError::Rejected(
+                        crate::error::ApiError::OrderRejected(format!(
+                            "Invalid instrument format: {}",
+                            request.key.instrument
+                        )),
+                    )),
+                });
+            }
+        };
 
-        // Get order ID from request
         let order_id = match &request.state.id {
             Some(id) => id,
             None => {
                 warn!("Cancel request missing order ID");
                 return Some(OrderResponseCancel {
                     key: OrderKey {
-                        exchange: ExchangeId::HyperliquidPerp,
+                        exchange: ExchangeId::HyperliquidSpot,
                         instrument: request.key.instrument.clone(),
                         strategy: request.key.strategy.clone(),
                         cid: request.key.cid.clone(),
@@ -544,14 +493,13 @@ impl ExecutionClient for HyperliquidClient {
             }
         };
 
-        // Parse order ID to u64
         let oid: u64 = match order_id.0.parse() {
             Ok(id) => id,
             Err(e) => {
                 warn!(?order_id, %e, "Failed to parse order ID as u64");
                 return Some(OrderResponseCancel {
                     key: OrderKey {
-                        exchange: ExchangeId::HyperliquidPerp,
+                        exchange: ExchangeId::HyperliquidSpot,
                         instrument: request.key.instrument.clone(),
                         strategy: request.key.strategy.clone(),
                         cid: request.key.cid.clone(),
@@ -570,10 +518,10 @@ impl ExecutionClient for HyperliquidClient {
         let response = match self.exchange_client.cancel(cancel_request, None).await {
             Ok(r) => r,
             Err(e) => {
-                warn!(%e, "Cancel order failed (transport)");
+                warn!(%e, "Spot cancel order failed (transport)");
                 return Some(OrderResponseCancel {
                     key: OrderKey {
-                        exchange: ExchangeId::HyperliquidPerp,
+                        exchange: ExchangeId::HyperliquidSpot,
                         instrument: request.key.instrument.clone(),
                         strategy: request.key.strategy.clone(),
                         cid: request.key.cid.clone(),
@@ -585,27 +533,27 @@ impl ExecutionClient for HyperliquidClient {
 
         match response {
             ExchangeResponseStatus::Ok(_) => {
-                debug!("Cancel order accepted");
-                // Hyperliquid cancel response doesn't include an exchange timestamp
+                debug!("Spot cancel order accepted");
                 Some(OrderResponseCancel {
                     key: OrderKey {
-                        exchange: ExchangeId::HyperliquidPerp,
+                        exchange: ExchangeId::HyperliquidSpot,
                         instrument: request.key.instrument.clone(),
                         strategy: request.key.strategy.clone(),
                         cid: request.key.cid.clone(),
                     },
                     state: Ok(Cancelled::new(
                         order_id.clone(),
+                        // SDK cancel response omits server timestamp; use local clock.
                         Utc::now(),
-                        Decimal::ZERO, // Cancel response doesn't include filled quantity
+                        Decimal::ZERO,
                     )),
                 })
             }
             ExchangeResponseStatus::Err(msg) => {
-                warn!(%msg, "Cancel rejected by exchange");
+                warn!(%msg, "Spot cancel rejected by exchange");
                 Some(OrderResponseCancel {
                     key: OrderKey {
-                        exchange: ExchangeId::HyperliquidPerp,
+                        exchange: ExchangeId::HyperliquidSpot,
                         instrument: request.key.instrument.clone(),
                         strategy: request.key.strategy.clone(),
                         cid: request.key.cid.clone(),
@@ -627,14 +575,67 @@ impl ExecutionClient for HyperliquidClient {
             ExchangeResponseStatus,
         };
 
-        let coin = instrument_to_perp_coin(request.key.instrument);
+        let coin = match instrument_to_spot_coin(request.key.instrument) {
+            Some(c) => c,
+            None => {
+                warn!(
+                    instrument = %request.key.instrument,
+                    "Invalid spot instrument format (expected BASE-QUOTE-SPOT)"
+                );
+                return Some(Order {
+                    key: OrderKey {
+                        exchange: ExchangeId::HyperliquidSpot,
+                        instrument: request.key.instrument.clone(),
+                        strategy: request.key.strategy.clone(),
+                        cid: request.key.cid.clone(),
+                    },
+                    side: request.state.side,
+                    price: request.state.price,
+                    quantity: request.state.quantity,
+                    kind: request.state.kind,
+                    time_in_force: request.state.time_in_force,
+                    state: OrderState::inactive(OrderError::Rejected(
+                        crate::error::ApiError::OrderRejected(format!(
+                            "Invalid instrument format: {}",
+                            request.key.instrument
+                        )),
+                    )),
+                });
+            }
+        };
         let is_buy = request.state.side == Side::Buy;
 
-        // Round price and quantity to 5 significant figures
         let limit_px = round_to_5_sig_figs(request.state.price);
         let sz = round_to_5_sig_figs(request.state.quantity);
 
-        // Map time-in-force (warn if FOK is substituted with IOC)
+        // Hyperliquid spot requires minimum $10 notional value
+        let notional = request.state.price * request.state.quantity;
+        if notional < Decimal::TEN {
+            warn!(
+                instrument = %request.key.instrument,
+                %notional,
+                "Spot order below $10 minimum notional value"
+            );
+            return Some(Order {
+                key: OrderKey {
+                    exchange: ExchangeId::HyperliquidSpot,
+                    instrument: request.key.instrument.clone(),
+                    strategy: request.key.strategy.clone(),
+                    cid: request.key.cid.clone(),
+                },
+                side: request.state.side,
+                price: request.state.price,
+                quantity: request.state.quantity,
+                kind: request.state.kind,
+                time_in_force: request.state.time_in_force,
+                state: OrderState::inactive(OrderError::Rejected(
+                    crate::error::ApiError::OrderRejected(format!(
+                        "Spot order notional ${notional} below $10 minimum"
+                    )),
+                )),
+            });
+        }
+
         if matches!(request.state.time_in_force, TimeInForce::FillOrKill) {
             warn!(
                 instrument = %request.key.instrument,
@@ -643,8 +644,6 @@ impl ExecutionClient for HyperliquidClient {
         }
         let tif = map_tif(&request.state.time_in_force).to_string();
 
-        // Build order request
-        // Pass cloid if cid is a valid UUID (enables order correlation via client ID)
         let cloid = cid_to_cloid(&request.key.cid);
         let order_request = ClientOrderRequest {
             asset: coin,
@@ -659,10 +658,10 @@ impl ExecutionClient for HyperliquidClient {
         let response = match self.exchange_client.order(order_request, None).await {
             Ok(r) => r,
             Err(e) => {
-                warn!(%e, "Open order failed");
+                warn!(%e, "Spot open order failed");
                 return Some(Order {
                     key: OrderKey {
-                        exchange: ExchangeId::HyperliquidPerp,
+                        exchange: ExchangeId::HyperliquidSpot,
                         instrument: request.key.instrument.clone(),
                         strategy: request.key.strategy.clone(),
                         cid: request.key.cid.clone(),
@@ -677,29 +676,28 @@ impl ExecutionClient for HyperliquidClient {
             }
         };
 
-        // Parse response
         let state = match response {
             ExchangeResponseStatus::Ok(exchange_resp) => {
-                // Check status from response data
                 let status = exchange_resp
                     .data
                     .and_then(|d| d.statuses.into_iter().next());
 
                 match status {
                     Some(ExchangeDataStatus::Resting(resting)) => {
-                        debug!(oid = resting.oid, "Order resting");
+                        debug!(oid = resting.oid, "Spot order resting");
                         OrderState::active(Open {
                             id: OrderId(format_smolstr!("{}", resting.oid)),
+                            // SDK does not return exchange timestamp on order placement; use local clock.
                             time_exchange: Utc::now(),
                             filled_quantity: Decimal::ZERO,
                         })
                     }
                     Some(ExchangeDataStatus::Filled(filled)) => {
-                        debug!(oid = filled.oid, avg_px = %filled.avg_px, "Order filled");
-                        // Hyperliquid provides avg_px for filled orders
+                        debug!(oid = filled.oid, avg_px = %filled.avg_px, "Spot order filled");
                         let avg_price = parse_decimal(&filled.avg_px, "avg_px");
                         OrderState::fully_filled(Filled::new(
                             OrderId(format_smolstr!("{}", filled.oid)),
+                            // SDK does not return exchange timestamp on order placement; use local clock.
                             Utc::now(),
                             parse_decimal(&filled.total_sz, "total_sz")
                                 .unwrap_or(request.state.quantity),
@@ -707,15 +705,13 @@ impl ExecutionClient for HyperliquidClient {
                         ))
                     }
                     Some(ExchangeDataStatus::Error(msg)) => {
-                        warn!(%msg, "Order rejected by exchange");
+                        warn!(%msg, "Spot order rejected by exchange");
                         OrderState::inactive(OrderError::Rejected(
                             crate::error::ApiError::OrderRejected(msg),
                         ))
                     }
                     Some(ExchangeDataStatus::WaitingForFill)
                     | Some(ExchangeDataStatus::WaitingForTrigger) => {
-                        // Trigger/conditional orders return no usable order ID.
-                        // Reject since we can't track or cancel these orders.
                         warn!("Trigger/conditional orders not supported");
                         OrderState::inactive(OrderError::Rejected(
                             crate::error::ApiError::OrderRejected(
@@ -724,9 +720,7 @@ impl ExecutionClient for HyperliquidClient {
                         ))
                     }
                     Some(ExchangeDataStatus::Success) | None => {
-                        // Generic success without order ID — SDK didn't return structured data.
-                        // This shouldn't happen for limit orders; reject to avoid silent failures.
-                        warn!("Order accepted but no order ID returned");
+                        warn!("Spot order accepted but no order ID returned");
                         OrderState::inactive(OrderError::Rejected(
                             crate::error::ApiError::OrderRejected(
                                 "no order ID in response".to_string(),
@@ -736,7 +730,7 @@ impl ExecutionClient for HyperliquidClient {
                 }
             }
             ExchangeResponseStatus::Err(msg) => {
-                warn!(%msg, "Order rejected");
+                warn!(%msg, "Spot order rejected");
                 OrderState::inactive(OrderError::Rejected(crate::error::ApiError::OrderRejected(
                     msg,
                 )))
@@ -745,7 +739,7 @@ impl ExecutionClient for HyperliquidClient {
 
         Some(Order {
             key: OrderKey {
-                exchange: ExchangeId::HyperliquidPerp,
+                exchange: ExchangeId::HyperliquidSpot,
                 instrument: request.key.instrument.clone(),
                 strategy: request.key.strategy.clone(),
                 cid: request.key.cid.clone(),
@@ -765,31 +759,14 @@ impl ExecutionClient for HyperliquidClient {
     ) -> Result<Vec<AssetBalance<AssetNameExchange>>, UnindexedClientError> {
         let address = self.wallet_h160();
 
-        let user_state = self
+        let token_balances = self
             .info_client
-            .user_state(address)
+            .user_token_balances(address)
             .await
             .map_err(map_sdk_error)?;
 
         let now = Utc::now();
-
-        // Hyperliquid perps use USDC as the only collateral
-        let account_value =
-            parse_decimal(&user_state.margin_summary.account_value, "account_value")
-                .unwrap_or(Decimal::ZERO);
-        let margin_used = parse_decimal(
-            &user_state.margin_summary.total_margin_used,
-            "total_margin_used",
-        )
-        .unwrap_or(Decimal::ZERO);
-
-        // Free balance can go negative during liquidation; clamp to zero
-        let free_balance = (account_value - margin_used).max(Decimal::ZERO);
-        Ok(vec![AssetBalance::new(
-            AssetNameExchange::from(USDC_ASSET),
-            Balance::new(account_value, free_balance),
-            now,
-        )])
+        Ok(parse_token_balances(&token_balances.balances, now))
     }
 
     async fn fetch_open_orders(
@@ -814,7 +791,12 @@ impl ExecutionClient for HyperliquidClient {
 
         let mut result = Vec::new();
         for order in open_orders {
-            let instrument = perp_coin_to_instrument(&order.coin);
+            // Filter: only spot coins
+            if !is_spot_coin(&order.coin) {
+                continue;
+            }
+
+            let instrument = spot_coin_to_instrument(&order.coin);
 
             if instrument_filter
                 .as_ref()
@@ -844,7 +826,7 @@ impl ExecutionClient for HyperliquidClient {
             let order_id = format_smolstr!("{}", order.oid);
             result.push(Order {
                 key: OrderKey {
-                    exchange: ExchangeId::HyperliquidPerp,
+                    exchange: ExchangeId::HyperliquidSpot,
                     instrument,
                     strategy: StrategyId::unknown(),
                     cid: ClientOrderId::new(order_id.clone()),
@@ -878,8 +860,8 @@ impl ExecutionClient for HyperliquidClient {
             .await
             .map_err(map_sdk_error)?;
 
-        // Clamp to 0 for dates before epoch (shouldn't happen in practice)
-        #[allow(clippy::cast_sign_loss)] // timestamp_millis >= 0 after max(0)
+        // Safety: .max(0) ensures the value is non-negative before casting to u64.
+        #[allow(clippy::cast_sign_loss)]
         let time_since_ms = time_since.timestamp_millis().max(0) as u64;
 
         let instrument_filter: Option<HashSet<_>> = if instruments.is_empty() {
@@ -897,7 +879,12 @@ impl ExecutionClient for HyperliquidClient {
                 continue;
             }
 
-            let instrument = perp_coin_to_instrument(&fill.coin);
+            // Filter: only spot coins (must contain '/') and parse base/quote in one pass
+            let Some((base_asset, quote_asset)) = fill.coin.split_once('/') else {
+                continue;
+            };
+
+            let instrument = spot_coin_to_instrument(&fill.coin);
 
             if instrument_filter
                 .as_ref()
@@ -922,6 +909,14 @@ impl ExecutionClient for HyperliquidClient {
                 continue;
             };
 
+            // REST `UserFillsResponse` does not expose `fee_token`. Infer the fee
+            // asset from side: spot BUY pays fee in base asset, SELL pays in quote.
+            let fee_asset = if matches!(side, Side::Buy) {
+                base_asset
+            } else {
+                quote_asset
+            };
+
             result.push(Trade {
                 id: TradeId(SmolStr::new(&fill.hash)),
                 order_id: OrderId(format_smolstr!("{}", fill.oid)),
@@ -932,9 +927,15 @@ impl ExecutionClient for HyperliquidClient {
                 price,
                 quantity,
                 fees: AssetFees {
-                    asset: AssetNameExchange::from("USDC"),
+                    asset: AssetNameExchange::from(fee_asset),
                     fees: fee,
-                    fees_quote: Some(fee),
+                    // Only set quote-equivalent when the fee is actually denominated in
+                    // the quote asset. The downstream indexer recomputes for base-asset fees.
+                    fees_quote: if fee_asset == quote_asset {
+                        Some(fee)
+                    } else {
+                        None
+                    },
                 },
             });
         }
@@ -943,15 +944,43 @@ impl ExecutionClient for HyperliquidClient {
     }
 }
 
-/// Convert SDK TradeInfo (fill) to AccountEvent::Trade.
+/// Parse spot token balances from SDK response.
+fn parse_token_balances(
+    balances: &[hyperliquid_rust_sdk::UserTokenBalance],
+    now: DateTime<Utc>,
+) -> Vec<AssetBalance<AssetNameExchange>> {
+    balances
+        .iter()
+        .map(|bal| {
+            let total = parse_decimal(&bal.total, "total").unwrap_or(Decimal::ZERO);
+            let hold = parse_decimal(&bal.hold, "hold").unwrap_or(Decimal::ZERO);
+            let free = (total - hold).max(Decimal::ZERO);
+
+            AssetBalance::new(
+                AssetNameExchange::from(bal.coin.as_str()),
+                Balance::new(total, free),
+                now,
+            )
+        })
+        .collect()
+}
+
+/// Convert SDK TradeInfo (fill) to AccountEvent::Trade for spot.
 fn fill_to_account_event(fill: &hyperliquid_rust_sdk::TradeInfo) -> Option<UnindexedAccountEvent> {
     let side = parse_side(&fill.side)?;
     let price = parse_decimal(&fill.px, "fill.px")?;
     let quantity = parse_decimal(&fill.sz, "fill.sz")?;
     let fee = parse_decimal(&fill.fee, "fill.fee").unwrap_or(Decimal::ZERO);
     let time_exchange = millis_to_datetime(fill.time)?;
-    let instrument = perp_coin_to_instrument(&fill.coin);
+
+    // Parse base/quote in one pass to avoid redundant string scan
+    let (_base, quote_asset) = fill.coin.split_once('/').unwrap_or(("", "USDC"));
+    let instrument = spot_coin_to_instrument(&fill.coin);
     let order_id = OrderId(format_smolstr!("{}", fill.oid));
+
+    // SDK's `TradeInfo` exposes `fee_token` directly, which is the asset the fee is
+    // denominated in (typically base asset for buys, quote asset for sells).
+    let fee_asset = fill.fee_token.as_str();
 
     let trade = Trade {
         id: TradeId(SmolStr::new(&fill.hash)),
@@ -963,19 +992,25 @@ fn fill_to_account_event(fill: &hyperliquid_rust_sdk::TradeInfo) -> Option<Unind
         price,
         quantity,
         fees: AssetFees {
-            asset: AssetNameExchange::from("USDC"),
+            asset: AssetNameExchange::from(fee_asset),
             fees: fee,
-            fees_quote: Some(fee),
+            // Only set quote-equivalent when the fee is actually denominated in
+            // the quote asset. The downstream indexer recomputes for base-asset fees.
+            fees_quote: if fee_asset.eq_ignore_ascii_case(quote_asset) {
+                Some(fee)
+            } else {
+                None
+            },
         },
     };
 
     Some(AccountEvent::new(
-        ExchangeId::HyperliquidPerp,
+        ExchangeId::HyperliquidSpot,
         AccountEventKind::Trade(trade),
     ))
 }
 
-/// Convert SDK OrderUpdate to AccountEvent::OrderSnapshot.
+/// Convert SDK OrderUpdate to AccountEvent::OrderSnapshot for spot.
 fn order_update_to_account_event(
     update: &hyperliquid_rust_sdk::OrderUpdate,
 ) -> Option<UnindexedAccountEvent> {
@@ -984,9 +1019,8 @@ fn order_update_to_account_event(
     let price = parse_decimal(&order.limit_px, "order.limit_px")?;
     let orig_sz = parse_decimal(&order.orig_sz, "order.orig_sz")?;
     let time_exchange = millis_to_datetime(update.status_timestamp)?;
-    let instrument = perp_coin_to_instrument(&order.coin);
+    let instrument = spot_coin_to_instrument(&order.coin);
 
-    // Use cloid (client order ID) if available, fall back to OID
     let order_id_smol = format_smolstr!("{}", order.oid);
     let cid = order
         .cloid
@@ -994,7 +1028,6 @@ fn order_update_to_account_event(
         .map(|c| ClientOrderId::new(SmolStr::new(c)))
         .unwrap_or_else(|| ClientOrderId::new(order_id_smol.clone()));
 
-    // Determine order state from status
     let state = match update.status.as_str() {
         "open" | "resting" => {
             let current_sz = parse_decimal(&order.sz, "order.sz")?;
@@ -1008,8 +1041,8 @@ fn order_update_to_account_event(
         "filled" => crate::order::state::OrderState::fully_filled(Filled::new(
             OrderId(order_id_smol),
             time_exchange,
-            orig_sz, // Fully filled means filled_quantity == orig_sz
-            None,    // OrderUpdate doesn't include avg_price
+            orig_sz,
+            None,
         )),
         "canceled" | "cancelled" => {
             let current_sz = parse_decimal(&order.sz, "order.sz")?;
@@ -1026,11 +1059,9 @@ fn order_update_to_account_event(
         }
     };
 
-    // SDK's OrderUpdate doesn't include original order type or TIF, so we default
-    // to Limit/GTC. This is a known limitation — IOC/FOK orders will be misrepresented.
     let order_snapshot = Order {
         key: OrderKey {
-            exchange: ExchangeId::HyperliquidPerp,
+            exchange: ExchangeId::HyperliquidSpot,
             instrument,
             strategy: StrategyId::unknown(),
             cid,
@@ -1044,7 +1075,7 @@ fn order_update_to_account_event(
     };
 
     Some(AccountEvent::new(
-        ExchangeId::HyperliquidPerp,
+        ExchangeId::HyperliquidSpot,
         AccountEventKind::OrderSnapshot(Snapshot(order_snapshot)),
     ))
 }
@@ -1057,21 +1088,21 @@ mod tests {
     use rust_decimal_macros::dec;
 
     #[test]
-    fn test_fill_to_account_event() {
+    fn test_fill_to_account_event_spot() {
         let fill_json = r#"{
-            "coin": "BTC",
+            "coin": "PURR/USDC",
             "side": "B",
-            "px": "65000.5",
-            "sz": "0.1",
+            "px": "0.05",
+            "sz": "1000",
             "time": 1714100000000,
-            "hash": "0xabc123",
+            "hash": "0xspot123",
             "startPosition": "0",
             "dir": "Open Long",
             "closedPnl": "0",
             "oid": 12345,
             "cloid": null,
             "crossed": false,
-            "fee": "0.65",
+            "fee": "0.025",
             "feeToken": "USDC",
             "tid": 99999
         }"#;
@@ -1079,64 +1110,31 @@ mod tests {
         let fill: hyperliquid_rust_sdk::TradeInfo = serde_json::from_str(fill_json).unwrap();
         let event = fill_to_account_event(&fill).unwrap();
 
-        assert_eq!(event.exchange, ExchangeId::HyperliquidPerp);
+        assert_eq!(event.exchange, ExchangeId::HyperliquidSpot);
         match event.kind {
             AccountEventKind::Trade(trade) => {
-                assert_eq!(trade.instrument.as_ref(), "BTC-USD-PERP");
+                assert_eq!(trade.instrument.as_ref(), "PURR-USDC-SPOT");
                 assert_eq!(trade.side, Side::Buy);
-                assert_eq!(trade.price, dec!(65000.5));
-                assert_eq!(trade.quantity, dec!(0.1));
-                assert_eq!(trade.fees.fees, dec!(0.65));
+                assert_eq!(trade.price, dec!(0.05));
+                assert_eq!(trade.quantity, dec!(1000));
+                assert_eq!(trade.fees.fees, dec!(0.025));
+                assert_eq!(trade.fees.asset.as_ref(), "USDC");
             }
             _ => panic!("Expected Trade event"),
         }
     }
 
     #[test]
-    fn test_fill_to_account_event_sell() {
-        let fill_json = r#"{
-            "coin": "ETH",
-            "side": "A",
-            "px": "3200",
-            "sz": "1.5",
-            "time": 1714100000000,
-            "hash": "0xdef456",
-            "startPosition": "1.5",
-            "dir": "Close Long",
-            "closedPnl": "150.0",
-            "oid": 12346,
-            "cloid": null,
-            "crossed": true,
-            "fee": "4.8",
-            "feeToken": "USDC",
-            "tid": 100000
-        }"#;
-
-        let fill: hyperliquid_rust_sdk::TradeInfo = serde_json::from_str(fill_json).unwrap();
-        let event = fill_to_account_event(&fill).unwrap();
-
-        match event.kind {
-            AccountEventKind::Trade(trade) => {
-                assert_eq!(trade.instrument.as_ref(), "ETH-USD-PERP");
-                assert_eq!(trade.side, Side::Sell);
-                assert_eq!(trade.price, dec!(3200));
-                assert_eq!(trade.quantity, dec!(1.5));
-            }
-            _ => panic!("Expected Trade event"),
-        }
-    }
-
-    #[test]
-    fn test_order_update_to_account_event_open() {
+    fn test_order_update_to_account_event_spot() {
         let update_json = r#"{
             "order": {
-                "coin": "BTC",
-                "side": "B",
-                "limitPx": "64000",
-                "sz": "0.5",
-                "oid": 12345,
+                "coin": "HYPE/USDC",
+                "side": "A",
+                "limitPx": "25.5",
+                "sz": "10",
+                "oid": 12346,
                 "timestamp": 1714100000000,
-                "origSz": "0.5",
+                "origSz": "10",
                 "cloid": null
             },
             "status": "open",
@@ -1146,13 +1144,13 @@ mod tests {
         let update: hyperliquid_rust_sdk::OrderUpdate = serde_json::from_str(update_json).unwrap();
         let event = order_update_to_account_event(&update).unwrap();
 
-        assert_eq!(event.exchange, ExchangeId::HyperliquidPerp);
+        assert_eq!(event.exchange, ExchangeId::HyperliquidSpot);
         match event.kind {
             AccountEventKind::OrderSnapshot(Snapshot(order)) => {
-                assert_eq!(order.key.instrument.as_ref(), "BTC-USD-PERP");
-                assert_eq!(order.side, Side::Buy);
-                assert_eq!(order.price, dec!(64000));
-                assert_eq!(order.quantity, dec!(0.5));
+                assert_eq!(order.key.instrument.as_ref(), "HYPE-USDC-SPOT");
+                assert_eq!(order.side, Side::Sell);
+                assert_eq!(order.price, dec!(25.5));
+                assert_eq!(order.quantity, dec!(10));
                 assert!(matches!(
                     order.state,
                     crate::order::state::OrderState::Active(_)
@@ -1160,95 +1158,5 @@ mod tests {
             }
             _ => panic!("Expected OrderSnapshot event"),
         }
-    }
-
-    #[test]
-    fn test_order_update_to_account_event_filled() {
-        let update_json = r#"{
-            "order": {
-                "coin": "ETH",
-                "side": "A",
-                "limitPx": "3250",
-                "sz": "0",
-                "oid": 12346,
-                "timestamp": 1714100000000,
-                "origSz": "2.0",
-                "cloid": null
-            },
-            "status": "filled",
-            "statusTimestamp": 1714100001000
-        }"#;
-
-        let update: hyperliquid_rust_sdk::OrderUpdate = serde_json::from_str(update_json).unwrap();
-        let event = order_update_to_account_event(&update).unwrap();
-
-        match event.kind {
-            AccountEventKind::OrderSnapshot(Snapshot(order)) => {
-                assert_eq!(order.side, Side::Sell);
-                assert!(matches!(
-                    order.state,
-                    crate::order::state::OrderState::Inactive(
-                        crate::order::state::InactiveOrderState::FullyFilled(_)
-                    )
-                ));
-            }
-            _ => panic!("Expected OrderSnapshot event"),
-        }
-    }
-
-    #[test]
-    fn test_order_update_to_account_event_cancelled() {
-        let update_json = r#"{
-            "order": {
-                "coin": "SOL",
-                "side": "B",
-                "limitPx": "150",
-                "sz": "10",
-                "oid": 12347,
-                "timestamp": 1714100000000,
-                "origSz": "10",
-                "cloid": null
-            },
-            "status": "canceled",
-            "statusTimestamp": 1714100002000
-        }"#;
-
-        let update: hyperliquid_rust_sdk::OrderUpdate = serde_json::from_str(update_json).unwrap();
-        let event = order_update_to_account_event(&update).unwrap();
-
-        match event.kind {
-            AccountEventKind::OrderSnapshot(Snapshot(order)) => {
-                assert_eq!(order.key.instrument.as_ref(), "SOL-USD-PERP");
-                assert!(matches!(
-                    order.state,
-                    crate::order::state::OrderState::Inactive(
-                        crate::order::state::InactiveOrderState::Cancelled(_)
-                    )
-                ));
-            }
-            _ => panic!("Expected OrderSnapshot event"),
-        }
-    }
-
-    #[test]
-    fn test_order_update_unknown_status_returns_none() {
-        let update_json = r#"{
-            "order": {
-                "coin": "BTC",
-                "side": "B",
-                "limitPx": "64000",
-                "sz": "0.5",
-                "oid": 12345,
-                "timestamp": 1714100000000,
-                "origSz": "0.5",
-                "cloid": null
-            },
-            "status": "unknown_status",
-            "statusTimestamp": 1714100000000
-        }"#;
-
-        let update: hyperliquid_rust_sdk::OrderUpdate = serde_json::from_str(update_json).unwrap();
-        let event = order_update_to_account_event(&update);
-        assert!(event.is_none());
     }
 }

--- a/barter-execution/src/client/mod.rs
+++ b/barter-execution/src/client/mod.rs
@@ -24,7 +24,7 @@ pub mod alpaca;
 #[cfg(feature = "binance")]
 pub mod binance;
 
-// Hyperliquid perpetual futures ExecutionClient implementation
+// Hyperliquid perpetual futures and spot ExecutionClient implementations
 #[cfg(feature = "hyperliquid")]
 pub mod hyperliquid;
 

--- a/barter-execution/tests/hyperliquid_spot_execution.rs
+++ b/barter-execution/tests/hyperliquid_spot_execution.rs
@@ -1,0 +1,557 @@
+//! Hyperliquid Spot Execution Client Integration Tests
+//!
+//! These tests require a funded Hyperliquid testnet account.
+//!
+//! # Prerequisites
+//!
+//! 1. Hyperliquid testnet account with mock USDC (claim at app.hyperliquid-testnet.xyz/drip)
+//! 2. Environment variables set (see .env.template):
+//!    - HYPERLIQUID_PRIVATE_KEY: Wallet private key (hex)
+//!    - HYPERLIQUID_TESTNET=true
+//!
+//! # Running
+//!
+//! ```bash
+//! # Load env vars from .env (optional, or export manually)
+//! source .env
+//!
+//! # Run all Hyperliquid spot integration tests
+//! cargo test --test hyperliquid_spot_execution --features hyperliquid -- --ignored
+//!
+//! # Run specific test
+//! cargo test --test hyperliquid_spot_execution --features hyperliquid test_spot_connection -- --ignored
+//! ```
+//!
+//! Tests are marked `#[ignore]` to avoid CI failures without testnet connectivity.
+//!
+//! # Spot vs Perpetuals
+//!
+//! - Uses `HyperliquidSpotClient` instead of `HyperliquidClient`
+//! - Instrument format: "BTC-USDC-SPOT" (converts to "BTC/USDC" for API)
+//! - Balances from `user_token_balances()` instead of margin summary
+//! - No positions (spot has no margin/leverage)
+//! - $10 minimum order notional value
+
+#![cfg(feature = "hyperliquid")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use barter_execution::{
+    client::{
+        ExecutionClient,
+        hyperliquid::{config::HyperliquidConfig, spot::HyperliquidSpotClient},
+    },
+    order::{
+        OrderKey, OrderKind, TimeInForce,
+        id::{ClientOrderId, StrategyId},
+        request::RequestOpen,
+        state::{ActiveOrderState, OrderState},
+    },
+};
+use barter_instrument::{
+    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
+    instrument::name::InstrumentNameExchange,
+};
+use rust_decimal_macros::dec;
+use std::time::Duration;
+use tokio_stream::StreamExt;
+use tracing_subscriber::{EnvFilter, fmt};
+
+fn init_logging() {
+    let _ = fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(tracing::Level::DEBUG.into())
+                .from_env_lossy(),
+        )
+        .try_init();
+}
+
+fn test_config() -> HyperliquidConfig {
+    HyperliquidConfig::from_env().expect(
+        "HYPERLIQUID_PRIVATE_KEY env var required. Set HYPERLIQUID_TESTNET=true for testnet.",
+    )
+}
+
+fn hype_spot_instrument() -> InstrumentNameExchange {
+    // HYPE/USDC is a real spot pair on Hyperliquid (index @107 on mainnet)
+    // Note: Hyperliquid spot markets are memecoins, not BTC/ETH
+    "HYPE-USDC-SPOT".into()
+}
+
+// ============================================================================
+// Connection Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_connection() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "Integration tests must run on testnet");
+
+    println!("Wallet address: {}", config.wallet_address_hex());
+
+    let client = HyperliquidSpotClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    assert_eq!(HyperliquidSpotClient::EXCHANGE, ExchangeId::HyperliquidSpot);
+    println!("Client wallet: {}", client.wallet_address());
+    println!("Spot client created successfully");
+}
+
+// ============================================================================
+// Account Snapshot Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_fetch_balances() {
+    init_logging();
+
+    let config = test_config();
+    let client = HyperliquidSpotClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let assets: Vec<AssetNameExchange> = vec![];
+    let result = client.fetch_balances(&assets).await;
+
+    assert!(result.is_ok(), "fetch_balances failed: {:?}", result.err());
+
+    let balances = result.unwrap();
+    println!("Fetched {} spot balance(s)", balances.len());
+    for balance in &balances {
+        println!(
+            "  {}: total={}, free={}",
+            balance.asset, balance.balance.total, balance.balance.free
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_account_snapshot() {
+    init_logging();
+
+    let config = test_config();
+    let client = HyperliquidSpotClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let assets: Vec<AssetNameExchange> = vec![];
+    let instruments: Vec<InstrumentNameExchange> = vec![];
+
+    let result = client.account_snapshot(&assets, &instruments).await;
+
+    assert!(
+        result.is_ok(),
+        "account_snapshot failed: {:?}",
+        result.err()
+    );
+
+    let snapshot = result.unwrap();
+    println!("Exchange: {:?}", snapshot.exchange);
+    println!("Spot balances: {}", snapshot.balances.len());
+    for balance in &snapshot.balances {
+        println!(
+            "  {}: total={}, free={}",
+            balance.asset, balance.balance.total, balance.balance.free
+        );
+    }
+    println!("Instruments with orders: {}", snapshot.instruments.len());
+    for inst in &snapshot.instruments {
+        println!(
+            "  {}: orders={}, position={:?}",
+            inst.instrument,
+            inst.orders.len(),
+            inst.position.as_ref().map(|p| p.quantity)
+        );
+    }
+}
+
+// ============================================================================
+// Open Orders Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_fetch_open_orders() {
+    init_logging();
+
+    let config = test_config();
+    let client = HyperliquidSpotClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let instruments: Vec<InstrumentNameExchange> = vec![];
+    let result = client.fetch_open_orders(&instruments).await;
+
+    assert!(
+        result.is_ok(),
+        "fetch_open_orders failed: {:?}",
+        result.err()
+    );
+
+    let orders = result.unwrap();
+    println!("Open spot orders: {}", orders.len());
+    for order in &orders {
+        println!(
+            "  {:?} {} {} @ {}",
+            order.side, order.quantity, order.key.instrument, order.price
+        );
+    }
+}
+
+// ============================================================================
+// Historical Trades Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_fetch_trades() {
+    init_logging();
+
+    let config = test_config();
+    let client = HyperliquidSpotClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let since = chrono::Utc::now() - chrono::Duration::days(7);
+    let instruments: Vec<InstrumentNameExchange> = vec![];
+
+    let result = client.fetch_trades(since, &instruments).await;
+
+    assert!(result.is_ok(), "fetch_trades failed: {:?}", result.err());
+
+    let trades = result.unwrap();
+    println!("Spot trades in last 7 days: {}", trades.len());
+    for trade in trades.iter().take(10) {
+        println!(
+            "  {} {:?} {} {} @ {} (fee: {})",
+            trade.time_exchange.format("%Y-%m-%d %H:%M:%S"),
+            trade.side,
+            trade.quantity,
+            trade.instrument,
+            trade.price,
+            trade.fees.fees
+        );
+    }
+}
+
+// ============================================================================
+// Order Lifecycle Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_place_and_cancel_limit_order() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = HyperliquidSpotClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let instrument = hype_spot_instrument();
+    let strategy = StrategyId::new("test-spot-strategy");
+    let order_cid = ClientOrderId::new(format!(
+        "spot-test-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::HyperliquidSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Place a limit buy below market price (won't fill)
+    // HYPE on testnet ~$90, place at $60 (within 80% of market, won't fill)
+    // 1 HYPE @ $60 = $60 notional (above $10 minimum)
+    let request_open = RequestOpen {
+        side: Side::Buy,
+        price: dec!(60.0),
+        quantity: dec!(1.0),
+        kind: OrderKind::Limit,
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = barter_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing spot limit order: BUY 1 HYPE-USDC-SPOT @ $60 (won't fill)");
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Spot order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {}", open_state.id);
+
+            // Wait a moment for order to be fully processed
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Cancel the order
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::HyperliquidSpot,
+                instrument: &instrument,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = barter_execution::order::OrderEvent {
+                key: cancel_key,
+                state: barter_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling spot order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            let cancel_response = cancel_response.unwrap();
+
+            match &cancel_response.state {
+                Ok(cancelled) => {
+                    println!("Spot order canceled successfully!");
+                    println!("  Cancelled at: {}", cancelled.time_exchange);
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("Spot order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_minimum_notional_validation() {
+    init_logging();
+
+    let config = test_config();
+    let client = HyperliquidSpotClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let instrument = hype_spot_instrument();
+    let strategy = StrategyId::new("test-min-notional");
+    let order_cid = ClientOrderId::new(format!("min-{}", chrono::Utc::now().timestamp_millis()));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::HyperliquidSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Order below $10 minimum: 0.1 HYPE @ $60 = $6 notional
+    let request_open = RequestOpen {
+        side: Side::Buy,
+        price: dec!(60.0),
+        quantity: dec!(0.1),
+        kind: OrderKind::Limit,
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = barter_execution::order::OrderEvent {
+        key: order_key,
+        state: request_open,
+    };
+
+    println!("Placing order below $10 minimum (should be rejected locally)");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Inactive(e) => {
+            println!("Order correctly rejected: {:?}", e);
+            // Verify it mentions the minimum
+            let error_msg = format!("{:?}", e);
+            assert!(
+                error_msg.contains("10") || error_msg.contains("minimum"),
+                "Error should mention $10 minimum: {error_msg}"
+            );
+        }
+        other => {
+            panic!("Expected rejection, got: {:?}", other);
+        }
+    }
+}
+
+// ============================================================================
+// Account Stream Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_account_stream() {
+    init_logging();
+
+    let config = test_config();
+    let client = HyperliquidSpotClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let assets: Vec<AssetNameExchange> = vec![];
+    let instruments: Vec<InstrumentNameExchange> = vec![];
+
+    let stream_result = client.account_stream(&assets, &instruments).await;
+
+    assert!(
+        stream_result.is_ok(),
+        "account_stream failed: {:?}",
+        stream_result.err()
+    );
+
+    let mut stream = stream_result.unwrap();
+
+    println!("Spot account stream started. Waiting for events (10 second timeout)...");
+    println!("(Note: stream receives both spot and perp events, filtered to spot only)");
+
+    let timeout = tokio::time::timeout(Duration::from_secs(10), async {
+        let mut count = 0;
+        while let Some(event) = stream.next().await {
+            println!("Event: {:?}", event.kind);
+            count += 1;
+            if count >= 3 {
+                break;
+            }
+        }
+        count
+    })
+    .await;
+
+    match timeout {
+        Ok(count) => println!("Received {} events", count),
+        Err(_) => println!("Timeout reached (this is normal if no spot orders are active)"),
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_spot_account_stream_with_order() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = HyperliquidSpotClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    // Start account stream
+    let assets: Vec<AssetNameExchange> = vec![];
+    let instruments: Vec<InstrumentNameExchange> = vec![];
+
+    let stream_result = client.account_stream(&assets, &instruments).await;
+    assert!(
+        stream_result.is_ok(),
+        "account_stream failed: {:?}",
+        stream_result.err()
+    );
+    let mut stream = stream_result.unwrap();
+
+    println!("Spot account stream started, placing order to trigger events...");
+
+    // Give WebSocket time to fully connect
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Place an order to trigger stream events
+    let instrument = hype_spot_instrument();
+    let strategy = StrategyId::new("stream-test");
+    let order_cid = ClientOrderId::new(format!("stream-{}", chrono::Utc::now().timestamp_millis()));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::HyperliquidSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // 1 HYPE @ $60 = $60 notional (above minimum, within 80% of testnet market ~$90)
+    let request_open = RequestOpen {
+        side: Side::Buy,
+        price: dec!(60.0),
+        quantity: dec!(1.0),
+        kind: OrderKind::Limit,
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = barter_execution::order::OrderEvent {
+        key: order_key,
+        state: request_open,
+    };
+
+    println!("Placing spot order (1 HYPE @ $60) to trigger stream events...");
+    let response = client.open_order(open_request).await;
+
+    if let Some(response) = response
+        && let OrderState::Active(ActiveOrderState::Open(open_state)) = &response.state
+    {
+        println!("Order placed, waiting for stream events...");
+
+        // Wait for order update in stream
+        let timeout = tokio::time::timeout(Duration::from_secs(5), async {
+            let mut count = 0;
+            while let Some(event) = stream.next().await {
+                println!("Stream event: {:?}", event.kind);
+                count += 1;
+                if count >= 2 {
+                    break;
+                }
+            }
+            count
+        })
+        .await;
+
+        match timeout {
+            Ok(count) => println!("Received {} events from stream", count),
+            Err(_) => println!("Timeout (events may have arrived before stream ready)"),
+        }
+
+        // Cleanup: cancel the order
+        let cancel_key = OrderKey {
+            exchange: ExchangeId::HyperliquidSpot,
+            instrument: &instrument,
+            strategy: response.key.strategy.clone(),
+            cid: response.key.cid.clone(),
+        };
+
+        let cancel_request = barter_execution::order::OrderEvent {
+            key: cancel_key,
+            state: barter_execution::order::request::RequestCancel {
+                id: Some(open_state.id.clone()),
+            },
+        };
+
+        let _ = client.cancel_order(cancel_request).await;
+        println!("Cleanup: order canceled");
+    }
+}

--- a/barter-instrument/src/exchange.rs
+++ b/barter-instrument/src/exchange.rs
@@ -71,6 +71,8 @@ pub enum ExchangeId {
     Htx,
     /// Hyperliquid perpetual futures (decentralized, EVM-based)
     HyperliquidPerp,
+    /// Hyperliquid spot trading (decentralized, EVM-based)
+    HyperliquidSpot,
     /// Interactive Brokers — equities, futures, options, forex
     Ibkr,
     Kraken,
@@ -123,6 +125,7 @@ impl ExchangeId {
             ExchangeId::Hitbtc => "hitbtc",
             ExchangeId::Htx => "htx", // huobi alias
             ExchangeId::HyperliquidPerp => "hyperliquid_perp",
+            ExchangeId::HyperliquidSpot => "hyperliquid_spot",
             ExchangeId::Ibkr => "ibkr",
             ExchangeId::Kraken => "kraken",
             ExchangeId::Kucoin => "kucoin",


### PR DESCRIPTION
Extends Hyperliquid integration to support spot trading alongside perpetual futures, enabling unified account access with $10 minimum order values and unified collateral.

Changes:

**Market Data (barter-data)**
- Add `HyperliquidSpot` connector struct for spot market subscriptions
- Implement `SpotMetaResolver` to map token names to `@{index}` WebSocket format
- Add `spot_meta.rs` module for `spotMeta` API caching and pair resolution
- Extend `HyperliquidMarket` to handle both perps (symbol) and spot (pair format)
- Add channel/market identifiers for `HyperliquidSpot` subscriptions
- Add `examples/hyperliquid_spot_market_data.rs` demonstrating trades + L2 books
- Add `tests/hyperliquid_spot_data.rs` integration test (testnet)

**Execution (barter-execution)**
- Extract shared utilities to `hyperliquid/common.rs`:
  - Error mapping (`map_sdk_error`, `map_order_error`)
  - Parsing helpers (`parse_decimal`, `parse_side`, `millis_to_datetime`)
  - Price rounding (`round_to_5_sig_figs`), TIF mapping, UUID parsing
  - `CancelOnDropStream` wrapper for cleanup on drop
- Add `HyperliquidSpotClient` struct implementing `ExecutionClient`
  - Uses same `HyperliquidConfig` and SDK clients as perps
  - Account snapshots via `user_token_balances()` (no margin/positions)
  - Coin naming helpers: `instrument_to_spot_coin()`, `spot_coin_to_instrument()`
  - Filtering by coin format: `/` present = spot, absent = perp
  - Local validation: $10 minimum order value
  - WebSocket: Filters `UserFills`/`OrderUpdates` by coin name
- Update `HyperliquidClient` to use extracted common module
- Add `examples/hyperliquid_spot_execution.rs` demonstrating account snapshot, order placement, cancellation
- Add `tests/hyperliquid_spot_execution.rs` integration test (testnet)

**Instrument (barter-instrument)**
- Add `HyperliquidSpot` variant to `ExchangeId` enum

**Documentation**
- Update README.md and barter-data/README.md to list spot support
- Document unified account model: spot balances count as perp collateral
- Document separate wallets within unified account (explicit transfer required)
- Document WebSocket behavior: UserFills/OrderUpdates deliver both spot and perp events
- Document spot-specific limitations: no leverage, $10 minimum, `reduce_only` supported