### PR TITLE
deps: batch update reqwest, hmac, sha2, convert_case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde_urlencoded = { version = "0.7.1" }
 
 # Protocol
 url = { version = "2.5.4" }
-reqwest = { version = "0.12.9",default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.13.3", default-features = false, features = ["rustls", "json", "query"] }
 tokio-tungstenite = { version = "0.26.0", features = ["url","rustls-tls-webpki-roots"] }
 
 # Data Structures
@@ -64,8 +64,8 @@ fnv = { version = "1.0.7" }
 indexmap = { version = "2.6.0" }
 
 # Crytographic Signatures
-hmac = { version = "0.12.1" }
-sha2 = { version = "0.10.8" }
+hmac = { version = "0.13.0" }
+sha2 = { version = "0.11.0" }
 hex = { version = "0.4.3" }
 base64 = { version = "0.22.1" }
 

--- a/rustrade-integration/examples/signed_get_request.rs
+++ b/rustrade-integration/examples/signed_get_request.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
 
 use chrono::{DateTime, Utc};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use reqwest::{RequestBuilder, StatusCode};
 use rustrade_instrument::asset::name::AssetNameInternal;
 use rustrade_integration::{

--- a/rustrade-macro/Cargo.toml
+++ b/rustrade-macro/Cargo.toml
@@ -20,4 +20,4 @@ syn = "2.0.117"
 quote = "1.0.23"
 
 # Misc
-convert_case = "0.6.0"
+convert_case = "0.11.0"

--- a/rustrade-macro/src/lib.rs
+++ b/rustrade-macro/src/lib.rs
@@ -84,7 +84,7 @@ pub fn de_sub_kind_derive(input: TokenStream) -> TokenStream {
     let expected_sub_kind = sub_kind
         .to_string()
         .from_case(Case::Pascal)
-        .without_boundaries(&Boundary::letter_digit())
+        .remove_boundaries(&Boundary::letter_digit())
         .to_case(Case::Snake);
 
     let generated = quote! {


### PR DESCRIPTION
## Summary
- Update reqwest 0.12.9 → 0.13.3 (feature rename: rustls-tls → rustls, add query)
- Update hmac 0.12.1 → 0.13.0 (requires KeyInit trait import)
- Update sha2 0.10.8 → 0.11.0
- Update convert_case 0.6.0 → 0.11.0 (API: without_boundaries → remove_boundaries)

## Supersedes
Closes #30, closes #31, closes #35, closes #37

These dependabot PRs failed checks due to breaking API changes that required coordinated updates across crates.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes