### PR TITLE
feat(data): Add Massive market data connector

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -45,3 +45,10 @@ ALPACA_PAPER=true
 # Get API key from: https://databento.com/portal/keys
 # Provides institutional-grade market data for equities, futures, options
 DATABENTO_API_KEY=
+
+# =============================================================================
+# Massive (formerly Polygon.io)
+# =============================================================================
+# Get API key from: https://massive.com/dashboard/api-keys
+# Provides market data across stocks, options, indices, forex, crypto, futures
+MASSIVE_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `MassiveRestClient`: Historical aggregates, trades, quotes with streaming pagination
   - `MassiveLive`: Real-time WebSocket streaming for trades, quotes, and aggregates
   - Reference data: `fetch_tickers()`, `fetch_ticker_details()`, `fetch_exchanges()`, `fetch_market_status()`, `fetch_market_holidays()`
+  - Corporate actions: `fetch_dividends()`, `fetch_splits()` for stocks/ETFs
   - `TickerQuery` builder for filtering ticker searches
   - `ExchangeId::Massive` variant
   - Supports all asset classes: stocks, crypto, forex, options, indices, futures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Massive market data connector**: Historical, live, and reference data via `massive` feature
+  - `MassiveRestClient`: Historical aggregates, trades, quotes with streaming pagination
+  - `MassiveLive`: Real-time WebSocket streaming for trades, quotes, and aggregates
+  - Reference data: `fetch_tickers()`, `fetch_ticker_details()`, `fetch_exchanges()`, `fetch_market_status()`, `fetch_market_holidays()`
+  - `TickerQuery` builder for filtering ticker searches
+  - `ExchangeId::Massive` variant
+  - Supports all asset classes: stocks, crypto, forex, options, indices, futures
 - **Databento market data connector**: Historical and live data via `databento` feature
   - `DatabentoHistorical`: One-shot queries for trades and quotes in DBN format
   - `DatabentoLive<K>`: Real-time WebSocket streaming with `PitSymbolMap` symbol resolution

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio-stream = { version = "0.1.17" }
 tokio-test = { version = "0.4.4" }
 futures = { version = "0.3.31" }
 futures-util = { version = "0.3.31" }
+async-stream = { version = "0.3" }
 async-trait = { version = "0.1.83" }
 pin-project = { version = "1.1.7" }
 
@@ -85,3 +86,4 @@ spin_sleep = { version = "1.3.0 "}
 criterion = { version = "0.8.2" }
 wiremock = { version = "0.6" }
 prost = { version = "0.14.3" }
+temp-env = { version = "0.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,4 @@ criterion = { version = "0.8.2" }
 wiremock = { version = "0.6" }
 prost = { version = "0.14.3" }
 temp-env = { version = "0.3" }
+serial_test = { version = "3.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tokio-tungstenite = { version = "0.29.0", features = ["url","rustls-tls-webpki-r
 vecmap-rs = { version = "0.2.2" }
 parking_lot = { version = "0.12.3" }
 lru = { version = "0.18" }
-rust_decimal = { version = "1.36.0", features = ["maths"] }
+rust_decimal = { version = "1.36.0", features = ["maths", "serde-with-str"] }
 smol_str = { version = "0.3.2" }
 fnv = { version = "1.0.7" }
 indexmap = { version = "2.6.0" }

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -17,11 +17,13 @@ ibkr = ["dep:ibapi", "dep:time", "rustrade-instrument/ibkr"]
 hyperliquid = ["dep:hyperliquid_rust_sdk"]
 alpaca = []
 databento = ["dep:databento"]
+massive = ["dep:tokio-tungstenite", "dep:async-stream", "rust_decimal/serde-float"]
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 rust_decimal_macros = { workspace = true }
 time = { version = "0.3", features = ["macros"] }  # For ibkr tests and databento examples
+temp-env = { workspace = true }
 
 [dependencies]
 # Rustrade Ecosystem
@@ -37,6 +39,7 @@ tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 futures = { workspace = true }
 futures-util = { workspace = true }
+async-stream = { workspace = true, optional = true }
 async-trait = { workspace = true }
 
 # Protocol
@@ -72,3 +75,6 @@ hyperliquid_rust_sdk = { version = "0.6", optional = true }
 # Databento (optional, behind "databento" feature)
 # Note: databento re-exports dbn, so we don't need a separate dbn dependency
 databento = { version = "0.49", optional = true }
+
+# Massive (optional, behind "massive" feature)
+tokio-tungstenite = { version = "0.29", optional = true, features = ["native-tls"] }

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -17,7 +17,7 @@ ibkr = ["dep:ibapi", "dep:time", "rustrade-instrument/ibkr"]
 hyperliquid = ["dep:hyperliquid_rust_sdk"]
 alpaca = []
 databento = ["dep:databento"]
-massive = ["dep:tokio-tungstenite", "dep:async-stream", "rust_decimal/serde-float"]
+massive = ["dep:tokio-tungstenite", "dep:async-stream", "rust_decimal/serde-float", "serde_json/raw_value"]
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -17,7 +17,7 @@ ibkr = ["dep:ibapi", "dep:time", "rustrade-instrument/ibkr"]
 hyperliquid = ["dep:hyperliquid_rust_sdk"]
 alpaca = []
 databento = ["dep:databento"]
-massive = ["dep:tokio-tungstenite", "dep:async-stream", "rust_decimal/serde-float", "serde_json/raw_value"]
+massive = ["dep:tokio-tungstenite", "dep:async-stream", "dep:urlencoding", "rust_decimal/serde-float", "serde_json/raw_value"]
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
@@ -78,3 +78,4 @@ databento = { version = "0.49", optional = true }
 
 # Massive (optional, behind "massive" feature)
 tokio-tungstenite = { version = "0.29", optional = true, features = ["native-tls"] }
+urlencoding = { version = "2.1", optional = true }

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 rust_decimal_macros = { workspace = true }
 time = { version = "0.3", features = ["macros"] }  # For ibkr tests and databento examples
 temp-env = { workspace = true }
+serial_test = { workspace = true }  # For Massive WebSocket tests (1 connection limit)
 
 [dependencies]
 # Rustrade Ecosystem

--- a/rustrade-data/src/exchange/massive/error.rs
+++ b/rustrade-data/src/exchange/massive/error.rs
@@ -1,0 +1,118 @@
+//! Error types for Massive integration.
+
+use crate::error::DataError;
+use std::time::Duration;
+
+/// Massive-specific errors.
+///
+/// The library returns these errors without automatic retry or reconnection.
+/// Consumers decide how to handle rate limits, disconnections, and auth failures.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MassiveError {
+    /// Rate limited by the API. Contains optional retry-after duration.
+    ///
+    /// Returned on HTTP 429 responses. The consumer decides whether and when to retry.
+    RateLimited { retry_after: Option<Duration> },
+
+    /// WebSocket connection dropped or ping timeout exceeded.
+    ///
+    /// Returned when:
+    /// - WebSocket connection closes unexpectedly
+    /// - Pong not received within 19 seconds of ping
+    ///
+    /// The consumer owns reconnection policy (backoff, credential refresh, dedup).
+    Disconnected { reason: String },
+
+    /// Authentication failed.
+    ///
+    /// Returned when:
+    /// - API key is invalid or expired
+    /// - API key lacks permission for the requested resource
+    Auth { message: String },
+
+    /// API returned an error response.
+    ///
+    /// Covers non-auth, non-rate-limit API errors (invalid parameters, not found, etc.)
+    Api { status: u16, message: String },
+
+    /// Network or HTTP client error.
+    Http { message: String },
+
+    /// JSON deserialization failed.
+    Deserialize { message: String, payload: String },
+
+    /// Environment variable not set.
+    EnvVar { var: &'static str },
+
+    /// Client-side input validation failed.
+    ///
+    /// Returned when input parameters are invalid before making an API request
+    /// (e.g., timestamp out of representable range).
+    InvalidInput { message: String },
+}
+
+impl std::fmt::Display for MassiveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MassiveError::RateLimited { retry_after } => {
+                write!(f, "Massive rate limited")?;
+                if let Some(duration) = retry_after {
+                    write!(f, " (retry after {:?})", duration)?;
+                }
+                Ok(())
+            }
+            MassiveError::Disconnected { reason } => {
+                write!(f, "Massive disconnected: {}", reason)
+            }
+            MassiveError::Auth { message } => {
+                write!(f, "Massive auth failed: {}", message)
+            }
+            MassiveError::Api { status, message } => {
+                write!(f, "Massive API error ({}): {}", status, message)
+            }
+            MassiveError::Http { message } => {
+                write!(f, "Massive HTTP error: {}", message)
+            }
+            MassiveError::Deserialize { message, payload } => {
+                let boundary = payload.floor_char_boundary(100);
+                let truncated = &payload[..boundary];
+                let ellipsis = if boundary < payload.len() { "..." } else { "" };
+                write!(
+                    f,
+                    "Massive deserialize error: {} (payload: {truncated}{ellipsis})",
+                    message
+                )
+            }
+            MassiveError::EnvVar { var } => {
+                write!(f, "Massive environment variable not set: {}", var)
+            }
+            MassiveError::InvalidInput { message } => {
+                write!(f, "Massive invalid input: {}", message)
+            }
+        }
+    }
+}
+
+impl std::error::Error for MassiveError {}
+
+impl From<MassiveError> for DataError {
+    fn from(err: MassiveError) -> Self {
+        DataError::Socket(err.to_string())
+    }
+}
+
+impl From<reqwest::Error> for MassiveError {
+    fn from(err: reqwest::Error) -> Self {
+        MassiveError::Http {
+            message: err.to_string(),
+        }
+    }
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for MassiveError {
+    fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
+        MassiveError::Disconnected {
+            reason: err.to_string(),
+        }
+    }
+}

--- a/rustrade-data/src/exchange/massive/live.rs
+++ b/rustrade-data/src/exchange/massive/live.rs
@@ -1,0 +1,978 @@
+//! WebSocket live streaming client for Massive real-time market data.
+//!
+//! Provides real-time market data streaming via [`MassiveLive`].
+//!
+//! # Architecture
+//!
+//! - **One connection per market**: Each `MassiveLive` instance connects to one market
+//!   (stocks, crypto, forex, options). For multiple markets, create separate instances.
+//! - **Multiple symbols per connection**: Subscribe to multiple symbols before calling `start()`.
+//! - **No auto-reconnect**: Returns [`MassiveError::Disconnected`] on connection drop; consumer owns
+//!   reconnection policy (backoff, credential refresh, dedup/fill-recovery).
+//!
+//! # Connection Limits
+//!
+//! Massive limits concurrent WebSocket connections per subscription tier:
+//! - **Individual plan**: 1 connection per purchased product
+//! - **Business plan**: 3 connections per purchased product
+//!
+//! See <https://massive.com/knowledge-base/article/how-many-massive-websocket-connections-can-i-use-at-one-time>
+//!
+//! # Symbol Formats (WebSocket vs REST)
+//!
+//! **Important**: WebSocket uses different symbol formats than REST API:
+//!
+//! | Market | REST Format | WebSocket Format |
+//! |--------|-------------|------------------|
+//! | Crypto | `X:BTCUSD` | `BTC-USD` |
+//! | Forex | `C:EURUSD` | `EUR-USD` |
+//! | Stocks | `AAPL` | `AAPL` |
+//! | Options | `O:AAPL251219C00150000` | `O:AAPL251219C00150000` |
+//!
+//! # Keepalive
+//!
+//! The client sends ping frames every 20 seconds and checks for pong responses at each ping tick.
+//! If no pong has been received since the last ping, the connection is considered dead and
+//! `MassiveError::Disconnected` is returned. Effective timeout is up to 40 seconds (two ping intervals).
+//!
+//! # Example
+//!
+//! ```ignore
+//! use rustrade_data::exchange::massive::{MassiveLive, Market, ChannelType};
+//! use rustrade_instrument::exchange::ExchangeId;
+//! use std::collections::HashMap;
+//! use futures::StreamExt;
+//!
+//! // Map WebSocket symbols to your instrument keys
+//! let instruments: HashMap<String, String> = [
+//!     ("BTC-USD".to_string(), "btc-usd".to_string()),
+//!     ("ETH-USD".to_string(), "eth-usd".to_string()),
+//! ].into_iter().collect();
+//!
+//! let mut client = MassiveLive::from_env(
+//!     Market::Crypto,
+//!     ExchangeId::Massive,
+//!     instruments,
+//! )?;
+//!
+//! // Subscribe to channels (can call multiple times before start)
+//! client.subscribe(&["BTC-USD", "ETH-USD"], ChannelType::Trade);
+//! client.subscribe(&["BTC-USD"], ChannelType::Quote);
+//!
+//! // Start streaming (consumes client)
+//! let mut stream = client.start().await?;
+//!
+//! while let Some(event) = stream.next().await {
+//!     match event {
+//!         Ok(market_event) => println!("{:?}", market_event),
+//!         Err(e) => {
+//!             eprintln!("Error: {}", e);
+//!             // Consumer decides: reconnect, backoff, or exit
+//!             break;
+//!         }
+//!     }
+//! }
+//! ```
+
+use super::error::MassiveError;
+use super::transformer::{WsMessage, parse_ws_message};
+use crate::event::{DataKind, MarketEvent};
+use chrono::{DateTime, Utc};
+use futures::{SinkExt, Stream, StreamExt};
+use rustrade_instrument::exchange::ExchangeId;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::env;
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::time::{Instant, interval_at};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
+use tracing::{debug, trace, warn};
+
+const ENV_API_KEY: &str = "MASSIVE_API_KEY";
+
+const PING_INTERVAL: Duration = Duration::from_secs(20);
+const PONG_TIMEOUT: Duration = Duration::from_secs(19);
+
+/// Market type for WebSocket connection.
+///
+/// Each market requires a separate WebSocket connection to a different endpoint.
+/// Massive allows one simultaneous connection per cluster (market type).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Market {
+    /// US equities (NYSE, NASDAQ, etc.)
+    Stocks,
+    /// Cryptocurrency pairs (BTC-USD, ETH-USD, etc.)
+    Crypto,
+    /// Foreign exchange pairs (EUR-USD, GBP-USD, etc.)
+    Forex,
+    /// US equity options
+    Options,
+}
+
+impl Market {
+    /// Get the WebSocket endpoint URL for this market.
+    ///
+    /// Massive operates on Polygon.io infrastructure; endpoints are unchanged from Polygon.
+    fn ws_url(&self) -> &'static str {
+        match self {
+            Market::Stocks => "wss://socket.polygon.io/stocks",
+            Market::Crypto => "wss://socket.polygon.io/crypto",
+            Market::Forex => "wss://socket.polygon.io/forex",
+            Market::Options => "wss://socket.polygon.io/options",
+        }
+    }
+}
+
+/// Channel types for WebSocket subscriptions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChannelType {
+    /// Tick-level trades
+    /// - Stocks: `T.AAPL`
+    /// - Crypto: `XT.BTC-USD`
+    /// - Forex: Not available (use Quote instead)
+    Trade,
+    /// Quote updates / BBO
+    /// - Stocks: `Q.AAPL`
+    /// - Crypto: `XQ.BTC-USD`
+    /// - Forex: `C.EUR-USD`
+    Quote,
+    /// Per-second aggregates
+    /// - Stocks: `A.AAPL`
+    /// - Crypto: `XA.BTC-USD`
+    /// - Forex: `CA.EUR-USD`
+    AggregateSecond,
+    /// Per-minute aggregates
+    /// - Stocks: `AM.AAPL`
+    /// - Crypto: `XAM.BTC-USD`
+    /// - Forex: `CAM.EUR-USD`
+    AggregateMinute,
+}
+
+impl ChannelType {
+    /// Get the channel prefix for a given market.
+    ///
+    /// Returns `None` if the channel type is not supported for the market
+    /// (e.g., Trade for Forex).
+    fn prefix(self, market: Market) -> Option<&'static str> {
+        match (self, market) {
+            // Stocks
+            (ChannelType::Trade, Market::Stocks) => Some("T"),
+            (ChannelType::Quote, Market::Stocks) => Some("Q"),
+            (ChannelType::AggregateSecond, Market::Stocks) => Some("A"),
+            (ChannelType::AggregateMinute, Market::Stocks) => Some("AM"),
+            // Crypto
+            (ChannelType::Trade, Market::Crypto) => Some("XT"),
+            (ChannelType::Quote, Market::Crypto) => Some("XQ"),
+            (ChannelType::AggregateSecond, Market::Crypto) => Some("XA"),
+            (ChannelType::AggregateMinute, Market::Crypto) => Some("XAM"),
+            // Forex (no trades channel)
+            (ChannelType::Trade, Market::Forex) => None,
+            (ChannelType::Quote, Market::Forex) => Some("C"),
+            (ChannelType::AggregateSecond, Market::Forex) => Some("CA"),
+            (ChannelType::AggregateMinute, Market::Forex) => Some("CAM"),
+            // Options
+            (ChannelType::Trade, Market::Options) => Some("T"),
+            (ChannelType::Quote, Market::Options) => Some("Q"),
+            (ChannelType::AggregateSecond, Market::Options) => Some("A"),
+            (ChannelType::AggregateMinute, Market::Options) => Some("AM"),
+        }
+    }
+
+    /// Build channel string for a symbol.
+    ///
+    /// Returns `None` if this channel type is not supported for the market.
+    fn channel_for(self, market: Market, symbol: &str) -> Option<String> {
+        let prefix = self.prefix(market)?;
+        Some(format!("{}.{}", prefix, symbol))
+    }
+}
+
+/// WebSocket message for authentication.
+#[derive(Serialize)]
+struct AuthMessage<'a> {
+    action: &'static str,
+    params: &'a str,
+}
+
+/// WebSocket message for subscription.
+#[derive(Serialize)]
+struct SubscribeMessage {
+    action: &'static str,
+    params: String,
+}
+
+/// Live streaming client for Massive WebSocket API.
+///
+/// Connects to Massive's WebSocket endpoint for real-time market data.
+/// Each instance connects to one market (stocks, crypto, forex, options).
+///
+/// # Connection Limits
+///
+/// See module docs and <https://massive.com/knowledge-base/article/how-many-massive-websocket-connections-can-i-use-at-one-time>
+pub struct MassiveLive<K> {
+    api_key: String,
+    market: Market,
+    instruments: HashMap<String, K>,
+    exchange: ExchangeId,
+    subscriptions: Vec<String>,
+    ws_url: String,
+}
+
+impl<K: std::fmt::Debug> std::fmt::Debug for MassiveLive<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MassiveLive")
+            .field("api_key", &"[REDACTED]")
+            .field("market", &self.market)
+            .field("instruments", &self.instruments)
+            .field("exchange", &self.exchange)
+            .field("subscriptions", &self.subscriptions)
+            .field("ws_url", &self.ws_url)
+            .finish()
+    }
+}
+
+impl<K> MassiveLive<K> {
+    /// Create a new live client with explicit API key.
+    ///
+    /// # Arguments
+    ///
+    /// * `api_key` - Massive API key from <https://massive.com/dashboard/api-keys>
+    /// * `market` - Market type to connect to
+    /// * `exchange` - ExchangeId to tag events with
+    /// * `instruments` - Map from WebSocket symbol strings to user's instrument keys
+    ///
+    /// # Symbol Formats
+    ///
+    /// Use WebSocket-native formats (different from REST API):
+    /// - Crypto: `BTC-USD`, `ETH-USD` (hyphenated)
+    /// - Forex: `EUR-USD`, `GBP-USD` (hyphenated)
+    /// - Stocks: `AAPL`, `MSFT` (plain)
+    /// - Options: `O:AAPL251219C00150000`
+    pub fn new(
+        api_key: impl Into<String>,
+        market: Market,
+        exchange: ExchangeId,
+        instruments: HashMap<String, K>,
+    ) -> Self {
+        Self {
+            api_key: api_key.into(),
+            market,
+            instruments,
+            exchange,
+            subscriptions: Vec::new(),
+            ws_url: market.ws_url().to_string(),
+        }
+    }
+
+    /// Create a new live client from `MASSIVE_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if `MASSIVE_API_KEY` is not set.
+    pub fn from_env(
+        market: Market,
+        exchange: ExchangeId,
+        instruments: HashMap<String, K>,
+    ) -> Result<Self, MassiveError> {
+        let api_key =
+            env::var(ENV_API_KEY).map_err(|_| MassiveError::EnvVar { var: ENV_API_KEY })?;
+        Ok(Self::new(api_key, market, exchange, instruments))
+    }
+
+    /// Override the WebSocket URL (useful for testing).
+    #[must_use]
+    pub fn with_ws_url(mut self, url: impl Into<String>) -> Self {
+        self.ws_url = url.into();
+        self
+    }
+
+    /// Get the market type for this client.
+    pub fn market(&self) -> Market {
+        self.market
+    }
+
+    /// Subscribe to channels for the given symbols.
+    ///
+    /// Can be called multiple times before `start()` to add more subscriptions.
+    /// Subscriptions are batched and sent after authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbols` - Symbol identifiers in WebSocket format:
+    ///   - Crypto: `BTC-USD`, `ETH-USD` (hyphenated)
+    ///   - Forex: `EUR-USD`, `GBP-USD` (hyphenated)
+    ///   - Stocks: `AAPL`, `MSFT` (plain)
+    ///   - Options: `O:AAPL251219C00150000`
+    /// * `channel_type` - Type of data to subscribe to
+    ///
+    /// # Notes
+    ///
+    /// If `channel_type` is not supported for this market (e.g., `Trade` for `Forex`),
+    /// a warning is logged and the subscription is skipped.
+    pub fn subscribe(&mut self, symbols: &[&str], channel_type: ChannelType) {
+        for symbol in symbols {
+            if let Some(channel) = channel_type.channel_for(self.market, symbol) {
+                debug!(channel = %channel, "Adding subscription");
+                self.subscriptions.push(channel);
+            } else {
+                warn!(
+                    symbol = %symbol,
+                    channel_type = ?channel_type,
+                    market = ?self.market,
+                    "Channel type not supported for this market, skipping"
+                );
+            }
+        }
+    }
+
+    /// Get the list of pending subscriptions.
+    pub fn subscriptions(&self) -> &[String] {
+        &self.subscriptions
+    }
+}
+
+impl<K: Clone + Send + 'static> MassiveLive<K> {
+    /// Connect, authenticate, subscribe, and start streaming.
+    ///
+    /// Consumes `self` because the WebSocket connection requires exclusive access.
+    /// The stream will emit events until the connection closes or an error occurs.
+    ///
+    /// # Returns
+    ///
+    /// A stream of `MarketEvent<K, DataKind>` where `DataKind` depends on the
+    /// subscribed channels (Trade, OrderBookL1, or Candle).
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - WebSocket connection fails
+    /// - Authentication fails
+    /// - Subscription fails
+    ///
+    /// Stream items may contain `MassiveError::Disconnected` if:
+    /// - Connection drops unexpectedly
+    /// - Pong not received within one ping interval (checked at each 20s tick)
+    pub async fn start(
+        self,
+    ) -> Result<impl Stream<Item = Result<MarketEvent<K, DataKind>, MassiveError>>, MassiveError>
+    {
+        debug!(url = %self.ws_url, market = ?self.market, "Connecting to Massive WebSocket");
+
+        // Connect
+        let (ws_stream, _response) = connect_async(&self.ws_url).await?;
+        let (mut write, mut read) = ws_stream.split();
+
+        // Consume the initial "connected" status frame before sending auth
+        Self::consume_connected_frame(&mut read).await?;
+
+        // Authenticate
+        debug!("Sending auth message");
+        let auth_msg = AuthMessage {
+            action: "auth",
+            params: &self.api_key,
+        };
+        // AuthMessage contains only &'static str and &str — serialization cannot fail
+        #[allow(clippy::expect_used)]
+        let auth_json = serde_json::to_string(&auth_msg).expect("infallible");
+        write.send(Message::Text(auth_json.into())).await?;
+
+        // Wait for auth response
+        let auth_response = tokio::time::timeout(Duration::from_secs(10), read.next())
+            .await
+            .map_err(|_| MassiveError::Auth {
+                message: "Auth response timeout".into(),
+            })?
+            .ok_or_else(|| MassiveError::Disconnected {
+                reason: "Connection closed before auth response".into(),
+            })??;
+
+        Self::verify_auth_response(&auth_response)?;
+        debug!("Authentication successful");
+
+        // Subscribe to channels
+        if self.subscriptions.is_empty() {
+            warn!("start() called with no subscriptions; stream will receive no market data");
+        }
+        if !self.subscriptions.is_empty() {
+            let params = self.subscriptions.join(",");
+            debug!(channels = %params, "Subscribing to channels");
+
+            let sub_msg = SubscribeMessage {
+                action: "subscribe",
+                params,
+            };
+            // SubscribeMessage contains only &'static str and String — serialization cannot fail
+            #[allow(clippy::expect_used)]
+            let sub_json = serde_json::to_string(&sub_msg).expect("infallible");
+            write.send(Message::Text(sub_json.into())).await?;
+
+            // Wait for subscription confirmation
+            let sub_response = tokio::time::timeout(Duration::from_secs(10), read.next())
+                .await
+                .map_err(|_| MassiveError::Disconnected {
+                    reason: "Subscription response timeout".into(),
+                })?
+                .ok_or_else(|| MassiveError::Disconnected {
+                    reason: "Connection closed before subscription response".into(),
+                })??;
+
+            Self::verify_subscription_response(&sub_response)?;
+            debug!("Subscription successful");
+        }
+
+        // Reunite the stream for the read loop
+        let ws_stream = write
+            .reunite(read)
+            .map_err(|e| MassiveError::Disconnected {
+                reason: format!("Failed to reunite WebSocket stream: {}", e),
+            })?;
+
+        // Create the event stream with ping/pong handling
+        Ok(Self::create_event_stream(
+            ws_stream,
+            self.instruments,
+            self.exchange,
+        ))
+    }
+
+    /// Consume the initial "connected" status frame sent by the server on connect.
+    ///
+    /// Polygon/Massive sends `[{"ev":"status","status":"connected",...}]` immediately
+    /// when a WebSocket connection is established, before the client sends auth.
+    async fn consume_connected_frame(
+        read: &mut futures::stream::SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
+    ) -> Result<(), MassiveError> {
+        let msg = tokio::time::timeout(Duration::from_secs(10), read.next())
+            .await
+            .map_err(|_| MassiveError::Disconnected {
+                reason: "Timeout waiting for connected frame".into(),
+            })?
+            .ok_or_else(|| MassiveError::Disconnected {
+                reason: "Connection closed before connected frame".into(),
+            })??;
+
+        match &msg {
+            Message::Text(text) => {
+                // Verify it's a "connected" status message
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(text)
+                    && let Some(arr) = parsed.as_array()
+                {
+                    for m in arr {
+                        if m.get("ev").and_then(|v| v.as_str()) == Some("status")
+                            && m.get("status").and_then(|v| v.as_str()) == Some("connected")
+                        {
+                            debug!("Received connected frame");
+                            return Ok(());
+                        }
+                    }
+                }
+                // Not a connected frame - unexpected but continue anyway
+                debug!(msg = %text, "Unexpected initial frame (expected connected status)");
+                Ok(())
+            }
+            Message::Close(frame) => Err(MassiveError::Disconnected {
+                reason: frame
+                    .as_ref()
+                    .map(|f| f.reason.to_string())
+                    .unwrap_or_else(|| "Connection closed".into()),
+            }),
+            _ => {
+                // Intentional: unexpected non-text/non-close frames (e.g., Ping) are ignored;
+                // the server drove an unusual handshake but we continue to auth
+                debug!(?msg, "Unexpected message type before auth");
+                Ok(())
+            }
+        }
+    }
+
+    /// Verify the authentication response.
+    fn verify_auth_response(msg: &Message) -> Result<(), MassiveError> {
+        match msg {
+            Message::Text(text) => {
+                // Parse status message: [{"ev":"status","status":"auth_success",...}]
+                let parsed: serde_json::Value =
+                    serde_json::from_str(text).map_err(|e| MassiveError::Auth {
+                        message: format!("Failed to parse auth response: {}", e),
+                    })?;
+
+                // Response is an array of status messages
+                let messages = parsed.as_array().ok_or_else(|| MassiveError::Auth {
+                    message: "Auth response is not an array".into(),
+                })?;
+
+                for msg in messages {
+                    if msg.get("ev").and_then(|v| v.as_str()) == Some("status") {
+                        let status = msg.get("status").and_then(|v| v.as_str());
+                        match status {
+                            Some("auth_success") => return Ok(()),
+                            Some("auth_failed") => {
+                                let message = msg
+                                    .get("message")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("Authentication failed");
+                                return Err(MassiveError::Auth {
+                                    message: message.into(),
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
+                Err(MassiveError::Auth {
+                    message: format!("Unexpected auth response: {}", text),
+                })
+            }
+            Message::Close(frame) => Err(MassiveError::Disconnected {
+                reason: frame
+                    .as_ref()
+                    .map(|f| f.reason.to_string())
+                    .unwrap_or_else(|| "Connection closed".into()),
+            }),
+            _ => Err(MassiveError::Auth {
+                message: format!("Unexpected message type during auth: {:?}", msg),
+            }),
+        }
+    }
+
+    /// Verify the subscription response.
+    fn verify_subscription_response(msg: &Message) -> Result<(), MassiveError> {
+        match msg {
+            Message::Text(text) => {
+                // Parse status message: [{"ev":"status","status":"success","message":"subscribed to: ..."}]
+                let parsed: serde_json::Value =
+                    serde_json::from_str(text).map_err(|e| MassiveError::Disconnected {
+                        reason: format!("Failed to parse subscription response: {}", e),
+                    })?;
+
+                let messages = parsed
+                    .as_array()
+                    .ok_or_else(|| MassiveError::Disconnected {
+                        reason: "Subscription response is not an array".into(),
+                    })?;
+
+                for msg in messages {
+                    if msg.get("ev").and_then(|v| v.as_str()) == Some("status") {
+                        let status = msg.get("status").and_then(|v| v.as_str());
+                        if status == Some("success") {
+                            return Ok(());
+                        }
+                    }
+                }
+
+                // No success status found — observable failure over silent one
+                Err(MassiveError::Disconnected {
+                    reason: format!("Subscription failed: {}", text),
+                })
+            }
+            Message::Close(frame) => Err(MassiveError::Disconnected {
+                reason: frame
+                    .as_ref()
+                    .map(|f| f.reason.to_string())
+                    .unwrap_or_else(|| "Connection closed".into()),
+            }),
+            _ => {
+                // Observable failure over silent one: unexpected message types should error
+                Err(MassiveError::Disconnected {
+                    reason: format!("Unexpected message type during subscription: {:?}", msg),
+                })
+            }
+        }
+    }
+
+    /// Create the event stream with ping/pong handling.
+    ///
+    /// # Note
+    ///
+    /// If the internal streaming task panics, the stream ends without emitting an error item.
+    /// Panics in the streaming task are not expected under normal operation.
+    fn create_event_stream(
+        ws_stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+        instruments: HashMap<String, K>,
+        exchange: ExchangeId,
+    ) -> impl Stream<Item = Result<MarketEvent<K, DataKind>, MassiveError>> {
+        let (mut write, mut read) = ws_stream.split();
+
+        // Channel for passing events from the read task
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        // Spawn the read/ping task
+        tokio::spawn(async move {
+            // Skip the immediate first tick; first ping sent after PING_INTERVAL
+            let mut ping_interval = interval_at(Instant::now() + PING_INTERVAL, PING_INTERVAL);
+            let mut ping_sent_at: Option<Instant> = None;
+
+            loop {
+                tokio::select! {
+                    // Send ping at regular intervals
+                    _ = ping_interval.tick() => {
+                        // Check if we're still waiting for a pong from the last ping
+                        if let Some(sent_at) = ping_sent_at
+                            && sent_at.elapsed() > PONG_TIMEOUT
+                        {
+                            let _ = tx.send(Err(MassiveError::Disconnected {
+                                reason: "Pong timeout".into(),
+                            }));
+                            break;
+                        }
+
+                        trace!("Sending ping");
+                        if let Err(e) = write.send(Message::Ping(vec![].into())).await {
+                            let _ = tx.send(Err(MassiveError::Disconnected {
+                                reason: format!("Failed to send ping: {}", e),
+                            }));
+                            break;
+                        }
+                        ping_sent_at = Some(Instant::now());
+                    }
+
+                    // Read incoming messages
+                    msg = read.next() => {
+                        match msg {
+                            Some(Ok(Message::Text(text))) => {
+                                // Sample time once per frame for all events
+                                let time_received = Utc::now();
+                                // Parse and emit market events
+                                match parse_ws_message(&text) {
+                                    Ok(messages) => {
+                                        for ws_msg in messages {
+                                            if let Some(event) = Self::ws_message_to_event(
+                                                ws_msg,
+                                                &instruments,
+                                                exchange,
+                                                time_received,
+                                            ) && tx.send(Ok(event)).is_err() {
+                                                // Receiver dropped
+                                                return;
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(error = %e, "Failed to parse WebSocket message");
+                                    }
+                                }
+                            }
+                            Some(Ok(Message::Pong(_))) => {
+                                trace!("Received pong");
+                                ping_sent_at = None;
+                            }
+                            Some(Ok(Message::Ping(data))) => {
+                                trace!("Received ping, sending pong");
+                                if let Err(e) = write.send(Message::Pong(data)).await {
+                                    let _ = tx.send(Err(MassiveError::Disconnected {
+                                        reason: format!("Failed to send pong: {}", e),
+                                    }));
+                                    break;
+                                }
+                            }
+                            Some(Ok(Message::Close(frame))) => {
+                                let reason = frame
+                                    .as_ref()
+                                    .map(|f| f.reason.to_string())
+                                    .unwrap_or_else(|| "Connection closed".into());
+                                let _ = tx.send(Err(MassiveError::Disconnected { reason }));
+                                break;
+                            }
+                            Some(Ok(Message::Binary(_))) => {
+                                // Unexpected binary message, ignore
+                                trace!("Received unexpected binary message");
+                            }
+                            Some(Ok(Message::Frame(_))) => {
+                                // Raw frame, ignore
+                            }
+                            Some(Err(e)) => {
+                                let _ = tx.send(Err(MassiveError::Disconnected {
+                                    reason: e.to_string(),
+                                }));
+                                break;
+                            }
+                            None => {
+                                let _ = tx.send(Err(MassiveError::Disconnected {
+                                    reason: "WebSocket stream ended".into(),
+                                }));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // Convert the channel receiver into a stream
+        futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        })
+    }
+
+    /// Convert a WebSocket message to a MarketEvent.
+    fn ws_message_to_event(
+        msg: WsMessage,
+        instruments: &HashMap<String, K>,
+        exchange: ExchangeId,
+        time_received: DateTime<Utc>,
+    ) -> Option<MarketEvent<K, DataKind>> {
+        match msg {
+            WsMessage::TradeStocks(trade) | WsMessage::TradeCrypto(trade) => {
+                let instrument = instruments.get(&trade.symbol)?.clone();
+                let (time_exchange, public_trade) = trade.into_public_trade();
+
+                Some(MarketEvent {
+                    time_exchange,
+                    time_received,
+                    exchange,
+                    instrument,
+                    kind: DataKind::Trade(public_trade),
+                })
+            }
+            WsMessage::QuoteStocks(quote)
+            | WsMessage::QuoteCrypto(quote)
+            | WsMessage::QuoteForex(quote) => {
+                let instrument = instruments.get(&quote.symbol)?.clone();
+                let (time_exchange, l1) = quote.into_order_book_l1();
+
+                Some(MarketEvent {
+                    time_exchange,
+                    time_received,
+                    exchange,
+                    instrument,
+                    kind: DataKind::OrderBookL1(l1),
+                })
+            }
+            WsMessage::AggSecondStocks(agg)
+            | WsMessage::AggMinuteStocks(agg)
+            | WsMessage::AggSecondCrypto(agg)
+            | WsMessage::AggMinuteCrypto(agg)
+            | WsMessage::AggSecondForex(agg)
+            | WsMessage::AggMinuteForex(agg) => {
+                let instrument = instruments.get(&agg.symbol)?.clone();
+                let (time_exchange, candle) = agg.into_candle();
+
+                Some(MarketEvent {
+                    time_exchange,
+                    time_received,
+                    exchange,
+                    instrument,
+                    kind: DataKind::Candle(candle),
+                })
+            }
+            WsMessage::Status(_) => {
+                // Status messages are handled during auth/subscribe, not emitted as events
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_market_ws_url() {
+        assert_eq!(Market::Stocks.ws_url(), "wss://socket.polygon.io/stocks");
+        assert_eq!(Market::Crypto.ws_url(), "wss://socket.polygon.io/crypto");
+        assert_eq!(Market::Forex.ws_url(), "wss://socket.polygon.io/forex");
+        assert_eq!(Market::Options.ws_url(), "wss://socket.polygon.io/options");
+    }
+
+    #[test]
+    fn test_channel_type_prefix_stocks() {
+        assert_eq!(ChannelType::Trade.prefix(Market::Stocks), Some("T"));
+        assert_eq!(ChannelType::Quote.prefix(Market::Stocks), Some("Q"));
+        assert_eq!(
+            ChannelType::AggregateSecond.prefix(Market::Stocks),
+            Some("A")
+        );
+        assert_eq!(
+            ChannelType::AggregateMinute.prefix(Market::Stocks),
+            Some("AM")
+        );
+    }
+
+    #[test]
+    fn test_channel_type_prefix_crypto() {
+        assert_eq!(ChannelType::Trade.prefix(Market::Crypto), Some("XT"));
+        assert_eq!(ChannelType::Quote.prefix(Market::Crypto), Some("XQ"));
+        assert_eq!(
+            ChannelType::AggregateSecond.prefix(Market::Crypto),
+            Some("XA")
+        );
+        assert_eq!(
+            ChannelType::AggregateMinute.prefix(Market::Crypto),
+            Some("XAM")
+        );
+    }
+
+    #[test]
+    fn test_channel_type_prefix_forex() {
+        // Forex has no trades channel
+        assert_eq!(ChannelType::Trade.prefix(Market::Forex), None);
+        assert_eq!(ChannelType::Quote.prefix(Market::Forex), Some("C"));
+        assert_eq!(
+            ChannelType::AggregateSecond.prefix(Market::Forex),
+            Some("CA")
+        );
+        assert_eq!(
+            ChannelType::AggregateMinute.prefix(Market::Forex),
+            Some("CAM")
+        );
+    }
+
+    #[test]
+    fn test_channel_for() {
+        // Crypto
+        assert_eq!(
+            ChannelType::Trade.channel_for(Market::Crypto, "BTC-USD"),
+            Some("XT.BTC-USD".to_string())
+        );
+        assert_eq!(
+            ChannelType::Quote.channel_for(Market::Crypto, "BTC-USD"),
+            Some("XQ.BTC-USD".to_string())
+        );
+        assert_eq!(
+            ChannelType::AggregateMinute.channel_for(Market::Crypto, "BTC-USD"),
+            Some("XAM.BTC-USD".to_string())
+        );
+
+        // Stocks
+        assert_eq!(
+            ChannelType::Trade.channel_for(Market::Stocks, "AAPL"),
+            Some("T.AAPL".to_string())
+        );
+        assert_eq!(
+            ChannelType::Quote.channel_for(Market::Stocks, "AAPL"),
+            Some("Q.AAPL".to_string())
+        );
+        assert_eq!(
+            ChannelType::AggregateMinute.channel_for(Market::Stocks, "AAPL"),
+            Some("AM.AAPL".to_string())
+        );
+
+        // Forex (no trades)
+        assert_eq!(
+            ChannelType::Trade.channel_for(Market::Forex, "EUR-USD"),
+            None
+        );
+        assert_eq!(
+            ChannelType::Quote.channel_for(Market::Forex, "EUR-USD"),
+            Some("C.EUR-USD".to_string())
+        );
+    }
+
+    #[test]
+    fn test_subscribe_accumulates() {
+        let instruments: HashMap<String, String> = HashMap::new();
+        let mut client =
+            MassiveLive::new("test_key", Market::Crypto, ExchangeId::Massive, instruments);
+
+        client.subscribe(&["BTC-USD", "ETH-USD"], ChannelType::Trade);
+        client.subscribe(&["BTC-USD"], ChannelType::Quote);
+
+        assert_eq!(client.subscriptions().len(), 3);
+        assert!(client.subscriptions().contains(&"XT.BTC-USD".to_string()));
+        assert!(client.subscriptions().contains(&"XT.ETH-USD".to_string()));
+        assert!(client.subscriptions().contains(&"XQ.BTC-USD".to_string()));
+    }
+
+    #[test]
+    fn test_subscribe_skips_unsupported() {
+        let instruments: HashMap<String, String> = HashMap::new();
+        let mut client =
+            MassiveLive::new("test_key", Market::Forex, ExchangeId::Massive, instruments);
+
+        // Forex doesn't support trades
+        client.subscribe(&["EUR-USD"], ChannelType::Trade);
+        client.subscribe(&["EUR-USD"], ChannelType::Quote);
+
+        // Only quote subscription should be added
+        assert_eq!(client.subscriptions().len(), 1);
+        assert!(client.subscriptions().contains(&"C.EUR-USD".to_string()));
+    }
+
+    #[test]
+    fn test_from_env_missing() {
+        temp_env::with_var_unset(ENV_API_KEY, || {
+            let result: Result<MassiveLive<String>, _> =
+                MassiveLive::from_env(Market::Crypto, ExchangeId::Massive, HashMap::new());
+            assert!(matches!(result, Err(MassiveError::EnvVar { .. })));
+        });
+    }
+
+    #[test]
+    fn test_with_ws_url_override() {
+        let instruments: HashMap<String, String> = HashMap::new();
+        let client = MassiveLive::new("test_key", Market::Crypto, ExchangeId::Massive, instruments)
+            .with_ws_url("wss://test.example.com/crypto");
+
+        assert_eq!(client.ws_url, "wss://test.example.com/crypto");
+    }
+
+    // ========================================================================
+    // Auth/Subscription Response Tests
+    // ========================================================================
+
+    #[test]
+    fn test_verify_auth_response_success() {
+        let msg = Message::Text(
+            r#"[{"ev":"status","status":"auth_success","message":"authenticated"}]"#.into(),
+        );
+        assert!(MassiveLive::<String>::verify_auth_response(&msg).is_ok());
+    }
+
+    #[test]
+    fn test_verify_auth_response_failed() {
+        let msg = Message::Text(
+            r#"[{"ev":"status","status":"auth_failed","message":"invalid api key"}]"#.into(),
+        );
+        let result = MassiveLive::<String>::verify_auth_response(&msg);
+        assert!(matches!(result, Err(MassiveError::Auth { .. })));
+    }
+
+    #[test]
+    fn test_verify_auth_response_close_frame() {
+        let msg = Message::Close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+            code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Normal,
+            reason: "server shutdown".into(),
+        }));
+        let result = MassiveLive::<String>::verify_auth_response(&msg);
+        assert!(matches!(result, Err(MassiveError::Disconnected { .. })));
+    }
+
+    #[test]
+    fn test_verify_auth_response_connected_status_is_unexpected() {
+        // "connected" status should be consumed before auth is sent,
+        // so if we see it here, it's unexpected and should error
+        let msg = Message::Text(
+            r#"[{"ev":"status","status":"connected","message":"Connected Successfully"}]"#.into(),
+        );
+        let result = MassiveLive::<String>::verify_auth_response(&msg);
+        assert!(matches!(result, Err(MassiveError::Auth { .. })));
+    }
+
+    #[test]
+    fn test_verify_subscription_response_success() {
+        let msg = Message::Text(
+            r#"[{"ev":"status","status":"success","message":"subscribed to: XT.BTC-USD"}]"#.into(),
+        );
+        assert!(MassiveLive::<String>::verify_subscription_response(&msg).is_ok());
+    }
+
+    #[test]
+    fn test_verify_subscription_response_failure() {
+        // No "success" status in response should now return error
+        let msg = Message::Text(
+            r#"[{"ev":"status","status":"error","message":"invalid symbol"}]"#.into(),
+        );
+        let result = MassiveLive::<String>::verify_subscription_response(&msg);
+        assert!(matches!(result, Err(MassiveError::Disconnected { .. })));
+    }
+
+    #[test]
+    fn test_verify_subscription_response_close_frame() {
+        let msg = Message::Close(None);
+        let result = MassiveLive::<String>::verify_subscription_response(&msg);
+        assert!(matches!(result, Err(MassiveError::Disconnected { .. })));
+    }
+}

--- a/rustrade-data/src/exchange/massive/mod.rs
+++ b/rustrade-data/src/exchange/massive/mod.rs
@@ -3,6 +3,25 @@
 //! Provides access to institutional-grade market data across all major asset classes:
 //! stocks, options, indices, forex, crypto, and futures.
 //!
+//! # Testing Status
+//!
+//! **Partially integration-tested.** We have a currencies subscription (crypto + forex)
+//! but not stocks, options, indices, or futures subscriptions. Verified endpoints:
+//!
+//! - ✅ REST aggregates (crypto, forex, stocks, options, futures via free tier)
+//! - ✅ REST tick trades (crypto)
+//! - ✅ REST quotes (forex)
+//! - ✅ WebSocket streaming (crypto)
+//! - ✅ Reference data (tickers, exchanges, market status, holidays)
+//! - ✅ Corporate actions (dividends, splits)
+//! - ❌ REST aggregates (indices) — requires indices subscription
+//! - ❌ REST tick trades (stocks) — requires stocks subscription
+//! - ❌ REST quotes (stocks) — requires stocks subscription
+//! - ❌ WebSocket (stocks) — requires stocks subscription
+//!
+//! Unit tests for JSON transformation live inline in `reference.rs` and `transformer.rs`.
+//! Live API integration tests are in `tests/massive_integration.rs`.
+//!
 //! # Architecture
 //!
 //! - [`MassiveRestClient`]: Historical and intraday data via REST API
@@ -64,8 +83,8 @@ pub(crate) mod transformer;
 pub use error::MassiveError;
 pub use live::{ChannelType, Market, MassiveLive};
 pub use reference::{
-    Address, CurrencyStatus, Exchange, MarketHoliday, MarketStatus, SortOrder, Ticker,
-    TickerDetails, TickerQuery,
+    Address, CurrencyStatus, Dividend, DividendFrequency, DividendQuery, Exchange, MarketHoliday,
+    MarketStatus, SortOrder, SplitQuery, StockSplit, Ticker, TickerDetails, TickerQuery,
 };
 pub use rest::MassiveRestClient;
 pub use transformer::FairMarketValue;

--- a/rustrade-data/src/exchange/massive/mod.rs
+++ b/rustrade-data/src/exchange/massive/mod.rs
@@ -1,0 +1,41 @@
+//! Massive (formerly Polygon.io) market data connectors.
+//!
+//! Provides access to institutional-grade market data across all major asset classes:
+//! stocks, options, indices, forex, crypto, and futures.
+//!
+//! # Architecture
+//!
+//! - [`MassiveRestClient`]: Historical and intraday data via REST API
+//!
+//! WebSocket streaming (`MassiveLive`) is planned for a future release.
+//!
+//! # Authentication
+//!
+//! Requires `MASSIVE_API_KEY` environment variable from an active Massive subscription.
+//! Get your API key from: <https://massive.com/dashboard/api-keys>
+//!
+//! # Symbol Conventions
+//!
+//! Massive uses prefix conventions to identify asset classes:
+//! - `X:BTCUSD` — Crypto
+//! - `C:EURUSD` — Forex
+//! - `O:AAPL251219C00150000` — Options
+//! - `I:SPX` — Indices
+//! - (no prefix) — Stocks
+//!
+//! # Example
+//!
+//! ```ignore
+//! use rustrade_data::exchange::massive::MassiveRestClient;
+//!
+//! let client = MassiveRestClient::from_env()?;
+//! let candles = client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to).await?;
+//! ```
+
+mod error;
+pub mod rest;
+pub(crate) mod transformer;
+
+pub use error::MassiveError;
+pub use rest::MassiveRestClient;
+pub use transformer::FairMarketValue;

--- a/rustrade-data/src/exchange/massive/mod.rs
+++ b/rustrade-data/src/exchange/massive/mod.rs
@@ -57,10 +57,15 @@
 
 mod error;
 pub(crate) mod live;
+pub(crate) mod reference;
 pub(crate) mod rest;
 pub(crate) mod transformer;
 
 pub use error::MassiveError;
 pub use live::{ChannelType, Market, MassiveLive};
+pub use reference::{
+    Address, CurrencyStatus, Exchange, MarketHoliday, MarketStatus, SortOrder, Ticker,
+    TickerDetails, TickerQuery,
+};
 pub use rest::MassiveRestClient;
 pub use transformer::FairMarketValue;

--- a/rustrade-data/src/exchange/massive/mod.rs
+++ b/rustrade-data/src/exchange/massive/mod.rs
@@ -6,8 +6,7 @@
 //! # Architecture
 //!
 //! - [`MassiveRestClient`]: Historical and intraday data via REST API
-//!
-//! WebSocket streaming (`MassiveLive`) is planned for a future release.
+//! - [`MassiveLive`]: Real-time streaming via WebSocket
 //!
 //! # Authentication
 //!
@@ -16,14 +15,26 @@
 //!
 //! # Symbol Conventions
 //!
-//! Massive uses prefix conventions to identify asset classes:
+//! **Important**: REST API and WebSocket use different symbol formats!
+//!
+//! ## REST API Symbols
+//!
 //! - `X:BTCUSD` — Crypto
 //! - `C:EURUSD` — Forex
 //! - `O:AAPL251219C00150000` — Options
 //! - `I:SPX` — Indices
-//! - (no prefix) — Stocks
+//! - `AAPL` — Stocks
 //!
-//! # Example
+//! ## WebSocket Symbols
+//!
+//! - `BTC-USD` — Crypto (hyphenated)
+//! - `EUR-USD` — Forex (hyphenated)
+//! - `O:AAPL251219C00150000` — Options
+//! - `AAPL` — Stocks
+//!
+//! # Examples
+//!
+//! ## REST Client
 //!
 //! ```ignore
 //! use rustrade_data::exchange::massive::MassiveRestClient;
@@ -31,11 +42,25 @@
 //! let client = MassiveRestClient::from_env()?;
 //! let candles = client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to).await?;
 //! ```
+//!
+//! ## WebSocket Client
+//!
+//! ```ignore
+//! use rustrade_data::exchange::massive::{MassiveLive, Market, ChannelType};
+//! use std::collections::HashMap;
+//!
+//! let instruments = HashMap::from([("BTC-USD".into(), "btc".into())]);
+//! let mut client = MassiveLive::from_env(Market::Crypto, ExchangeId::Massive, instruments)?;
+//! client.subscribe(&["BTC-USD"], ChannelType::Trade);
+//! let stream = client.start().await?;
+//! ```
 
 mod error;
-pub mod rest;
+pub(crate) mod live;
+pub(crate) mod rest;
 pub(crate) mod transformer;
 
 pub use error::MassiveError;
+pub use live::{ChannelType, Market, MassiveLive};
 pub use rest::MassiveRestClient;
 pub use transformer::FairMarketValue;

--- a/rustrade-data/src/exchange/massive/reference.rs
+++ b/rustrade-data/src/exchange/massive/reference.rs
@@ -1,0 +1,1084 @@
+//! Reference data endpoints for Massive API.
+//!
+//! Provides access to ticker information, exchanges, market status, and holidays.
+
+use super::error::MassiveError;
+use super::rest::MassiveRestClient;
+use async_stream::try_stream;
+use chrono::{DateTime, NaiveDate, Utc};
+use futures::Stream;
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tracing::{debug, warn};
+
+// ============================================================================
+// Query Builders
+// ============================================================================
+
+/// Sort order for paginated results.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SortOrder {
+    #[default]
+    Asc,
+    Desc,
+}
+
+impl SortOrder {
+    fn as_str(self) -> &'static str {
+        match self {
+            SortOrder::Asc => "asc",
+            SortOrder::Desc => "desc",
+        }
+    }
+}
+
+/// Filter parameters for the `/v3/reference/tickers` endpoint.
+///
+/// All fields are optional. Construct with [`TickerQuery::new`] and chain
+/// setters. The stream handles pagination automatically.
+///
+/// # Example
+///
+/// ```ignore
+/// use rustrade_data::exchange::massive::{MassiveRestClient, TickerQuery};
+///
+/// let client = MassiveRestClient::from_env()?;
+/// let query = TickerQuery::new()
+///     .market("stocks")
+///     .active(true)
+///     .limit(500);
+///
+/// let mut stream = client.fetch_tickers(&query);
+/// while let Some(ticker) = stream.next().await {
+///     println!("{:?}", ticker?);
+/// }
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct TickerQuery {
+    /// Filter by ticker symbol (exact match or prefix).
+    pub ticker: Option<String>,
+    /// Filter by asset type (CS, ETF, ADRC, etc.).
+    pub asset_type: Option<String>,
+    /// Filter by market (stocks, crypto, fx, otc, indices).
+    pub market: Option<String>,
+    /// Filter by primary exchange MIC code (XNYS, XNAS, etc.).
+    pub exchange: Option<String>,
+    /// Filter by active trading status.
+    pub active: Option<bool>,
+    /// Text search across ticker and company name.
+    pub search: Option<String>,
+    /// Results per page (max 1000).
+    pub limit: Option<u16>,
+    /// Sort direction.
+    pub order: Option<SortOrder>,
+    /// Field to sort by (e.g., "ticker", "name").
+    pub sort: Option<String>,
+    /// Ticker greater than or equal to.
+    pub ticker_gte: Option<String>,
+    /// Ticker greater than.
+    pub ticker_gt: Option<String>,
+    /// Ticker less than or equal to.
+    pub ticker_lte: Option<String>,
+    /// Ticker less than.
+    pub ticker_lt: Option<String>,
+}
+
+impl TickerQuery {
+    /// Create a new empty query (all tickers, default pagination).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by exact ticker symbol or prefix.
+    #[must_use]
+    pub fn ticker(mut self, v: impl Into<String>) -> Self {
+        self.ticker = Some(v.into());
+        self
+    }
+
+    /// Filter by asset type (CS, ETF, ADRC, etc.).
+    #[must_use]
+    pub fn asset_type(mut self, v: impl Into<String>) -> Self {
+        self.asset_type = Some(v.into());
+        self
+    }
+
+    /// Filter by market (stocks, crypto, fx, otc, indices).
+    #[must_use]
+    pub fn market(mut self, v: impl Into<String>) -> Self {
+        self.market = Some(v.into());
+        self
+    }
+
+    /// Filter by primary exchange MIC code (XNYS, XNAS, etc.).
+    #[must_use]
+    pub fn exchange(mut self, v: impl Into<String>) -> Self {
+        self.exchange = Some(v.into());
+        self
+    }
+
+    /// Filter by active trading status.
+    #[must_use]
+    pub fn active(mut self, v: bool) -> Self {
+        self.active = Some(v);
+        self
+    }
+
+    /// Text search across ticker and company name.
+    #[must_use]
+    pub fn search(mut self, v: impl Into<String>) -> Self {
+        self.search = Some(v.into());
+        self
+    }
+
+    /// Set results per page (clamped to max 1000).
+    #[must_use]
+    pub fn limit(mut self, v: u16) -> Self {
+        self.limit = Some(v.min(1000));
+        self
+    }
+
+    /// Set sort direction.
+    #[must_use]
+    pub fn order(mut self, v: SortOrder) -> Self {
+        self.order = Some(v);
+        self
+    }
+
+    /// Set field to sort by.
+    #[must_use]
+    pub fn sort(mut self, v: impl Into<String>) -> Self {
+        self.sort = Some(v.into());
+        self
+    }
+
+    /// Filter tickers >= value.
+    #[must_use]
+    pub fn ticker_gte(mut self, v: impl Into<String>) -> Self {
+        self.ticker_gte = Some(v.into());
+        self
+    }
+
+    /// Filter tickers > value.
+    #[must_use]
+    pub fn ticker_gt(mut self, v: impl Into<String>) -> Self {
+        self.ticker_gt = Some(v.into());
+        self
+    }
+
+    /// Filter tickers <= value.
+    #[must_use]
+    pub fn ticker_lte(mut self, v: impl Into<String>) -> Self {
+        self.ticker_lte = Some(v.into());
+        self
+    }
+
+    /// Filter tickers < value.
+    #[must_use]
+    pub fn ticker_lt(mut self, v: impl Into<String>) -> Self {
+        self.ticker_lt = Some(v.into());
+        self
+    }
+
+    /// Build query string parameters.
+    fn to_query_string(&self) -> String {
+        let mut pairs: Vec<(&str, String)> = Vec::new();
+
+        if let Some(ref v) = self.ticker {
+            pairs.push(("ticker", v.clone()));
+        }
+        if let Some(ref v) = self.asset_type {
+            pairs.push(("type", v.clone()));
+        }
+        if let Some(ref v) = self.market {
+            pairs.push(("market", v.clone()));
+        }
+        if let Some(ref v) = self.exchange {
+            pairs.push(("exchange", v.clone()));
+        }
+        if let Some(v) = self.active {
+            pairs.push(("active", v.to_string()));
+        }
+        if let Some(ref v) = self.search {
+            pairs.push(("search", v.clone()));
+        }
+        if let Some(v) = self.limit {
+            pairs.push(("limit", v.to_string()));
+        }
+        if let Some(v) = self.order {
+            pairs.push(("order", v.as_str().to_string()));
+        }
+        if let Some(ref v) = self.sort {
+            pairs.push(("sort", v.clone()));
+        }
+        if let Some(ref v) = self.ticker_gte {
+            pairs.push(("ticker.gte", v.clone()));
+        }
+        if let Some(ref v) = self.ticker_gt {
+            pairs.push(("ticker.gt", v.clone()));
+        }
+        if let Some(ref v) = self.ticker_lte {
+            pairs.push(("ticker.lte", v.clone()));
+        }
+        if let Some(ref v) = self.ticker_lt {
+            pairs.push(("ticker.lt", v.clone()));
+        }
+
+        if pairs.is_empty() {
+            String::new()
+        } else {
+            let encoded: Vec<String> = pairs
+                .into_iter()
+                .map(|(k, v)| format!("{}={}", k, urlencoding::encode(&v)))
+                .collect();
+            format!("?{}", encoded.join("&"))
+        }
+    }
+}
+
+// ============================================================================
+// Response Types
+// ============================================================================
+
+/// Ticker summary from the tickers list endpoint.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ticker {
+    /// Ticker symbol.
+    pub ticker: String,
+    /// Company or asset name.
+    pub name: String,
+    /// Market category (stocks, crypto, fx, etc.).
+    pub market: String,
+    /// Asset type (CS, ETF, CRYPTO, etc.).
+    pub asset_type: String,
+    /// Whether the ticker is actively traded.
+    pub active: bool,
+    /// Primary exchange MIC code.
+    pub primary_exchange: Option<String>,
+    /// Trading currency.
+    pub currency_name: Option<String>,
+    /// Composite FIGI identifier.
+    pub composite_figi: Option<String>,
+    /// Locale (us, global).
+    pub locale: Option<String>,
+    /// Last update timestamp.
+    pub last_updated_utc: Option<DateTime<Utc>>,
+}
+
+/// Detailed ticker information from the ticker details endpoint.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TickerDetails {
+    /// Basic ticker info.
+    pub ticker: Ticker,
+    /// Company description.
+    pub description: Option<String>,
+    /// Company homepage URL.
+    pub homepage_url: Option<String>,
+    /// Total number of employees.
+    pub total_employees: Option<u64>,
+    /// Market capitalization.
+    pub market_cap: Option<Decimal>,
+    /// Phone number.
+    pub phone_number: Option<String>,
+    /// Company address.
+    pub address: Option<Address>,
+    /// SIC code.
+    pub sic_code: Option<String>,
+    /// SIC description.
+    pub sic_description: Option<String>,
+    /// Ticker root (e.g., AAPL for AAPL).
+    pub ticker_root: Option<String>,
+    /// IPO/listing date.
+    pub list_date: Option<NaiveDate>,
+    /// Delisting date (if delisted).
+    pub delisted_utc: Option<DateTime<Utc>>,
+    /// Shares outstanding.
+    pub share_class_shares_outstanding: Option<u64>,
+    /// Weighted shares outstanding.
+    pub weighted_shares_outstanding: Option<u64>,
+    /// Round lot size.
+    pub round_lot: Option<u32>,
+}
+
+/// Company address.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Address {
+    pub address1: Option<String>,
+    pub city: Option<String>,
+    pub state: Option<String>,
+    pub postal_code: Option<String>,
+}
+
+/// Exchange information.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Exchange {
+    /// Internal exchange ID.
+    pub id: i64,
+    /// Exchange name.
+    pub name: String,
+    /// Exchange acronym (NYSE, NASDAQ, etc.).
+    pub acronym: Option<String>,
+    /// Market Identifier Code (ISO 10383).
+    pub mic: Option<String>,
+    /// Operating MIC.
+    pub operating_mic: Option<String>,
+    /// Asset class (stocks, crypto, fx, etc.).
+    pub asset_class: String,
+    /// Locale (us, global).
+    pub locale: String,
+    /// Exchange type.
+    pub exchange_type: Option<String>,
+    /// Exchange URL.
+    pub url: Option<String>,
+}
+
+/// Current market status.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MarketStatus {
+    /// Overall market status.
+    pub market: String,
+    /// Server timestamp.
+    pub server_time: DateTime<Utc>,
+    /// Whether after-hours trading is active.
+    pub after_hours: bool,
+    /// Whether early/pre-market trading is active.
+    pub early_hours: bool,
+    /// Status of currency markets.
+    pub currencies: CurrencyStatus,
+    /// Status of individual exchanges.
+    pub exchanges: HashMap<String, String>,
+    /// Status of index groups.
+    pub indices_groups: HashMap<String, String>,
+}
+
+/// Currency market status.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct CurrencyStatus {
+    /// Crypto market status.
+    pub crypto: String,
+    /// Forex market status.
+    pub fx: String,
+}
+
+/// Market holiday information.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MarketHoliday {
+    /// Holiday date.
+    pub date: NaiveDate,
+    /// Exchange code.
+    pub exchange: String,
+    /// Holiday name.
+    pub name: String,
+    /// Status: "closed" or "early-close".
+    pub status: String,
+    /// Trading open time (for early-close days).
+    pub open: Option<DateTime<Utc>>,
+    /// Trading close time (for early-close days).
+    pub close: Option<DateTime<Utc>>,
+}
+
+// ============================================================================
+// Internal Deserialization Types
+// ============================================================================
+
+#[derive(Deserialize)]
+struct TickersResponse {
+    results: Option<Vec<RawTicker>>,
+    next_url: Option<String>,
+    // Deserialized to satisfy serde; not surfaced in public type.
+    #[allow(dead_code)]
+    status: Option<String>,
+    // Deserialized to satisfy serde; not surfaced in public type.
+    #[allow(dead_code)]
+    count: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct RawTicker {
+    ticker: String,
+    name: Option<String>,
+    market: Option<String>,
+    #[serde(rename = "type")]
+    asset_type: Option<String>,
+    active: Option<bool>,
+    primary_exchange: Option<String>,
+    currency_name: Option<String>,
+    composite_figi: Option<String>,
+    locale: Option<String>,
+    last_updated_utc: Option<String>,
+}
+
+impl RawTicker {
+    fn into_ticker(self) -> Ticker {
+        Ticker {
+            ticker: self.ticker,
+            name: self.name.unwrap_or_default(),
+            market: self.market.unwrap_or_default(),
+            asset_type: self.asset_type.unwrap_or_default(),
+            active: self.active.unwrap_or(true),
+            primary_exchange: self.primary_exchange,
+            currency_name: self.currency_name,
+            composite_figi: self.composite_figi,
+            locale: self.locale,
+            last_updated_utc: self.last_updated_utc.and_then(parse_rfc3339_or_warn),
+        }
+    }
+}
+
+/// Parse an RFC3339 timestamp, logging a warning and returning `None` on failure.
+fn parse_rfc3339_or_warn(s: String) -> Option<DateTime<Utc>> {
+    match DateTime::parse_from_rfc3339(&s) {
+        Ok(dt) => Some(dt.with_timezone(&Utc)),
+        Err(e) => {
+            warn!(value = %s, error = %e, "Failed to parse RFC3339 timestamp from Massive API");
+            None
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct TickerDetailsResponse {
+    results: Option<RawTickerDetails>,
+    // Deserialized to satisfy serde; not surfaced in public type.
+    #[allow(dead_code)]
+    status: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawTickerDetails {
+    ticker: String,
+    name: Option<String>,
+    market: Option<String>,
+    #[serde(rename = "type")]
+    asset_type: Option<String>,
+    active: Option<bool>,
+    primary_exchange: Option<String>,
+    currency_name: Option<String>,
+    composite_figi: Option<String>,
+    locale: Option<String>,
+    last_updated_utc: Option<String>,
+    description: Option<String>,
+    homepage_url: Option<String>,
+    total_employees: Option<u64>,
+    market_cap: Option<f64>,
+    phone_number: Option<String>,
+    address: Option<RawAddress>,
+    sic_code: Option<String>,
+    sic_description: Option<String>,
+    ticker_root: Option<String>,
+    list_date: Option<String>,
+    delisted_utc: Option<String>,
+    share_class_shares_outstanding: Option<u64>,
+    weighted_shares_outstanding: Option<u64>,
+    round_lot: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct RawAddress {
+    address1: Option<String>,
+    city: Option<String>,
+    state: Option<String>,
+    postal_code: Option<String>,
+}
+
+impl RawTickerDetails {
+    fn into_ticker_details(self) -> TickerDetails {
+        let ticker = Ticker {
+            ticker: self.ticker,
+            name: self.name.unwrap_or_default(),
+            market: self.market.unwrap_or_default(),
+            asset_type: self.asset_type.unwrap_or_default(),
+            active: self.active.unwrap_or(true),
+            primary_exchange: self.primary_exchange,
+            currency_name: self.currency_name,
+            composite_figi: self.composite_figi,
+            locale: self.locale,
+            last_updated_utc: self.last_updated_utc.and_then(parse_rfc3339_or_warn),
+        };
+
+        TickerDetails {
+            ticker,
+            description: self.description,
+            homepage_url: self.homepage_url,
+            total_employees: self.total_employees,
+            market_cap: self.market_cap.and_then(|v| {
+                let d = Decimal::from_f64_retain(v);
+                if d.is_none() {
+                    warn!(value = %v, "Non-finite market_cap from Massive API; dropping");
+                }
+                d
+            }),
+            phone_number: self.phone_number,
+            address: self.address.map(|a| Address {
+                address1: a.address1,
+                city: a.city,
+                state: a.state,
+                postal_code: a.postal_code,
+            }),
+            sic_code: self.sic_code,
+            sic_description: self.sic_description,
+            ticker_root: self.ticker_root,
+            list_date: self.list_date.and_then(|s| match s.parse() {
+                Ok(d) => Some(d),
+                Err(e) => {
+                    warn!(value = %s, error = %e, "Failed to parse list_date from Massive API");
+                    None
+                }
+            }),
+            delisted_utc: self.delisted_utc.and_then(parse_rfc3339_or_warn),
+            share_class_shares_outstanding: self.share_class_shares_outstanding,
+            weighted_shares_outstanding: self.weighted_shares_outstanding,
+            round_lot: self.round_lot,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ExchangesResponse {
+    results: Option<Vec<RawExchange>>,
+    // Deserialized to satisfy serde; not surfaced in public type.
+    #[allow(dead_code)]
+    status: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawExchange {
+    id: i64,
+    name: String,
+    acronym: Option<String>,
+    mic: Option<String>,
+    operating_mic: Option<String>,
+    asset_class: Option<String>,
+    locale: Option<String>,
+    #[serde(rename = "type")]
+    exchange_type: Option<String>,
+    url: Option<String>,
+}
+
+impl RawExchange {
+    fn into_exchange(self) -> Exchange {
+        Exchange {
+            id: self.id,
+            name: self.name,
+            acronym: self.acronym,
+            mic: self.mic,
+            operating_mic: self.operating_mic,
+            asset_class: self.asset_class.unwrap_or_default(),
+            locale: self.locale.unwrap_or_default(),
+            exchange_type: self.exchange_type,
+            url: self.url,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RawMarketStatus {
+    market: Option<String>,
+    #[serde(rename = "serverTime")]
+    server_time: Option<String>,
+    #[serde(rename = "afterHours")]
+    after_hours: Option<bool>,
+    #[serde(rename = "earlyHours")]
+    early_hours: Option<bool>,
+    currencies: Option<RawCurrencyStatus>,
+    exchanges: Option<HashMap<String, String>>,
+    #[serde(rename = "indicesGroups")]
+    indices_groups: Option<HashMap<String, String>>,
+}
+
+#[derive(Deserialize)]
+struct RawCurrencyStatus {
+    crypto: Option<String>,
+    fx: Option<String>,
+}
+
+impl RawMarketStatus {
+    fn into_market_status(self) -> Result<MarketStatus, MassiveError> {
+        let server_time = match self.server_time {
+            Some(s) => DateTime::parse_from_rfc3339(&s)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(|e| MassiveError::Deserialize {
+                    message: format!("invalid serverTime: {e}"),
+                    payload: s,
+                })?,
+            None => {
+                return Err(MassiveError::Deserialize {
+                    message: "missing serverTime".into(),
+                    payload: String::new(),
+                });
+            }
+        };
+
+        Ok(MarketStatus {
+            market: self.market.unwrap_or_else(|| "unknown".into()),
+            server_time,
+            after_hours: self.after_hours.unwrap_or(false),
+            early_hours: self.early_hours.unwrap_or(false),
+            currencies: self
+                .currencies
+                .map(|c| CurrencyStatus {
+                    crypto: c.crypto.unwrap_or_else(|| "unknown".into()),
+                    fx: c.fx.unwrap_or_else(|| "unknown".into()),
+                })
+                .unwrap_or_default(),
+            exchanges: self.exchanges.unwrap_or_default(),
+            indices_groups: self.indices_groups.unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct RawMarketHoliday {
+    date: String,
+    exchange: Option<String>,
+    name: Option<String>,
+    status: Option<String>,
+    open: Option<String>,
+    close: Option<String>,
+}
+
+impl RawMarketHoliday {
+    fn into_market_holiday(self) -> Result<MarketHoliday, MassiveError> {
+        let date = self.date.parse().map_err(|e: chrono::format::ParseError| {
+            MassiveError::Deserialize {
+                message: format!("invalid date format: {e}"),
+                payload: self.date.clone(),
+            }
+        })?;
+
+        Ok(MarketHoliday {
+            date,
+            exchange: self.exchange.unwrap_or_default(),
+            name: self.name.unwrap_or_default(),
+            status: self.status.unwrap_or_else(|| "closed".into()),
+            open: self.open.and_then(parse_rfc3339_or_warn),
+            close: self.close.and_then(parse_rfc3339_or_warn),
+        })
+    }
+}
+
+// ============================================================================
+// Client Implementation
+// ============================================================================
+
+impl MassiveRestClient {
+    /// Fetch all tickers matching the query.
+    ///
+    /// Returns a stream that handles pagination automatically.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let query = TickerQuery::new().market("stocks").active(true);
+    /// let mut stream = client.fetch_tickers(&query);
+    /// while let Some(ticker) = stream.next().await {
+    ///     println!("{:?}", ticker?);
+    /// }
+    /// ```
+    pub fn fetch_tickers<'a>(
+        &'a self,
+        query: &'a TickerQuery,
+    ) -> impl Stream<Item = Result<Ticker, MassiveError>> + 'a {
+        let base_url = self.base_url();
+        try_stream! {
+            let initial_url = format!(
+                "{}/v3/reference/tickers{}",
+                base_url,
+                query.to_query_string()
+            );
+
+            let mut next_url: Option<String> = Some(initial_url);
+
+            while let Some(url) = next_url.take() {
+                debug!(url = %url, "Fetching tickers page");
+
+                let body = self.fetch_page_body(&url).await?;
+                let parsed: TickersResponse = serde_json::from_str(&body).map_err(|e| {
+                    MassiveError::Deserialize {
+                        message: e.to_string(),
+                        payload: body,
+                    }
+                })?;
+
+                if let Some(results) = parsed.results {
+                    for raw in results {
+                        yield raw.into_ticker();
+                    }
+                }
+
+                if let Some(ref url) = parsed.next_url {
+                    Self::validate_next_url(url, base_url)?;
+                }
+                next_url = parsed.next_url;
+            }
+        }
+    }
+
+    /// Fetch detailed information for a single ticker.
+    ///
+    /// # Arguments
+    ///
+    /// * `ticker` - Ticker symbol (e.g., "AAPL", "X:BTCUSD")
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let details = client.fetch_ticker_details("AAPL").await?;
+    /// println!("Market cap: {:?}", details.market_cap);
+    /// ```
+    pub async fn fetch_ticker_details(&self, ticker: &str) -> Result<TickerDetails, MassiveError> {
+        Self::validate_ticker(ticker)?;
+
+        let url = format!("{}/v3/reference/tickers/{}", self.base_url(), ticker);
+        debug!(url = %url, "Fetching ticker details");
+
+        let body = self.fetch_page_body(&url).await?;
+        let parsed: TickerDetailsResponse =
+            serde_json::from_str(&body).map_err(|e| MassiveError::Deserialize {
+                message: e.to_string(),
+                payload: body,
+            })?;
+
+        parsed
+            .results
+            .map(|r| r.into_ticker_details())
+            .ok_or_else(|| MassiveError::Api {
+                status: 404,
+                message: format!("Ticker not found: {}", ticker),
+            })
+    }
+
+    /// Fetch all exchanges.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset_class` - Optional filter by asset class (stocks, crypto, fx, etc.)
+    /// * `locale` - Optional filter by locale (us, global)
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let exchanges = client.fetch_exchanges(Some("stocks"), Some("us")).await?;
+    /// for exchange in exchanges {
+    ///     println!("{}: {}", exchange.mic.unwrap_or_default(), exchange.name);
+    /// }
+    /// ```
+    pub async fn fetch_exchanges(
+        &self,
+        asset_class: Option<&str>,
+        locale: Option<&str>,
+    ) -> Result<Vec<Exchange>, MassiveError> {
+        let mut url = format!("{}/v3/reference/exchanges", self.base_url());
+
+        let mut params = Vec::new();
+        if let Some(ac) = asset_class {
+            params.push(format!("asset_class={}", urlencoding::encode(ac)));
+        }
+        if let Some(loc) = locale {
+            params.push(format!("locale={}", urlencoding::encode(loc)));
+        }
+        if !params.is_empty() {
+            url.push('?');
+            url.push_str(&params.join("&"));
+        }
+
+        debug!(url = %url, "Fetching exchanges");
+
+        let body = self.fetch_page_body(&url).await?;
+        let parsed: ExchangesResponse =
+            serde_json::from_str(&body).map_err(|e| MassiveError::Deserialize {
+                message: e.to_string(),
+                payload: body,
+            })?;
+
+        Ok(parsed
+            .results
+            .unwrap_or_default()
+            .into_iter()
+            .map(|r| r.into_exchange())
+            .collect())
+    }
+
+    /// Fetch current market status.
+    ///
+    /// Returns the current trading status for various exchanges and overall markets.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let status = client.fetch_market_status().await?;
+    /// println!("Market: {}, Crypto: {}", status.market, status.currencies.crypto);
+    /// ```
+    pub async fn fetch_market_status(&self) -> Result<MarketStatus, MassiveError> {
+        let url = format!("{}/v1/marketstatus/now", self.base_url());
+        debug!(url = %url, "Fetching market status");
+
+        let body = self.fetch_page_body(&url).await?;
+        let parsed: RawMarketStatus =
+            serde_json::from_str(&body).map_err(|e| MassiveError::Deserialize {
+                message: e.to_string(),
+                payload: body,
+            })?;
+
+        parsed.into_market_status()
+    }
+
+    /// Fetch upcoming market holidays.
+    ///
+    /// Returns a list of upcoming holidays with their corresponding open/close times.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let holidays = client.fetch_market_holidays().await?;
+    /// for holiday in holidays {
+    ///     println!("{}: {} ({})", holiday.date, holiday.name, holiday.status);
+    /// }
+    /// ```
+    pub async fn fetch_market_holidays(&self) -> Result<Vec<MarketHoliday>, MassiveError> {
+        let url = format!("{}/v1/marketstatus/upcoming", self.base_url());
+        debug!(url = %url, "Fetching market holidays");
+
+        let body = self.fetch_page_body(&url).await?;
+        let parsed: Vec<RawMarketHoliday> =
+            serde_json::from_str(&body).map_err(|e| MassiveError::Deserialize {
+                message: e.to_string(),
+                payload: body,
+            })?;
+
+        parsed
+            .into_iter()
+            .map(|r| r.into_market_holiday())
+            .collect()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Tests should panic on unexpected values
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ticker_query_empty() {
+        let query = TickerQuery::new();
+        assert_eq!(query.to_query_string(), "");
+    }
+
+    #[test]
+    fn test_ticker_query_single_param() {
+        let query = TickerQuery::new().market("stocks");
+        assert_eq!(query.to_query_string(), "?market=stocks");
+    }
+
+    #[test]
+    fn test_ticker_query_multiple_params() {
+        let query = TickerQuery::new().market("stocks").active(true).limit(500);
+        let qs = query.to_query_string();
+        assert!(qs.contains("market=stocks"));
+        assert!(qs.contains("active=true"));
+        assert!(qs.contains("limit=500"));
+    }
+
+    #[test]
+    fn test_ticker_query_type_serialization() {
+        let query = TickerQuery::new().asset_type("CS");
+        assert_eq!(query.to_query_string(), "?type=CS");
+    }
+
+    #[test]
+    fn test_ticker_query_limit_clamping() {
+        let query = TickerQuery::new().limit(5000);
+        assert_eq!(query.limit, Some(1000));
+    }
+
+    #[test]
+    fn test_ticker_query_url_encoding() {
+        let query = TickerQuery::new().search("apple inc");
+        assert_eq!(query.to_query_string(), "?search=apple%20inc");
+    }
+
+    #[test]
+    fn test_ticker_query_range_operators() {
+        let query = TickerQuery::new().ticker_gte("A").ticker_lt("B");
+        let qs = query.to_query_string();
+        assert!(qs.contains("ticker.gte=A"));
+        assert!(qs.contains("ticker.lt=B"));
+    }
+
+    #[test]
+    fn test_parse_ticker_response() {
+        let json = r#"{
+            "results": [{
+                "ticker": "AAPL",
+                "name": "Apple Inc.",
+                "market": "stocks",
+                "type": "CS",
+                "active": true,
+                "primary_exchange": "XNAS",
+                "currency_name": "usd"
+            }],
+            "status": "OK",
+            "count": 1
+        }"#;
+
+        let parsed: TickersResponse = serde_json::from_str(json).unwrap();
+        let results = parsed.results.unwrap();
+        assert_eq!(results.len(), 1);
+
+        let ticker = results.into_iter().next().unwrap().into_ticker();
+        assert_eq!(ticker.ticker, "AAPL");
+        assert_eq!(ticker.name, "Apple Inc.");
+        assert_eq!(ticker.market, "stocks");
+        assert_eq!(ticker.asset_type, "CS");
+        assert!(ticker.active);
+        assert_eq!(ticker.primary_exchange, Some("XNAS".into()));
+    }
+
+    #[test]
+    fn test_parse_ticker_details_response() {
+        let json = r#"{
+            "results": {
+                "ticker": "AAPL",
+                "name": "Apple Inc.",
+                "market": "stocks",
+                "type": "CS",
+                "active": true,
+                "description": "Apple Inc. designs, manufactures, and markets smartphones.",
+                "market_cap": 2500000000000.0,
+                "total_employees": 164000,
+                "homepage_url": "https://www.apple.com",
+                "address": {
+                    "address1": "One Apple Park Way",
+                    "city": "Cupertino",
+                    "state": "CA",
+                    "postal_code": "95014"
+                },
+                "list_date": "1980-12-12"
+            },
+            "status": "OK"
+        }"#;
+
+        let parsed: TickerDetailsResponse = serde_json::from_str(json).unwrap();
+        let details = parsed.results.unwrap().into_ticker_details();
+
+        assert_eq!(details.ticker.ticker, "AAPL");
+        assert!(details.description.unwrap().contains("Apple"));
+        assert_eq!(
+            details.market_cap,
+            Decimal::from_f64_retain(2_500_000_000_000.0)
+        );
+        assert_eq!(details.total_employees, Some(164_000));
+        assert!(details.address.is_some());
+        let addr = details.address.unwrap();
+        assert_eq!(addr.city, Some("Cupertino".into()));
+        assert_eq!(
+            details.list_date,
+            Some(NaiveDate::from_ymd_opt(1980, 12, 12).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_parse_exchanges_response() {
+        let json = r#"{
+            "results": [{
+                "id": 1,
+                "name": "NYSE American, LLC",
+                "acronym": "AMEX",
+                "mic": "XASE",
+                "operating_mic": "XNYS",
+                "asset_class": "stocks",
+                "locale": "us",
+                "type": "exchange"
+            }],
+            "status": "OK"
+        }"#;
+
+        let parsed: ExchangesResponse = serde_json::from_str(json).unwrap();
+        let results = parsed.results.unwrap();
+        assert_eq!(results.len(), 1);
+
+        let exchange = results.into_iter().next().unwrap().into_exchange();
+        assert_eq!(exchange.id, 1);
+        assert_eq!(exchange.name, "NYSE American, LLC");
+        assert_eq!(exchange.mic, Some("XASE".into()));
+        assert_eq!(exchange.asset_class, "stocks");
+    }
+
+    #[test]
+    fn test_parse_market_status_response() {
+        let json = r#"{
+            "market": "open",
+            "serverTime": "2026-05-06T14:30:00-04:00",
+            "afterHours": false,
+            "earlyHours": false,
+            "currencies": {
+                "crypto": "open",
+                "fx": "open"
+            },
+            "exchanges": {
+                "nasdaq": "open",
+                "nyse": "open"
+            },
+            "indicesGroups": {
+                "s_and_p": "open"
+            }
+        }"#;
+
+        let parsed: RawMarketStatus = serde_json::from_str(json).unwrap();
+        let status = parsed.into_market_status().unwrap();
+
+        assert_eq!(status.market, "open");
+        assert!(!status.after_hours);
+        assert_eq!(status.currencies.crypto, "open");
+        assert_eq!(status.exchanges.get("nasdaq"), Some(&"open".into()));
+    }
+
+    #[test]
+    fn test_parse_market_holidays_response() {
+        let json = r#"[
+            {
+                "date": "2026-12-25",
+                "exchange": "NYSE",
+                "name": "Christmas",
+                "status": "closed"
+            },
+            {
+                "date": "2026-11-27",
+                "exchange": "NYSE",
+                "name": "Thanksgiving",
+                "status": "early-close",
+                "open": "2026-11-27T13:30:00Z",
+                "close": "2026-11-27T18:00:00Z"
+            }
+        ]"#;
+
+        let parsed: Vec<RawMarketHoliday> = serde_json::from_str(json).unwrap();
+        let holidays: Vec<MarketHoliday> = parsed
+            .into_iter()
+            .map(|r| r.into_market_holiday().unwrap())
+            .collect();
+
+        assert_eq!(holidays.len(), 2);
+        assert_eq!(holidays[0].name, "Christmas");
+        assert_eq!(holidays[0].status, "closed");
+        assert!(holidays[0].open.is_none());
+
+        assert_eq!(holidays[1].name, "Thanksgiving");
+        assert_eq!(holidays[1].status, "early-close");
+        assert!(holidays[1].open.is_some());
+        assert!(holidays[1].close.is_some());
+    }
+
+    #[test]
+    fn test_sort_order() {
+        assert_eq!(SortOrder::Asc.as_str(), "asc");
+        assert_eq!(SortOrder::Desc.as_str(), "desc");
+        assert_eq!(SortOrder::default(), SortOrder::Asc);
+    }
+}

--- a/rustrade-data/src/exchange/massive/reference.rs
+++ b/rustrade-data/src/exchange/massive/reference.rs
@@ -379,6 +379,351 @@ pub struct MarketHoliday {
     pub close: Option<DateTime<Utc>>,
 }
 
+/// Dividend payment frequency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DividendFrequency {
+    /// Once per year.
+    Annual,
+    /// Twice per year.
+    SemiAnnual,
+    /// Four times per year.
+    Quarterly,
+    /// Twelve times per year.
+    Monthly,
+    /// Frequency not specified or unrecognized.
+    Unknown(u8),
+}
+
+impl DividendFrequency {
+    /// Create from raw API value.
+    #[must_use]
+    pub fn from_raw(value: u8) -> Self {
+        match value {
+            1 => Self::Annual,
+            2 => Self::SemiAnnual,
+            4 => Self::Quarterly,
+            12 => Self::Monthly,
+            other => Self::Unknown(other),
+        }
+    }
+
+    /// Convert to raw API value.
+    #[must_use]
+    pub fn to_raw(self) -> u8 {
+        match self {
+            Self::Annual => 1,
+            Self::SemiAnnual => 2,
+            Self::Quarterly => 4,
+            Self::Monthly => 12,
+            Self::Unknown(v) => v,
+        }
+    }
+}
+
+impl std::fmt::Display for DividendFrequency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Annual => write!(f, "annual"),
+            Self::SemiAnnual => write!(f, "semi-annual"),
+            Self::Quarterly => write!(f, "quarterly"),
+            Self::Monthly => write!(f, "monthly"),
+            Self::Unknown(v) => write!(f, "unknown({v})"),
+        }
+    }
+}
+
+/// Dividend information.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Dividend {
+    /// Ticker symbol.
+    pub ticker: String,
+    /// Cash amount per share.
+    pub cash_amount: Decimal,
+    /// Currency of the dividend.
+    pub currency: String,
+    /// Declaration date.
+    pub declaration_date: Option<NaiveDate>,
+    /// Ex-dividend date (must hold shares before this date).
+    pub ex_dividend_date: NaiveDate,
+    /// Record date.
+    pub record_date: Option<NaiveDate>,
+    /// Payment date.
+    pub pay_date: Option<NaiveDate>,
+    /// Dividend frequency.
+    pub frequency: Option<DividendFrequency>,
+    /// Distribution type (CD=regular, SC=special, LT=long-term, ST=short-term).
+    pub dividend_type: Option<String>,
+}
+
+/// Stock split information.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StockSplit {
+    /// Ticker symbol.
+    pub ticker: String,
+    /// Execution date of the split.
+    pub execution_date: NaiveDate,
+    /// Split ratio numerator (shares after split).
+    pub split_to: Decimal,
+    /// Split ratio denominator (shares before split).
+    pub split_from: Decimal,
+}
+
+// ============================================================================
+// Query Builders — Corporate Actions
+// ============================================================================
+
+/// Filter parameters for the `/v3/reference/dividends` endpoint.
+#[derive(Debug, Default, Clone)]
+pub struct DividendQuery {
+    /// Filter by ticker symbol.
+    pub ticker: Option<String>,
+    /// Filter by ex-dividend date (exact).
+    pub ex_dividend_date: Option<NaiveDate>,
+    /// Filter by ex-dividend date >= value.
+    pub ex_dividend_date_gte: Option<NaiveDate>,
+    /// Filter by ex-dividend date <= value.
+    pub ex_dividend_date_lte: Option<NaiveDate>,
+    /// Filter by dividend type (CD, SC, LT, ST).
+    pub dividend_type: Option<String>,
+    /// Results per page (max 1000).
+    pub limit: Option<u16>,
+    /// Sort direction.
+    pub order: Option<SortOrder>,
+}
+
+impl DividendQuery {
+    /// Create a new empty query.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by ticker symbol.
+    #[must_use]
+    pub fn ticker(mut self, v: impl Into<String>) -> Self {
+        self.ticker = Some(v.into());
+        self
+    }
+
+    /// Filter by exact ex-dividend date.
+    #[must_use]
+    pub fn ex_dividend_date(mut self, v: NaiveDate) -> Self {
+        self.ex_dividend_date = Some(v);
+        self
+    }
+
+    /// Filter by ex-dividend date >= value.
+    #[must_use]
+    pub fn ex_dividend_date_gte(mut self, v: NaiveDate) -> Self {
+        self.ex_dividend_date_gte = Some(v);
+        self
+    }
+
+    /// Filter by ex-dividend date <= value.
+    #[must_use]
+    pub fn ex_dividend_date_lte(mut self, v: NaiveDate) -> Self {
+        self.ex_dividend_date_lte = Some(v);
+        self
+    }
+
+    /// Filter by dividend type (CD=regular, SC=special, LT=long-term, ST=short-term).
+    #[must_use]
+    pub fn dividend_type(mut self, v: impl Into<String>) -> Self {
+        self.dividend_type = Some(v.into());
+        self
+    }
+
+    /// Set results per page (clamped to max 1000).
+    #[must_use]
+    pub fn limit(mut self, v: u16) -> Self {
+        self.limit = Some(v.min(1000));
+        self
+    }
+
+    /// Set sort direction.
+    #[must_use]
+    pub fn order(mut self, v: SortOrder) -> Self {
+        self.order = Some(v);
+        self
+    }
+
+    /// Validate the query for conflicting filters.
+    ///
+    /// Returns an error if both an exact `ex_dividend_date` and a range filter
+    /// (`ex_dividend_date_gte` or `ex_dividend_date_lte`) are set. The API behavior
+    /// when both are provided is undefined.
+    pub fn validate(&self) -> Result<(), MassiveError> {
+        let has_exact = self.ex_dividend_date.is_some();
+        let has_range = self.ex_dividend_date_gte.is_some() || self.ex_dividend_date_lte.is_some();
+
+        if has_exact && has_range {
+            return Err(MassiveError::InvalidInput {
+                message: "DividendQuery: cannot set both ex_dividend_date (exact) and \
+                          ex_dividend_date_gte/lte (range) filters"
+                    .into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Build query string parameters.
+    fn to_query_string(&self) -> String {
+        let mut pairs: Vec<(&str, String)> = Vec::new();
+
+        if let Some(ref v) = self.ticker {
+            pairs.push(("ticker", v.clone()));
+        }
+        if let Some(v) = self.ex_dividend_date {
+            pairs.push(("ex_dividend_date", v.to_string()));
+        }
+        if let Some(v) = self.ex_dividend_date_gte {
+            pairs.push(("ex_dividend_date.gte", v.to_string()));
+        }
+        if let Some(v) = self.ex_dividend_date_lte {
+            pairs.push(("ex_dividend_date.lte", v.to_string()));
+        }
+        if let Some(ref v) = self.dividend_type {
+            pairs.push(("dividend_type", v.clone()));
+        }
+        if let Some(v) = self.limit {
+            pairs.push(("limit", v.to_string()));
+        }
+        if let Some(v) = self.order {
+            pairs.push(("order", v.as_str().to_string()));
+        }
+
+        if pairs.is_empty() {
+            String::new()
+        } else {
+            let encoded: Vec<String> = pairs
+                .into_iter()
+                .map(|(k, v)| format!("{}={}", k, urlencoding::encode(&v)))
+                .collect();
+            format!("?{}", encoded.join("&"))
+        }
+    }
+}
+
+/// Filter parameters for the `/v3/reference/splits` endpoint.
+#[derive(Debug, Default, Clone)]
+pub struct SplitQuery {
+    /// Filter by ticker symbol.
+    pub ticker: Option<String>,
+    /// Filter by execution date (exact).
+    pub execution_date: Option<NaiveDate>,
+    /// Filter by execution date >= value.
+    pub execution_date_gte: Option<NaiveDate>,
+    /// Filter by execution date <= value.
+    pub execution_date_lte: Option<NaiveDate>,
+    /// Results per page (max 1000).
+    pub limit: Option<u16>,
+    /// Sort direction.
+    pub order: Option<SortOrder>,
+}
+
+impl SplitQuery {
+    /// Create a new empty query.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by ticker symbol.
+    #[must_use]
+    pub fn ticker(mut self, v: impl Into<String>) -> Self {
+        self.ticker = Some(v.into());
+        self
+    }
+
+    /// Filter by exact execution date.
+    #[must_use]
+    pub fn execution_date(mut self, v: NaiveDate) -> Self {
+        self.execution_date = Some(v);
+        self
+    }
+
+    /// Filter by execution date >= value.
+    #[must_use]
+    pub fn execution_date_gte(mut self, v: NaiveDate) -> Self {
+        self.execution_date_gte = Some(v);
+        self
+    }
+
+    /// Filter by execution date <= value.
+    #[must_use]
+    pub fn execution_date_lte(mut self, v: NaiveDate) -> Self {
+        self.execution_date_lte = Some(v);
+        self
+    }
+
+    /// Set results per page (clamped to max 1000).
+    #[must_use]
+    pub fn limit(mut self, v: u16) -> Self {
+        self.limit = Some(v.min(1000));
+        self
+    }
+
+    /// Set sort direction.
+    #[must_use]
+    pub fn order(mut self, v: SortOrder) -> Self {
+        self.order = Some(v);
+        self
+    }
+
+    /// Validate the query for conflicting filters.
+    ///
+    /// Returns an error if both an exact `execution_date` and a range filter
+    /// (`execution_date_gte` or `execution_date_lte`) are set. The API behavior
+    /// when both are provided is undefined.
+    pub fn validate(&self) -> Result<(), MassiveError> {
+        let has_exact = self.execution_date.is_some();
+        let has_range = self.execution_date_gte.is_some() || self.execution_date_lte.is_some();
+
+        if has_exact && has_range {
+            return Err(MassiveError::InvalidInput {
+                message: "SplitQuery: cannot set both execution_date (exact) and \
+                          execution_date_gte/lte (range) filters"
+                    .into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Build query string parameters.
+    fn to_query_string(&self) -> String {
+        let mut pairs: Vec<(&str, String)> = Vec::new();
+
+        if let Some(ref v) = self.ticker {
+            pairs.push(("ticker", v.clone()));
+        }
+        if let Some(v) = self.execution_date {
+            pairs.push(("execution_date", v.to_string()));
+        }
+        if let Some(v) = self.execution_date_gte {
+            pairs.push(("execution_date.gte", v.to_string()));
+        }
+        if let Some(v) = self.execution_date_lte {
+            pairs.push(("execution_date.lte", v.to_string()));
+        }
+        if let Some(v) = self.limit {
+            pairs.push(("limit", v.to_string()));
+        }
+        if let Some(v) = self.order {
+            pairs.push(("order", v.as_str().to_string()));
+        }
+
+        if pairs.is_empty() {
+            String::new()
+        } else {
+            let encoded: Vec<String> = pairs
+                .into_iter()
+                .map(|(k, v)| format!("{}={}", k, urlencoding::encode(&v)))
+                .collect();
+            format!("?{}", encoded.join("&"))
+        }
+    }
+}
+
 // ============================================================================
 // Internal Deserialization Types
 // ============================================================================
@@ -659,6 +1004,110 @@ impl RawMarketHoliday {
     }
 }
 
+#[derive(Deserialize)]
+struct DividendsResponse {
+    results: Option<Vec<RawDividend>>,
+    next_url: Option<String>,
+    // Deserialized to satisfy serde; not surfaced in public type.
+    #[allow(dead_code)]
+    status: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawDividend {
+    ticker: String,
+    #[serde(with = "rust_decimal::serde::float")]
+    cash_amount: Decimal,
+    #[serde(default)]
+    currency: Option<String>,
+    declaration_date: Option<String>,
+    ex_dividend_date: String,
+    record_date: Option<String>,
+    pay_date: Option<String>,
+    frequency: Option<u8>,
+    dividend_type: Option<String>,
+}
+
+impl RawDividend {
+    fn into_dividend(self) -> Result<Dividend, MassiveError> {
+        let ex_dividend_date =
+            self.ex_dividend_date
+                .parse()
+                .map_err(|e: chrono::format::ParseError| MassiveError::Deserialize {
+                    message: format!("invalid ex_dividend_date: {e}"),
+                    payload: self.ex_dividend_date.clone(),
+                })?;
+
+        Ok(Dividend {
+            ticker: self.ticker,
+            cash_amount: self.cash_amount,
+            currency: self.currency.unwrap_or_else(|| "USD".into()),
+            declaration_date: self.declaration_date.and_then(|s| match s.parse() {
+                Ok(d) => Some(d),
+                Err(e) => {
+                    warn!(value = %s, error = %e, "Failed to parse declaration_date");
+                    None
+                }
+            }),
+            ex_dividend_date,
+            record_date: self.record_date.and_then(|s| match s.parse() {
+                Ok(d) => Some(d),
+                Err(e) => {
+                    warn!(value = %s, error = %e, "Failed to parse record_date");
+                    None
+                }
+            }),
+            pay_date: self.pay_date.and_then(|s| match s.parse() {
+                Ok(d) => Some(d),
+                Err(e) => {
+                    warn!(value = %s, error = %e, "Failed to parse pay_date");
+                    None
+                }
+            }),
+            frequency: self.frequency.map(DividendFrequency::from_raw),
+            dividend_type: self.dividend_type,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct SplitsResponse {
+    results: Option<Vec<RawSplit>>,
+    next_url: Option<String>,
+    // Deserialized to satisfy serde; not surfaced in public type.
+    #[allow(dead_code)]
+    status: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawSplit {
+    ticker: String,
+    execution_date: String,
+    #[serde(with = "rust_decimal::serde::float")]
+    split_to: Decimal,
+    #[serde(with = "rust_decimal::serde::float")]
+    split_from: Decimal,
+}
+
+impl RawSplit {
+    fn into_stock_split(self) -> Result<StockSplit, MassiveError> {
+        let execution_date =
+            self.execution_date
+                .parse()
+                .map_err(|e: chrono::format::ParseError| MassiveError::Deserialize {
+                    message: format!("invalid execution_date: {e}"),
+                    payload: self.execution_date.clone(),
+                })?;
+
+        Ok(StockSplit {
+            ticker: self.ticker,
+            execution_date,
+            split_to: self.split_to,
+            split_from: self.split_from,
+        })
+    }
+}
+
 // ============================================================================
 // Client Implementation
 // ============================================================================
@@ -852,6 +1301,114 @@ impl MassiveRestClient {
             .into_iter()
             .map(|r| r.into_market_holiday())
             .collect()
+    }
+
+    /// Fetch dividends matching the query.
+    ///
+    /// Returns a stream that handles pagination automatically.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let query = DividendQuery::new().ticker("AAPL").limit(100);
+    /// let mut stream = client.fetch_dividends(&query);
+    /// while let Some(dividend) = stream.next().await {
+    ///     println!("{:?}", dividend?);
+    /// }
+    /// ```
+    pub fn fetch_dividends<'a>(
+        &'a self,
+        query: &'a DividendQuery,
+    ) -> impl Stream<Item = Result<Dividend, MassiveError>> + 'a {
+        let base_url = self.base_url();
+        try_stream! {
+            query.validate()?;
+
+            let initial_url = format!(
+                "{}/v3/reference/dividends{}",
+                base_url,
+                query.to_query_string()
+            );
+
+            let mut next_url: Option<String> = Some(initial_url);
+
+            while let Some(url) = next_url.take() {
+                debug!(url = %url, "Fetching dividends page");
+
+                let body = self.fetch_page_body(&url).await?;
+                let parsed: DividendsResponse = serde_json::from_str(&body).map_err(|e| {
+                    MassiveError::Deserialize {
+                        message: e.to_string(),
+                        payload: body,
+                    }
+                })?;
+
+                if let Some(results) = parsed.results {
+                    for raw in results {
+                        yield raw.into_dividend()?;
+                    }
+                }
+
+                if let Some(ref url) = parsed.next_url {
+                    Self::validate_next_url(url, base_url)?;
+                }
+                next_url = parsed.next_url;
+            }
+        }
+    }
+
+    /// Fetch stock splits matching the query.
+    ///
+    /// Returns a stream that handles pagination automatically.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let query = SplitQuery::new().ticker("AAPL").limit(100);
+    /// let mut stream = client.fetch_splits(&query);
+    /// while let Some(split) = stream.next().await {
+    ///     println!("{:?}", split?);
+    /// }
+    /// ```
+    pub fn fetch_splits<'a>(
+        &'a self,
+        query: &'a SplitQuery,
+    ) -> impl Stream<Item = Result<StockSplit, MassiveError>> + 'a {
+        let base_url = self.base_url();
+        try_stream! {
+            query.validate()?;
+
+            let initial_url = format!(
+                "{}/v3/reference/splits{}",
+                base_url,
+                query.to_query_string()
+            );
+
+            let mut next_url: Option<String> = Some(initial_url);
+
+            while let Some(url) = next_url.take() {
+                debug!(url = %url, "Fetching splits page");
+
+                let body = self.fetch_page_body(&url).await?;
+                let parsed: SplitsResponse = serde_json::from_str(&body).map_err(|e| {
+                    MassiveError::Deserialize {
+                        message: e.to_string(),
+                        payload: body,
+                    }
+                })?;
+
+                if let Some(results) = parsed.results {
+                    for raw in results {
+                        yield raw.into_stock_split()?;
+                    }
+                }
+
+                if let Some(ref url) = parsed.next_url {
+                    Self::validate_next_url(url, base_url)?;
+                }
+                next_url = parsed.next_url;
+            }
+        }
     }
 }
 
@@ -1080,5 +1637,187 @@ mod tests {
         assert_eq!(SortOrder::Asc.as_str(), "asc");
         assert_eq!(SortOrder::Desc.as_str(), "desc");
         assert_eq!(SortOrder::default(), SortOrder::Asc);
+    }
+
+    // ========================================================================
+    // Corporate Actions Tests
+    // ========================================================================
+
+    #[test]
+    fn test_dividend_query_empty() {
+        let query = DividendQuery::new();
+        assert_eq!(query.to_query_string(), "");
+    }
+
+    #[test]
+    fn test_dividend_query_with_ticker() {
+        let query = DividendQuery::new().ticker("AAPL");
+        assert_eq!(query.to_query_string(), "?ticker=AAPL");
+    }
+
+    #[test]
+    fn test_dividend_query_with_date_range() {
+        let from = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let to = NaiveDate::from_ymd_opt(2024, 12, 31).unwrap();
+        let query = DividendQuery::new()
+            .ticker("AAPL")
+            .ex_dividend_date_gte(from)
+            .ex_dividend_date_lte(to);
+        let qs = query.to_query_string();
+        assert!(qs.contains("ticker=AAPL"));
+        assert!(qs.contains("ex_dividend_date.gte=2024-01-01"));
+        assert!(qs.contains("ex_dividend_date.lte=2024-12-31"));
+    }
+
+    #[test]
+    fn test_dividend_query_limit_clamping() {
+        let query = DividendQuery::new().limit(5000);
+        assert_eq!(query.limit, Some(1000));
+    }
+
+    #[test]
+    fn test_parse_dividends_response() {
+        let json = r#"{
+            "results": [{
+                "ticker": "AAPL",
+                "cash_amount": 0.25,
+                "currency": "USD",
+                "declaration_date": "2024-02-01",
+                "ex_dividend_date": "2024-02-09",
+                "record_date": "2024-02-12",
+                "pay_date": "2024-02-15",
+                "frequency": 4,
+                "dividend_type": "CD"
+            }],
+            "status": "OK"
+        }"#;
+
+        let parsed: DividendsResponse = serde_json::from_str(json).unwrap();
+        let results = parsed.results.unwrap();
+        assert_eq!(results.len(), 1);
+
+        let dividend = results.into_iter().next().unwrap().into_dividend().unwrap();
+        assert_eq!(dividend.ticker, "AAPL");
+        assert_eq!(
+            dividend.cash_amount,
+            Decimal::from_f64_retain(0.25).unwrap()
+        );
+        assert_eq!(dividend.currency, "USD");
+        assert_eq!(
+            dividend.ex_dividend_date,
+            NaiveDate::from_ymd_opt(2024, 2, 9).unwrap()
+        );
+        assert_eq!(dividend.frequency, Some(DividendFrequency::Quarterly));
+        assert_eq!(dividend.dividend_type, Some("CD".into()));
+    }
+
+    #[test]
+    fn test_parse_dividends_minimal() {
+        let json = r#"{
+            "results": [{
+                "ticker": "MSFT",
+                "cash_amount": 0.75,
+                "ex_dividend_date": "2024-05-15"
+            }],
+            "status": "OK"
+        }"#;
+
+        let parsed: DividendsResponse = serde_json::from_str(json).unwrap();
+        let results = parsed.results.unwrap();
+        let dividend = results.into_iter().next().unwrap().into_dividend().unwrap();
+
+        assert_eq!(dividend.ticker, "MSFT");
+        assert_eq!(dividend.currency, "USD"); // Defaults to USD
+        assert!(dividend.declaration_date.is_none());
+        assert!(dividend.frequency.is_none());
+    }
+
+    #[test]
+    fn test_split_query_empty() {
+        let query = SplitQuery::new();
+        assert_eq!(query.to_query_string(), "");
+    }
+
+    #[test]
+    fn test_split_query_with_ticker() {
+        let query = SplitQuery::new().ticker("TSLA");
+        assert_eq!(query.to_query_string(), "?ticker=TSLA");
+    }
+
+    #[test]
+    fn test_split_query_with_date_range() {
+        let from = NaiveDate::from_ymd_opt(2020, 1, 1).unwrap();
+        let to = NaiveDate::from_ymd_opt(2024, 12, 31).unwrap();
+        let query = SplitQuery::new()
+            .ticker("NVDA")
+            .execution_date_gte(from)
+            .execution_date_lte(to);
+        let qs = query.to_query_string();
+        assert!(qs.contains("ticker=NVDA"));
+        assert!(qs.contains("execution_date.gte=2020-01-01"));
+        assert!(qs.contains("execution_date.lte=2024-12-31"));
+    }
+
+    #[test]
+    fn test_split_query_limit_clamping() {
+        let query = SplitQuery::new().limit(2000);
+        assert_eq!(query.limit, Some(1000));
+    }
+
+    #[test]
+    fn test_parse_splits_response() {
+        let json = r#"{
+            "results": [{
+                "ticker": "TSLA",
+                "execution_date": "2022-08-25",
+                "split_to": 3.0,
+                "split_from": 1.0
+            }],
+            "status": "OK"
+        }"#;
+
+        let parsed: SplitsResponse = serde_json::from_str(json).unwrap();
+        let results = parsed.results.unwrap();
+        assert_eq!(results.len(), 1);
+
+        let split = results
+            .into_iter()
+            .next()
+            .unwrap()
+            .into_stock_split()
+            .unwrap();
+        assert_eq!(split.ticker, "TSLA");
+        assert_eq!(
+            split.execution_date,
+            NaiveDate::from_ymd_opt(2022, 8, 25).unwrap()
+        );
+        assert_eq!(split.split_to, Decimal::from(3));
+        assert_eq!(split.split_from, Decimal::from(1));
+    }
+
+    #[test]
+    fn test_parse_splits_reverse_split() {
+        let json = r#"{
+            "results": [{
+                "ticker": "GE",
+                "execution_date": "2021-08-02",
+                "split_to": 1.0,
+                "split_from": 8.0
+            }],
+            "status": "OK"
+        }"#;
+
+        let parsed: SplitsResponse = serde_json::from_str(json).unwrap();
+        let results = parsed.results.unwrap();
+        let split = results
+            .into_iter()
+            .next()
+            .unwrap()
+            .into_stock_split()
+            .unwrap();
+
+        assert_eq!(split.ticker, "GE");
+        assert_eq!(split.split_to, Decimal::from(1));
+        assert_eq!(split.split_from, Decimal::from(8)); // 1:8 reverse split
     }
 }

--- a/rustrade-data/src/exchange/massive/rest.rs
+++ b/rustrade-data/src/exchange/massive/rest.rs
@@ -24,34 +24,6 @@ fn truncate_body(body: &str) -> String {
     body[..boundary].to_owned()
 }
 
-/// Validate ticker doesn't contain URL-breaking characters.
-fn validate_ticker(ticker: &str) -> Result<(), MassiveError> {
-    if ticker.is_empty() {
-        return Err(MassiveError::InvalidInput {
-            message: "ticker must not be empty".into(),
-        });
-    }
-    if ticker.contains(['/', '?', '#', ' ', '%']) {
-        return Err(MassiveError::InvalidInput {
-            message: "ticker contains invalid URL characters".into(),
-        });
-    }
-    Ok(())
-}
-
-/// Validate next_url is from the expected origin to prevent token leakage.
-fn validate_next_url(next_url: &str, base_url: &str) -> Result<(), MassiveError> {
-    if !next_url.starts_with(base_url) {
-        return Err(MassiveError::InvalidInput {
-            message: format!(
-                "next_url origin mismatch: expected {}, got {}",
-                base_url, next_url
-            ),
-        });
-    }
-    Ok(())
-}
-
 /// REST client for Massive historical and intraday market data.
 ///
 /// # Example
@@ -129,8 +101,41 @@ impl MassiveRestClient {
         self
     }
 
+    /// Get the base URL.
+    pub(super) fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Validate ticker doesn't contain URL-breaking characters.
+    pub(super) fn validate_ticker(ticker: &str) -> Result<(), MassiveError> {
+        if ticker.is_empty() {
+            return Err(MassiveError::InvalidInput {
+                message: "ticker must not be empty".into(),
+            });
+        }
+        if ticker.contains(['/', '?', '#', ' ', '%']) {
+            return Err(MassiveError::InvalidInput {
+                message: "ticker contains invalid URL characters".into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Validate next_url is from the expected origin to prevent token leakage.
+    pub(super) fn validate_next_url(next_url: &str, base_url: &str) -> Result<(), MassiveError> {
+        if !next_url.starts_with(base_url) {
+            return Err(MassiveError::InvalidInput {
+                message: format!(
+                    "next_url origin mismatch: expected {}, got {}",
+                    base_url, next_url
+                ),
+            });
+        }
+        Ok(())
+    }
+
     /// Fetch a page body from the given URL with standard error handling.
-    async fn fetch_page_body(&self, url: &str) -> Result<String, MassiveError> {
+    pub(super) async fn fetch_page_body(&self, url: &str) -> Result<String, MassiveError> {
         let response = self.client.get(url).send().await?;
         let status = response.status();
 
@@ -198,7 +203,7 @@ impl MassiveRestClient {
         to: chrono::DateTime<chrono::Utc>,
     ) -> impl Stream<Item = Result<Candle, MassiveError>> + 'a {
         try_stream! {
-            validate_ticker(ticker)?;
+            Self::validate_ticker(ticker)?;
 
             let from_ms = from.timestamp_millis();
             let to_ms = to.timestamp_millis();
@@ -232,7 +237,7 @@ impl MassiveRestClient {
 
                 // Validate next_url origin before following
                 if let Some(ref url) = parsed.next_url {
-                    validate_next_url(url, &self.base_url)?;
+                    Self::validate_next_url(url, &self.base_url)?;
                 }
                 next_url = parsed.next_url;
             }
@@ -255,7 +260,7 @@ impl MassiveRestClient {
         to: chrono::DateTime<chrono::Utc>,
     ) -> impl Stream<Item = Result<PublicTrade, MassiveError>> + 'a {
         try_stream! {
-            validate_ticker(ticker)?;
+            Self::validate_ticker(ticker)?;
 
             let from_ns = from.timestamp_nanos_opt().ok_or_else(|| MassiveError::InvalidInput {
                 message: "from timestamp out of nanosecond range (~1678-2262)".into(),
@@ -290,7 +295,7 @@ impl MassiveRestClient {
 
                 // Validate next_url origin before following
                 if let Some(ref url) = parsed.next_url {
-                    validate_next_url(url, &self.base_url)?;
+                    Self::validate_next_url(url, &self.base_url)?;
                 }
                 next_url = parsed.next_url;
             }
@@ -319,7 +324,7 @@ impl MassiveRestClient {
         to: chrono::DateTime<chrono::Utc>,
     ) -> impl Stream<Item = Result<OrderBookL1, MassiveError>> + 'a {
         try_stream! {
-            validate_ticker(ticker)?;
+            Self::validate_ticker(ticker)?;
 
             let from_ns = from.timestamp_nanos_opt().ok_or_else(|| MassiveError::InvalidInput {
                 message: "from timestamp out of nanosecond range (~1678-2262)".into(),
@@ -354,7 +359,7 @@ impl MassiveRestClient {
 
                 // Validate next_url origin before following
                 if let Some(ref url) = parsed.next_url {
-                    validate_next_url(url, &self.base_url)?;
+                    Self::validate_next_url(url, &self.base_url)?;
                 }
                 next_url = parsed.next_url;
             }

--- a/rustrade-data/src/exchange/massive/rest.rs
+++ b/rustrade-data/src/exchange/massive/rest.rs
@@ -1,0 +1,388 @@
+//! REST client for Massive historical and intraday data.
+//!
+//! Provides access to aggregates (OHLCV), trades, and quotes across all asset classes.
+
+use super::error::MassiveError;
+use super::transformer::{
+    AggregatesResponse, QuotesResponse, TradesResponse, parse_aggregates_response,
+    parse_quotes_response, parse_trades_response, timespan_to_duration,
+};
+use crate::subscription::{book::OrderBookL1, candle::Candle, trade::PublicTrade};
+use async_stream::try_stream;
+use futures::Stream;
+use reqwest::{Client, StatusCode, header};
+use std::env;
+use std::time::Duration;
+use tracing::debug;
+
+const BASE_URL: &str = "https://api.massive.com";
+const ENV_API_KEY: &str = "MASSIVE_API_KEY";
+
+/// Truncate response body for error messages (max 512 chars, UTF-8 safe).
+fn truncate_body(body: &str) -> String {
+    let boundary = body.floor_char_boundary(512);
+    body[..boundary].to_owned()
+}
+
+/// Validate ticker doesn't contain URL-breaking characters.
+fn validate_ticker(ticker: &str) -> Result<(), MassiveError> {
+    if ticker.is_empty() {
+        return Err(MassiveError::InvalidInput {
+            message: "ticker must not be empty".into(),
+        });
+    }
+    if ticker.contains(['/', '?', '#', ' ', '%']) {
+        return Err(MassiveError::InvalidInput {
+            message: "ticker contains invalid URL characters".into(),
+        });
+    }
+    Ok(())
+}
+
+/// Validate next_url is from the expected origin to prevent token leakage.
+fn validate_next_url(next_url: &str, base_url: &str) -> Result<(), MassiveError> {
+    if !next_url.starts_with(base_url) {
+        return Err(MassiveError::InvalidInput {
+            message: format!(
+                "next_url origin mismatch: expected {}, got {}",
+                base_url, next_url
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// REST client for Massive historical and intraday market data.
+///
+/// # Example
+///
+/// ```ignore
+/// use rustrade_data::exchange::massive::MassiveRestClient;
+/// use chrono::{Utc, Duration};
+///
+/// let client = MassiveRestClient::from_env()?;
+/// let to = Utc::now();
+/// let from = to - Duration::days(1);
+///
+/// let mut stream = client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to);
+/// while let Some(candle) = stream.next().await {
+///     println!("{:?}", candle?);
+/// }
+/// ```
+#[derive(Clone)]
+pub struct MassiveRestClient {
+    client: Client,
+    #[allow(dead_code)] // Retained for WebSocket auth; HTTP auth is in client headers
+    api_key: String,
+    base_url: String,
+}
+
+impl std::fmt::Debug for MassiveRestClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MassiveRestClient")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl MassiveRestClient {
+    /// Create a new client with explicit API key.
+    ///
+    /// # Arguments
+    ///
+    /// * `api_key` - Massive API key from <https://massive.com/dashboard/api-keys>
+    pub fn new(api_key: impl Into<String>) -> Result<Self, MassiveError> {
+        let api_key = api_key.into();
+        let mut headers = header::HeaderMap::new();
+        let auth_value =
+            header::HeaderValue::from_str(&format!("Bearer {}", api_key)).map_err(|e| {
+                MassiveError::Auth {
+                    message: format!("Invalid API key format: {}", e),
+                }
+            })?;
+        headers.insert(header::AUTHORIZATION, auth_value);
+
+        let client = Client::builder()
+            .default_headers(headers)
+            .timeout(Duration::from_secs(30))
+            .build()?;
+
+        Ok(Self {
+            client,
+            api_key,
+            base_url: BASE_URL.to_string(),
+        })
+    }
+
+    /// Create a new client from `MASSIVE_API_KEY` environment variable.
+    pub fn from_env() -> Result<Self, MassiveError> {
+        let api_key =
+            env::var(ENV_API_KEY).map_err(|_| MassiveError::EnvVar { var: ENV_API_KEY })?;
+        Self::new(api_key)
+    }
+
+    /// Override the base URL (useful for testing or legacy polygon.io endpoint).
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// Fetch a page body from the given URL with standard error handling.
+    async fn fetch_page_body(&self, url: &str) -> Result<String, MassiveError> {
+        let response = self.client.get(url).send().await?;
+        let status = response.status();
+
+        // Extract retry-after before consuming response
+        let retry_after = response
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+            .map(Duration::from_secs);
+
+        // Check rate limit before consuming body (avoids wasted I/O on 429)
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            return Err(MassiveError::RateLimited { retry_after });
+        }
+
+        let body = response.text().await?;
+
+        if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+            return Err(MassiveError::Auth {
+                message: truncate_body(&body),
+            });
+        }
+
+        if !status.is_success() {
+            return Err(MassiveError::Api {
+                status: status.as_u16(),
+                message: truncate_body(&body),
+            });
+        }
+
+        Ok(body)
+    }
+
+    /// Fetch a single page of aggregates from the given URL.
+    async fn fetch_aggregates_page(&self, url: &str) -> Result<AggregatesResponse, MassiveError> {
+        let body = self.fetch_page_body(url).await?;
+        parse_aggregates_response(&body)
+    }
+
+    /// Fetch aggregated OHLCV bars for a symbol.
+    ///
+    /// Returns a stream that handles pagination automatically. Does not collect
+    /// results into memory — processes each page as it arrives.
+    ///
+    /// # Arguments
+    ///
+    /// * `ticker` - Symbol with asset class prefix (e.g., `X:BTCUSD`, `C:EURUSD`, `AAPL`)
+    /// * `multiplier` - Size of the timespan multiplier (e.g., 1, 5, 15)
+    /// * `timespan` - Size unit: `second`, `minute`, `hour`, `day`, `week`, `month`, `quarter`, `year`
+    /// * `from` - Start timestamp
+    /// * `to` - End timestamp
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let stream = client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to);
+    /// ```
+    pub fn fetch_aggregates<'a>(
+        &'a self,
+        ticker: &'a str,
+        multiplier: u32,
+        timespan: &'a str,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> impl Stream<Item = Result<Candle, MassiveError>> + 'a {
+        try_stream! {
+            validate_ticker(ticker)?;
+
+            let from_ms = from.timestamp_millis();
+            let to_ms = to.timestamp_millis();
+
+            let initial_url = format!(
+                "{}/v2/aggs/ticker/{}/range/{}/{}/{}/{}?adjusted=true&sort=asc&limit=50000",
+                self.base_url, ticker, multiplier, timespan, from_ms, to_ms
+            );
+
+            let mut next_url: Option<String> = Some(initial_url);
+
+            // Pre-compute duration once for all bars in this stream
+            let bar_duration = timespan_to_duration(multiplier, timespan);
+
+            while let Some(url) = next_url.take() {
+                debug!(url = %url, "Fetching aggregates page");
+
+                let parsed = self.fetch_aggregates_page(&url).await?;
+
+                debug!(
+                    results_count = parsed.results_count,
+                    has_next = parsed.next_url.is_some(),
+                    "Parsed aggregates response"
+                );
+
+                if let Some(results) = parsed.results {
+                    for bar in results {
+                        yield bar.into_candle_with_duration(bar_duration);
+                    }
+                }
+
+                // Validate next_url origin before following
+                if let Some(ref url) = parsed.next_url {
+                    validate_next_url(url, &self.base_url)?;
+                }
+                next_url = parsed.next_url;
+            }
+        }
+    }
+
+    /// Fetch tick-level trades for a symbol.
+    ///
+    /// Returns a stream that handles pagination automatically.
+    ///
+    /// # Arguments
+    ///
+    /// * `ticker` - Symbol with asset class prefix (e.g., `X:BTCUSD`, `AAPL`)
+    /// * `from` - Start timestamp
+    /// * `to` - End timestamp
+    pub fn fetch_trades<'a>(
+        &'a self,
+        ticker: &'a str,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> impl Stream<Item = Result<PublicTrade, MassiveError>> + 'a {
+        try_stream! {
+            validate_ticker(ticker)?;
+
+            let from_ns = from.timestamp_nanos_opt().ok_or_else(|| MassiveError::InvalidInput {
+                message: "from timestamp out of nanosecond range (~1678-2262)".into(),
+            })?;
+            let to_ns = to.timestamp_nanos_opt().ok_or_else(|| MassiveError::InvalidInput {
+                message: "to timestamp out of nanosecond range (~1678-2262)".into(),
+            })?;
+
+            let initial_url = format!(
+                "{}/v3/trades/{}?timestamp.gte={}&timestamp.lte={}&limit=50000&sort=timestamp&order=asc",
+                self.base_url, ticker, from_ns, to_ns
+            );
+
+            let mut next_url: Option<String> = Some(initial_url);
+
+            while let Some(url) = next_url.take() {
+                debug!(url = %url, "Fetching trades page");
+
+                let parsed = self.fetch_trades_page(&url).await?;
+
+                debug!(
+                    results_count = parsed.results_count,
+                    has_next = parsed.next_url.is_some(),
+                    "Parsed trades response"
+                );
+
+                if let Some(results) = parsed.results {
+                    for trade in results {
+                        yield trade.into_public_trade();
+                    }
+                }
+
+                // Validate next_url origin before following
+                if let Some(ref url) = parsed.next_url {
+                    validate_next_url(url, &self.base_url)?;
+                }
+                next_url = parsed.next_url;
+            }
+        }
+    }
+
+    /// Fetch a single page of trades from the given URL.
+    async fn fetch_trades_page(&self, url: &str) -> Result<TradesResponse, MassiveError> {
+        let body = self.fetch_page_body(url).await?;
+        parse_trades_response(&body)
+    }
+
+    /// Fetch quotes (BBO/NBBO) for a symbol.
+    ///
+    /// Returns a stream that handles pagination automatically.
+    ///
+    /// # Arguments
+    ///
+    /// * `ticker` - Symbol with asset class prefix (e.g., `C:EURUSD`, `AAPL`)
+    /// * `from` - Start timestamp
+    /// * `to` - End timestamp
+    pub fn fetch_quotes<'a>(
+        &'a self,
+        ticker: &'a str,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> impl Stream<Item = Result<OrderBookL1, MassiveError>> + 'a {
+        try_stream! {
+            validate_ticker(ticker)?;
+
+            let from_ns = from.timestamp_nanos_opt().ok_or_else(|| MassiveError::InvalidInput {
+                message: "from timestamp out of nanosecond range (~1678-2262)".into(),
+            })?;
+            let to_ns = to.timestamp_nanos_opt().ok_or_else(|| MassiveError::InvalidInput {
+                message: "to timestamp out of nanosecond range (~1678-2262)".into(),
+            })?;
+
+            let initial_url = format!(
+                "{}/v3/quotes/{}?timestamp.gte={}&timestamp.lte={}&limit=50000&sort=timestamp&order=asc",
+                self.base_url, ticker, from_ns, to_ns
+            );
+
+            let mut next_url: Option<String> = Some(initial_url);
+
+            while let Some(url) = next_url.take() {
+                debug!(url = %url, "Fetching quotes page");
+
+                let parsed = self.fetch_quotes_page(&url).await?;
+
+                debug!(
+                    results_count = parsed.results_count,
+                    has_next = parsed.next_url.is_some(),
+                    "Parsed quotes response"
+                );
+
+                if let Some(results) = parsed.results {
+                    for quote in results {
+                        yield quote.into_order_book_l1();
+                    }
+                }
+
+                // Validate next_url origin before following
+                if let Some(ref url) = parsed.next_url {
+                    validate_next_url(url, &self.base_url)?;
+                }
+                next_url = parsed.next_url;
+            }
+        }
+    }
+
+    /// Fetch a single page of quotes from the given URL.
+    async fn fetch_quotes_page(&self, url: &str) -> Result<QuotesResponse, MassiveError> {
+        let body = self.fetch_page_body(url).await?;
+        parse_quotes_response(&body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_creation() {
+        let client = MassiveRestClient::new("test_api_key");
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_from_env_missing() {
+        temp_env::with_var_unset(ENV_API_KEY, || {
+            let result = MassiveRestClient::from_env();
+            assert!(matches!(result, Err(MassiveError::EnvVar { .. })));
+        });
+    }
+}

--- a/rustrade-data/src/exchange/massive/transformer.rs
+++ b/rustrade-data/src/exchange/massive/transformer.rs
@@ -1,0 +1,573 @@
+//! JSON to rustrade type transformations for Massive API responses.
+
+use super::error::MassiveError;
+use crate::{
+    books::Level,
+    subscription::{book::OrderBookL1, candle::Candle, trade::PublicTrade},
+};
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use rust_decimal::Decimal;
+use rustrade_instrument::Side;
+use serde::{Deserialize, Deserializer, Serialize};
+use smol_str::SmolStr;
+
+/// Deserialize only the first element of a conditions array.
+fn deserialize_first_condition<'de, D>(deserializer: D) -> Result<Option<i32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let conditions: Option<Vec<i32>> = Option::deserialize(deserializer)?;
+    Ok(conditions.and_then(|v| v.into_iter().next()))
+}
+
+/// Raw aggregates response from Massive REST API.
+#[derive(Debug, Deserialize)]
+pub struct AggregatesResponse {
+    /// Ticker symbol requested
+    #[allow(dead_code)] // Retained for API schema; internal pagination uses next_url
+    pub ticker: Option<String>,
+
+    /// Number of results in this response
+    #[serde(rename = "resultsCount", default)]
+    pub results_count: usize,
+
+    /// Status of the request
+    #[serde(default)]
+    #[allow(dead_code)] // HTTP status already checked in fetch_page_body
+    pub status: String,
+
+    /// Request ID for debugging
+    #[allow(dead_code)] // Retained for API schema completeness
+    pub request_id: Option<String>,
+
+    /// URL for next page of results (pagination)
+    pub next_url: Option<String>,
+
+    /// Aggregate bars
+    pub results: Option<Vec<AggregateBar>>,
+}
+
+/// Single OHLCV bar from Massive aggregates endpoint.
+#[derive(Debug, Deserialize)]
+pub struct AggregateBar {
+    /// Open price
+    #[serde(rename = "o", with = "rust_decimal::serde::float")]
+    pub open: Decimal,
+
+    /// High price
+    #[serde(rename = "h", with = "rust_decimal::serde::float")]
+    pub high: Decimal,
+
+    /// Low price
+    #[serde(rename = "l", with = "rust_decimal::serde::float")]
+    pub low: Decimal,
+
+    /// Close price
+    #[serde(rename = "c", with = "rust_decimal::serde::float")]
+    pub close: Decimal,
+
+    /// Volume
+    #[serde(rename = "v", with = "rust_decimal::serde::float")]
+    pub volume: Decimal,
+
+    /// Volume-weighted average price
+    #[serde(rename = "vw", with = "rust_decimal::serde::float_option", default)]
+    #[allow(dead_code)] // Retained for API schema completeness; not yet consumed
+    pub vwap: Option<Decimal>,
+
+    /// Unix timestamp in milliseconds (start of the bar)
+    #[serde(rename = "t")]
+    pub timestamp: i64,
+
+    /// Number of trades in this bar
+    #[serde(rename = "n")]
+    pub trade_count: Option<u64>,
+}
+
+impl AggregateBar {
+    /// Convert to rustrade Candle type.
+    ///
+    /// The `close_time` is calculated as `timestamp + (multiplier * timespan_duration)`.
+    #[allow(dead_code)] // Public API; internal code uses into_candle_with_duration
+    pub fn into_candle(self, multiplier: u32, timespan: &str) -> Candle {
+        let duration = timespan_to_duration(multiplier, timespan);
+        self.into_candle_with_duration(duration)
+    }
+
+    /// Convert to rustrade Candle type with a pre-computed duration.
+    ///
+    /// Use this variant when processing multiple bars with the same timespan
+    /// to avoid recomputing the duration for each bar.
+    pub fn into_candle_with_duration(self, duration: Duration) -> Candle {
+        let start_time = Utc
+            .timestamp_millis_opt(self.timestamp)
+            .single()
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    timestamp_ms = self.timestamp,
+                    "AggregateBar has out-of-range timestamp; using UNIX_EPOCH"
+                );
+                DateTime::<Utc>::UNIX_EPOCH
+            });
+        let close_time = start_time + duration;
+
+        Candle {
+            close_time,
+            open: self.open,
+            high: self.high,
+            low: self.low,
+            close: self.close,
+            volume: self.volume,
+            trade_count: self.trade_count.unwrap_or(0),
+        }
+    }
+}
+
+/// Parse aggregates JSON response.
+pub fn parse_aggregates_response(body: &str) -> Result<AggregatesResponse, MassiveError> {
+    serde_json::from_str(body).map_err(|e| MassiveError::Deserialize {
+        message: e.to_string(),
+        payload: body[..body.floor_char_boundary(512)].to_owned(),
+    })
+}
+
+/// Convert timespan string to chrono Duration.
+pub fn timespan_to_duration(multiplier: u32, timespan: &str) -> Duration {
+    let mult = multiplier as i64;
+    match timespan {
+        "second" => Duration::seconds(mult),
+        "minute" => Duration::minutes(mult),
+        "hour" => Duration::hours(mult),
+        "day" => Duration::days(mult),
+        "week" => Duration::weeks(mult),
+        "month" => Duration::days(mult * 30),   // Approximate
+        "quarter" => Duration::days(mult * 91), // Approximate
+        "year" => Duration::days(mult * 365),   // Approximate
+        _ => {
+            tracing::warn!(timespan = %timespan, "unknown timespan, defaulting to minutes");
+            Duration::minutes(mult)
+        }
+    }
+}
+
+// ============================================================================
+// Trades
+// ============================================================================
+
+/// Raw trades response from Massive REST API.
+#[derive(Debug, Deserialize)]
+pub struct TradesResponse {
+    /// Number of results in this response
+    #[serde(rename = "resultsCount", default)]
+    pub results_count: usize,
+
+    /// Status of the request
+    #[serde(default)]
+    #[allow(dead_code)] // HTTP status already checked in fetch_page_body
+    pub status: String,
+
+    /// URL for next page of results (pagination)
+    pub next_url: Option<String>,
+
+    /// Trade results
+    pub results: Option<Vec<TradeRecord>>,
+}
+
+/// Single trade from Massive trades endpoint.
+#[derive(Debug, Deserialize)]
+pub struct TradeRecord {
+    /// First trade condition code (crypto: 1=sell, 2=buy; equities: SIP codes differ).
+    ///
+    /// Only the first condition is extracted; remaining conditions are ignored.
+    #[serde(
+        rename = "conditions",
+        default,
+        deserialize_with = "deserialize_first_condition"
+    )]
+    pub first_condition: Option<i32>,
+
+    /// Exchange ID
+    #[serde(rename = "exchange")]
+    #[allow(dead_code)] // Retained for API schema completeness
+    pub exchange: Option<i32>,
+
+    /// Trade ID
+    #[serde(rename = "id", default)]
+    pub id: String,
+
+    /// Participant timestamp (nanoseconds)
+    #[serde(rename = "participant_timestamp", default)]
+    #[allow(dead_code)] // Accessed via timestamp() method
+    pub participant_timestamp: i64,
+
+    /// Trade price
+    #[serde(rename = "price", with = "rust_decimal::serde::float")]
+    pub price: Decimal,
+
+    /// Trade size
+    #[serde(rename = "size", with = "rust_decimal::serde::float")]
+    pub size: Decimal,
+
+    /// SIP timestamp (nanoseconds) - when SIP received the trade
+    #[serde(rename = "sip_timestamp", default)]
+    #[allow(dead_code)] // Retained for API schema completeness
+    pub sip_timestamp: i64,
+}
+
+impl TradeRecord {
+    /// Convert to rustrade PublicTrade type.
+    ///
+    /// # Side Detection (Crypto Only)
+    ///
+    /// The `side` field is only meaningful for **crypto tickers** (`X:` prefix).
+    /// Crypto condition codes: 1 = sell-initiated, 2 = buy-initiated.
+    ///
+    /// For equities and other asset classes, condition codes represent SIP/CTA
+    /// tape conditions (e.g., 1 = Regular Trade) which are unrelated to trade
+    /// direction. The `side` will be `None` or incorrect for non-crypto tickers.
+    ///
+    /// # Timestamps
+    ///
+    /// Trade timestamps are not preserved in [`PublicTrade`]. If timestamp
+    /// information is required, access the raw [`TradeRecord`] via
+    /// [`parse_trades_response`] directly.
+    pub fn into_public_trade(self) -> PublicTrade {
+        // Crypto condition codes: 1 = sell-initiated, 2 = buy-initiated
+        // Note: This mapping is ONLY valid for crypto (X: prefix) tickers
+        let side = self.first_condition.and_then(|c| match c {
+            1 => Some(Side::Sell),
+            2 => Some(Side::Buy),
+            _ => None,
+        });
+
+        PublicTrade {
+            id: SmolStr::from(self.id),
+            price: self.price,
+            amount: self.size,
+            side,
+        }
+    }
+
+    /// Get the exchange timestamp as DateTime<Utc>.
+    #[allow(dead_code)] // Public API for consumers accessing raw TradeRecord
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        nanos_to_datetime(self.participant_timestamp)
+    }
+}
+
+/// Convert nanosecond timestamp to DateTime<Utc>.
+///
+/// Returns [`DateTime::<Utc>::UNIX_EPOCH`] for out-of-range timestamps.
+/// Negative values (pre-epoch) are handled correctly using Euclidean division.
+fn nanos_to_datetime(nanos: i64) -> DateTime<Utc> {
+    let secs = nanos.div_euclid(1_000_000_000);
+    // rem_euclid always returns non-negative value in [0, 999_999_999], fits u32
+    #[allow(clippy::cast_possible_truncation)]
+    let nsecs = nanos.rem_euclid(1_000_000_000) as u32;
+    Utc.timestamp_opt(secs, nsecs).single().unwrap_or_else(|| {
+        tracing::warn!(nanos, "out-of-range nanosecond timestamp; using UNIX_EPOCH");
+        DateTime::<Utc>::UNIX_EPOCH
+    })
+}
+
+/// Parse trades JSON response.
+pub fn parse_trades_response(body: &str) -> Result<TradesResponse, MassiveError> {
+    serde_json::from_str(body).map_err(|e| MassiveError::Deserialize {
+        message: e.to_string(),
+        payload: body[..body.floor_char_boundary(512)].to_owned(),
+    })
+}
+
+// ============================================================================
+// Quotes (BBO/NBBO)
+// ============================================================================
+
+/// Raw quotes response from Massive REST API.
+#[derive(Debug, Deserialize)]
+pub struct QuotesResponse {
+    /// Number of results in this response
+    #[serde(rename = "resultsCount", default)]
+    pub results_count: usize,
+
+    /// Status of the request
+    #[serde(default)]
+    #[allow(dead_code)] // HTTP status already checked in fetch_page_body
+    pub status: String,
+
+    /// URL for next page of results (pagination)
+    pub next_url: Option<String>,
+
+    /// Quote results
+    pub results: Option<Vec<QuoteRecord>>,
+}
+
+/// Single quote from Massive quotes endpoint.
+#[derive(Debug, Deserialize)]
+pub struct QuoteRecord {
+    /// Ask price
+    #[serde(rename = "ask_price", with = "rust_decimal::serde::float")]
+    pub ask_price: Decimal,
+
+    /// Ask size
+    #[serde(rename = "ask_size", with = "rust_decimal::serde::float")]
+    pub ask_size: Decimal,
+
+    /// Bid price
+    #[serde(rename = "bid_price", with = "rust_decimal::serde::float")]
+    pub bid_price: Decimal,
+
+    /// Bid size
+    #[serde(rename = "bid_size", with = "rust_decimal::serde::float")]
+    pub bid_size: Decimal,
+
+    /// Participant timestamp (nanoseconds)
+    #[serde(rename = "participant_timestamp", default)]
+    pub participant_timestamp: i64,
+
+    /// SIP timestamp (nanoseconds)
+    #[serde(rename = "sip_timestamp", default)]
+    #[allow(dead_code)] // Retained for API schema completeness
+    pub sip_timestamp: i64,
+}
+
+impl QuoteRecord {
+    /// Convert to rustrade OrderBookL1 type.
+    pub fn into_order_book_l1(self) -> OrderBookL1 {
+        let timestamp = self.timestamp();
+
+        OrderBookL1 {
+            last_update_time: timestamp,
+            best_bid: Some(Level {
+                price: self.bid_price,
+                amount: self.bid_size,
+            }),
+            best_ask: Some(Level {
+                price: self.ask_price,
+                amount: self.ask_size,
+            }),
+        }
+    }
+
+    /// Get the exchange timestamp as DateTime<Utc>.
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        nanos_to_datetime(self.participant_timestamp)
+    }
+}
+
+/// Parse quotes JSON response.
+pub fn parse_quotes_response(body: &str) -> Result<QuotesResponse, MassiveError> {
+    serde_json::from_str(body).map_err(|e| MassiveError::Deserialize {
+        message: e.to_string(),
+        payload: body[..body.floor_char_boundary(512)].to_owned(),
+    })
+}
+
+// ============================================================================
+// Fair Market Value
+// ============================================================================
+
+/// Fair Market Value - a calculated mid-price from Massive.
+///
+/// This is a dedicated type (not mapped to PublicTrade) because FMV represents
+/// a calculated value, not an actual trade execution.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct FairMarketValue {
+    /// Timestamp of the FMV calculation
+    pub time: DateTime<Utc>,
+    /// Calculated fair market value price
+    pub price: Decimal,
+}
+
+impl FairMarketValue {
+    /// Create a new FairMarketValue.
+    pub fn new(time: DateTime<Utc>, price: Decimal) -> Self {
+        Self { time, price }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Tests should panic on unexpected values
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    const SAMPLE_AGGREGATES: &str = r#"{
+        "ticker": "X:BTCUSD",
+        "queryCount": 2,
+        "resultsCount": 2,
+        "adjusted": true,
+        "results": [
+            {
+                "v": 234.5678,
+                "vw": 65432.1,
+                "o": 65000.0,
+                "c": 65100.0,
+                "h": 65200.0,
+                "l": 64900.0,
+                "t": 1704067200000,
+                "n": 150
+            },
+            {
+                "v": 345.6789,
+                "vw": 65150.0,
+                "o": 65100.0,
+                "c": 65250.0,
+                "h": 65300.0,
+                "l": 65050.0,
+                "t": 1704067260000,
+                "n": 175
+            }
+        ],
+        "status": "OK",
+        "request_id": "abc123"
+    }"#;
+
+    #[test]
+    fn test_parse_aggregates() {
+        let response = parse_aggregates_response(SAMPLE_AGGREGATES).unwrap();
+        assert_eq!(response.ticker, Some("X:BTCUSD".to_string()));
+        assert_eq!(response.results_count, 2);
+        assert_eq!(response.status, "OK");
+
+        let results = response.results.unwrap();
+        assert_eq!(results.len(), 2);
+
+        let bar = &results[0];
+        assert_eq!(bar.open, dec!(65000.0));
+        assert_eq!(bar.close, dec!(65100.0));
+        assert_eq!(bar.high, dec!(65200.0));
+        assert_eq!(bar.low, dec!(64900.0));
+        assert_eq!(bar.trade_count, Some(150));
+    }
+
+    #[test]
+    fn test_aggregate_bar_to_candle() {
+        let bar = AggregateBar {
+            open: dec!(65000.0),
+            high: dec!(65200.0),
+            low: dec!(64900.0),
+            close: dec!(65100.0),
+            volume: dec!(234.5678),
+            vwap: Some(dec!(65050.0)),
+            timestamp: 1704067200000,
+            trade_count: Some(150),
+        };
+
+        let candle = bar.into_candle(1, "minute");
+
+        assert_eq!(candle.open, dec!(65000.0));
+        assert_eq!(candle.close, dec!(65100.0));
+        assert_eq!(candle.trade_count, 150);
+
+        // close_time should be 1 minute after start
+        let expected_close =
+            Utc.timestamp_millis_opt(1704067200000).single().unwrap() + Duration::minutes(1);
+        assert_eq!(candle.close_time, expected_close);
+    }
+
+    #[test]
+    fn test_parse_with_next_url() {
+        let json = r#"{
+            "ticker": "X:BTCUSD",
+            "resultsCount": 50000,
+            "status": "OK",
+            "next_url": "https://api.massive.com/v2/aggs/ticker/X:BTCUSD/range/1/minute/1704067200000/1704153600000?cursor=abc123",
+            "results": []
+        }"#;
+
+        let response = parse_aggregates_response(json).unwrap();
+        assert!(response.next_url.is_some());
+        assert!(response.next_url.unwrap().contains("cursor="));
+    }
+
+    #[test]
+    fn test_parse_empty_results() {
+        let json = r#"{
+            "ticker": "X:BTCUSD",
+            "resultsCount": 0,
+            "status": "OK",
+            "results": []
+        }"#;
+
+        let response = parse_aggregates_response(json).unwrap();
+        assert_eq!(response.results_count, 0);
+        assert!(response.results.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_timespan_to_duration() {
+        assert_eq!(timespan_to_duration(1, "second"), Duration::seconds(1));
+        assert_eq!(timespan_to_duration(5, "minute"), Duration::minutes(5));
+        assert_eq!(timespan_to_duration(1, "hour"), Duration::hours(1));
+        assert_eq!(timespan_to_duration(1, "day"), Duration::days(1));
+        assert_eq!(timespan_to_duration(1, "week"), Duration::weeks(1));
+    }
+
+    #[test]
+    fn test_parse_trades() {
+        let json = r#"{
+            "results": [
+                {
+                    "conditions": [2],
+                    "exchange": 1,
+                    "id": "12345",
+                    "participant_timestamp": 1704067200000000000,
+                    "price": 65100.50,
+                    "size": 0.5,
+                    "sip_timestamp": 1704067200001000000
+                }
+            ],
+            "status": "OK",
+            "resultsCount": 1
+        }"#;
+
+        let response = parse_trades_response(json).unwrap();
+        assert_eq!(response.results_count, 1);
+
+        let results = response.results.unwrap();
+        let trade = &results[0];
+        assert_eq!(trade.price, dec!(65100.50));
+        assert_eq!(trade.size, dec!(0.5));
+        assert_eq!(trade.first_condition, Some(2)); // buy-initiated (crypto)
+
+        let public_trade = results.into_iter().next().unwrap().into_public_trade();
+        assert_eq!(public_trade.side, Some(Side::Buy));
+    }
+
+    #[test]
+    fn test_parse_quotes() {
+        let json = r#"{
+            "results": [
+                {
+                    "ask_price": 65200.0,
+                    "ask_size": 1.5,
+                    "bid_price": 65100.0,
+                    "bid_size": 2.0,
+                    "participant_timestamp": 1704067200000000000,
+                    "sip_timestamp": 1704067200001000000
+                }
+            ],
+            "status": "OK",
+            "resultsCount": 1
+        }"#;
+
+        let response = parse_quotes_response(json).unwrap();
+        assert_eq!(response.results_count, 1);
+
+        let results = response.results.unwrap();
+        let quote = results.into_iter().next().unwrap();
+        let l1 = quote.into_order_book_l1();
+
+        assert_eq!(l1.best_bid.unwrap().price, dec!(65100.0));
+        assert_eq!(l1.best_ask.unwrap().price, dec!(65200.0));
+    }
+
+    #[test]
+    fn test_fair_market_value() {
+        let fmv = FairMarketValue::new(
+            Utc.timestamp_millis_opt(1704067200000).single().unwrap(),
+            dec!(65150.0),
+        );
+        assert_eq!(fmv.price, dec!(65150.0));
+    }
+}

--- a/rustrade-data/src/exchange/massive/transformer.rs
+++ b/rustrade-data/src/exchange/massive/transformer.rs
@@ -337,17 +337,25 @@ pub struct QuoteRecord {
     #[serde(rename = "ask_price", with = "rust_decimal::serde::float")]
     pub ask_price: Decimal,
 
-    /// Ask size
-    #[serde(rename = "ask_size", with = "rust_decimal::serde::float")]
-    pub ask_size: Decimal,
+    /// Ask size (optional - forex quotes don't include size)
+    #[serde(
+        rename = "ask_size",
+        default,
+        with = "rust_decimal::serde::float_option"
+    )]
+    pub ask_size: Option<Decimal>,
 
     /// Bid price
     #[serde(rename = "bid_price", with = "rust_decimal::serde::float")]
     pub bid_price: Decimal,
 
-    /// Bid size
-    #[serde(rename = "bid_size", with = "rust_decimal::serde::float")]
-    pub bid_size: Decimal,
+    /// Bid size (optional - forex quotes don't include size)
+    #[serde(
+        rename = "bid_size",
+        default,
+        with = "rust_decimal::serde::float_option"
+    )]
+    pub bid_size: Option<Decimal>,
 
     /// Participant timestamp (nanoseconds)
     #[serde(rename = "participant_timestamp", default)]
@@ -361,6 +369,11 @@ pub struct QuoteRecord {
 
 impl QuoteRecord {
     /// Convert to rustrade OrderBookL1 type.
+    ///
+    /// Forex quotes from Massive omit `bid_size`/`ask_size`; absent sizes are
+    /// represented as `Decimal::ZERO` to satisfy the shared `Level` type.
+    /// Callers handling venues that may report zero-size quotes should
+    /// disambiguate via the source feed if required.
     pub fn into_order_book_l1(self) -> OrderBookL1 {
         let timestamp = self.timestamp();
 
@@ -368,11 +381,11 @@ impl QuoteRecord {
             last_update_time: timestamp,
             best_bid: Some(Level {
                 price: self.bid_price,
-                amount: self.bid_size,
+                amount: self.bid_size.unwrap_or(Decimal::ZERO),
             }),
             best_ask: Some(Level {
                 price: self.ask_price,
-                amount: self.ask_size,
+                amount: self.ask_size.unwrap_or(Decimal::ZERO),
             }),
         }
     }

--- a/rustrade-data/src/exchange/massive/transformer.rs
+++ b/rustrade-data/src/exchange/massive/transformer.rs
@@ -11,13 +11,42 @@ use rustrade_instrument::Side;
 use serde::{Deserialize, Deserializer, Serialize};
 use smol_str::SmolStr;
 
-/// Deserialize only the first element of a conditions array.
+/// Deserialize only the first element of a conditions array without allocating a Vec.
 fn deserialize_first_condition<'de, D>(deserializer: D) -> Result<Option<i32>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let conditions: Option<Vec<i32>> = Option::deserialize(deserializer)?;
-    Ok(conditions.and_then(|v| v.into_iter().next()))
+    use serde::de::{SeqAccess, Visitor};
+
+    struct FirstElementVisitor;
+
+    impl<'de> Visitor<'de> for FirstElementVisitor {
+        type Value = Option<i32>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("an array of integers or null")
+        }
+
+        fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D: Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            deserializer.deserialize_seq(self)
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let first = seq.next_element()?;
+            // Drain remaining elements without storing them
+            while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+            Ok(first)
+        }
+    }
+
+    deserializer.deserialize_option(FirstElementVisitor)
 }
 
 /// Raw aggregates response from Massive REST API.
@@ -363,6 +392,323 @@ pub fn parse_quotes_response(body: &str) -> Result<QuotesResponse, MassiveError>
 }
 
 // ============================================================================
+// WebSocket Messages
+// ============================================================================
+
+/// Parsed WebSocket message variants.
+///
+/// Uses serde's internally-tagged enum for single-pass deserialization.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "ev")]
+pub(crate) enum WsMessage {
+    /// Stock trade
+    #[serde(rename = "T")]
+    TradeStocks(WsTradeMsg),
+    /// Crypto trade
+    #[serde(rename = "XT")]
+    TradeCrypto(WsTradeMsg),
+    /// Stock quote
+    #[serde(rename = "Q")]
+    QuoteStocks(WsQuoteMsg),
+    /// Crypto quote
+    #[serde(rename = "XQ")]
+    QuoteCrypto(WsQuoteMsg),
+    /// Forex quote
+    #[serde(rename = "C")]
+    QuoteForex(WsQuoteMsg),
+    /// Stock per-second aggregate
+    #[serde(rename = "A")]
+    AggSecondStocks(WsAggregateMsg),
+    /// Stock per-minute aggregate
+    #[serde(rename = "AM")]
+    AggMinuteStocks(WsAggregateMsg),
+    /// Crypto per-second aggregate
+    #[serde(rename = "XA")]
+    AggSecondCrypto(WsAggregateMsg),
+    /// Crypto per-minute aggregate
+    #[serde(rename = "XAM")]
+    AggMinuteCrypto(WsAggregateMsg),
+    /// Forex per-second aggregate
+    #[serde(rename = "CA")]
+    AggSecondForex(WsAggregateMsg),
+    /// Forex per-minute aggregate
+    #[serde(rename = "CAM")]
+    AggMinuteForex(WsAggregateMsg),
+    /// Status message (auth, subscription confirmations).
+    /// Inner fields are populated by serde but not inspected directly; we only match the variant
+    /// and return None from ws_message_to_event.
+    #[serde(rename = "status")]
+    #[allow(dead_code)]
+    // variant matched but inner type not inspected; serde needs the type for deserialization
+    Status(WsStatusMsg),
+}
+
+/// WebSocket trade message.
+///
+/// Stocks: `{"ev":"T","sym":"AAPL","p":150.25,"s":100,"t":1682592000000,...}`
+/// Crypto: `{"ev":"XT","pair":"BTC-USD","p":45230.50,"s":0.5,"t":1682592000000,...}`
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WsTradeMsg {
+    /// Symbol (stocks: "sym", crypto: "pair")
+    #[serde(alias = "sym", alias = "pair")]
+    pub symbol: String,
+
+    /// Trade price
+    #[serde(rename = "p", with = "rust_decimal::serde::float")]
+    pub price: Decimal,
+
+    /// Trade size
+    #[serde(rename = "s", with = "rust_decimal::serde::float")]
+    pub size: Decimal,
+
+    /// Timestamp in milliseconds
+    #[serde(rename = "t")]
+    pub timestamp: i64,
+
+    /// First trade condition (optional). Crypto: 1 = sell, 2 = buy.
+    #[serde(
+        rename = "c",
+        default,
+        deserialize_with = "deserialize_first_condition"
+    )]
+    pub condition: Option<i32>,
+
+    /// Trade ID (optional)
+    #[serde(rename = "i", default)]
+    pub id: Option<String>,
+}
+
+impl WsTradeMsg {
+    /// Convert to PublicTrade with exchange timestamp.
+    pub fn into_public_trade(self) -> (DateTime<Utc>, PublicTrade) {
+        let time = millis_to_datetime(self.timestamp);
+
+        // Crypto condition codes: 1 = sell, 2 = buy
+        let side = self.condition.and_then(|c| match c {
+            1 => Some(Side::Sell),
+            2 => Some(Side::Buy),
+            _ => None,
+        });
+
+        let trade = PublicTrade {
+            id: SmolStr::from(self.id.unwrap_or_default()),
+            price: self.price,
+            amount: self.size,
+            side,
+        };
+
+        (time, trade)
+    }
+}
+
+/// WebSocket quote message.
+///
+/// Stocks: `{"ev":"Q","sym":"AAPL","bp":150.20,"bs":500,"ap":150.30,"as":1000,"t":1682592000000,...}`
+/// Crypto: `{"ev":"XQ","pair":"BTC-USD","bp":45220.00,"bs":2.5,"ap":45240.00,"as":3.0,"t":1682592000000,...}`
+/// Forex: `{"ev":"C","p":"EUR-USD","b":1.0850,"a":1.0852,"t":1682592000000,...}`
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WsQuoteMsg {
+    /// Symbol (stocks: "sym", crypto: "pair", forex: "p").
+    ///
+    /// The `"p"` alias is for forex quotes (`ev="C"`), where it denotes the currency pair.
+    /// This is distinct from `WsTradeMsg` where `"p"` is the trade price.
+    ///
+    /// No canonical `#[serde(rename)]` — wire name differs per market; all real names are aliases.
+    /// This struct is deserialize-only; the canonical field name is never serialized.
+    #[serde(alias = "sym", alias = "pair", alias = "p")]
+    pub symbol: String,
+
+    /// Bid price (stocks/crypto: "bp", forex: "b")
+    #[serde(
+        alias = "bp",
+        alias = "b",
+        with = "rust_decimal::serde::float",
+        default
+    )]
+    pub bid_price: Decimal,
+
+    /// Bid size (stocks/crypto: "bs", forex: not available)
+    #[serde(alias = "bs", with = "rust_decimal::serde::float_option", default)]
+    pub bid_size: Option<Decimal>,
+
+    /// Ask price (stocks/crypto: "ap", forex: "a")
+    #[serde(
+        alias = "ap",
+        alias = "a",
+        with = "rust_decimal::serde::float",
+        default
+    )]
+    pub ask_price: Decimal,
+
+    /// Ask size (stocks/crypto: "as", forex: not available)
+    #[serde(alias = "as", with = "rust_decimal::serde::float_option", default)]
+    pub ask_size: Option<Decimal>,
+
+    /// Timestamp in milliseconds
+    #[serde(rename = "t")]
+    pub timestamp: i64,
+}
+
+impl WsQuoteMsg {
+    /// Convert to OrderBookL1 with exchange timestamp.
+    pub fn into_order_book_l1(self) -> (DateTime<Utc>, OrderBookL1) {
+        let time = millis_to_datetime(self.timestamp);
+
+        let l1 = OrderBookL1 {
+            last_update_time: time,
+            best_bid: Some(Level {
+                price: self.bid_price,
+                amount: self.bid_size.unwrap_or(Decimal::ZERO),
+            }),
+            best_ask: Some(Level {
+                price: self.ask_price,
+                amount: self.ask_size.unwrap_or(Decimal::ZERO),
+            }),
+        };
+
+        (time, l1)
+    }
+}
+
+/// WebSocket aggregate message.
+///
+/// Stocks: `{"ev":"A","sym":"AAPL","o":150.10,"h":150.50,"l":150.05,"c":150.25,"v":1000,"s":1682592000000,"e":1682592001000,...}`
+/// Crypto: `{"ev":"XA","pair":"BTC-USD","o":45200.0,"h":45250.0,"l":45180.0,"c":45230.0,"v":10.5,"s":1682592000000,"e":1682592001000,...}`
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WsAggregateMsg {
+    /// Symbol (stocks: "sym", crypto: "pair", forex: "pair")
+    #[serde(alias = "sym", alias = "pair")]
+    pub symbol: String,
+
+    /// Open price
+    #[serde(rename = "o", with = "rust_decimal::serde::float")]
+    pub open: Decimal,
+
+    /// High price
+    #[serde(rename = "h", with = "rust_decimal::serde::float")]
+    pub high: Decimal,
+
+    /// Low price
+    #[serde(rename = "l", with = "rust_decimal::serde::float")]
+    pub low: Decimal,
+
+    /// Close price
+    #[serde(rename = "c", with = "rust_decimal::serde::float")]
+    pub close: Decimal,
+
+    /// Volume
+    #[serde(rename = "v", with = "rust_decimal::serde::float")]
+    pub volume: Decimal,
+
+    /// Window start timestamp in milliseconds.
+    /// Deserialized for API completeness but unused; candle uses end_timestamp.
+    #[serde(rename = "s")]
+    #[allow(dead_code)] // deserialized for API completeness; candle uses end_timestamp
+    pub start_timestamp: i64,
+
+    /// Window end timestamp in milliseconds
+    #[serde(rename = "e")]
+    pub end_timestamp: i64,
+
+    /// Number of trades (optional)
+    #[serde(rename = "z", default)]
+    pub trade_count: Option<u64>,
+}
+
+impl WsAggregateMsg {
+    /// Convert to Candle with exchange timestamp.
+    pub fn into_candle(self) -> (DateTime<Utc>, Candle) {
+        let time = millis_to_datetime(self.end_timestamp);
+
+        let candle = Candle {
+            close_time: time,
+            open: self.open,
+            high: self.high,
+            low: self.low,
+            close: self.close,
+            volume: self.volume,
+            trade_count: self.trade_count.unwrap_or(0),
+        };
+
+        (time, candle)
+    }
+}
+
+/// WebSocket status message.
+///
+/// Fields are deserialized for completeness but not read directly.
+/// Auth/subscribe verification uses manual JSON parsing instead.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct WsStatusMsg {
+    /// Status: "auth_success", "auth_failed", "success", etc.
+    pub status: String,
+
+    /// Optional message
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+/// Convert millisecond timestamp to DateTime<Utc>.
+fn millis_to_datetime(millis: i64) -> DateTime<Utc> {
+    Utc.timestamp_millis_opt(millis)
+        .single()
+        .unwrap_or_else(|| {
+            tracing::warn!(
+                millis,
+                "out-of-range millisecond timestamp; using UNIX_EPOCH"
+            );
+            DateTime::<Utc>::UNIX_EPOCH
+        })
+}
+
+/// Parse a WebSocket message JSON string, skipping unknown event types.
+///
+/// Massive sends messages as JSON arrays: `[{...}, {...}, ...]`
+/// Each element is parsed individually; unknown event types (e.g. "lagg") are
+/// logged at trace level and skipped rather than failing the entire frame.
+///
+/// # Why RawValue
+///
+/// `&serde_json::value::RawValue` is a zero-copy borrowed slice into `text`.
+/// Parsing the outer array to `Vec<&RawValue>` allocates only the Vec itself
+/// (one allocation per frame regardless of element count). Each element's typed
+/// parse is then independent.
+pub(crate) fn parse_ws_message(text: &str) -> Result<Vec<WsMessage>, MassiveError> {
+    // Parse the outer array, borrowing each element as a raw JSON slice.
+    let raw_elements: Vec<&serde_json::value::RawValue> =
+        serde_json::from_str(text).map_err(|e| MassiveError::Deserialize {
+            message: e.to_string(),
+            payload: text[..text.floor_char_boundary(512)].to_owned(),
+        })?;
+
+    let mut messages = Vec::with_capacity(raw_elements.len());
+    for raw in raw_elements {
+        match serde_json::from_str::<WsMessage>(raw.get()) {
+            Ok(msg) => messages.push(msg),
+            Err(_) => {
+                // Extract the "ev" field for logging without allocating a full Value DOM.
+                let ev = extract_ev_tag(raw.get());
+                tracing::trace!(
+                    ev = ev.unwrap_or("<missing>"),
+                    "Skipping unknown WS event type"
+                );
+            }
+        }
+    }
+    Ok(messages)
+}
+
+/// Extract the `"ev"` field value from a JSON object string without full Value allocation.
+fn extract_ev_tag(json: &str) -> Option<&str> {
+    #[derive(Deserialize)]
+    struct EvOnly<'a> {
+        ev: &'a str,
+    }
+    serde_json::from_str::<EvOnly<'_>>(json).ok().map(|e| e.ev)
+}
+
+// ============================================================================
 // Fair Market Value
 // ============================================================================
 
@@ -569,5 +915,269 @@ mod tests {
             dec!(65150.0),
         );
         assert_eq!(fmv.price, dec!(65150.0));
+    }
+
+    // ========================================================================
+    // WebSocket Message Tests
+    // ========================================================================
+
+    #[test]
+    fn test_parse_ws_crypto_trade() {
+        let json = r#"[{
+            "ev": "XT",
+            "pair": "BTC-USD",
+            "p": 45230.50,
+            "s": 0.5,
+            "t": 1704067200000,
+            "c": [2],
+            "i": "trade123"
+        }]"#;
+
+        let messages = parse_ws_message(json).unwrap();
+        assert_eq!(messages.len(), 1);
+
+        match &messages[0] {
+            WsMessage::TradeCrypto(trade) => {
+                assert_eq!(trade.symbol, "BTC-USD");
+                assert_eq!(trade.price, dec!(45230.50));
+                assert_eq!(trade.size, dec!(0.5));
+                assert_eq!(trade.condition, Some(2));
+            }
+            _ => panic!("Expected crypto trade message"),
+        }
+    }
+
+    #[test]
+    fn test_parse_ws_stock_trade() {
+        let json = r#"[{
+            "ev": "T",
+            "sym": "AAPL",
+            "p": 150.25,
+            "s": 100,
+            "t": 1704067200000,
+            "c": [],
+            "i": "12345"
+        }]"#;
+
+        let messages = parse_ws_message(json).unwrap();
+        assert_eq!(messages.len(), 1);
+
+        match &messages[0] {
+            WsMessage::TradeStocks(trade) => {
+                assert_eq!(trade.symbol, "AAPL");
+                assert_eq!(trade.price, dec!(150.25));
+                assert_eq!(trade.size, dec!(100));
+            }
+            _ => panic!("Expected stock trade message"),
+        }
+    }
+
+    #[test]
+    fn test_parse_ws_crypto_quote() {
+        let json = r#"[{
+            "ev": "XQ",
+            "pair": "BTC-USD",
+            "bp": 45220.00,
+            "bs": 2.5,
+            "ap": 45240.00,
+            "as": 3.0,
+            "t": 1704067200000
+        }]"#;
+
+        let messages = parse_ws_message(json).unwrap();
+        assert_eq!(messages.len(), 1);
+
+        match &messages[0] {
+            WsMessage::QuoteCrypto(quote) => {
+                assert_eq!(quote.symbol, "BTC-USD");
+                assert_eq!(quote.bid_price, dec!(45220.00));
+                assert_eq!(quote.ask_price, dec!(45240.00));
+            }
+            _ => panic!("Expected crypto quote message"),
+        }
+    }
+
+    #[test]
+    fn test_parse_ws_forex_quote() {
+        let json = r#"[{
+            "ev": "C",
+            "p": "EUR-USD",
+            "b": 1.0850,
+            "a": 1.0852,
+            "t": 1704067200000
+        }]"#;
+
+        let messages = parse_ws_message(json).unwrap();
+        assert_eq!(messages.len(), 1);
+
+        match &messages[0] {
+            WsMessage::QuoteForex(quote) => {
+                assert_eq!(quote.symbol, "EUR-USD");
+                assert_eq!(quote.bid_price, dec!(1.0850));
+                assert_eq!(quote.ask_price, dec!(1.0852));
+            }
+            _ => panic!("Expected forex quote message"),
+        }
+    }
+
+    #[test]
+    fn test_parse_ws_aggregate() {
+        let json = r#"[{
+            "ev": "XAM",
+            "pair": "BTC-USD",
+            "o": 45200.0,
+            "h": 45250.0,
+            "l": 45180.0,
+            "c": 45230.0,
+            "v": 10.5,
+            "s": 1704067200000,
+            "e": 1704067260000,
+            "z": 150
+        }]"#;
+
+        let messages = parse_ws_message(json).unwrap();
+        assert_eq!(messages.len(), 1);
+
+        match &messages[0] {
+            WsMessage::AggMinuteCrypto(agg) => {
+                assert_eq!(agg.symbol, "BTC-USD");
+                assert_eq!(agg.open, dec!(45200.0));
+                assert_eq!(agg.high, dec!(45250.0));
+                assert_eq!(agg.low, dec!(45180.0));
+                assert_eq!(agg.close, dec!(45230.0));
+                assert_eq!(agg.volume, dec!(10.5));
+                assert_eq!(agg.trade_count, Some(150));
+            }
+            _ => panic!("Expected crypto aggregate message"),
+        }
+    }
+
+    #[test]
+    fn test_parse_ws_status() {
+        let json = r#"[{
+            "ev": "status",
+            "status": "auth_success",
+            "message": "authenticated"
+        }]"#;
+
+        let messages = parse_ws_message(json).unwrap();
+        assert_eq!(messages.len(), 1);
+
+        match &messages[0] {
+            WsMessage::Status(status) => {
+                assert_eq!(status.status, "auth_success");
+                assert_eq!(status.message, Some("authenticated".to_string()));
+            }
+            _ => panic!("Expected status message"),
+        }
+    }
+
+    #[test]
+    fn test_parse_ws_multiple_messages() {
+        let json = r#"[
+            {"ev": "XT", "pair": "BTC-USD", "p": 45230.50, "s": 0.5, "t": 1704067200000, "c": []},
+            {"ev": "XQ", "pair": "BTC-USD", "bp": 45220.0, "bs": 2.5, "ap": 45240.0, "as": 3.0, "t": 1704067200000}
+        ]"#;
+
+        let messages = parse_ws_message(json).unwrap();
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(&messages[0], WsMessage::TradeCrypto(_)));
+        assert!(matches!(&messages[1], WsMessage::QuoteCrypto(_)));
+    }
+
+    #[test]
+    fn test_ws_trade_to_public_trade() {
+        let trade = WsTradeMsg {
+            symbol: "BTC-USD".to_string(),
+            price: dec!(45230.50),
+            size: dec!(0.5),
+            timestamp: 1704067200000,
+            condition: Some(2),
+            id: Some("trade123".to_string()),
+        };
+
+        let (time, public_trade) = trade.into_public_trade();
+
+        assert_eq!(public_trade.price, dec!(45230.50));
+        assert_eq!(public_trade.amount, dec!(0.5));
+        assert_eq!(public_trade.side, Some(Side::Buy));
+        assert_eq!(
+            time,
+            Utc.timestamp_millis_opt(1704067200000).single().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_ws_quote_to_order_book_l1() {
+        let quote = WsQuoteMsg {
+            symbol: "BTC-USD".to_string(),
+            bid_price: dec!(45220.00),
+            bid_size: Some(dec!(2.5)),
+            ask_price: dec!(45240.00),
+            ask_size: Some(dec!(3.0)),
+            timestamp: 1704067200000,
+        };
+
+        let (time, l1) = quote.into_order_book_l1();
+
+        assert_eq!(l1.best_bid.unwrap().price, dec!(45220.00));
+        assert_eq!(l1.best_bid.unwrap().amount, dec!(2.5));
+        assert_eq!(l1.best_ask.unwrap().price, dec!(45240.00));
+        assert_eq!(l1.best_ask.unwrap().amount, dec!(3.0));
+        assert_eq!(
+            time,
+            Utc.timestamp_millis_opt(1704067200000).single().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_ws_aggregate_to_candle() {
+        let agg = WsAggregateMsg {
+            symbol: "BTC-USD".to_string(),
+            open: dec!(45200.0),
+            high: dec!(45250.0),
+            low: dec!(45180.0),
+            close: dec!(45230.0),
+            volume: dec!(10.5),
+            start_timestamp: 1704067200000,
+            end_timestamp: 1704067260000,
+            trade_count: Some(150),
+        };
+
+        let (time, candle) = agg.into_candle();
+
+        assert_eq!(candle.open, dec!(45200.0));
+        assert_eq!(candle.high, dec!(45250.0));
+        assert_eq!(candle.low, dec!(45180.0));
+        assert_eq!(candle.close, dec!(45230.0));
+        assert_eq!(candle.volume, dec!(10.5));
+        assert_eq!(candle.trade_count, 150);
+        assert_eq!(
+            time,
+            Utc.timestamp_millis_opt(1704067260000).single().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_parse_ws_unknown_event_skipped() {
+        // A frame with known trades plus an unknown "lagg" event.
+        // The trades must be returned; "lagg" must be silently skipped.
+        let json = r#"[
+            {"ev":"XT","pair":"BTC-USD","p":45000.0,"s":0.1,"t":1704067200000,"c":[]},
+            {"ev":"lagg","data":"some lag info"},
+            {"ev":"XT","pair":"ETH-USD","p":2500.0,"s":1.0,"t":1704067200001,"c":[]}
+        ]"#;
+
+        let messages = parse_ws_message(json).unwrap();
+        assert_eq!(messages.len(), 2, "expected 2 known messages, lagg skipped");
+        assert!(matches!(&messages[0], WsMessage::TradeCrypto(t) if t.symbol == "BTC-USD"));
+        assert!(matches!(&messages[1], WsMessage::TradeCrypto(t) if t.symbol == "ETH-USD"));
+    }
+
+    #[test]
+    fn test_parse_ws_malformed_outer_array_is_error() {
+        // Malformed JSON is a hard error, not a skip.
+        let result = parse_ws_message("{not an array}");
+        assert!(result.is_err());
     }
 }

--- a/rustrade-data/src/exchange/mod.rs
+++ b/rustrade-data/src/exchange/mod.rs
@@ -52,6 +52,10 @@ pub mod alpaca;
 #[cfg(feature = "databento")]
 pub mod databento;
 
+/// `Massive` (formerly Polygon.io) market data (behind `massive` feature).
+#[cfg(feature = "massive")]
+pub mod massive;
+
 /// Defines the generic [`ExchangeSub`] containing a market and channel combination used by an
 /// exchange [`Connector`] to build [`WsMessage`] subscription payloads.
 pub mod subscription;

--- a/rustrade-data/tests/databento_transformer.rs
+++ b/rustrade-data/tests/databento_transformer.rs
@@ -3,6 +3,8 @@
 //! Uses pre-downloaded DBN fixtures to test transformation logic without API calls.
 //! These tests run in CI.
 
+#![cfg(feature = "databento")]
+
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use rustrade_data::exchange::databento::{load_quotes_from_dbn, load_trades_from_dbn};

--- a/rustrade-data/tests/massive_integration.rs
+++ b/rustrade-data/tests/massive_integration.rs
@@ -1,0 +1,916 @@
+//! Massive Market Data Integration Tests
+//!
+//! These tests verify connectivity and data reception from Massive (formerly Polygon) APIs.
+//!
+//! # Status
+//!
+//! **Partially tested.** We have a currencies subscription (crypto + forex) but not
+//! stocks, options, indices, or futures subscriptions. The following are verified:
+//!
+//! | Category | Tested | Notes |
+//! |----------|--------|-------|
+//! | REST aggregates (crypto, forex) | ✅ | Free tier + currencies sub |
+//! | REST aggregates (stocks) | ✅ | Free tier (minute aggs only) |
+//! | REST aggregates (options, futures) | ✅ | Free tier (minute aggs only) |
+//! | REST aggregates (indices) | ❌ | Requires indices subscription |
+//! | REST tick trades (crypto) | ✅ | Currencies subscription |
+//! | REST tick trades (stocks) | ❌ | Requires stocks subscription |
+//! | REST quotes (forex) | ✅ | Currencies subscription |
+//! | REST quotes (stocks) | ❌ | Requires stocks subscription |
+//! | WebSocket (crypto) | ✅ | Currencies subscription |
+//! | WebSocket (stocks) | ❌ | Requires stocks subscription |
+//! | Reference data | ✅ | Free tier |
+//! | Corporate actions (dividends, splits) | ✅ | Free tier |
+//!
+//! Transformation logic is tested via unit tests in `transformer.rs`. Network
+//! integration for untested endpoints has not been verified against real data.
+//!
+//! # Prerequisites
+//!
+//! 1. Massive account with API key
+//! 2. Environment variable set (see .env.template):
+//!    - MASSIVE_API_KEY: API key from <https://massive.com/dashboard/api-keys>
+//!
+//! # Free Tier Limitations
+//!
+//! All asset classes have free Basic tiers with:
+//! - 2 years historical data (1+ year for indices)
+//! - 5 API calls/minute rate limit
+//! - End of day + minute aggregates
+//! - Reference data
+//!
+//! REST aggregates tests use data from ~1 month ago to stay within free tier limits.
+//! Tick-level trades and quotes require paid subscriptions.
+//!
+//! # WebSocket Limitations
+//!
+//! - **Individual plan**: 1 concurrent WebSocket connection per product
+//! - WebSocket tests are marked `#[serial]` to prevent connection conflicts
+//! - Live streaming requires an active subscription for the asset class
+//!
+//! # Running
+//!
+//! ```bash
+//! # Load env vars from .env
+//! source .env
+//!
+//! # Run all Massive integration tests
+//! cargo test --test massive_integration --features massive -- --ignored
+//!
+//! # Run specific test
+//! cargo test --test massive_integration --features massive test_rest_aggregates_crypto -- --ignored
+//!
+//! # Run tests that should pass with currencies subscription
+//! cargo test --test massive_integration --features massive -- --ignored \
+//!     test_rest_aggregates_crypto test_rest_aggregates_forex \
+//!     test_rest_trades_crypto test_rest_quotes_forex test_websocket_crypto
+//! ```
+
+#![cfg(feature = "massive")]
+// Integration tests use unwrap/expect for concise failure messages; panics are the intended failure mode.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use chrono::{Duration, Utc};
+use futures_util::StreamExt;
+use rust_decimal::Decimal;
+use rustrade_data::exchange::massive::{
+    ChannelType, DividendQuery, Market, MassiveLive, MassiveRestClient, SplitQuery, TickerQuery,
+};
+use rustrade_instrument::exchange::ExchangeId;
+use serial_test::serial;
+use std::collections::HashMap;
+use std::pin::pin;
+use tracing_subscriber::{EnvFilter, fmt};
+
+fn init_logging() {
+    let _ = fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(tracing::Level::DEBUG.into())
+                .from_env_lossy(),
+        )
+        .try_init();
+}
+
+/// Get a time range from ~1 month ago (5 minutes of data).
+/// This is well within the 2-year free tier limit for all asset classes.
+fn historical_time_range() -> (chrono::DateTime<Utc>, chrono::DateTime<Utc>) {
+    let end = Utc::now() - Duration::days(30);
+    let start = end - Duration::minutes(5);
+    (start, end)
+}
+
+// ============================================================================
+// REST Client Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_client_creation() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env();
+    assert!(
+        client.is_ok(),
+        "Failed to create REST client: {:?}",
+        client.err()
+    );
+    tracing::info!("REST client created successfully");
+}
+
+// ============================================================================
+// REST Aggregates Tests (12.5.2 - 12.5.4)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_aggregates_crypto() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+    let (from, to) = historical_time_range();
+
+    tracing::info!(%from, %to, "Fetching X:BTCUSD minute aggregates");
+
+    let stream = client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        let candle = result.expect("Failed to fetch candle");
+        assert!(candle.open > Decimal::ZERO, "Open should be positive");
+        assert!(candle.high >= candle.low, "High should be >= low");
+        assert!(
+            candle.volume >= Decimal::ZERO,
+            "Volume should be non-negative"
+        );
+        count += 1;
+
+        if count == 1 {
+            tracing::info!(
+                open = %candle.open,
+                high = %candle.high,
+                low = %candle.low,
+                close = %candle.close,
+                volume = %candle.volume,
+                "First crypto candle"
+            );
+        }
+    }
+
+    tracing::info!(count, "Fetched crypto aggregates");
+    assert!(count > 0, "Should have received at least one candle");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_aggregates_forex() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+    let (from, to) = historical_time_range();
+
+    tracing::info!(%from, %to, "Fetching C:EURUSD minute aggregates");
+
+    let stream = client.fetch_aggregates("C:EURUSD", 1, "minute", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        let candle = result.expect("Failed to fetch candle");
+        assert!(candle.open > Decimal::ZERO, "Open should be positive");
+        assert!(candle.high >= candle.low, "High should be >= low");
+        count += 1;
+
+        if count == 1 {
+            tracing::info!(
+                open = %candle.open,
+                high = %candle.high,
+                low = %candle.low,
+                close = %candle.close,
+                "First forex candle"
+            );
+        }
+    }
+
+    tracing::info!(count, "Fetched forex aggregates");
+    assert!(count > 0, "Should have received at least one candle");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_aggregates_stocks() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+    let (from, to) = historical_time_range();
+
+    tracing::info!(%from, %to, "Fetching AAPL minute aggregates");
+
+    let stream = client.fetch_aggregates("AAPL", 1, "minute", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        let candle = result.expect("Failed to fetch candle");
+        assert!(candle.open > Decimal::ZERO, "Open should be positive");
+        assert!(candle.high >= candle.low, "High should be >= low");
+        count += 1;
+
+        if count == 1 {
+            tracing::info!(
+                open = %candle.open,
+                high = %candle.high,
+                low = %candle.low,
+                close = %candle.close,
+                volume = %candle.volume,
+                "First stock candle"
+            );
+        }
+    }
+
+    tracing::info!(count, "Fetched stock aggregates");
+    // Note: May be 0 if the time range falls on a weekend/holiday
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_aggregates_options() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    // Use a historical AAPL option that was active ~1 month ago
+    // Format: O:{underlying}{YYMMDD}{C/P}{strike*1000}
+    // Using a strike near AAPL's price range
+    let (from, to) = historical_time_range();
+
+    // Find a valid option contract by querying tickers first
+    let query = TickerQuery::new().market("options").search("AAPL").limit(1);
+
+    let tickers: Vec<_> = client
+        .fetch_tickers(&query)
+        .take(1)
+        .collect::<Vec<_>>()
+        .await;
+
+    if tickers.is_empty() {
+        tracing::warn!("No AAPL options found, skipping test");
+        return;
+    }
+
+    let ticker = match &tickers[0] {
+        Ok(t) => &t.ticker,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to fetch options ticker");
+            return;
+        }
+    };
+
+    tracing::info!(%from, %to, %ticker, "Fetching options minute aggregates");
+
+    let stream = client.fetch_aggregates(ticker, 1, "minute", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(candle) => {
+                assert!(candle.open >= Decimal::ZERO, "Open should be non-negative");
+                count += 1;
+                if count == 1 {
+                    tracing::info!(
+                        open = %candle.open,
+                        volume = %candle.volume,
+                        "First options candle"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Options fetch error");
+                break;
+            }
+        }
+    }
+
+    tracing::info!(count, "Fetched options aggregates");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_aggregates_indices() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+    let (from, to) = historical_time_range();
+
+    tracing::info!(%from, %to, "Fetching I:SPX minute aggregates");
+
+    let stream = client.fetch_aggregates("I:SPX", 1, "minute", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        let candle = result.expect("Failed to fetch candle");
+        assert!(candle.open > Decimal::ZERO, "Open should be positive");
+        assert!(candle.high >= candle.low, "High should be >= low");
+        count += 1;
+
+        if count == 1 {
+            tracing::info!(
+                open = %candle.open,
+                high = %candle.high,
+                low = %candle.low,
+                close = %candle.close,
+                "First index candle"
+            );
+        }
+    }
+
+    tracing::info!(count, "Fetched index aggregates");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_aggregates_futures() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    // Find an active futures contract
+    let query = TickerQuery::new().market("futures").limit(1);
+
+    let tickers: Vec<_> = client
+        .fetch_tickers(&query)
+        .take(1)
+        .collect::<Vec<_>>()
+        .await;
+
+    if tickers.is_empty() {
+        tracing::warn!("No futures tickers found, skipping test");
+        return;
+    }
+
+    let ticker = match &tickers[0] {
+        Ok(t) => &t.ticker,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to fetch futures ticker");
+            return;
+        }
+    };
+
+    let (from, to) = historical_time_range();
+    tracing::info!(%from, %to, %ticker, "Fetching futures minute aggregates");
+
+    let stream = client.fetch_aggregates(ticker, 1, "minute", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(candle) => {
+                assert!(candle.open > Decimal::ZERO, "Open should be positive");
+                count += 1;
+                if count == 1 {
+                    tracing::info!(
+                        open = %candle.open,
+                        volume = %candle.volume,
+                        "First futures candle"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Futures fetch error");
+                break;
+            }
+        }
+    }
+
+    tracing::info!(count, "Fetched futures aggregates");
+}
+
+// ============================================================================
+// REST Trades Tests (12.5.5)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_trades_crypto() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+    let (from, to) = historical_time_range();
+
+    tracing::info!(%from, %to, "Fetching X:BTCUSD trades");
+
+    let stream = client.fetch_trades("X:BTCUSD", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        let trade = result.expect("Failed to fetch trade");
+        assert!(trade.price > Decimal::ZERO, "Price should be positive");
+        assert!(trade.amount > Decimal::ZERO, "Amount should be positive");
+        count += 1;
+
+        if count == 1 {
+            tracing::info!(
+                price = %trade.price,
+                amount = %trade.amount,
+                "First crypto trade"
+            );
+        }
+
+        // Limit to avoid rate limits
+        if count >= 100 {
+            break;
+        }
+    }
+
+    tracing::info!(count, "Fetched crypto trades");
+    assert!(count > 0, "Should have received at least one trade");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_trades_stocks() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+    let (from, to) = historical_time_range();
+
+    tracing::info!(%from, %to, "Fetching AAPL trades");
+
+    let stream = client.fetch_trades("AAPL", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        let trade = result.expect("Failed to fetch trade");
+        assert!(trade.price > Decimal::ZERO, "Price should be positive");
+        assert!(trade.amount > Decimal::ZERO, "Amount should be positive");
+        count += 1;
+
+        if count == 1 {
+            tracing::info!(
+                price = %trade.price,
+                amount = %trade.amount,
+                "First stock trade"
+            );
+        }
+
+        if count >= 100 {
+            break;
+        }
+    }
+
+    tracing::info!(count, "Fetched stock trades");
+}
+
+// ============================================================================
+// REST Quotes Tests (12.5.6)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_quotes_forex() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+    let (from, to) = historical_time_range();
+
+    tracing::info!(%from, %to, "Fetching C:EURUSD quotes");
+
+    let stream = client.fetch_quotes("C:EURUSD", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        let quote = result.expect("Failed to fetch quote");
+        let bid = quote.best_bid.expect("Should have bid");
+        let ask = quote.best_ask.expect("Should have ask");
+        assert!(bid.price > Decimal::ZERO, "Bid should be positive");
+        assert!(ask.price > Decimal::ZERO, "Ask should be positive");
+        assert!(ask.price >= bid.price, "Ask should be >= bid");
+        count += 1;
+
+        if count == 1 {
+            tracing::info!(
+                bid = %bid.price,
+                ask = %ask.price,
+                "First forex quote"
+            );
+        }
+
+        if count >= 100 {
+            break;
+        }
+    }
+
+    tracing::info!(count, "Fetched forex quotes");
+    assert!(count > 0, "Should have received at least one quote");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_rest_quotes_stocks() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+    let (from, to) = historical_time_range();
+
+    tracing::info!(%from, %to, "Fetching AAPL quotes (NBBO)");
+
+    let stream = client.fetch_quotes("AAPL", from, to);
+    let mut stream = pin!(stream);
+
+    let mut count = 0;
+    while let Some(result) = stream.next().await {
+        let quote = result.expect("Failed to fetch quote");
+        let bid = quote.best_bid.expect("Should have bid");
+        let ask = quote.best_ask.expect("Should have ask");
+        assert!(bid.price > Decimal::ZERO, "Bid should be positive");
+        assert!(ask.price > Decimal::ZERO, "Ask should be positive");
+        assert!(ask.price >= bid.price, "Ask should be >= bid");
+        count += 1;
+
+        if count == 1 {
+            tracing::info!(
+                bid = %bid.price,
+                ask = %ask.price,
+                "First stock NBBO quote"
+            );
+        }
+
+        if count >= 100 {
+            break;
+        }
+    }
+
+    tracing::info!(count, "Fetched stock quotes");
+}
+
+// ============================================================================
+// WebSocket Tests (12.5.7 - 12.5.8)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_websocket_crypto() {
+    init_logging();
+
+    let instruments: HashMap<String, String> = [("BTC-USD".to_string(), "btc-usd".to_string())]
+        .into_iter()
+        .collect();
+
+    let mut client = MassiveLive::from_env(Market::Crypto, ExchangeId::Massive, instruments)
+        .expect("Failed to create WebSocket client");
+
+    client.subscribe(&["BTC-USD"], ChannelType::Trade);
+    tracing::info!("Subscribed to BTC-USD trades");
+
+    let stream = client.start().await.expect("Failed to start stream");
+    let mut stream = pin!(stream);
+
+    let timeout = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        let mut count = 0;
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(market_event) => {
+                    tracing::info!(?market_event, "Received market event");
+                    count += 1;
+                    if count >= 3 {
+                        return Ok(count);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Stream error");
+                }
+            }
+        }
+        Err("Stream ended without sufficient data")
+    })
+    .await;
+
+    match timeout {
+        Ok(Ok(count)) => tracing::info!(count, "WebSocket crypto test passed"),
+        Ok(Err(e)) => panic!("Stream error: {}", e),
+        Err(_) => panic!("Timeout waiting for crypto WebSocket data"),
+    }
+}
+
+/// WebSocket test for stocks - requires stocks subscription
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_websocket_stocks() {
+    init_logging();
+
+    let instruments: HashMap<String, String> = [("AAPL".to_string(), "aapl".to_string())]
+        .into_iter()
+        .collect();
+
+    let mut client = MassiveLive::from_env(Market::Stocks, ExchangeId::Massive, instruments)
+        .expect("Failed to create WebSocket client");
+
+    client.subscribe(&["AAPL"], ChannelType::Trade);
+    tracing::info!("Subscribed to AAPL trades");
+
+    let stream = client.start().await.expect("Failed to start stream");
+    let mut stream = pin!(stream);
+
+    let timeout = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        let mut count = 0;
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(market_event) => {
+                    tracing::info!(?market_event, "Received market event");
+                    count += 1;
+                    if count >= 3 {
+                        return Ok(count);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Stream error");
+                }
+            }
+        }
+        Err("Stream ended without sufficient data")
+    })
+    .await;
+
+    match timeout {
+        Ok(Ok(count)) => tracing::info!(count, "WebSocket stocks test passed"),
+        Ok(Err(e)) => panic!("Stream error: {}", e),
+        Err(_) => panic!("Timeout waiting for stock WebSocket data"),
+    }
+}
+
+// ============================================================================
+// Reference Data Tests (12.5.9)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_reference_tickers() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    // Query crypto tickers
+    let query = TickerQuery::new().market("crypto").limit(10);
+
+    tracing::info!("Fetching crypto tickers");
+
+    let tickers: Vec<_> = client
+        .fetch_tickers(&query)
+        .take(10)
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(!tickers.is_empty(), "Should have received tickers");
+
+    for result in &tickers {
+        let ticker = result.as_ref().expect("Failed to fetch ticker");
+        assert!(
+            !ticker.ticker.is_empty(),
+            "Ticker symbol should not be empty"
+        );
+        tracing::info!(
+            ticker = %ticker.ticker,
+            name = %ticker.name,
+            market = %ticker.market,
+            "Ticker"
+        );
+    }
+
+    tracing::info!(count = tickers.len(), "Fetched tickers");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_reference_ticker_details() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    tracing::info!("Fetching AAPL ticker details");
+
+    let details = client.fetch_ticker_details("AAPL").await;
+    let details = details.expect("Failed to fetch ticker details");
+
+    assert_eq!(details.ticker.ticker, "AAPL");
+    assert!(!details.ticker.name.is_empty(), "Name should not be empty");
+
+    tracing::info!(
+        ticker = %details.ticker.ticker,
+        name = %details.ticker.name,
+        market = %details.ticker.market,
+        primary_exchange = ?details.ticker.primary_exchange,
+        "Ticker details"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_reference_exchanges() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    tracing::info!("Fetching exchanges");
+
+    let exchanges = client.fetch_exchanges(None, None).await;
+    let exchanges = exchanges.expect("Failed to fetch exchanges");
+
+    assert!(!exchanges.is_empty(), "Should have received exchanges");
+
+    for exchange in exchanges.iter().take(5) {
+        tracing::info!(
+            id = exchange.id,
+            mic = ?exchange.mic,
+            name = %exchange.name,
+            exchange_type = ?exchange.exchange_type,
+            "Exchange"
+        );
+    }
+
+    tracing::info!(count = exchanges.len(), "Fetched exchanges");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_reference_market_status() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    tracing::info!("Fetching market status");
+
+    let status = client.fetch_market_status().await;
+    let status = status.expect("Failed to fetch market status");
+
+    tracing::info!(
+        market = %status.market,
+        server_time = %status.server_time,
+        exchanges = ?status.exchanges,
+        currencies = ?status.currencies,
+        "Market status"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_reference_market_holidays() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    tracing::info!("Fetching market holidays");
+
+    let holidays = client.fetch_market_holidays().await;
+    let holidays = holidays.expect("Failed to fetch market holidays");
+
+    assert!(!holidays.is_empty(), "Should have received holidays");
+
+    for holiday in holidays.iter().take(5) {
+        tracing::info!(
+            date = %holiday.date,
+            name = %holiday.name,
+            exchange = %holiday.exchange,
+            status = %holiday.status,
+            "Holiday"
+        );
+    }
+
+    tracing::info!(count = holidays.len(), "Fetched market holidays");
+}
+
+// ============================================================================
+// Corporate Actions Tests (12.6.2)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_corporate_actions_dividends() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    // Query AAPL dividends from the last 2 years (within free tier)
+    let two_years_ago = (Utc::now() - Duration::days(730)).date_naive();
+    let query = DividendQuery::new()
+        .ticker("AAPL")
+        .ex_dividend_date_gte(two_years_ago)
+        .limit(10);
+
+    tracing::info!(%two_years_ago, "Fetching AAPL dividends");
+
+    let dividends: Vec<_> = client
+        .fetch_dividends(&query)
+        .take(10)
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(!dividends.is_empty(), "Should have received dividends");
+
+    for result in &dividends {
+        let dividend = result.as_ref().expect("Failed to fetch dividend");
+        assert_eq!(dividend.ticker, "AAPL");
+        assert!(
+            dividend.cash_amount > Decimal::ZERO,
+            "Cash amount should be positive"
+        );
+
+        tracing::info!(
+            ticker = %dividend.ticker,
+            cash_amount = %dividend.cash_amount,
+            ex_dividend_date = %dividend.ex_dividend_date,
+            frequency = ?dividend.frequency,
+            dividend_type = ?dividend.dividend_type,
+            "Dividend"
+        );
+    }
+
+    tracing::info!(count = dividends.len(), "Fetched dividends");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_corporate_actions_splits() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    // Query recent stock splits (within free tier data range)
+    let two_years_ago = (Utc::now() - Duration::days(730)).date_naive();
+    let query = SplitQuery::new()
+        .execution_date_gte(two_years_ago)
+        .limit(10);
+
+    tracing::info!(%two_years_ago, "Fetching recent stock splits");
+
+    let splits: Vec<_> = client
+        .fetch_splits(&query)
+        .take(10)
+        .collect::<Vec<_>>()
+        .await;
+
+    // Note: May be empty if no splits occurred in the period
+    for result in &splits {
+        let split = result.as_ref().expect("Failed to fetch split");
+        assert!(
+            split.split_to > Decimal::ZERO,
+            "split_to should be positive"
+        );
+        assert!(
+            split.split_from > Decimal::ZERO,
+            "split_from should be positive"
+        );
+
+        tracing::info!(
+            ticker = %split.ticker,
+            execution_date = %split.execution_date,
+            split_to = %split.split_to,
+            split_from = %split.split_from,
+            "Split"
+        );
+    }
+
+    tracing::info!(count = splits.len(), "Fetched splits");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_corporate_actions_splits_specific_ticker() {
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    // Query NVDA splits - they had a 10:1 split in 2024
+    let query = SplitQuery::new().ticker("NVDA").limit(5);
+
+    tracing::info!("Fetching NVDA stock splits");
+
+    let splits: Vec<_> = client
+        .fetch_splits(&query)
+        .take(5)
+        .collect::<Vec<_>>()
+        .await;
+
+    for result in &splits {
+        let split = result.as_ref().expect("Failed to fetch split");
+        assert_eq!(split.ticker, "NVDA");
+
+        tracing::info!(
+            ticker = %split.ticker,
+            execution_date = %split.execution_date,
+            split_to = %split.split_to,
+            split_from = %split.split_from,
+            "NVDA Split"
+        );
+    }
+
+    tracing::info!(count = splits.len(), "Fetched NVDA splits");
+}

--- a/rustrade-execution/src/fee.rs
+++ b/rustrade-execution/src/fee.rs
@@ -33,6 +33,7 @@ impl FeeModel for ZeroFeeModel {
 /// not per underlying share.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct PerContractFeeModel {
+    #[serde(with = "rust_decimal::serde::str")]
     pub commission_per_contract: Decimal,
 }
 
@@ -55,6 +56,7 @@ pub struct PercentageFeeModel {
     ///
     /// No validation is performed; values outside `[0, 1]` are accepted
     /// but produce unusual fee amounts.
+    #[serde(with = "rust_decimal::serde::str")]
     pub rate: Decimal,
 }
 

--- a/rustrade-instrument/src/exchange.rs
+++ b/rustrade-instrument/src/exchange.rs
@@ -100,6 +100,8 @@ pub enum ExchangeId {
     Kraken,
     Kucoin,
     Liquid,
+    /// Massive (formerly Polygon.io) — consolidated market data across all asset classes
+    Massive,
     Mexc,
     Okx,
     Poloniex,
@@ -162,6 +164,7 @@ impl ExchangeId {
             ExchangeId::Kraken => "kraken",
             ExchangeId::Kucoin => "kucoin",
             ExchangeId::Liquid => "liquid",
+            ExchangeId::Massive => "massive",
             ExchangeId::Mexc => "mexc",
             ExchangeId::Okx => "okx",
             ExchangeId::Poloniex => "poloniex",


### PR DESCRIPTION
## Summary

- **REST client** (`MassiveRestClient`): Historical aggregates, trades, quotes with streaming pagination
- **WebSocket client** (`MassiveLive`): Real-time streaming for trades, quotes, aggregates with ping/pong keepalive
- **Reference data**: Tickers, exchanges, market status, holidays, corporate actions (dividends, splits)
- **All asset classes**: Stocks, crypto, forex, options, indices, futures

## Key Features

- Asset-class agnostic design with `Market` enum routing to correct endpoints
- Streaming pagination for large historical queries (no memory collection)
- `MassiveError::RateLimited { retry_after }` returned on 429 — consumer decides retry policy
- `MassiveError::Disconnected` on WebSocket drop — consumer owns reconnection
- 63 unit tests with JSON fixtures (CI-ready)
- 900-line integration test suite (`#[ignore]` — requires API key)

## Testing

Unit tests run in CI without credentials. Integration tests require `MASSIVE_API_KEY`:
- REST tests work with free Basic tier (2-year historical, 5 calls/min)
- WebSocket tests require active subscription

```bash
# Unit tests (CI)
cargo test --lib --features massive massive

# Integration tests (manual, requires API key)
MASSIVE_API_KEY=xxx cargo test --test massive_integration
```

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` clean
- [x] 63 unit tests pass
- [x] Integration tests pass locally with API key