### PR TITLE
feat(data): Migrate price/amount fields from f64 to Decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `DatabentoHistorical`: One-shot queries for trades and quotes in DBN format
   - `DatabentoLive<K>`: Real-time WebSocket streaming with `PitSymbolMap` symbol resolution
   - `ExchangeId` variants: `DatabentoGlbx`, `DatabentoXnas`, `DatabentoXnys`, `DatabentoDbeq`, `DatabentoOpra`
-  - Nanosecond-precision timestamps, both f64 and Decimal price support
+  - Nanosecond-precision timestamps and lossless Decimal price conversion
   - **Note**: Live data integration is NOT TESTED — Databento does not offer development/sandbox keys and we do not have a subscription.
     Offline fixture tests verify transformation logic; network integration is unverified.
 - **Alpaca market data connector**: Real-time trades and quotes via WebSocket
@@ -23,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Quotes subscription kind**: Generic top-of-book quotes (`SubKind::Quotes`)
 - `ExchangeId::AlpacaBroker`: Dedicated variant for Alpaca execution client
   (distinct from market data feed identifiers)
+
+### Changed
+
+- **BREAKING**: `PublicTrade`, `Quote`, `Candle`, and `Liquidation` price/amount fields
+  changed from `f64` to `rust_decimal::Decimal` for financial precision.
+  - `PublicTrade`: `price`, `amount` now `Decimal`
+  - `Quote`: `bid_price`, `ask_price`, `bid_amount`, `ask_amount` now `Decimal`
+  - `Candle`: `open`, `high`, `low`, `close`, `volume` now `Decimal`
+  - `Liquidation`: `price`, `quantity` now `Decimal`
+  - Migration: Use `dec!()` macro for literals, `> Decimal::ZERO` for positivity checks.
+    For string-typed JSON fields, use `de_str` deserializer or `.parse::<Decimal>()`.
+    Use `Decimal::try_from(f64)` only when the source is already `f64` (e.g., IBKR API).
 
 ### Deprecated
 

--- a/rustrade-data/src/exchange/alpaca/quote.rs
+++ b/rustrade-data/src/exchange/alpaca/quote.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::exchange::ExchangeId;
 use rustrade_integration::{
     Transformer, protocol::websocket::WsMessage, subscription::SubscriptionId,
@@ -47,13 +48,13 @@ pub struct AlpacaQuote {
     #[serde(rename = "S", deserialize_with = "de_quote_subscription_id")]
     pub subscription_id: SubscriptionId,
     #[serde(rename = "bp")]
-    pub bid_price: f64,
+    pub bid_price: Decimal,
     #[serde(rename = "bs")]
-    pub bid_size: f64,
+    pub bid_size: Decimal,
     #[serde(rename = "ap")]
-    pub ask_price: f64,
+    pub ask_price: Decimal,
     #[serde(rename = "as")]
-    pub ask_size: f64,
+    pub ask_size: Decimal,
     #[serde(rename = "t")]
     pub timestamp: DateTime<Utc>,
     #[serde(rename = "bx", default)]
@@ -175,6 +176,7 @@ where
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_de_equities_quote() {
@@ -182,10 +184,10 @@ mod tests {
         let quote: AlpacaQuote = serde_json::from_str(input).unwrap();
 
         assert_eq!(quote.subscription_id.as_ref(), "quotes|AAPL");
-        assert_eq!(quote.bid_price, 150.20);
-        assert_eq!(quote.bid_size, 200.0);
-        assert_eq!(quote.ask_price, 150.25);
-        assert_eq!(quote.ask_size, 100.0);
+        assert_eq!(quote.bid_price, dec!(150.20));
+        assert_eq!(quote.bid_size, dec!(200));
+        assert_eq!(quote.ask_price, dec!(150.25));
+        assert_eq!(quote.ask_size, dec!(100));
         assert_eq!(quote.bid_exchange, Some(SmolStr::new("Q")));
         assert_eq!(quote.ask_exchange, Some(SmolStr::new("V")));
         assert_eq!(quote.tape, Some(SmolStr::new("C")));
@@ -197,10 +199,10 @@ mod tests {
         let quote: AlpacaQuote = serde_json::from_str(input).unwrap();
 
         assert_eq!(quote.subscription_id.as_ref(), "quotes|BTC/USD");
-        assert_eq!(quote.bid_price, 60000.00);
-        assert_eq!(quote.bid_size, 2.0);
-        assert_eq!(quote.ask_price, 60000.50);
-        assert_eq!(quote.ask_size, 1.0);
+        assert_eq!(quote.bid_price, dec!(60000.00));
+        assert_eq!(quote.bid_size, dec!(2.0));
+        assert_eq!(quote.ask_price, dec!(60000.50));
+        assert_eq!(quote.ask_size, dec!(1.0));
         assert!(quote.bid_exchange.is_none());
         assert!(quote.ask_exchange.is_none());
         assert!(quote.tape.is_none());

--- a/rustrade-data/src/exchange/alpaca/trade.rs
+++ b/rustrade-data/src/exchange/alpaca/trade.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::{
     Transformer, protocol::websocket::WsMessage, subscription::SubscriptionId,
@@ -49,9 +50,9 @@ pub struct AlpacaTrade {
     #[serde(rename = "i")]
     pub id: u64,
     #[serde(rename = "p")]
-    pub price: f64,
+    pub price: Decimal,
     #[serde(rename = "s")]
-    pub size: f64,
+    pub size: Decimal,
     #[serde(rename = "t")]
     pub timestamp: DateTime<Utc>,
     #[serde(rename = "x", default)]
@@ -190,6 +191,7 @@ where
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_de_equities_trade() {
@@ -198,8 +200,8 @@ mod tests {
 
         assert_eq!(trade.subscription_id.as_ref(), "trades|AAPL");
         assert_eq!(trade.id, 123);
-        assert_eq!(trade.price, 150.25);
-        assert_eq!(trade.size, 100.0);
+        assert_eq!(trade.price, dec!(150.25));
+        assert_eq!(trade.size, dec!(100));
         assert_eq!(trade.exchange, Some(SmolStr::new("V")));
         assert_eq!(trade.tape, Some(SmolStr::new("C")));
         assert!(trade.taker_side.is_none());
@@ -212,8 +214,8 @@ mod tests {
 
         assert_eq!(trade.subscription_id.as_ref(), "trades|BTC/USD");
         assert_eq!(trade.id, 456);
-        assert_eq!(trade.price, 60000.50);
-        assert_eq!(trade.size, 0.5);
+        assert_eq!(trade.price, dec!(60000.50));
+        assert_eq!(trade.size, dec!(0.5));
         assert!(trade.exchange.is_none());
         assert!(trade.tape.is_none());
         assert_eq!(trade.taker_side, Some(SmolStr::new("B")));

--- a/rustrade-data/src/exchange/binance/futures/liquidation.rs
+++ b/rustrade-data/src/exchange/binance/futures/liquidation.rs
@@ -5,6 +5,7 @@ use crate::{
     subscription::liquidation::Liquidation,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::subscription::SubscriptionId;
 use serde::{Deserialize, Serialize};
@@ -68,12 +69,12 @@ pub struct BinanceLiquidationOrder {
         alias = "p",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub price: f64,
+    pub price: Decimal,
     #[serde(
         alias = "q",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub quantity: f64,
+    pub quantity: Decimal,
     #[serde(
         alias = "T",
         deserialize_with = "rustrade_integration::serde::de::de_u64_epoch_ms_as_datetime_utc"
@@ -128,6 +129,7 @@ mod tests {
 
     mod de {
         use super::*;
+        use rust_decimal_macros::dec;
         use rustrade_integration::serde::de::datetime_utc_from_epoch_duration;
         use std::time::Duration;
 
@@ -159,8 +161,8 @@ mod tests {
                     order: BinanceLiquidationOrder {
                         subscription_id: SubscriptionId::from("@forceOrder|BTCUSDT"),
                         side: Side::Sell,
-                        price: 18917.15,
-                        quantity: 0.009,
+                        price: dec!(18917.15),
+                        quantity: dec!(0.009),
                         time: datetime_utc_from_epoch_duration(Duration::from_millis(
                             1665523974217,
                         )),

--- a/rustrade-data/src/exchange/binance/trade.rs
+++ b/rustrade-data/src/exchange/binance/trade.rs
@@ -6,6 +6,7 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::subscription::SubscriptionId;
 use serde::{Deserialize, Serialize};
@@ -67,12 +68,12 @@ pub struct BinanceTrade {
         alias = "p",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub price: f64,
+    pub price: Decimal,
     #[serde(
         alias = "q",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub amount: f64,
+    pub amount: Decimal,
     #[serde(alias = "m", deserialize_with = "de_side_from_buyer_is_maker")]
     pub side: Side,
 }
@@ -138,6 +139,7 @@ mod tests {
         use std::time::Duration;
 
         use super::*;
+        use rust_decimal_macros::dec;
         use rustrade_integration::{
             error::SocketError, serde::de::datetime_utc_from_epoch_duration,
         };
@@ -166,8 +168,8 @@ mod tests {
                             1749354825200,
                         )),
                         id: 1000000000,
-                        price: 10000.19,
-                        amount: 0.239000,
+                        price: dec!(10000.19),
+                        amount: dec!(0.239000),
                         side: Side::Buy,
                     }),
                 },
@@ -197,8 +199,8 @@ mod tests {
                             1749354825200,
                         )),
                         id: 1000000000,
-                        price: 10000.19,
-                        amount: 0.239000,
+                        price: dec!(10000.19),
+                        amount: dec!(0.239000),
                         side: Side::Sell,
                     }),
                 },
@@ -216,8 +218,8 @@ mod tests {
                             1749354825200,
                         )),
                         id: 1000000000,
-                        price: 10000.19,
-                        amount: 0.239000,
+                        price: dec!(10000.19),
+                        amount: dec!(0.239000),
                         side: Side::Buy,
                     }),
                 },
@@ -233,8 +235,8 @@ mod tests {
                             1749354825200,
                         )),
                         id: 1000000000,
-                        price: 10000.19,
-                        amount: 0.239000,
+                        price: dec!(10000.19),
+                        amount: dec!(0.239000),
                         side: Side::Buy,
                     }),
                 },

--- a/rustrade-data/src/exchange/bitfinex/message.rs
+++ b/rustrade-data/src/exchange/bitfinex/message.rs
@@ -132,6 +132,7 @@ impl<'de> serde::Deserialize<'de> for BitfinexMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
     use rustrade_instrument::Side;
     use rustrade_integration::{error::SocketError, serde::de::datetime_utc_from_epoch_duration};
     use std::time::Duration;
@@ -159,8 +160,8 @@ mod tests {
                             1665452200022,
                         )),
                         side: Side::Sell,
-                        price: 19027.02807752,
-                        amount: 0.08980641,
+                        price: dec!(19027.02807752),
+                        amount: dec!(0.08980641),
                     }),
                 }),
             },
@@ -175,8 +176,8 @@ mod tests {
                             1665452200022,
                         )),
                         side: Side::Buy,
-                        price: 19027.02807752,
-                        amount: 0.08980641,
+                        price: dec!(19027.02807752),
+                        amount: dec!(0.08980641),
                     }),
                 }),
             },

--- a/rustrade-data/src/exchange/bitfinex/trade.rs
+++ b/rustrade-data/src/exchange/bitfinex/trade.rs
@@ -3,6 +3,7 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::serde::de::{datetime_utc_from_epoch_duration, extract_next};
 use serde::Serialize;
@@ -39,8 +40,8 @@ pub struct BitfinexTrade {
     pub id: u64,
     pub time: DateTime<Utc>,
     pub side: Side,
-    pub price: f64,
-    pub amount: f64,
+    pub price: Decimal,
+    pub amount: Decimal,
 }
 
 impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BitfinexTrade)>
@@ -86,7 +87,7 @@ impl<'de> serde::Deserialize<'de> for BitfinexTrade {
                 // Trade: [ID, TIME, AMOUNT,PRICE]
                 let id = extract_next(&mut seq, "id")?;
                 let time_millis = extract_next(&mut seq, "time")?;
-                let amount: f64 = extract_next(&mut seq, "amount")?;
+                let amount: Decimal = extract_next(&mut seq, "amount")?;
                 let price = extract_next(&mut seq, "price")?;
                 let side = match amount.is_sign_positive() {
                     true => Side::Buy,

--- a/rustrade-data/src/exchange/bitmex/trade.rs
+++ b/rustrade-data/src/exchange/bitmex/trade.rs
@@ -4,6 +4,7 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use serde::{Deserialize, Serialize};
 
@@ -40,8 +41,8 @@ pub struct BitmexTradeInner {
     pub symbol: String,
     pub side: Side,
     #[serde(rename = "size")]
-    pub amount: f64,
-    pub price: f64,
+    pub amount: Decimal,
+    pub price: Decimal,
 
     #[serde(rename = "trdMatchID")]
     pub id: String,
@@ -81,6 +82,7 @@ mod tests {
     mod de {
         use super::*;
         use chrono::{Duration, TimeZone};
+        use rust_decimal_macros::dec;
         use rustrade_integration::error::SocketError;
 
         #[test]
@@ -113,8 +115,8 @@ mod tests {
                             + Duration::milliseconds(701),
                         symbol: "XBTUSD".to_string(),
                         side: Side::Sell,
-                        amount: 200.0,
-                        price: 24564.5,
+                        amount: dec!(200),
+                        price: dec!(24564.5),
                         id: "31e50cb7-e005-a44e-f354-86e88dff52eb".to_string(),
                     }),
                 },
@@ -177,8 +179,8 @@ mod tests {
                                 + Duration::milliseconds(701),
                             symbol: "XBTUSD".to_string(),
                             side: Side::Sell,
-                            amount: 200.0,
-                            price: 24564.5,
+                            amount: dec!(200),
+                            price: dec!(24564.5),
                             id: "31e50cb7-e005-a44e-f354-86e88dff52eb".to_string(),
                         }],
                     }),

--- a/rustrade-data/src/exchange/bybit/trade.rs
+++ b/rustrade-data/src/exchange/bybit/trade.rs
@@ -4,6 +4,7 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use serde::{Deserialize, Serialize};
 
@@ -43,13 +44,13 @@ pub struct BybitTradeInner {
         alias = "v",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub amount: f64,
+    pub amount: Decimal,
 
     #[serde(
         alias = "p",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub price: f64,
+    pub price: Decimal,
 
     #[serde(rename = "i")]
     pub id: String,
@@ -90,6 +91,7 @@ mod tests {
         use crate::exchange::bybit::message::BybitPayloadKind;
 
         use super::*;
+        use rust_decimal_macros::dec;
         use rustrade_integration::{
             error::SocketError, serde::de::datetime_utc_from_epoch_duration,
             subscription::SubscriptionId,
@@ -125,8 +127,8 @@ mod tests {
                         )),
                         market: "BTCUSDT".to_string(),
                         side: Side::Buy,
-                        amount: 0.001,
-                        price: 16578.50,
+                        amount: dec!(0.001),
+                        price: dec!(16578.50),
                         id: "20f43950-d8dd-5b31-9112-a178eb6023af".to_string(),
                     }),
                 },
@@ -150,8 +152,8 @@ mod tests {
                         )),
                         market: "BTCUSDT".to_string(),
                         side: Side::Sell,
-                        amount: 0.001,
-                        price: 16578.50,
+                        amount: dec!(0.001),
+                        price: dec!(16578.50),
                         id: "20f43950-d8dd-5b31-9112-a178eb6023af".to_string(),
                     }),
                 },
@@ -247,8 +249,8 @@ mod tests {
                                 )),
                                 market: "BTCUSDT".to_string(),
                                 side: Side::Buy,
-                                amount: 0.001,
-                                price: 16578.50,
+                                amount: dec!(0.001),
+                                price: dec!(16578.50),
                                 id: "20f43950-d8dd-5b31-9112-a178eb6023af".to_string(),
                             },
                             BybitTradeInner {
@@ -257,8 +259,8 @@ mod tests {
                                 )),
                                 market: "BTCUSDT".to_string(),
                                 side: Side::Sell,
-                                amount: 0.001,
-                                price: 16578.50,
+                                amount: dec!(0.001),
+                                price: dec!(16578.50),
                                 id: "20f43950-d8dd-5b31-9112-a178eb6023af".to_string(),
                             },
                         ],

--- a/rustrade-data/src/exchange/coinbase/trade.rs
+++ b/rustrade-data/src/exchange/coinbase/trade.rs
@@ -6,6 +6,7 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::subscription::SubscriptionId;
 use serde::{Deserialize, Serialize};
@@ -41,9 +42,9 @@ pub struct CoinbaseTrade {
         alias = "size",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub amount: f64,
+    pub amount: Decimal,
     #[serde(deserialize_with = "rustrade_integration::serde::de::de_str")]
-    pub price: f64,
+    pub price: Decimal,
     pub side: Side,
 }
 
@@ -87,6 +88,7 @@ where
 mod tests {
     use super::*;
     use chrono::NaiveDateTime;
+    use rust_decimal_macros::dec;
     use rustrade_integration::error::SocketError;
     use serde::de::Error;
     use std::str::FromStr;
@@ -120,8 +122,8 @@ mod tests {
                 expected: Ok(CoinbaseTrade {
                     subscription_id: SubscriptionId::from("matches|BTC-USD"),
                     id: 10,
-                    price: 400.23,
-                    amount: 5.23512,
+                    price: dec!(400.23),
+                    amount: dec!(5.23512),
                     side: Side::Sell,
                     time: NaiveDateTime::from_str("2014-11-07T08:19:27.028459")
                         .unwrap()

--- a/rustrade-data/src/exchange/databento/transformer.rs
+++ b/rustrade-data/src/exchange/databento/transformer.rs
@@ -5,10 +5,7 @@
 //! # Price Format
 //!
 //! DBN uses fixed-point `i64` with 1e-9 scaling (9 decimal places).
-//!
-//! - **Lossless (preferred)**: `Decimal::new(px, 9)` — used by [`dbn_mbp1_to_orderbook_l1`].
-//! - **f64**: `price as f64 / FIXED_PRICE_SCALE` — used by [`dbn_trade_to_public_trade`]
-//!   and [`dbn_mbp1_to_quote`] where `f64` output is required.
+//! All conversions use `Decimal::new(px, 9)` for lossless representation.
 //!
 //! # Timestamp Format
 //!
@@ -24,8 +21,6 @@ use rust_decimal::Decimal;
 use rustrade_instrument::Side;
 use smol_str::format_smolstr;
 
-const FIXED_PRICE_SCALE: f64 = 1_000_000_000.0;
-
 const UNDEF_PRICE: i64 = i64::MAX;
 const UNDEF_SIZE: u32 = u32::MAX;
 
@@ -39,8 +34,8 @@ pub fn dbn_trade_to_public_trade(
         return Err("undefined price");
     }
 
-    let price = trade.price as f64 / FIXED_PRICE_SCALE;
-    let amount = trade.size as f64;
+    let price = Decimal::new(trade.price, 9);
+    let amount = Decimal::from(trade.size);
 
     let time_exchange = nanos_to_datetime(trade.hd.ts_event)?;
 
@@ -68,7 +63,7 @@ pub fn dbn_trade_to_public_trade(
 /// Returns the exchange timestamp and the converted quote, or an error description.
 ///
 /// Note: When DBN provides `UNDEF_SIZE` (`u32::MAX`) for bid/ask size, the
-/// corresponding `bid_amount`/`ask_amount` is set to `0.0`. Callers cannot
+/// corresponding `bid_amount`/`ask_amount` is set to zero. Callers cannot
 /// distinguish "empty book level" from "size unavailable in feed."
 pub fn dbn_mbp1_to_quote(msg: &Mbp1Msg) -> Result<(DateTime<Utc>, Quote), &'static str> {
     let [level] = &msg.levels;
@@ -77,18 +72,18 @@ pub fn dbn_mbp1_to_quote(msg: &Mbp1Msg) -> Result<(DateTime<Utc>, Quote), &'stat
         return Err("undefined bid or ask price");
     }
 
-    let bid_price = level.bid_px as f64 / FIXED_PRICE_SCALE;
-    let ask_price = level.ask_px as f64 / FIXED_PRICE_SCALE;
-    // UNDEF_SIZE (u32::MAX) means size unavailable; map to 0.0 (see rustdoc note)
+    let bid_price = Decimal::new(level.bid_px, 9);
+    let ask_price = Decimal::new(level.ask_px, 9);
+    // UNDEF_SIZE (u32::MAX) means size unavailable; map to zero (see rustdoc note)
     let bid_amount = if level.bid_sz == UNDEF_SIZE {
-        0.0
+        Decimal::ZERO
     } else {
-        level.bid_sz as f64
+        Decimal::from(level.bid_sz)
     };
     let ask_amount = if level.ask_sz == UNDEF_SIZE {
-        0.0
+        Decimal::ZERO
     } else {
-        level.ask_sz as f64
+        Decimal::from(level.ask_sz)
     };
 
     let time_exchange = nanos_to_datetime(msg.hd.ts_event)?;
@@ -108,8 +103,8 @@ pub fn dbn_mbp1_to_quote(msg: &Mbp1Msg) -> Result<(DateTime<Utc>, Quote), &'stat
 ///
 /// Returns the exchange timestamp and the converted order book snapshot, or an error description.
 ///
-/// Unlike [`dbn_mbp1_to_quote`] which returns f64 prices, this returns [`OrderBookL1`] with
-/// [`Decimal`] prices suitable for use with [`DataKind`](crate::event::DataKind).
+/// Unlike [`dbn_mbp1_to_quote`] which returns a flat [`Quote`], this returns [`OrderBookL1`]
+/// with `Option<Level>` fields, allowing callers to distinguish "no data" from "level exists."
 ///
 /// Prices are converted losslessly from DBN's fixed-point `i64` (9 decimal places) to `Decimal`.
 pub fn dbn_mbp1_to_orderbook_l1(
@@ -171,6 +166,8 @@ mod tests {
 
     #[test]
     fn test_trade_conversion() {
+        use rust_decimal_macros::dec;
+
         let mut trade = TradeMsg::default();
         trade.hd.ts_event = 1_700_000_000_000_000_000;
         trade.price = 150_250_000_000;
@@ -180,8 +177,8 @@ mod tests {
 
         let (time, public_trade) = dbn_trade_to_public_trade(&trade).unwrap();
 
-        assert_eq!(public_trade.price, 150.25);
-        assert_eq!(public_trade.amount, 100.0);
+        assert_eq!(public_trade.price, dec!(150.25));
+        assert_eq!(public_trade.amount, dec!(100));
         assert_eq!(public_trade.side, Side::Buy);
         assert_eq!(public_trade.id.as_str(), "12345");
         assert_eq!(time.timestamp(), 1_700_000_000);
@@ -222,6 +219,8 @@ mod tests {
 
     #[test]
     fn test_quote_conversion() {
+        use rust_decimal_macros::dec;
+
         let mut msg = Mbp1Msg::default();
         msg.hd.ts_event = 1_700_000_000_000_000_000;
         msg.levels[0].bid_px = 100_000_000_000;
@@ -231,10 +230,10 @@ mod tests {
 
         let (time, quote) = dbn_mbp1_to_quote(&msg).unwrap();
 
-        assert_eq!(quote.bid_price, 100.0);
-        assert_eq!(quote.ask_price, 100.5);
-        assert_eq!(quote.bid_amount, 1000.0);
-        assert_eq!(quote.ask_amount, 500.0);
+        assert_eq!(quote.bid_price, dec!(100));
+        assert_eq!(quote.ask_price, dec!(100.5));
+        assert_eq!(quote.bid_amount, dec!(1000));
+        assert_eq!(quote.ask_amount, dec!(500));
         assert_eq!(time.timestamp(), 1_700_000_000);
     }
 

--- a/rustrade-data/src/exchange/gateio/perpetual/trade.rs
+++ b/rustrade-data/src/exchange/gateio/perpetual/trade.rs
@@ -6,10 +6,20 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::subscription::SubscriptionId;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use smol_str::format_smolstr;
+
+/// Deserialize a signed integer (i64) as Decimal.
+/// Gate.io Futures sends `size` as a bare JSON integer (e.g., -108 for sells).
+fn de_i64_as_decimal<'de, D>(deserializer: D) -> Result<Decimal, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    i64::deserialize(deserializer).map(Decimal::from)
+}
 
 /// Terse type alias for a `GateioFuturesUsdt`, `GateioFuturesBtc`, `GateioPerpetualUsdt` and
 /// `GateioPerpetualBtc` real-time trades WebSocket message.
@@ -55,9 +65,9 @@ pub struct GateioFuturesTradeInner {
     pub time: DateTime<Utc>,
     pub id: u64,
     #[serde(deserialize_with = "rustrade_integration::serde::de::de_str")]
-    pub price: f64,
-    #[serde(rename = "size")]
-    pub amount: f64,
+    pub price: Decimal,
+    #[serde(rename = "size", deserialize_with = "de_i64_as_decimal")]
+    pub amount: Decimal,
 }
 
 impl Identifier<Option<SubscriptionId>> for GateioFuturesTrades {
@@ -86,7 +96,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, GateioFuturesTrades)
                     kind: PublicTrade {
                         id: format_smolstr!("{}", trade.id),
                         price: trade.price,
-                        amount: trade.amount,
+                        amount: trade.amount.abs(),
                         side: if trade.amount.is_sign_positive() {
                             Side::Buy
                         } else {

--- a/rustrade-data/src/exchange/gateio/spot/trade.rs
+++ b/rustrade-data/src/exchange/gateio/spot/trade.rs
@@ -6,6 +6,7 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::subscription::SubscriptionId;
 use serde::{Deserialize, Serialize};
@@ -40,13 +41,13 @@ pub struct GateioSpotTradeInner {
     pub time: DateTime<Utc>,
     pub id: u64,
     #[serde(deserialize_with = "rustrade_integration::serde::de::de_str")]
-    pub price: f64,
+    pub price: Decimal,
 
     #[serde(
         alias = "size",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub amount: f64,
+    pub amount: Decimal,
 
     /// Taker [`Side`] of the trade.
     pub side: Side,

--- a/rustrade-data/src/exchange/hyperliquid/historical.rs
+++ b/rustrade-data/src/exchange/hyperliquid/historical.rs
@@ -26,6 +26,7 @@
 use crate::{error::DataError, subscription::candle::Candle};
 use chrono::{DateTime, TimeZone, Utc};
 use hyperliquid_rust_sdk::{BaseUrl, InfoClient};
+use rust_decimal::Decimal;
 use tracing::debug;
 
 /// Historical data fetcher for Hyperliquid.
@@ -230,23 +231,23 @@ fn sdk_candle_to_candle(
 
     let open = sdk
         .open
-        .parse::<f64>()
+        .parse::<Decimal>()
         .map_err(|e| DataError::Socket(format!("parse open: {e}")))?;
     let high = sdk
         .high
-        .parse::<f64>()
+        .parse::<Decimal>()
         .map_err(|e| DataError::Socket(format!("parse high: {e}")))?;
     let low = sdk
         .low
-        .parse::<f64>()
+        .parse::<Decimal>()
         .map_err(|e| DataError::Socket(format!("parse low: {e}")))?;
     let close = sdk
         .close
-        .parse::<f64>()
+        .parse::<Decimal>()
         .map_err(|e| DataError::Socket(format!("parse close: {e}")))?;
     let volume = sdk
         .vlm
-        .parse::<f64>()
+        .parse::<Decimal>()
         .map_err(|e| DataError::Socket(format!("parse volume: {e}")))?;
 
     Ok(Candle {
@@ -290,6 +291,8 @@ mod tests {
 
     #[test]
     fn test_sdk_candle_to_candle() {
+        use rust_decimal_macros::dec;
+
         let sdk_candle = hyperliquid_rust_sdk::CandlesSnapshotResponse {
             time_open: 1704067200000,
             time_close: 1704070800000,
@@ -305,11 +308,11 @@ mod tests {
 
         let candle = sdk_candle_to_candle(&sdk_candle).unwrap();
 
-        assert_eq!(candle.open, 45000.5);
-        assert_eq!(candle.high, 45500.0);
-        assert_eq!(candle.low, 44800.0);
-        assert_eq!(candle.close, 45250.0);
-        assert_eq!(candle.volume, 1234.56);
+        assert_eq!(candle.open, dec!(45000.5));
+        assert_eq!(candle.high, dec!(45500.0));
+        assert_eq!(candle.low, dec!(44800.0));
+        assert_eq!(candle.close, dec!(45250.0));
+        assert_eq!(candle.volume, dec!(1234.56));
         assert_eq!(candle.trade_count, 5000);
     }
 }

--- a/rustrade-data/src/exchange/hyperliquid/trade.rs
+++ b/rustrade-data/src/exchange/hyperliquid/trade.rs
@@ -7,6 +7,7 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{TimeZone, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::subscription::SubscriptionId;
 use serde::{Deserialize, Serialize};
@@ -47,9 +48,9 @@ pub struct HyperliquidTradeData {
     pub coin: SmolStr,
     pub side: SmolStr,
     #[serde(deserialize_with = "rustrade_integration::serde::de::de_str")]
-    pub px: f64,
+    pub px: Decimal,
     #[serde(deserialize_with = "rustrade_integration::serde::de::de_str")]
-    pub sz: f64,
+    pub sz: Decimal,
     pub time: u64,
     pub tid: u64,
 }
@@ -164,6 +165,7 @@ where
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_de_hyperliquid_trade_message() {
@@ -187,8 +189,8 @@ mod tests {
         let trade: HyperliquidTrade = serde_json::from_str(input).unwrap();
         assert_eq!(trade.trades.len(), 1);
         assert_eq!(trade.trades[0].coin, "BTC");
-        assert_eq!(trade.trades[0].px, 45250.5);
-        assert_eq!(trade.trades[0].sz, 0.5);
+        assert_eq!(trade.trades[0].px, dec!(45250.5));
+        assert_eq!(trade.trades[0].sz, dec!(0.5));
         assert_eq!(trade.trades[0].side, "A");
     }
 
@@ -212,8 +214,8 @@ mod tests {
         HyperliquidTradeData {
             coin: SmolStr::new_static("BTC"),
             side: SmolStr::new(side),
-            px: 100.0,
-            sz: 1.0,
+            px: dec!(100),
+            sz: dec!(1),
             time: 1704067200000,
             tid: 1,
         }

--- a/rustrade-data/src/exchange/ibkr/historical.rs
+++ b/rustrade-data/src/exchange/ibkr/historical.rs
@@ -36,6 +36,7 @@ use ibapi::{
         historical::{BarSize, Duration, WhatToShow},
     },
 };
+use rust_decimal::Decimal;
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tracing::{debug, info};
@@ -231,6 +232,9 @@ impl HistoricalRequest {
 ///
 /// Note: `Bar::wap` (volume-weighted average price) is not mapped to `Candle`
 /// as rustrade's `Candle` type does not include VWAP.
+///
+/// Returns `Err(DataError::Socket(...))` if any price/volume value cannot be
+/// converted to Decimal (e.g., NaN, Infinity from the IB API).
 fn bar_to_candle(bar: &ibapi::market_data::historical::Bar) -> Result<Candle, DataError> {
     let close_time = DateTime::from_timestamp(bar.date.unix_timestamp(), bar.date.nanosecond())
         .ok_or_else(|| {
@@ -240,13 +244,24 @@ fn bar_to_candle(bar: &ibapi::market_data::historical::Bar) -> Result<Candle, Da
             ))
         })?;
 
+    let open =
+        Decimal::try_from(bar.open).map_err(|e| DataError::Socket(format!("parse open: {e}")))?;
+    let high =
+        Decimal::try_from(bar.high).map_err(|e| DataError::Socket(format!("parse high: {e}")))?;
+    let low =
+        Decimal::try_from(bar.low).map_err(|e| DataError::Socket(format!("parse low: {e}")))?;
+    let close =
+        Decimal::try_from(bar.close).map_err(|e| DataError::Socket(format!("parse close: {e}")))?;
+    let volume = Decimal::try_from(bar.volume)
+        .map_err(|e| DataError::Socket(format!("parse volume: {e}")))?;
+
     Ok(Candle {
         close_time,
-        open: bar.open,
-        high: bar.high,
-        low: bar.low,
-        close: bar.close,
-        volume: bar.volume,
+        open,
+        high,
+        low,
+        close,
+        volume,
         #[allow(clippy::cast_sign_loss)] // IB returns -1 when unavailable; .max(0) guarantees non-negative
         trade_count: bar.count.max(0) as u64,
     })
@@ -262,6 +277,8 @@ mod tests {
 
     #[test]
     fn bar_to_candle_converts_all_fields() {
+        use rust_decimal_macros::dec;
+
         let bar = ibapi::market_data::historical::Bar {
             date: datetime!(2024-01-15 16:00 UTC),
             open: 150.0,
@@ -275,11 +292,11 @@ mod tests {
 
         let candle = bar_to_candle(&bar).unwrap();
 
-        assert_eq!(candle.open, 150.0);
-        assert_eq!(candle.high, 155.0);
-        assert_eq!(candle.low, 149.0);
-        assert_eq!(candle.close, 153.5);
-        assert_eq!(candle.volume, 1_000_000.0);
+        assert_eq!(candle.open, dec!(150));
+        assert_eq!(candle.high, dec!(155));
+        assert_eq!(candle.low, dec!(149));
+        assert_eq!(candle.close, dec!(153.5));
+        assert_eq!(candle.volume, dec!(1_000_000));
         assert_eq!(candle.trade_count, 50_000);
 
         // Check timestamp conversion

--- a/rustrade-data/src/exchange/ibkr/trades.rs
+++ b/rustrade-data/src/exchange/ibkr/trades.rs
@@ -11,6 +11,7 @@
 use crate::subscription::trade::PublicTrade;
 use chrono::{DateTime, Utc};
 use ibapi::market_data::realtime::Trade;
+use rust_decimal::Decimal;
 use rustrade_instrument::Side;
 use smol_str::{SmolStr, format_smolstr};
 use std::{
@@ -60,10 +61,15 @@ pub fn from_ib_trade(trade: &Trade) -> Option<PublicTrade> {
         return None;
     }
 
+    // is_finite guards above handle NaN/Inf with rate-limited logging.
+    // try_from is a safety net — can only fail for |x| > 7.9e28 (impossible for prices).
+    let price = Decimal::try_from(trade.price).ok()?;
+    let amount = Decimal::try_from(trade.size).ok()?;
+
     Some(PublicTrade {
         id: generate_trade_id(trade),
-        price: trade.price,
-        amount: trade.size,
+        price,
+        amount,
         side: Side::Buy,
     })
 }
@@ -142,11 +148,13 @@ mod tests {
 
     #[test]
     fn converts_trade_fields() {
+        use rust_decimal_macros::dec;
+
         let ib_trade = make_trade(1700000000, 150.25, 100.0);
         let trade = from_ib_trade(&ib_trade).unwrap();
 
-        assert_eq!(trade.price, 150.25);
-        assert_eq!(trade.amount, 100.0);
+        assert_eq!(trade.price, dec!(150.25));
+        assert_eq!(trade.amount, dec!(100));
         assert_eq!(trade.side, Side::Buy);
         assert!(!trade.id.is_empty());
     }

--- a/rustrade-data/src/exchange/kraken/trade.rs
+++ b/rustrade-data/src/exchange/kraken/trade.rs
@@ -5,6 +5,7 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::{
     serde::de::{datetime_utc_from_epoch_duration, extract_next},
@@ -34,9 +35,9 @@ pub struct KrakenTradesInner {
 /// See docs: <https://docs.kraken.com/websockets/#message-trade>
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Serialize)]
 pub struct KrakenTrade {
-    pub price: f64,
+    pub price: Decimal,
     #[serde(rename = "quantity")]
-    pub amount: f64,
+    pub amount: Decimal,
     pub time: DateTime<Utc>,
     pub side: Side,
 }
@@ -166,20 +167,20 @@ impl<'de> serde::de::Deserialize<'de> for KrakenTrade {
                 // [price, volume, time, side, orderType, misc]
                 // <https://docs.kraken.com/websockets/#message-trade>
 
-                // Extract String price & parse to f64
+                // Extract String price & parse to Decimal
                 let price = extract_next::<SeqAccessor, String>(&mut seq, "price")?
                     .parse()
                     .map_err(serde::de::Error::custom)?;
 
-                // Extract String amount & parse to f64
+                // Extract String amount & parse to Decimal
                 let amount = extract_next::<SeqAccessor, String>(&mut seq, "quantity")?
                     .parse()
                     .map_err(serde::de::Error::custom)?;
 
-                // Extract String price, parse to f64, map to DateTime<Utc>
+                // Extract String time, parse to f64, map to DateTime<Utc>
                 let time = extract_next::<SeqAccessor, String>(&mut seq, "time")?
                     .parse()
-                    .map(|time| {
+                    .map(|time: f64| {
                         datetime_utc_from_epoch_duration(std::time::Duration::from_secs_f64(time))
                     })
                     .map_err(serde::de::Error::custom)?;
@@ -211,6 +212,7 @@ mod tests {
 
     mod de {
         use super::*;
+        use rust_decimal_macros::dec;
         use rustrade_instrument::Side;
         use rustrade_integration::{
             error::SocketError, serde::de::datetime_utc_from_epoch_duration,
@@ -255,16 +257,16 @@ mod tests {
                     subscription_id: SubscriptionId::from("trade|XBT/USD"),
                     trades: vec![
                         KrakenTrade {
-                            price: 5541.2,
-                            amount: 0.15850568,
+                            price: dec!(5541.20000),
+                            amount: dec!(0.15850568),
                             time: datetime_utc_from_epoch_duration(
                                 std::time::Duration::from_secs_f64(1534614057.321597),
                             ),
                             side: Side::Sell,
                         },
                         KrakenTrade {
-                            price: 6060.0,
-                            amount: 0.02455000,
+                            price: dec!(6060.00000),
+                            amount: dec!(0.02455000),
                             time: datetime_utc_from_epoch_duration(
                                 std::time::Duration::from_secs_f64(1534614057.324998),
                             ),

--- a/rustrade-data/src/exchange/okx/trade.rs
+++ b/rustrade-data/src/exchange/okx/trade.rs
@@ -5,6 +5,7 @@ use crate::{
     subscription::trade::PublicTrade,
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
 use rustrade_integration::subscription::SubscriptionId;
 use serde::{Deserialize, Serialize};
@@ -84,12 +85,12 @@ pub struct OkxTrade {
         rename = "px",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub price: f64,
+    pub price: Decimal,
     #[serde(
         rename = "sz",
         deserialize_with = "rustrade_integration::serde::de::de_str"
     )]
-    pub amount: f64,
+    pub amount: Decimal,
     pub side: Side,
     #[serde(
         rename = "ts",
@@ -147,6 +148,7 @@ mod tests {
 
     mod de {
         use super::*;
+        use rust_decimal_macros::dec;
         use rustrade_integration::{
             error::SocketError, serde::de::datetime_utc_from_epoch_duration,
         };
@@ -178,8 +180,8 @@ mod tests {
                 subscription_id: SubscriptionId::from("trades|BTC-USDT"),
                 data: vec![OkxTrade {
                     id: "130639474".to_string(),
-                    price: 42219.9,
-                    amount: 0.12060306,
+                    price: dec!(42219.9),
+                    amount: dec!(0.12060306),
                     side: Side::Buy,
                     time: datetime_utc_from_epoch_duration(Duration::from_millis(1630048897897)),
                 }],

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -391,14 +391,15 @@ pub mod test_utils {
         subscription::trade::PublicTrade,
     };
     use chrono::{DateTime, Utc};
+    use rust_decimal::Decimal;
     use rustrade_instrument::{Side, exchange::ExchangeId};
 
     pub fn market_event_trade_buy<InstrumentKey>(
         time_exchange: DateTime<Utc>,
         time_received: DateTime<Utc>,
         instrument: InstrumentKey,
-        price: f64,
-        quantity: f64,
+        price: Decimal,
+        quantity: Decimal,
     ) -> MarketEvent<InstrumentKey, DataKind> {
         MarketEvent {
             time_exchange,

--- a/rustrade-data/src/subscription/candle.rs
+++ b/rustrade-data/src/subscription/candle.rs
@@ -1,5 +1,6 @@
 use super::SubscriptionKind;
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 /// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`Candle`]
@@ -27,10 +28,10 @@ impl std::fmt::Display for Candles {
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct Candle {
     pub close_time: DateTime<Utc>,
-    pub open: f64,
-    pub high: f64,
-    pub low: f64,
-    pub close: f64,
-    pub volume: f64,
+    pub open: Decimal,
+    pub high: Decimal,
+    pub low: Decimal,
+    pub close: Decimal,
+    pub volume: Decimal,
     pub trade_count: u64,
 }

--- a/rustrade-data/src/subscription/liquidation.rs
+++ b/rustrade-data/src/subscription/liquidation.rs
@@ -1,5 +1,6 @@
 use super::SubscriptionKind;
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_instrument::Side;
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +29,7 @@ impl std::fmt::Display for Liquidations {
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct Liquidation {
     pub side: Side,
-    pub price: f64,
-    pub quantity: f64,
+    pub price: Decimal,
+    pub quantity: Decimal,
     pub time: DateTime<Utc>,
 }

--- a/rustrade-data/src/subscription/quote.rs
+++ b/rustrade-data/src/subscription/quote.rs
@@ -1,6 +1,10 @@
 use super::SubscriptionKind;
+use rust_decimal::Decimal;
 use rustrade_macro::{DeSubKind, SerSubKind};
 use serde::{Deserialize, Serialize};
+
+/// 10,000 as a Decimal constant for basis point calculations.
+const BPS_FACTOR: Decimal = Decimal::from_parts(10_000, 0, 0, false, 0);
 
 /// Barter [`Subscription`](super::Subscription) [`SubscriptionKind`] that yields [`Quote`]
 /// [`MarketEvent<T>`](crate::event::MarketEvent) events.
@@ -26,33 +30,33 @@ impl std::fmt::Display for Quotes {
 }
 
 /// Normalised Barter [`Quote`] model representing best bid/ask.
-#[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct Quote {
-    pub bid_price: f64,
-    pub bid_amount: f64,
-    pub ask_price: f64,
-    pub ask_amount: f64,
+    pub bid_price: Decimal,
+    pub bid_amount: Decimal,
+    pub ask_price: Decimal,
+    pub ask_amount: Decimal,
 }
 
 impl Quote {
     /// Calculate the mid-price as the average of bid and ask prices.
-    pub fn mid_price(&self) -> f64 {
-        (self.bid_price + self.ask_price) / 2.0
+    pub fn mid_price(&self) -> Decimal {
+        (self.bid_price + self.ask_price) / Decimal::TWO
     }
 
     /// Calculate the spread (ask - bid).
-    pub fn spread(&self) -> f64 {
+    pub fn spread(&self) -> Decimal {
         self.ask_price - self.bid_price
     }
 
     /// Calculate the spread in basis points (1 bps = 0.01%) relative to the mid-price.
-    /// Returns 0.0 if mid-price is zero.
-    pub fn spread_bps(&self) -> f64 {
+    /// Returns zero if mid-price is zero.
+    pub fn spread_bps(&self) -> Decimal {
         let mid = self.mid_price();
-        if mid == 0.0 {
-            0.0
+        if mid.is_zero() {
+            Decimal::ZERO
         } else {
-            (self.spread() / mid) * 10_000.0
+            (self.spread() / mid) * BPS_FACTOR
         }
     }
 }
@@ -60,38 +64,40 @@ impl Quote {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_quote_mid_price() {
         let quote = Quote {
-            bid_price: 100.0,
-            bid_amount: 10.0,
-            ask_price: 102.0,
-            ask_amount: 5.0,
+            bid_price: dec!(100),
+            bid_amount: dec!(10),
+            ask_price: dec!(102),
+            ask_amount: dec!(5),
         };
-        assert_eq!(quote.mid_price(), 101.0);
+        assert_eq!(quote.mid_price(), dec!(101));
     }
 
     #[test]
     fn test_quote_spread() {
         let quote = Quote {
-            bid_price: 100.0,
-            bid_amount: 10.0,
-            ask_price: 102.0,
-            ask_amount: 5.0,
+            bid_price: dec!(100),
+            bid_amount: dec!(10),
+            ask_price: dec!(102),
+            ask_amount: dec!(5),
         };
-        assert_eq!(quote.spread(), 2.0);
+        assert_eq!(quote.spread(), dec!(2));
     }
 
     #[test]
     fn test_quote_spread_bps() {
         let quote = Quote {
-            bid_price: 100.0,
-            bid_amount: 10.0,
-            ask_price: 101.0,
-            ask_amount: 5.0,
+            bid_price: dec!(100),
+            bid_amount: dec!(10),
+            ask_price: dec!(101),
+            ask_amount: dec!(5),
         };
-        // Spread = 1, mid = 100.5, spread_bps = 1/100.5 * 10000 ≈ 99.5
-        assert!((quote.spread_bps() - 99.502).abs() < 0.01);
+        // Spread = 1, mid = 100.5, spread_bps = 1/100.5 * 10000 ≈ 99.50248...
+        let bps = quote.spread_bps();
+        assert!(bps > dec!(99) && bps < dec!(100), "spread_bps={bps}");
     }
 }

--- a/rustrade-data/src/subscription/trade.rs
+++ b/rustrade-data/src/subscription/trade.rs
@@ -1,4 +1,5 @@
 use super::SubscriptionKind;
+use rust_decimal::Decimal;
 use rustrade_instrument::Side;
 use rustrade_macro::{DeSubKind, SerSubKind};
 use serde::{Deserialize, Serialize};
@@ -33,7 +34,7 @@ impl std::fmt::Display for PublicTrades {
 #[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct PublicTrade {
     pub id: SmolStr,
-    pub price: f64,
-    pub amount: f64,
+    pub price: Decimal,
+    pub amount: Decimal,
     pub side: Side,
 }

--- a/rustrade-data/tests/alpaca_data.rs
+++ b/rustrade-data/tests/alpaca_data.rs
@@ -38,6 +38,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use futures_util::StreamExt;
+use rust_decimal::Decimal;
 use rustrade_data::{
     exchange::alpaca::{AlpacaCrypto, AlpacaIex},
     streams::{
@@ -120,8 +121,8 @@ async fn test_crypto_trade_stream_receives_data() {
 
         if let Event::Item(trade) = event.unwrap() {
             tracing::info!(?trade, "Received crypto trade");
-            assert!(trade.kind.price > 0.0, "Invalid trade price");
-            assert!(trade.kind.amount > 0.0, "Invalid trade amount");
+            assert!(trade.kind.price > Decimal::ZERO, "Invalid trade price");
+            assert!(trade.kind.amount > Decimal::ZERO, "Invalid trade amount");
             return;
         }
     }
@@ -185,8 +186,8 @@ async fn test_crypto_quote_stream_receives_data() {
 
         if let Event::Item(quote) = event.unwrap() {
             tracing::info!(?quote, "Received crypto quote");
-            assert!(quote.kind.bid_price > 0.0, "Invalid bid price");
-            assert!(quote.kind.ask_price > 0.0, "Invalid ask price");
+            assert!(quote.kind.bid_price > Decimal::ZERO, "Invalid bid price");
+            assert!(quote.kind.ask_price > Decimal::ZERO, "Invalid ask price");
             assert!(
                 quote.kind.ask_price >= quote.kind.bid_price,
                 "Ask < Bid (crossed market)"
@@ -379,8 +380,8 @@ async fn test_iex_trade_stream_receives_data() {
         match timeout {
             Ok(Some(Event::Item(trade))) => {
                 tracing::info!(?trade, "Received IEX trade");
-                assert!(trade.kind.price > 0.0, "Invalid trade price");
-                assert!(trade.kind.amount > 0.0, "Invalid trade amount");
+                assert!(trade.kind.price > Decimal::ZERO, "Invalid trade price");
+                assert!(trade.kind.amount > Decimal::ZERO, "Invalid trade amount");
                 return;
             }
             Ok(Some(_)) => continue,
@@ -432,8 +433,8 @@ async fn test_iex_quote_stream_receives_data() {
         match timeout {
             Ok(Some(Event::Item(quote))) => {
                 tracing::info!(?quote, "Received IEX quote");
-                assert!(quote.kind.bid_price > 0.0, "Invalid bid price");
-                assert!(quote.kind.ask_price > 0.0, "Invalid ask price");
+                assert!(quote.kind.bid_price > Decimal::ZERO, "Invalid bid price");
+                assert!(quote.kind.ask_price > Decimal::ZERO, "Invalid ask price");
                 return;
             }
             Ok(Some(_)) => continue,

--- a/rustrade-data/tests/databento_integration.rs
+++ b/rustrade-data/tests/databento_integration.rs
@@ -44,6 +44,7 @@
 use databento::dbn::Schema;
 use databento::historical::timeseries::GetRangeParams;
 use futures_util::StreamExt;
+use rust_decimal::Decimal;
 use rustrade_data::exchange::databento::{DatabentoHistorical, DatabentoLive};
 use rustrade_instrument::exchange::ExchangeId;
 use std::collections::HashMap;
@@ -113,11 +114,17 @@ async fn test_historical_fetch_trades() {
     if !trades.is_empty() {
         let first = &trades[0];
         assert_eq!(first.exchange, ExchangeId::DatabentoGlbx);
-        assert!(first.kind.price > 0.0, "Trade price should be positive");
-        assert!(first.kind.amount > 0.0, "Trade amount should be positive");
+        assert!(
+            first.kind.price > Decimal::ZERO,
+            "Trade price should be positive"
+        );
+        assert!(
+            first.kind.amount > Decimal::ZERO,
+            "Trade amount should be positive"
+        );
         tracing::info!(
-            price = first.kind.price,
-            amount = first.kind.amount,
+            price = %first.kind.price,
+            amount = %first.kind.amount,
             "First trade"
         );
     }
@@ -155,15 +162,21 @@ async fn test_historical_fetch_quotes() {
     if !quotes.is_empty() {
         let first = &quotes[0];
         assert_eq!(first.exchange, ExchangeId::DatabentoGlbx);
-        assert!(first.kind.bid_price > 0.0, "Bid price should be positive");
-        assert!(first.kind.ask_price > 0.0, "Ask price should be positive");
+        assert!(
+            first.kind.bid_price > Decimal::ZERO,
+            "Bid price should be positive"
+        );
+        assert!(
+            first.kind.ask_price > Decimal::ZERO,
+            "Ask price should be positive"
+        );
         assert!(
             first.kind.ask_price >= first.kind.bid_price,
             "Ask should be >= bid"
         );
         tracing::info!(
-            bid = first.kind.bid_price,
-            ask = first.kind.ask_price,
+            bid = %first.kind.bid_price,
+            ask = %first.kind.ask_price,
             "First quote"
         );
     }

--- a/rustrade-data/tests/databento_transformer.rs
+++ b/rustrade-data/tests/databento_transformer.rs
@@ -3,6 +3,8 @@
 //! Uses pre-downloaded DBN fixtures to test transformation logic without API calls.
 //! These tests run in CI.
 
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use rustrade_data::exchange::databento::{load_quotes_from_dbn, load_trades_from_dbn};
 use rustrade_instrument::exchange::ExchangeId;
 use std::path::Path;
@@ -47,12 +49,18 @@ fn test_load_trades_from_dbn_fixture() {
 
     assert_eq!(first_trade.exchange, ExchangeId::DatabentoGlbx);
     assert_eq!(first_trade.instrument, "ESM4");
-    assert!(first_trade.kind.price > 0.0, "Price should be positive");
-    assert!(first_trade.kind.amount > 0.0, "Amount should be positive");
+    assert!(
+        first_trade.kind.price > Decimal::ZERO,
+        "Price should be positive"
+    );
+    assert!(
+        first_trade.kind.amount > Decimal::ZERO,
+        "Amount should be positive"
+    );
 
     // ES futures trade around June 2024 should be in 5000-6000 range
     assert!(
-        first_trade.kind.price > 1000.0 && first_trade.kind.price < 10000.0,
+        first_trade.kind.price > dec!(1000) && first_trade.kind.price < dec!(10000),
         "ES price {} outside expected range",
         first_trade.kind.price
     );
@@ -96,8 +104,14 @@ fn test_load_quotes_from_dbn_fixture() {
     assert_eq!(first_quote.instrument, "ESM4");
 
     let quote = &first_quote.kind;
-    assert!(quote.bid_price > 0.0, "Bid price should be positive");
-    assert!(quote.ask_price > 0.0, "Ask price should be positive");
+    assert!(
+        quote.bid_price > Decimal::ZERO,
+        "Bid price should be positive"
+    );
+    assert!(
+        quote.ask_price > Decimal::ZERO,
+        "Ask price should be positive"
+    );
     assert!(
         quote.ask_price >= quote.bid_price,
         "Ask should be >= bid, got bid={} ask={}",
@@ -107,7 +121,7 @@ fn test_load_quotes_from_dbn_fixture() {
 
     // ES futures around June 2024
     assert!(
-        quote.bid_price > 1000.0 && quote.bid_price < 10000.0,
+        quote.bid_price > dec!(1000) && quote.bid_price < dec!(10000),
         "ES bid {} outside expected range",
         quote.bid_price
     );
@@ -154,7 +168,7 @@ fn test_quote_spread_is_reasonable() {
         let spread = quote.kind.ask_price - quote.kind.bid_price;
         // ES spread should be small (typically 0.25 = 1 tick, sometimes 0.50)
         assert!(
-            (0.0..10.0).contains(&spread),
+            spread >= Decimal::ZERO && spread < dec!(10),
             "Spread {} is unreasonable for ES futures",
             spread
         );

--- a/rustrade-data/tests/hyperliquid_data.rs
+++ b/rustrade-data/tests/hyperliquid_data.rs
@@ -20,6 +20,7 @@
 
 use chrono::Duration;
 use futures_util::StreamExt;
+use rust_decimal::Decimal;
 use rustrade_data::{
     exchange::hyperliquid::{
         Hyperliquid,
@@ -84,9 +85,9 @@ async fn test_historical_candles_hourly() {
     assert!(!candles.is_empty(), "No candles returned");
 
     let first = &candles[0];
-    assert!(first.open > 0.0, "Invalid open price");
+    assert!(first.open > Decimal::ZERO, "Invalid open price");
     assert!(first.high >= first.low, "High < Low");
-    assert!(first.volume >= 0.0, "Negative volume");
+    assert!(!first.volume.is_sign_negative(), "Negative volume");
 
     tracing::info!(count = candles.len(), "Received hourly candles");
 }
@@ -214,8 +215,8 @@ async fn test_trade_stream_receives_data() {
 
         if let Event::Item(trade) = event.unwrap() {
             tracing::info!(?trade, "Received trade");
-            assert!(trade.kind.price > 0.0, "Invalid trade price");
-            assert!(trade.kind.amount > 0.0, "Invalid trade amount");
+            assert!(trade.kind.price > Decimal::ZERO, "Invalid trade price");
+            assert!(trade.kind.amount > Decimal::ZERO, "Invalid trade amount");
             return;
         }
     }

--- a/rustrade-data/tests/hyperliquid_spot_data.rs
+++ b/rustrade-data/tests/hyperliquid_spot_data.rs
@@ -27,6 +27,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use futures_util::StreamExt;
+use rust_decimal::Decimal;
 use rustrade_data::{
     exchange::hyperliquid::HyperliquidSpot,
     streams::{
@@ -109,8 +110,8 @@ async fn test_spot_trade_stream_receives_data() {
         match timeout {
             Ok(Some(Event::Item(trade))) => {
                 tracing::info!(?trade, "Received spot trade");
-                assert!(trade.kind.price > 0.0, "Invalid trade price");
-                assert!(trade.kind.amount > 0.0, "Invalid trade amount");
+                assert!(trade.kind.price > Decimal::ZERO, "Invalid trade price");
+                assert!(trade.kind.amount > Decimal::ZERO, "Invalid trade amount");
                 return;
             }
             Ok(Some(Event::Reconnecting(info))) => {

--- a/rustrade-data/tests/ibkr_integration.rs
+++ b/rustrade-data/tests/ibkr_integration.rs
@@ -181,8 +181,8 @@ async fn test_historical_daily_bars() {
         first.close
     );
     assert!(
-        first.volume >= 0.0,
-        "Volume {:.2} should be non-negative",
+        !first.volume.is_sign_negative(),
+        "Volume {} should be non-negative",
         first.volume
     );
 }

--- a/rustrade/benches/backtest/mod.rs
+++ b/rustrade/benches/backtest/mod.rs
@@ -2,7 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use criterion::{Criterion, Throughput};
-use rust_decimal::{Decimal, prelude::FromPrimitive};
+use rust_decimal::Decimal;
 use rustrade::{
     backtest,
     backtest::{BacktestArgsConstant, BacktestArgsDynamic, market_data::MarketDataInMemory},
@@ -321,8 +321,8 @@ impl AlgoStrategy for LoseMoneyStrategy {
                     },
                     state: RequestOpen {
                         side: Side::Buy,
-                        price: Decimal::from_f64(trade_not_sent_as_order_open.price).unwrap(),
-                        quantity: Decimal::from_f64(trade_not_sent_as_order_open.amount).unwrap(),
+                        price: trade_not_sent_as_order_open.price,
+                        quantity: trade_not_sent_as_order_open.amount,
                         kind: OrderKind::Market,
                         time_in_force: TimeInForce::ImmediateOrCancel,
                         position_id: None,

--- a/rustrade/src/engine/state/instrument/data.rs
+++ b/rustrade/src/engine/state/instrument/data.rs
@@ -3,7 +3,7 @@ use crate::{
     engine::{Processor, state::order::in_flight_recorder::InFlightRequestRecorder},
 };
 use derive_more::Constructor;
-use rust_decimal::{Decimal, prelude::FromPrimitive};
+use rust_decimal::Decimal;
 use rustrade_data::{
     event::{DataKind, MarketEvent},
     subscription::book::OrderBookL1,
@@ -84,16 +84,14 @@ impl<InstrumentKey> Processor<&MarketEvent<InstrumentKey, DataKind>>
 
     fn process(&mut self, event: &MarketEvent<InstrumentKey, DataKind>) -> Self::Audit {
         match &event.kind {
-            DataKind::Trade(trade) => {
+            DataKind::Trade(trade)
                 if self
                     .last_traded_price
                     .as_ref()
-                    .is_none_or(|price| price.time < event.time_exchange)
-                    && let Some(price) = Decimal::from_f64(trade.price)
-                {
-                    self.last_traded_price
-                        .replace(Timed::new(price, event.time_exchange));
-                }
+                    .is_none_or(|price| price.time < event.time_exchange) =>
+            {
+                self.last_traded_price
+                    .replace(Timed::new(trade.price, event.time_exchange));
             }
             DataKind::OrderBookL1(l1) if self.l1.last_update_time < event.time_exchange => {
                 self.l1 = l1.clone()

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -139,14 +139,14 @@ fn test_engine_process_engine_event_with_audit() {
     assert_eq!(engine.state.connectivity.global, Health::Reconnecting);
 
     // Process 1st MarketEvent for btc_usdt
-    let event = market_event_trade(1, 0, 10_000.0);
+    let event = market_event_trade(1, 0, dec!(10_000));
     let audit = process_with_audit(&mut engine, event.clone());
     assert_eq!(audit.context.sequence, Sequence(1));
     assert_eq!(audit.event, EngineAudit::process(event));
     assert_eq!(engine.state.connectivity.global, Health::Healthy);
 
     // Process 1st MarketEvent for eth_btc
-    let event = market_event_trade(1, 1, 0.1);
+    let event = market_event_trade(1, 1, dec!(0.1));
     let audit = process_with_audit(&mut engine, event.clone());
     assert_eq!(audit.context.sequence, Sequence(2));
     assert_eq!(audit.event, EngineAudit::process(event));
@@ -345,13 +345,13 @@ fn test_engine_process_engine_event_with_audit() {
     );
 
     // Process 2nd MarketEvent for btc_usdt
-    let event = market_event_trade(2, 0, 20_000.0);
+    let event = market_event_trade(2, 0, dec!(20_000));
     let audit = process_with_audit(&mut engine, event.clone());
     assert_eq!(audit.context.sequence, Sequence(13));
     assert_eq!(audit.event, EngineAudit::process(event));
 
     // Process 2nd MarketEvent for eth_btc
-    let event = market_event_trade(2, 1, 0.05);
+    let event = market_event_trade(2, 1, dec!(0.05));
     let audit = process_with_audit(&mut engine, event.clone());
     assert_eq!(audit.context.sequence, Sequence(14));
     assert_eq!(audit.event, EngineAudit::process(event));
@@ -969,7 +969,7 @@ fn account_event_snapshot(assets: &AssetStates) -> EngineEvent<DataKind> {
     }))
 }
 
-fn market_event_trade(time_plus: u64, instrument: usize, price: f64) -> EngineEvent<DataKind> {
+fn market_event_trade(time_plus: u64, instrument: usize, price: Decimal) -> EngineEvent<DataKind> {
     EngineEvent::Market(MarketStreamEvent::Item(MarketEvent {
         time_exchange: time_plus_days(STARTING_TIMESTAMP, time_plus),
         time_received: time_plus_days(STARTING_TIMESTAMP, time_plus),
@@ -978,7 +978,7 @@ fn market_event_trade(time_plus: u64, instrument: usize, price: f64) -> EngineEv
         kind: DataKind::Trade(PublicTrade {
             id: time_plus.to_string().into(),
             price,
-            amount: 1.0,
+            amount: Decimal::ONE,
             side: Side::Buy,
         }),
     }))
@@ -1139,13 +1139,13 @@ fn build_option_engine(
 }
 
 /// Send a market trade event to set the spot price for instrument at index `instrument`.
-fn send_spot_price(engine: &mut TestEngine, instrument: usize, price: f64) {
+fn send_spot_price(engine: &mut TestEngine, instrument: usize, price: Decimal) {
     let event = market_event_trade(1, instrument, price);
     engine.process(event);
 }
 
 /// Open a long position in the option instrument (index 0) by sending a buy trade.
-fn open_option_position(engine: &mut TestEngine, quantity: f64, price: f64) {
+fn open_option_position(engine: &mut TestEngine, quantity: Decimal, price: Decimal) {
     let event = EngineEvent::Account(AccountStreamEvent::Item(AccountEvent {
         exchange: ExchangeIndex(0),
         kind: AccountEventKind::Trade(Trade {
@@ -1155,8 +1155,8 @@ fn open_option_position(engine: &mut TestEngine, quantity: f64, price: f64) {
             strategy: strategy_id(),
             time_exchange: time_plus_days(STARTING_TIMESTAMP, 1),
             side: Side::Buy,
-            price: Decimal::try_from(price).unwrap(),
-            quantity: Decimal::try_from(quantity).unwrap(),
+            price,
+            quantity,
             // Option instrument quote is USD = AssetIndex(1) in option engine
             fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
         }),
@@ -1170,10 +1170,10 @@ fn test_contract_expiry_otm_call() {
     let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
 
     // Set underlying spot price BELOW strike (50_000) → OTM (spot is at index 1)
-    send_spot_price(&mut engine, 1, 45_000.0);
+    send_spot_price(&mut engine, 1, dec!(45_000));
 
     // Open a long call position with 2 contracts at premium 1_000
-    open_option_position(&mut engine, 2.0, 1_000.0);
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
 
     // Verify position exists before expiry (option is at index 0)
     assert!(
@@ -1221,10 +1221,10 @@ fn test_contract_expiry_itm_call() {
 
     // Set underlying spot price ABOVE strike (50_000) → ITM (spot is at index 1)
     // Intrinsic value = spot - strike = 55_000 - 50_000 = 5_000
-    send_spot_price(&mut engine, 1, 55_000.0);
+    send_spot_price(&mut engine, 1, dec!(55_000));
 
     // Open a long call position with 1 contract at premium 2_000
-    open_option_position(&mut engine, 1.0, 2_000.0);
+    open_option_position(&mut engine, dec!(1), dec!(2_000));
 
     let exited = engine.process_contract_expiry(&InstrumentIndex(0));
 
@@ -1258,8 +1258,8 @@ fn test_contract_expiry_idempotent() {
     let (execution_tx, _execution_rx) = mpsc_unbounded();
     let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
 
-    send_spot_price(&mut engine, 1, 45_000.0);
-    open_option_position(&mut engine, 1.0, 1_000.0);
+    send_spot_price(&mut engine, 1, dec!(45_000));
+    open_option_position(&mut engine, dec!(1), dec!(1_000));
 
     // First expiry processes the position
     let exited_first = engine.process_contract_expiry(&InstrumentIndex(0));
@@ -1282,7 +1282,7 @@ fn test_contract_expiry_no_position() {
     let (execution_tx, _execution_rx) = mpsc_unbounded();
     let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
 
-    send_spot_price(&mut engine, 1, 45_000.0);
+    send_spot_price(&mut engine, 1, dec!(45_000));
 
     // No position open — expiry should still mark as processed
     let exited = engine.process_contract_expiry(&InstrumentIndex(0));
@@ -1304,7 +1304,7 @@ fn test_contract_expiry_missing_spot_price() {
     // Do NOT send any market data for the spot instrument
 
     // Open a position so expiry has something to settle
-    open_option_position(&mut engine, 1.0, 1_000.0);
+    open_option_position(&mut engine, dec!(1), dec!(1_000));
 
     // Without spot price, expiry cannot compute settlement — returns empty
     let exited = engine.process_contract_expiry(&InstrumentIndex(0));
@@ -1331,8 +1331,8 @@ fn test_contract_expiry_replica_state_cleared() {
     let (execution_tx, _execution_rx) = mpsc_unbounded();
     let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
 
-    send_spot_price(&mut engine, 1, 45_000.0);
-    open_option_position(&mut engine, 1.0, 1_000.0);
+    send_spot_price(&mut engine, 1, dec!(45_000));
+    open_option_position(&mut engine, dec!(1), dec!(1_000));
 
     // Process ContractExpiry on the live engine to get the real audit outputs.
     let expiry_event = EngineEvent::ContractExpiry(InstrumentIndex(0));
@@ -1341,8 +1341,8 @@ fn test_contract_expiry_replica_state_cleared() {
     // Build a separate replica state that mirrors the pre-expiry state.
     let (execution_tx2, _) = mpsc_unbounded();
     let mut replica_engine = build_option_engine(TradingState::Disabled, execution_tx2);
-    send_spot_price(&mut replica_engine, 1, 45_000.0);
-    open_option_position(&mut replica_engine, 1.0, 1_000.0);
+    send_spot_price(&mut replica_engine, 1, dec!(45_000));
+    open_option_position(&mut replica_engine, dec!(1), dec!(1_000));
 
     let seed_context = EngineContext {
         time: STARTING_TIMESTAMP,
@@ -1468,7 +1468,12 @@ fn build_put_option_engine(
 }
 
 /// Open a long or short option position at instrument index 0.
-fn open_option_position_side(engine: &mut TestEngine, side: Side, quantity: f64, price: f64) {
+fn open_option_position_side(
+    engine: &mut TestEngine,
+    side: Side,
+    quantity: Decimal,
+    price: Decimal,
+) {
     let trade_id = match side {
         Side::Buy => TradeId::new("opt-trade-open-buy"),
         Side::Sell => TradeId::new("opt-trade-open-sell"),
@@ -1482,8 +1487,8 @@ fn open_option_position_side(engine: &mut TestEngine, side: Side, quantity: f64,
             strategy: strategy_id(),
             time_exchange: time_plus_days(STARTING_TIMESTAMP, 1),
             side,
-            price: Decimal::try_from(price).unwrap(),
-            quantity: Decimal::try_from(quantity).unwrap(),
+            price,
+            quantity,
             // Put option instrument quote is USD = AssetIndex(1)
             fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
         }),
@@ -1498,8 +1503,8 @@ fn test_contract_expiry_itm_put() {
 
     // Spot BELOW strike (50_000) → ITM for put.
     // Intrinsic value = strike - spot = 50_000 - 45_000 = 5_000
-    send_spot_price(&mut engine, 1, 45_000.0);
-    open_option_position(&mut engine, 1.0, 2_000.0); // bought at 2_000 premium
+    send_spot_price(&mut engine, 1, dec!(45_000));
+    open_option_position(&mut engine, dec!(1), dec!(2_000)); // bought at 2_000 premium
 
     let exited = engine.process_contract_expiry(&InstrumentIndex(0));
 
@@ -1531,8 +1536,8 @@ fn test_contract_expiry_otm_put() {
     let mut engine = build_put_option_engine(TradingState::Disabled, execution_tx);
 
     // Spot ABOVE strike → OTM for put → settlement = 0
-    send_spot_price(&mut engine, 1, 55_000.0);
-    open_option_position(&mut engine, 1.0, 2_000.0);
+    send_spot_price(&mut engine, 1, dec!(55_000));
+    open_option_position(&mut engine, dec!(1), dec!(2_000));
 
     let exited = engine.process_contract_expiry(&InstrumentIndex(0));
 
@@ -1553,8 +1558,8 @@ fn test_contract_expiry_short_call_itm() {
     // Spot ABOVE strike (50_000) → ITM for call.
     // Intrinsic = 55_000 - 50_000 = 5_000
     // Short writer must "pay" intrinsic at settlement: pnl = premium_received - intrinsic
-    send_spot_price(&mut engine, 1, 55_000.0);
-    open_option_position_side(&mut engine, Side::Sell, 1.0, 2_000.0); // sold at 2_000 premium
+    send_spot_price(&mut engine, 1, dec!(55_000));
+    open_option_position_side(&mut engine, Side::Sell, dec!(1), dec!(2_000)); // sold at 2_000 premium
 
     let exited = engine.process_contract_expiry(&InstrumentIndex(0));
 
@@ -1571,8 +1576,8 @@ fn test_contract_expiry_short_call_otm() {
     let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
 
     // Spot BELOW strike → OTM → settlement = 0 → short writer keeps full premium
-    send_spot_price(&mut engine, 1, 45_000.0);
-    open_option_position_side(&mut engine, Side::Sell, 1.0, 2_000.0);
+    send_spot_price(&mut engine, 1, dec!(45_000));
+    open_option_position_side(&mut engine, Side::Sell, dec!(1), dec!(2_000));
 
     let exited = engine.process_contract_expiry(&InstrumentIndex(0));
 
@@ -1911,7 +1916,7 @@ fn test_contract_expiry_hedging_multi_position() {
     let mut engine = build_hedging_option_engine(TradingState::Disabled, execution_tx);
 
     // Set spot price above strike → ITM, intrinsic = 5_000
-    send_spot_price(&mut engine, 1, 55_000.0);
+    send_spot_price(&mut engine, 1, dec!(55_000));
 
     // Open two independent long positions (leg-a and leg-b).
     let cid_a = ClientOrderId::new("cid-a");
@@ -2040,7 +2045,7 @@ fn test_fee_model_zero_no_fees_on_trade() {
     let (execution_tx, _) = mpsc_unbounded();
     let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
     // Default fee model is Zero — exchange-reported zero fees stay zero.
-    open_option_position(&mut engine, 1.0, 1_000.0);
+    open_option_position(&mut engine, dec!(1), dec!(1_000));
 
     let instr = engine
         .state
@@ -2214,7 +2219,7 @@ fn test_contract_expiry_clears_pending_fills() {
     assert_eq!(instr.pending_fills.len(), 1, "setup: pending fill exists");
 
     // Set spot price for ITM settlement and trigger expiry.
-    send_spot_price(&mut engine, 1, 55_000.0); // ITM for strike 50_000
+    send_spot_price(&mut engine, 1, dec!(55_000)); // ITM for strike 50_000
 
     let expiry_event = EngineEvent::ContractExpiry(InstrumentIndex(0));
     engine.process(expiry_event);


### PR DESCRIPTION
## Summary

- **BREAKING**: All price/amount fields in market data types (`PublicTrade`, `Quote`, `Candle`, `Liquidation`) migrated from `f64` to `rust_decimal::Decimal`
- All exchange transformers (Alpaca, Binance, Bitfinex, BitMEX, Bybit, Coinbase, Databento, GateIO, Hyperliquid, IBKR, Kraken, OKX) updated to deserialize/transform as `Decimal`
- `Quote` made `Copy` for better ergonomics; utility methods (`mid_price()`, `spread()`, `spread_bps()`) return `Decimal`

Closes #48

## Migration Guide

- Use `dec!()` macro for literals instead of float literals
- Use `> Decimal::ZERO` instead of `> 0.0` for positivity checks
- For string-typed JSON fields, use `de_str` deserializer or `.parse::<Decimal>()`
- Use `Decimal::try_from(f64)` only when source is already `f64`

## Test Plan

- [x] `cargo check --workspace` passes
- [x] All exchange transformer tests updated with `dec!()` macro
- [x] Quote spread_bps test updated for Decimal precision semantics