### PR TITLE
feat(data): Migrate PublicTrade::side to Option<Side>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: `PublicTrade::side` changed from `Side` to `Option<Side>`.
+  - Crypto connectors (Binance, Hyperliquid, Alpaca Crypto, etc.): `Some(side)`
+  - Equities connectors (Alpaca IEX/SIP, IBKR): `None` — taker side not available
+  - Databento: `Some(side)` for 'A'/'B', `None` for 'N' (no side specified)
+  - Migration: Match on `Some(side)` to handle the `None` case explicitly, or use
+    `.is_some_and(|s| s == Side::Buy)` for boolean checks. (`Side` does not implement
+    `Default`, so `unwrap_or_default()` will not compile.)
 - **BREAKING**: `PublicTrade`, `Quote`, `Candle`, and `Liquidation` price/amount fields
   changed from `f64` to `rust_decimal::Decimal` for financial precision.
   - `PublicTrade`: `price`, `amount` now `Decimal`

--- a/rustrade-data/src/exchange/alpaca/trade.rs
+++ b/rustrade-data/src/exchange/alpaca/trade.rs
@@ -64,18 +64,15 @@ pub struct AlpacaTrade {
 }
 
 impl AlpacaTrade {
-    /// Returns the taker side for crypto trades, or `Side::Buy` as a sentinel for equities.
+    /// Returns the taker side for crypto trades, or `None` for equities.
     ///
-    /// # Note
     /// Alpaca equities (IEX/SIP) do not provide taker side information — the `tks` field
-    /// is only present on crypto trades. For equities, this returns `Side::Buy` as a
-    /// placeholder. Downstream consumers should not rely on `side` for equity trades.
-    // FIXME: Migrate PublicTrade::side to Option<Side> to properly represent this
-    fn side(&self) -> Side {
+    /// is only present on crypto trades.
+    fn side(&self) -> Option<Side> {
         match self.taker_side.as_deref() {
-            Some("B") => Side::Buy,
-            Some("S") => Side::Sell,
-            _ => Side::Buy,
+            Some("B") => Some(Side::Buy),
+            Some("S") => Some(Side::Sell),
+            _ => None,
         }
     }
 }
@@ -219,14 +216,21 @@ mod tests {
         assert!(trade.exchange.is_none());
         assert!(trade.tape.is_none());
         assert_eq!(trade.taker_side, Some(SmolStr::new("B")));
-        assert_eq!(trade.side(), Side::Buy);
+        assert_eq!(trade.side(), Some(Side::Buy));
     }
 
     #[test]
     fn test_crypto_side_sell() {
         let input = r#"{"T":"t","S":"ETH/USD","i":789,"p":3000.0,"s":1.0,"tks":"S","t":"2026-05-02T14:00:00Z"}"#;
         let trade: AlpacaTrade = serde_json::from_str(input).unwrap();
-        assert_eq!(trade.side(), Side::Sell);
+        assert_eq!(trade.side(), Some(Side::Sell));
+    }
+
+    #[test]
+    fn test_equities_side_none() {
+        let input = r#"{"T":"t","S":"AAPL","i":123,"x":"V","p":150.25,"s":100,"c":["@"],"z":"C","t":"2026-05-02T14:00:00Z"}"#;
+        let trade: AlpacaTrade = serde_json::from_str(input).unwrap();
+        assert!(trade.side().is_none());
     }
 
     #[test]

--- a/rustrade-data/src/exchange/binance/trade.rs
+++ b/rustrade-data/src/exchange/binance/trade.rs
@@ -97,7 +97,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BinanceTrade)>
                 id: format_smolstr!("{}", trade.id),
                 price: trade.price,
                 amount: trade.amount,
-                side: trade.side,
+                side: Some(trade.side),
             },
         })])
     }

--- a/rustrade-data/src/exchange/bitfinex/trade.rs
+++ b/rustrade-data/src/exchange/bitfinex/trade.rs
@@ -57,7 +57,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BitfinexTrade)>
                 id: format_smolstr!("{}", trade.id),
                 price: trade.price,
                 amount: trade.amount,
-                side: trade.side,
+                side: Some(trade.side),
             },
         })])
     }

--- a/rustrade-data/src/exchange/bitmex/trade.rs
+++ b/rustrade-data/src/exchange/bitmex/trade.rs
@@ -66,7 +66,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, BitmexTrade)>
                             id: trade.id.into(),
                             price: trade.price,
                             amount: trade.amount,
-                            side: trade.side,
+                            side: Some(trade.side),
                         },
                     })
                 })

--- a/rustrade-data/src/exchange/bybit/trade.rs
+++ b/rustrade-data/src/exchange/bybit/trade.rs
@@ -74,7 +74,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, BybitTrade)>
                             id: trade.id.into(),
                             price: trade.price,
                             amount: trade.amount,
-                            side: trade.side,
+                            side: Some(trade.side),
                         },
                     })
                 })

--- a/rustrade-data/src/exchange/coinbase/trade.rs
+++ b/rustrade-data/src/exchange/coinbase/trade.rs
@@ -67,7 +67,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, CoinbaseTrade)>
                 id: format_smolstr!("{}", trade.id),
                 price: trade.price,
                 amount: trade.amount,
-                side: trade.side,
+                side: Some(trade.side),
             },
         })])
     }

--- a/rustrade-data/src/exchange/databento/transformer.rs
+++ b/rustrade-data/src/exchange/databento/transformer.rs
@@ -27,6 +27,14 @@ const UNDEF_SIZE: u32 = u32::MAX;
 /// Convert a DBN TradeMsg to a PublicTrade.
 ///
 /// Returns the exchange timestamp and the converted trade, or an error description.
+///
+/// # Side Field
+///
+/// DBN side values:
+/// - `'A'` (65): Sell aggressor → `Some(Side::Sell)`
+/// - `'B'` (66): Buy aggressor → `Some(Side::Buy)`
+/// - `'N'` (78): No side specified by source → `None`
+/// - Other values: Returns error (malformed data)
 pub fn dbn_trade_to_public_trade(
     trade: &TradeMsg,
 ) -> Result<(DateTime<Utc>, PublicTrade), &'static str> {
@@ -42,9 +50,10 @@ pub fn dbn_trade_to_public_trade(
     // DBN guarantees Side is ASCII (range [0, 127]); i8 -> u8 cast is lossless.
     #[allow(clippy::cast_sign_loss)]
     let side = match trade.side as u8 {
-        b'A' => Side::Sell,
-        b'B' => Side::Buy,
-        _ => return Err("unknown or undefined trade side"),
+        b'A' => Some(Side::Sell),
+        b'B' => Some(Side::Buy),
+        b'N' => None,
+        _ => return Err("unknown trade side value"),
     };
 
     Ok((
@@ -179,7 +188,7 @@ mod tests {
 
         assert_eq!(public_trade.price, dec!(150.25));
         assert_eq!(public_trade.amount, dec!(100));
-        assert_eq!(public_trade.side, Side::Buy);
+        assert_eq!(public_trade.side, Some(Side::Buy));
         assert_eq!(public_trade.id.as_str(), "12345");
         assert_eq!(time.timestamp(), 1_700_000_000);
     }
@@ -194,16 +203,29 @@ mod tests {
         trade.sequence = 1;
 
         let (_, public_trade) = dbn_trade_to_public_trade(&trade).unwrap();
-        assert_eq!(public_trade.side, Side::Sell);
+        assert_eq!(public_trade.side, Some(Side::Sell));
     }
 
     #[test]
-    fn test_trade_unknown_side_rejected() {
+    fn test_trade_no_side() {
         let mut trade = TradeMsg::default();
         trade.hd.ts_event = 1_700_000_000_000_000_000;
         trade.price = 100_000_000_000;
         trade.size = 10;
         trade.side = b'N' as i8;
+        trade.sequence = 1;
+
+        let (_, public_trade) = dbn_trade_to_public_trade(&trade).unwrap();
+        assert!(public_trade.side.is_none());
+    }
+
+    #[test]
+    fn test_trade_invalid_side_rejected() {
+        let mut trade = TradeMsg::default();
+        trade.hd.ts_event = 1_700_000_000_000_000_000;
+        trade.price = 100_000_000_000;
+        trade.size = 10;
+        trade.side = b'X' as i8;
 
         assert!(dbn_trade_to_public_trade(&trade).is_err());
     }

--- a/rustrade-data/src/exchange/gateio/perpetual/trade.rs
+++ b/rustrade-data/src/exchange/gateio/perpetual/trade.rs
@@ -97,11 +97,11 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, GateioFuturesTrades)
                         id: format_smolstr!("{}", trade.id),
                         price: trade.price,
                         amount: trade.amount.abs(),
-                        side: if trade.amount.is_sign_positive() {
+                        side: Some(if trade.amount.is_sign_positive() {
                             Side::Buy
                         } else {
                             Side::Sell
-                        },
+                        }),
                     },
                 })
             })

--- a/rustrade-data/src/exchange/gateio/spot/trade.rs
+++ b/rustrade-data/src/exchange/gateio/spot/trade.rs
@@ -74,7 +74,7 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, GateioSpotTrade)>
                 id: format_smolstr!("{}", trade.data.id),
                 price: trade.data.price,
                 amount: trade.data.amount,
-                side: trade.data.side,
+                side: Some(trade.data.side),
             },
         })])
     }

--- a/rustrade-data/src/exchange/hyperliquid/trade.rs
+++ b/rustrade-data/src/exchange/hyperliquid/trade.rs
@@ -151,7 +151,7 @@ where
                         id: format_smolstr!("{}", trade.tid),
                         price: trade.px,
                         amount: trade.sz,
-                        side,
+                        side: Some(side),
                     },
                 })
             })
@@ -231,7 +231,7 @@ mod tests {
         let market_iter: MarketIter<&str, PublicTrade> =
             (ExchangeId::HyperliquidPerp, "BTC", hl_trade).into();
         let event = market_iter.0[0].as_ref().unwrap();
-        assert_eq!(event.kind.side, Side::Sell);
+        assert_eq!(event.kind.side, Some(Side::Sell));
     }
 
     #[test]
@@ -244,7 +244,7 @@ mod tests {
         let market_iter: MarketIter<&str, PublicTrade> =
             (ExchangeId::HyperliquidPerp, "BTC", hl_trade).into();
         let event = market_iter.0[0].as_ref().unwrap();
-        assert_eq!(event.kind.side, Side::Buy);
+        assert_eq!(event.kind.side, Some(Side::Buy));
     }
 
     #[test]

--- a/rustrade-data/src/exchange/ibkr/trades.rs
+++ b/rustrade-data/src/exchange/ibkr/trades.rs
@@ -2,17 +2,16 @@
 //!
 //! Transforms IB's `realtime::Trade` into rustrade's [`PublicTrade`].
 //!
-//! # Side Inference
+//! # Side Field
 //!
 //! IB tick-by-tick trades do not include trade side (buyer/seller initiated).
-//! This implementation defaults to `Side::Buy`. For more accurate side
-//! inference, consumers can compare trade price to concurrent bid/ask quotes.
+//! The `side` field is set to `None`. For side inference, consumers can compare
+//! the trade price to concurrent bid/ask quotes.
 
 use crate::subscription::trade::PublicTrade;
 use chrono::{DateTime, Utc};
 use ibapi::market_data::realtime::Trade;
 use rust_decimal::Decimal;
-use rustrade_instrument::Side;
 use smol_str::{SmolStr, format_smolstr};
 use std::{
     hash::{Hash, Hasher},
@@ -28,11 +27,10 @@ static BAD_SIZE_COUNT: AtomicU64 = AtomicU64::new(0);
 
 /// Convert an IB trade to a PublicTrade.
 ///
-/// # Side Inference
+/// # Side Field
 ///
-/// Trade side is not provided by IB. This function defaults to `Side::Buy`.
-/// For more accurate inference, compare the trade price to the current
-/// bid/ask spread.
+/// Trade side is not provided by IB, so `side` is set to `None`.
+/// For side inference, compare the trade price to the current bid/ask spread.
 ///
 /// # Returns
 ///
@@ -70,7 +68,7 @@ pub fn from_ib_trade(trade: &Trade) -> Option<PublicTrade> {
         id: generate_trade_id(trade),
         price,
         amount,
-        side: Side::Buy,
+        side: None,
     })
 }
 
@@ -155,7 +153,7 @@ mod tests {
 
         assert_eq!(trade.price, dec!(150.25));
         assert_eq!(trade.amount, dec!(100));
-        assert_eq!(trade.side, Side::Buy);
+        assert!(trade.side.is_none());
         assert!(!trade.id.is_empty());
     }
 

--- a/rustrade-data/src/exchange/kraken/trade.rs
+++ b/rustrade-data/src/exchange/kraken/trade.rs
@@ -78,7 +78,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, KrakenTrades)>
                             id: custom_kraken_trade_id(&trade),
                             price: trade.price,
                             amount: trade.amount,
-                            side: trade.side,
+                            side: Some(trade.side),
                         },
                     })
                 })

--- a/rustrade-data/src/exchange/okx/trade.rs
+++ b/rustrade-data/src/exchange/okx/trade.rs
@@ -116,7 +116,7 @@ impl<InstrumentKey: Clone> From<(ExchangeId, InstrumentKey, OkxTrades)>
                         id: trade.id.into(),
                         price: trade.price,
                         amount: trade.amount,
-                        side: trade.side,
+                        side: Some(trade.side),
                     },
                 })
             })

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -410,7 +410,7 @@ pub mod test_utils {
                 id: "trade_id".into(),
                 price,
                 amount: quantity,
-                side: Side::Buy,
+                side: Some(Side::Buy),
             }),
         }
     }

--- a/rustrade-data/src/subscription/trade.rs
+++ b/rustrade-data/src/subscription/trade.rs
@@ -31,10 +31,20 @@ impl std::fmt::Display for PublicTrades {
 /// Uses [`SmolStr`] for `id` to avoid heap allocation for typical trade IDs
 /// (up to 23 bytes on 64-bit systems are stored inline). Exceptions that
 /// heap-allocate: Bitmex UUIDs (36 bytes), Kraken composite IDs (~34 bytes).
+///
+/// # Side Field
+///
+/// The `side` field indicates the taker/aggressor side of the trade:
+/// - `Some(Side::Buy)`: Taker was buying (lifted the ask)
+/// - `Some(Side::Sell)`: Taker was selling (hit the bid)
+/// - `None`: Side information not available from the data source
+///
+/// Crypto exchanges typically provide side info. Equities feeds (e.g., Alpaca IEX/SIP)
+/// often do not, as consolidated tape data doesn't include aggressor information.
 #[derive(Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct PublicTrade {
     pub id: SmolStr,
     pub price: Decimal,
     pub amount: Decimal,
-    pub side: Side,
+    pub side: Option<Side>,
 }

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -979,7 +979,7 @@ fn market_event_trade(time_plus: u64, instrument: usize, price: Decimal) -> Engi
             id: time_plus.to_string().into(),
             price,
             amount: Decimal::ONE,
-            side: Side::Buy,
+            side: Some(Side::Buy),
         }),
     }))
 }


### PR DESCRIPTION
## Summary

Closes #42

- Change `PublicTrade::side` from `Side` to `Option<Side>` to properly represent absent taker side info
- Crypto exchanges wrap side in `Some()`, equities sources (Alpaca IEX/SIP, IBKR) return `None`
- Databento now handles 'N' (no side specified) as `None` instead of error

## Test plan

- [x] `cargo check` passes
- [x] All existing tests updated and passing
- [x] New test for equities trades without side
- [x] Databento tests for 'N' side value