### PR TITLE
feat(ibkr): IBKR Integration Expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Stop and Trailing Stop order types** (TG13 Phase 1+2):
+  - `OrderKind::Stop { trigger_price }`: Stop market orders
+  - `OrderKind::StopLimit { trigger_price }`: Stop-limit orders
+  - `OrderKind::TrailingStop { offset, offset_type }`: Trailing stop orders
+  - `OrderKind::TrailingStopLimit { offset, offset_type, limit_offset }`: Trailing stop-limit orders
+  - `TrailingOffsetType` enum: `Absolute`, `Percentage`, `BasisPoints`
+  - IBKR connector: Full support for all stop/trailing order types
+  - Binance/Alpaca connectors: Return `UnsupportedOrderType` error (support planned)
+- `OrderError::UnsupportedOrderType`: New error variant for connectors that don't support certain order types
 - **Massive market data connector**: Historical, live, and reference data via `massive` feature
   - `MassiveRestClient`: Historical aggregates, trades, quotes with streaming pagination
   - `MassiveLive`: Real-time WebSocket streaming for trades, quotes, and aggregates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Option Greeks support** (Phase 5): Real-time and computed Greeks for IBKR options
+  - `DataKind::OptionGreeks(OptionGreeks)` variant for the unified market data stream
+  - `IbkrSubscriptionKind::OptionGreeks` for live streaming via `market_data()` subscription
+  - `OptionGreeks` struct (`subscription::greeks`): `delta`, `gamma`, `theta`, `vega`, `implied_volatility`,
+    `theoretical_price`, `underlying_price` (all `Option<f64>`); marked `#[non_exhaustive]`
+  - `OptionGreeks::has_any_greek()` returns true when at least one first-order Greek is present
+    (excludes `theoretical_price` / `underlying_price`)
+  - `IbkrHistoricalData::calculate_theoretical_greeks(contract, volatility, underlying_price)`:
+    IB-side Greeks calculator from user-supplied IV and underlying
+  - `IbkrHistoricalData::calculate_implied_volatility(contract, option_price, underlying_price)`:
+    IB-side IV calculator from user-supplied option/underlying prices
+  - `IbkrHistoricalData::fetch_option_chain(symbol, exchange, security_type, contract_id)` returning
+    `Vec<OptionChainEntry>` with available expirations, strikes, trading classes, and exchanges
+  - `OptionChainEntry` struct (`exchange::ibkr::options`): marked `#[non_exhaustive]`; `strikes` is
+    `Vec<rust_decimal::Decimal>` (financial values must use `Decimal` per project standard)
+  - `IbkrMarketStream` rejects non-`SecurityType::Option` contracts on `OptionGreeks` subscription
+    with `DataError::Socket` (fail-fast over silent zero events)
+- **Historical tick data APIs** for IBKR: `fetch_historical_ticks`, `fetch_historical_bid_ask`
+- Cargo `required-features` declarations for feature-gated examples
+  (`download_databento_fixtures`, `hyperliquid_*`, `ibkr_*`); `cargo check --all-targets`
+  no longer fails on default features
 - **Stop and Trailing Stop order types** (TG13 Phase 1+2):
   - `OrderKind::Stop { trigger_price }`: Stop market orders
   - `OrderKind::StopLimit { trigger_price }`: Stop-limit orders
@@ -50,6 +71,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Migration: Match on `Some(side)` to handle the `None` case explicitly, or use
     `.is_some_and(|s| s == Side::Buy)` for boolean checks. (`Side` does not implement
     `Default`, so `unwrap_or_default()` will not compile.)
+- **BREAKING**: `OptionChainEntry::expirations` changed from `Vec<String>` to `Vec<NaiveDate>`.
+  - Removes IBKR wire format leakage (YYYYMMDD strings) from caller code
+  - Invalid expiration strings are now filtered during `from_ib()` conversion
+  - Migration: Replace string parsing with direct `NaiveDate` usage
 - **BREAKING**: `PublicTrade`, `Quote`, `Candle`, and `Liquidation` price/amount fields
   changed from `f64` to `rust_decimal::Decimal` for financial precision.
   - `PublicTrade`: `price`, `amount` now `Decimal`

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -80,3 +80,30 @@ databento = { version = "0.49", optional = true }
 # Massive (optional, behind "massive" feature)
 tokio-tungstenite = { version = "0.29", optional = true, features = ["native-tls"] }
 urlencoding = { version = "2.1", optional = true }
+
+# Examples that depend on optional features. Without `required-features`,
+# `cargo check --all-targets` (default features) fails to compile them.
+
+[[example]]
+name = "download_databento_fixtures"
+required-features = ["databento"]
+
+[[example]]
+name = "hyperliquid_historical"
+required-features = ["hyperliquid"]
+
+[[example]]
+name = "hyperliquid_market_data"
+required-features = ["hyperliquid"]
+
+[[example]]
+name = "hyperliquid_spot_market_data"
+required-features = ["hyperliquid"]
+
+[[example]]
+name = "ibkr_historical"
+required-features = ["ibkr"]
+
+[[example]]
+name = "ibkr_market_data"
+required-features = ["ibkr"]

--- a/rustrade-data/src/event.rs
+++ b/rustrade-data/src/event.rs
@@ -4,6 +4,7 @@ use crate::{
     subscription::{
         book::{OrderBookEvent, OrderBookL1},
         candle::Candle,
+        greeks::OptionGreeks,
         liquidation::Liquidation,
         trade::PublicTrade,
     },
@@ -98,6 +99,13 @@ impl<InstrumentKey> MarketEvent<InstrumentKey, DataKind> {
         }
     }
 
+    pub fn as_option_greeks(&self) -> Option<MarketEvent<&InstrumentKey, &OptionGreeks>> {
+        match &self.kind {
+            DataKind::OptionGreeks(greeks) => Some(self.as_event(greeks)),
+            _ => None,
+        }
+    }
+
     fn as_event<'a, K>(&'a self, kind: &'a K) -> MarketEvent<&'a InstrumentKey, &'a K> {
         MarketEvent {
             time_exchange: self.time_exchange,
@@ -127,6 +135,7 @@ pub enum DataKind {
     OrderBook(OrderBookEvent),
     Candle(Candle),
     Liquidation(Liquidation),
+    OptionGreeks(OptionGreeks),
 }
 
 impl DataKind {
@@ -137,7 +146,24 @@ impl DataKind {
             DataKind::OrderBook(_) => "l2",
             DataKind::Candle(_) => "candle",
             DataKind::Liquidation(_) => "liquidation",
+            DataKind::OptionGreeks(_) => "option_greeks",
         }
+    }
+}
+
+impl<InstrumentKey> From<MarketEvent<InstrumentKey, OptionGreeks>>
+    for MarketEvent<InstrumentKey, DataKind>
+{
+    fn from(value: MarketEvent<InstrumentKey, OptionGreeks>) -> Self {
+        value.map_kind(OptionGreeks::into)
+    }
+}
+
+impl<InstrumentKey> From<MarketStreamResult<InstrumentKey, OptionGreeks>>
+    for MarketStreamResult<InstrumentKey, DataKind>
+{
+    fn from(value: MarketStreamResult<InstrumentKey, OptionGreeks>) -> Self {
+        value.map_ok(MarketEvent::from)
     }
 }
 

--- a/rustrade-data/src/exchange/ibkr/greeks.rs
+++ b/rustrade-data/src/exchange/ibkr/greeks.rs
@@ -1,0 +1,146 @@
+//! Greeks aggregation for IB option tick data.
+//!
+//! IB sends option computation ticks containing real-time Greeks computed from
+//! live market data. This aggregator collects these updates and emits
+//! [`OptionGreeks`] values.
+//!
+//! Unlike the calculator APIs in [`IbkrHistoricalData`], these are real-time
+//! values computed by IB from live option prices.
+//!
+//! [`IbkrHistoricalData`]: super::historical::IbkrHistoricalData
+
+use super::options::OptionGreeks;
+use ibapi::market_data::realtime::TickTypes;
+
+/// Aggregates IB option computation ticks into OptionGreeks.
+///
+/// Emits an [`OptionGreeks`] on each `TickTypes::OptionComputation` update.
+/// Does not aggregate across multiple ticks — each tick is a complete snapshot.
+#[derive(Debug, Default)]
+pub struct GreeksAggregator;
+
+impl GreeksAggregator {
+    /// Create a new aggregator.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Process a tick and potentially emit OptionGreeks.
+    ///
+    /// Returns `Some(OptionGreeks)` when the tick contains option computation data.
+    /// Returns `None` for other tick types.
+    ///
+    /// # Arguments
+    ///
+    /// * `tick` - The tick update from IB
+    pub fn update(&self, tick: &TickTypes) -> Option<OptionGreeks> {
+        match tick {
+            TickTypes::OptionComputation(computation) => {
+                let greeks = OptionGreeks::from_ib(computation);
+                if greeks.has_any_greek() {
+                    Some(greeks)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use ibapi::contracts::tick_types::TickType;
+
+    fn make_option_computation(
+        delta: Option<f64>,
+        gamma: Option<f64>,
+        theta: Option<f64>,
+        vega: Option<f64>,
+        iv: Option<f64>,
+        price: Option<f64>,
+    ) -> TickTypes {
+        use ibapi::contracts::OptionComputation;
+
+        TickTypes::OptionComputation(OptionComputation {
+            field: TickType::ModelOption,
+            tick_attribute: Some(1),
+            delta,
+            gamma,
+            theta,
+            vega,
+            implied_volatility: iv,
+            option_price: price,
+            underlying_price: Some(150.0),
+            present_value_dividend: Some(0.0),
+        })
+    }
+
+    #[test]
+    fn aggregator_emits_greeks_on_option_computation() {
+        let agg = GreeksAggregator::new();
+
+        let tick = make_option_computation(
+            Some(0.55),
+            Some(0.02),
+            Some(-0.05),
+            Some(0.15),
+            Some(0.25),
+            Some(5.50),
+        );
+
+        let result = agg.update(&tick);
+        assert!(result.is_some());
+
+        let greeks = result.unwrap();
+        assert_eq!(greeks.delta, Some(0.55));
+        assert_eq!(greeks.gamma, Some(0.02));
+        assert_eq!(greeks.theta, Some(-0.05));
+        assert_eq!(greeks.vega, Some(0.15));
+        assert_eq!(greeks.implied_volatility, Some(0.25));
+        assert_eq!(greeks.theoretical_price, Some(5.50));
+    }
+
+    #[test]
+    fn aggregator_returns_none_for_empty_computation() {
+        let agg = GreeksAggregator::new();
+
+        let tick = make_option_computation(None, None, None, None, None, None);
+
+        let result = agg.update(&tick);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn aggregator_returns_none_for_other_tick_types() {
+        use ibapi::market_data::realtime::{TickAttribute, TickPrice};
+
+        let agg = GreeksAggregator::new();
+
+        let tick = TickTypes::Price(TickPrice {
+            tick_type: TickType::Bid,
+            price: 100.0,
+            attributes: TickAttribute::default(),
+        });
+
+        let result = agg.update(&tick);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn aggregator_emits_partial_greeks() {
+        let agg = GreeksAggregator::new();
+
+        let tick = make_option_computation(Some(0.55), None, None, None, Some(0.25), None);
+
+        let result = agg.update(&tick);
+        assert!(result.is_some());
+
+        let greeks = result.unwrap();
+        assert_eq!(greeks.delta, Some(0.55));
+        assert!(greeks.gamma.is_none());
+        assert_eq!(greeks.implied_volatility, Some(0.25));
+    }
+}

--- a/rustrade-data/src/exchange/ibkr/historical.rs
+++ b/rustrade-data/src/exchange/ibkr/historical.rs
@@ -55,6 +55,7 @@
 //!
 //! [`IbkrMarketStream`]: super::IbkrMarketStream
 
+use super::options::{OptionChainEntry, OptionGreeks};
 use crate::{
     books::Level,
     error::DataError,
@@ -63,7 +64,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use ibapi::{
     client::blocking::Client,
-    contracts::Contract,
+    contracts::{Contract, SecurityType},
     market_data::{
         TradingHours,
         historical::{BarSize, Duration, TickBidAsk, TickLast, WhatToShow},
@@ -380,6 +381,236 @@ impl IbkrHistoricalData {
         debug!(symbol = %symbol, count = quotes.len(), "Received historical bid/ask ticks");
 
         Ok(quotes)
+    }
+
+    // ========================================================================
+    // Option Greeks Calculators (Phase 5A)
+    // ========================================================================
+
+    /// Calculate theoretical option Greeks given volatility and underlying price.
+    ///
+    /// This is a **calculator** — you provide the volatility and underlying price,
+    /// and IB computes the theoretical Greeks. This does NOT fetch market data.
+    ///
+    /// For real-time Greeks based on live market prices, use the streaming API
+    /// (Phase 5B) with `TickTypes::OptionComputation`.
+    ///
+    /// # Arguments
+    ///
+    /// * `contract` - Option contract (must be SecurityType::Option)
+    /// * `volatility` - Implied volatility to use (e.g., 0.25 for 25%)
+    /// * `underlying_price` - Underlying price to use for calculation
+    ///
+    /// # Returns
+    ///
+    /// [`OptionGreeks`] containing computed delta, gamma, theta, vega, and
+    /// theoretical option price.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::Socket` if IB rejects the request (invalid contract,
+    /// missing subscription, etc.).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let client = IbkrHistoricalData::connect("127.0.0.1:4002", 102)?;
+    /// let option = Contract::call("AAPL").strike(150.0).expires_on(2024, 12, 20).build();
+    ///
+    /// let greeks = client.calculate_theoretical_greeks(&option, 0.25, 148.0).await?;
+    /// if let Some(delta) = greeks.delta {
+    ///     println!("Delta: {:.3}", delta);
+    /// }
+    /// ```
+    pub async fn calculate_theoretical_greeks(
+        &self,
+        contract: &Contract,
+        volatility: f64,
+        underlying_price: f64,
+    ) -> Result<OptionGreeks, DataError> {
+        let client = self.client.clone();
+        let contract = contract.clone();
+        let symbol = contract.symbol.to_string();
+
+        debug!(
+            symbol = %symbol,
+            volatility,
+            underlying_price,
+            "Calculating theoretical option Greeks"
+        );
+
+        let greeks = tokio::task::spawn_blocking(move || {
+            let computation = client
+                .calculate_option_price(&contract, volatility, underlying_price)
+                .map_err(|e| DataError::Socket(format!("calculate_option_price: {e}")))?;
+
+            Ok::<_, DataError>(OptionGreeks::from_ib(&computation))
+        })
+        .await
+        .map_err(|e| {
+            if e.is_panic() {
+                DataError::Socket(format!("calculate_option_price task panicked: {e}"))
+            } else {
+                DataError::Socket(format!("calculate_option_price task cancelled: {e}"))
+            }
+        })??;
+
+        debug!(
+            symbol = %symbol,
+            delta = ?greeks.delta,
+            gamma = ?greeks.gamma,
+            "Calculated option Greeks"
+        );
+
+        Ok(greeks)
+    }
+
+    /// Calculate implied volatility from option price and underlying price.
+    ///
+    /// This is a **calculator** — you provide the option and underlying prices,
+    /// and IB computes the implied volatility using its options model.
+    ///
+    /// # Arguments
+    ///
+    /// * `contract` - Option contract (must be SecurityType::Option)
+    /// * `option_price` - Current or hypothetical option price
+    /// * `underlying_price` - Current or hypothetical underlying price
+    ///
+    /// # Returns
+    ///
+    /// Implied volatility as a decimal (e.g., 0.25 for 25% IV).
+    /// Also returns other Greeks computed at this IV level.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::Socket` if IB rejects the request or if IV cannot
+    /// be computed (e.g., option price is below intrinsic value).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let client = IbkrHistoricalData::connect("127.0.0.1:4002", 102)?;
+    /// let option = Contract::call("AAPL").strike(150.0).expires_on(2024, 12, 20).build();
+    ///
+    /// let greeks = client.calculate_implied_volatility(&option, 7.50, 155.0).await?;
+    /// if let Some(iv) = greeks.implied_volatility {
+    ///     println!("Implied Volatility: {:.1}%", iv * 100.0);
+    /// }
+    /// ```
+    pub async fn calculate_implied_volatility(
+        &self,
+        contract: &Contract,
+        option_price: f64,
+        underlying_price: f64,
+    ) -> Result<OptionGreeks, DataError> {
+        let client = self.client.clone();
+        let contract = contract.clone();
+        let symbol = contract.symbol.to_string();
+
+        debug!(
+            symbol = %symbol,
+            option_price,
+            underlying_price,
+            "Calculating implied volatility"
+        );
+
+        let greeks = tokio::task::spawn_blocking(move || {
+            let computation = client
+                .calculate_implied_volatility(&contract, option_price, underlying_price)
+                .map_err(|e| DataError::Socket(format!("calculate_implied_volatility: {e}")))?;
+
+            Ok::<_, DataError>(OptionGreeks::from_ib(&computation))
+        })
+        .await
+        .map_err(|e| {
+            if e.is_panic() {
+                DataError::Socket(format!("calculate_implied_volatility task panicked: {e}"))
+            } else {
+                DataError::Socket(format!("calculate_implied_volatility task cancelled: {e}"))
+            }
+        })??;
+
+        debug!(
+            symbol = %symbol,
+            iv = ?greeks.implied_volatility,
+            "Calculated implied volatility"
+        );
+
+        Ok(greeks)
+    }
+
+    /// Fetch option chain metadata for an underlying security.
+    ///
+    /// Returns available expiration dates and strike prices for options on
+    /// the specified underlying. Does NOT return Greeks or prices — use
+    /// market data subscriptions for that.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - Underlying symbol (e.g., "AAPL")
+    /// * `exchange` - Exchange to query (e.g., "SMART", "CBOE")
+    /// * `security_type` - Type of underlying (typically `SecurityType::Stock`)
+    /// * `contract_id` - IB contract ID of the underlying (0 to search by symbol)
+    ///
+    /// # Returns
+    ///
+    /// Vector of [`OptionChainEntry`] for each exchange/trading class combination.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::Socket` if IB rejects the request.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let client = IbkrHistoricalData::connect("127.0.0.1:4002", 102)?;
+    ///
+    /// let chains = client.fetch_option_chain("AAPL", "SMART", SecurityType::Stock, 0).await?;
+    /// for chain in chains {
+    ///     println!("Exchange: {}, Expirations: {:?}", chain.exchange, chain.expirations);
+    /// }
+    /// ```
+    pub async fn fetch_option_chain(
+        &self,
+        symbol: &str,
+        exchange: &str,
+        security_type: SecurityType,
+        contract_id: i32,
+    ) -> Result<Vec<OptionChainEntry>, DataError> {
+        let client = self.client.clone();
+        let symbol = symbol.to_string();
+        let exchange = exchange.to_string();
+
+        debug!(
+            symbol = %symbol,
+            exchange = %exchange,
+            "Fetching option chain"
+        );
+
+        let chains = tokio::task::spawn_blocking(move || {
+            let subscription = client
+                .option_chain(&symbol, &exchange, security_type, contract_id)
+                .map_err(|e| DataError::Socket(format!("option_chain: {e}")))?;
+
+            let mut entries = Vec::with_capacity(16);
+            for chain in subscription {
+                entries.push(OptionChainEntry::from_ib(&chain));
+            }
+
+            debug!(symbol = %symbol, count = entries.len(), "Received option chain entries");
+
+            Ok::<_, DataError>(entries)
+        })
+        .await
+        .map_err(|e| {
+            if e.is_panic() {
+                DataError::Socket(format!("option_chain task panicked: {e}"))
+            } else {
+                DataError::Socket(format!("option_chain task cancelled: {e}"))
+            }
+        })??;
+
+        Ok(chains)
     }
 }
 

--- a/rustrade-data/src/exchange/ibkr/historical.rs
+++ b/rustrade-data/src/exchange/ibkr/historical.rs
@@ -1,9 +1,10 @@
 //! Historical data fetcher for Interactive Brokers.
 //!
-//! Provides one-shot historical bar data via `IbkrHistoricalData::fetch_candles()`.
+//! Provides one-shot historical bar data via `IbkrHistoricalData::fetch_candles()`
+//! and tick-level data via `fetch_historical_ticks()` / `fetch_historical_bid_ask()`.
 //! This is a separate utility API, not part of the streaming [`IbkrMarketStream`].
 //!
-//! # Example
+//! # Historical Bars Example
 //!
 //! ```ignore
 //! use rustrade_data::exchange::ibkr::historical::{IbkrHistoricalData, HistoricalRequest};
@@ -24,22 +25,58 @@
 //! let candles = client.fetch_candles(request).await?;
 //! ```
 //!
+//! # Historical Ticks Example
+//!
+//! ```ignore
+//! use rustrade_data::exchange::ibkr::historical::{IbkrHistoricalData, HistoricalTickRequest};
+//! use time::macros::datetime;
+//!
+//! let client = IbkrHistoricalData::connect("127.0.0.1:4002", 102)?;
+//! let contract = ibapi::contracts::Contract::stock("AAPL").build();
+//!
+//! let request = HistoricalTickRequest {
+//!     contract,
+//!     start: Some(datetime!(2024-01-15 14:30 UTC)),
+//!     end: None,
+//!     number_of_ticks: 100,
+//!     regular_trading_hours_only: true,
+//! };
+//!
+//! let trades = client.fetch_historical_ticks(request).await?;
+//! ```
+//!
+//! # Why Vec Instead of Stream
+//!
+//! The historical tick methods return `Vec<T>` rather than `Stream<Item = T>` because
+//! ibapi's underlying API is batch-oriented: you request up to 1000 ticks and IB sends
+//! them all in one response. Wrapping a fully-received batch in a Stream would add
+//! complexity without benefit. For large date ranges requiring multiple requests,
+//! consider implementing pagination at the caller level.
+//!
 //! [`IbkrMarketStream`]: super::IbkrMarketStream
 
-use crate::{error::DataError, subscription::candle::Candle};
-use chrono::DateTime;
+use crate::{
+    books::Level,
+    error::DataError,
+    subscription::{book::OrderBookL1, candle::Candle, trade::PublicTrade},
+};
+use chrono::{DateTime, Utc};
 use ibapi::{
     client::blocking::Client,
     contracts::Contract,
     market_data::{
         TradingHours,
-        historical::{BarSize, Duration, WhatToShow},
+        historical::{BarSize, Duration, TickBidAsk, TickLast, WhatToShow},
     },
 };
 use rust_decimal::Decimal;
-use std::sync::Arc;
+use smol_str::format_smolstr;
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 use time::OffsetDateTime;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Re-export commonly used types from ibapi for caller convenience.
 ///
@@ -50,8 +87,9 @@ pub use ibapi::market_data::historical::ToDuration;
 
 /// Historical data fetcher for Interactive Brokers.
 ///
-/// Wraps an IB client connection for fetching historical OHLCV bars.
-/// Unlike [`IbkrMarketStream`], this is a one-shot request/response API.
+/// Wraps an IB client connection for fetching historical OHLCV bars and
+/// tick-level data (trades, bid/ask quotes). Unlike [`IbkrMarketStream`],
+/// this is a one-shot request/response API.
 ///
 /// [`IbkrMarketStream`]: super::IbkrMarketStream
 #[derive(Debug)]
@@ -176,6 +214,173 @@ impl IbkrHistoricalData {
 
         Ok(candles)
     }
+
+    /// Fetch historical trade ticks for the given request.
+    ///
+    /// Returns individual trade executions (time & sales data) as [`PublicTrade`]s.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - Historical tick request parameters
+    ///
+    /// # Returns
+    ///
+    /// Vector of trades in chronological order. Invalid ticks (non-finite prices)
+    /// are filtered out with a warning.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::Socket` if IB rejects the request or network error occurs.
+    ///
+    /// # Notes
+    ///
+    /// - Maximum 1000 ticks per request (IB limit)
+    /// - Trade side is not available from IB historical data
+    /// - For larger ranges, paginate using last tick's timestamp as new `start`
+    pub async fn fetch_historical_ticks(
+        &self,
+        request: HistoricalTickRequest,
+    ) -> Result<Vec<PublicTrade>, DataError> {
+        if request.start.is_none() && request.end.is_none() {
+            return Err(DataError::Socket(
+                "HistoricalTickRequest: at least one of `start` or `end` must be set".into(),
+            ));
+        }
+
+        let client = self.client.clone();
+        let symbol = request.contract.symbol.clone();
+
+        debug!(
+            symbol = %symbol,
+            number_of_ticks = request.number_of_ticks,
+            "Fetching historical trade ticks"
+        );
+
+        let trades = tokio::task::spawn_blocking(move || {
+            let trading_hours = if request.regular_trading_hours_only {
+                TradingHours::Regular
+            } else {
+                TradingHours::Extended
+            };
+
+            let subscription = client
+                .historical_ticks_trade(
+                    &request.contract,
+                    request.start,
+                    request.end,
+                    request.number_of_ticks,
+                    trading_hours,
+                )
+                .map_err(|e| DataError::Socket(format!("historical_ticks_trade: {e}")))?;
+
+            let mut trades =
+                Vec::with_capacity(usize::try_from(request.number_of_ticks).unwrap_or(0));
+            for tick in subscription {
+                if let Some(trade) = tick_last_to_public_trade(&tick) {
+                    trades.push(trade);
+                }
+            }
+
+            Ok::<_, DataError>(trades)
+        })
+        .await
+        .map_err(|e| {
+            if e.is_panic() {
+                DataError::Socket(format!("historical_ticks_trade task panicked: {e}"))
+            } else {
+                DataError::Socket(format!("historical_ticks_trade task cancelled: {e}"))
+            }
+        })??;
+
+        debug!(symbol = %symbol, count = trades.len(), "Received historical trade ticks");
+
+        Ok(trades)
+    }
+
+    /// Fetch historical bid/ask ticks for the given request.
+    ///
+    /// Returns historical best bid/ask quotes as [`OrderBookL1`] snapshots.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - Historical tick request parameters
+    /// * `ignore_size` - If true, return ticks even when size is zero
+    ///
+    /// # Returns
+    ///
+    /// Vector of L1 quotes in chronological order. Invalid ticks (non-finite prices)
+    /// are filtered out with a warning.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DataError::Socket` if IB rejects the request or network error occurs.
+    ///
+    /// # Notes
+    ///
+    /// - Maximum 1000 ticks per request (IB limit)
+    /// - For larger ranges, paginate using last tick's timestamp as new `start`
+    pub async fn fetch_historical_bid_ask(
+        &self,
+        request: HistoricalTickRequest,
+        ignore_size: bool,
+    ) -> Result<Vec<OrderBookL1>, DataError> {
+        if request.start.is_none() && request.end.is_none() {
+            return Err(DataError::Socket(
+                "HistoricalTickRequest: at least one of `start` or `end` must be set".into(),
+            ));
+        }
+
+        let client = self.client.clone();
+        let symbol = request.contract.symbol.clone();
+
+        debug!(
+            symbol = %symbol,
+            number_of_ticks = request.number_of_ticks,
+            ignore_size,
+            "Fetching historical bid/ask ticks"
+        );
+
+        let quotes = tokio::task::spawn_blocking(move || {
+            let trading_hours = if request.regular_trading_hours_only {
+                TradingHours::Regular
+            } else {
+                TradingHours::Extended
+            };
+
+            let subscription = client
+                .historical_ticks_bid_ask(
+                    &request.contract,
+                    request.start,
+                    request.end,
+                    request.number_of_ticks,
+                    trading_hours,
+                    ignore_size,
+                )
+                .map_err(|e| DataError::Socket(format!("historical_ticks_bid_ask: {e}")))?;
+
+            let mut quotes =
+                Vec::with_capacity(usize::try_from(request.number_of_ticks).unwrap_or(0));
+            for tick in subscription {
+                if let Some(l1) = tick_bid_ask_to_order_book_l1(&tick) {
+                    quotes.push(l1);
+                }
+            }
+
+            Ok::<_, DataError>(quotes)
+        })
+        .await
+        .map_err(|e| {
+            if e.is_panic() {
+                DataError::Socket(format!("historical_ticks_bid_ask task panicked: {e}"))
+            } else {
+                DataError::Socket(format!("historical_ticks_bid_ask task cancelled: {e}"))
+            }
+        })??;
+
+        debug!(symbol = %symbol, count = quotes.len(), "Received historical bid/ask ticks");
+
+        Ok(quotes)
+    }
 }
 
 /// Parameters for a historical data request.
@@ -226,6 +431,144 @@ impl HistoricalRequest {
             regular_trading_hours_only: true,
         }
     }
+}
+
+/// Parameters for a historical tick data request.
+///
+/// Unlike [`HistoricalRequest`] which fetches OHLCV bars, this requests
+/// individual tick-level data (trades or bid/ask quotes).
+///
+/// # Time Range
+///
+/// Either `start` or `end` must be specified (not both `None`).
+/// IB returns ticks forward from `start` or backward from `end`.
+///
+/// # Limits
+///
+/// IB limits requests to 1000 ticks maximum. For larger ranges,
+/// make multiple requests using the last tick's timestamp as the
+/// new `start` time.
+#[derive(Debug, Clone)]
+pub struct HistoricalTickRequest {
+    /// IB contract to fetch tick data for.
+    pub contract: Contract,
+
+    /// Start time for the tick range (fetch forward from here).
+    ///
+    /// Either `start` or `end` must be specified.
+    pub start: Option<OffsetDateTime>,
+
+    /// End time for the tick range (fetch backward to here).
+    ///
+    /// Either `start` or `end` must be specified.
+    pub end: Option<OffsetDateTime>,
+
+    /// Maximum number of ticks to return (max 1000).
+    pub number_of_ticks: i32,
+
+    /// If true, only include ticks from regular trading hours.
+    pub regular_trading_hours_only: bool,
+}
+
+impl HistoricalTickRequest {
+    /// Create a request for recent ticks ending now.
+    ///
+    /// Fetches the most recent `count` ticks (up to 1000) ending at current time.
+    pub fn recent(contract: Contract, count: i32) -> Self {
+        Self {
+            contract,
+            start: None,
+            end: Some(OffsetDateTime::now_utc()),
+            number_of_ticks: count.min(1000),
+            regular_trading_hours_only: true,
+        }
+    }
+}
+
+/// Convert an ibapi `TickLast` (historical trade) to a rustrade `PublicTrade`.
+///
+/// # Side Field
+///
+/// IB historical tick data does not include trade side (buyer/seller initiated).
+/// The `side` field is set to `None`.
+///
+/// # Returns
+///
+/// Returns `None` if price is non-finite (invalid data from IB).
+fn tick_last_to_public_trade(tick: &TickLast) -> Option<PublicTrade> {
+    if !tick.price.is_finite() {
+        warn!(
+            price = tick.price,
+            "Historical tick has non-finite price, skipping"
+        );
+        return None;
+    }
+
+    let price = Decimal::try_from(tick.price).ok()?;
+    let amount = Decimal::from(tick.size);
+
+    Some(PublicTrade {
+        id: generate_tick_id(tick.timestamp, tick.price, tick.size),
+        price,
+        amount,
+        side: None,
+    })
+}
+
+/// Parse timestamp from a historical tick, preserving sub-second precision.
+///
+/// Returns `None` if the Unix timestamp is out of `DateTime<Utc>` range.
+/// Callers should drop the tick rather than substitute a fabricated time
+/// (which would corrupt chronological ordering).
+fn parse_tick_timestamp(timestamp: OffsetDateTime) -> Option<DateTime<Utc>> {
+    let unix_secs = timestamp.unix_timestamp();
+    let dt = DateTime::from_timestamp(unix_secs, timestamp.nanosecond());
+    if dt.is_none() {
+        warn!(
+            unix_timestamp = unix_secs,
+            "Invalid tick timestamp from IB, skipping tick"
+        );
+    }
+    dt
+}
+
+/// Generate a unique ID for a historical tick.
+///
+/// IB doesn't provide tick IDs, so we generate one from a hash of
+/// time + price + size.
+fn generate_tick_id(timestamp: OffsetDateTime, price: f64, size: i32) -> smol_str::SmolStr {
+    let mut hasher = fnv::FnvHasher::default();
+    timestamp.unix_timestamp_nanos().hash(&mut hasher);
+    price.to_bits().hash(&mut hasher);
+    size.hash(&mut hasher);
+    format_smolstr!("{:016x}", hasher.finish())
+}
+
+/// Convert an ibapi `TickBidAsk` to a rustrade `OrderBookL1`.
+///
+/// # Returns
+///
+/// Returns `None` if any price is non-finite (invalid data from IB).
+fn tick_bid_ask_to_order_book_l1(tick: &TickBidAsk) -> Option<OrderBookL1> {
+    if !tick.price_bid.is_finite() || !tick.price_ask.is_finite() {
+        warn!(
+            bid = tick.price_bid,
+            ask = tick.price_ask,
+            "Historical tick has non-finite price, skipping"
+        );
+        return None;
+    }
+
+    let bid_price = Decimal::try_from(tick.price_bid).ok()?;
+    let ask_price = Decimal::try_from(tick.price_ask).ok()?;
+    let bid_amount = Decimal::from(tick.size_bid);
+    let ask_amount = Decimal::from(tick.size_ask);
+
+    Some(OrderBookL1 {
+        last_update_time: parse_tick_timestamp(tick.timestamp)?,
+        best_bid: Some(Level::new(bid_price, bid_amount)),
+        best_ask: Some(Level::new(ask_price, ask_amount)),
+    })
 }
 
 /// Convert an ibapi `Bar` to a rustrade `Candle`.
@@ -335,5 +678,162 @@ mod tests {
         assert!(matches!(request.bar_size, BarSize::Day));
         assert!(matches!(request.what_to_show, WhatToShow::Trades));
         assert!(request.regular_trading_hours_only);
+    }
+
+    #[test]
+    fn historical_tick_request_recent_builder() {
+        let contract = Contract::stock("AAPL").build();
+        let request = HistoricalTickRequest::recent(contract, 500);
+
+        assert_eq!(request.contract.symbol.as_str(), "AAPL");
+        assert!(request.start.is_none());
+        assert!(request.end.is_some()); // IB requires start or end to be set
+        assert_eq!(request.number_of_ticks, 500);
+        assert!(request.regular_trading_hours_only);
+    }
+
+    #[test]
+    fn historical_tick_request_recent_clamps_to_1000() {
+        let contract = Contract::stock("AAPL").build();
+        let request = HistoricalTickRequest::recent(contract, 5000);
+
+        assert_eq!(request.number_of_ticks, 1000);
+    }
+
+    // ========================================================================
+    // Historical Tick Conversion Tests
+    // ========================================================================
+
+    fn make_tick_last(unix_time: i64, price: f64, size: i32) -> TickLast {
+        use ibapi::market_data::historical::TickAttributeLast;
+
+        TickLast {
+            timestamp: time::OffsetDateTime::from_unix_timestamp(unix_time)
+                .unwrap_or(time::OffsetDateTime::UNIX_EPOCH),
+            tick_attribute_last: TickAttributeLast {
+                past_limit: false,
+                unreported: false,
+            },
+            price,
+            size,
+            exchange: String::new(),
+            special_conditions: String::new(),
+        }
+    }
+
+    fn make_tick_bid_ask(
+        unix_time: i64,
+        bid_price: f64,
+        bid_size: i32,
+        ask_price: f64,
+        ask_size: i32,
+    ) -> TickBidAsk {
+        use ibapi::market_data::historical::TickAttributeBidAsk;
+
+        TickBidAsk {
+            timestamp: time::OffsetDateTime::from_unix_timestamp(unix_time)
+                .unwrap_or(time::OffsetDateTime::UNIX_EPOCH),
+            tick_attribute_bid_ask: TickAttributeBidAsk {
+                bid_past_low: false,
+                ask_past_high: false,
+            },
+            price_bid: bid_price,
+            price_ask: ask_price,
+            size_bid: bid_size,
+            size_ask: ask_size,
+        }
+    }
+
+    #[test]
+    fn tick_last_converts_to_public_trade() {
+        use rust_decimal_macros::dec;
+
+        let tick = make_tick_last(1700000000, 150.25, 100);
+        let trade = tick_last_to_public_trade(&tick).unwrap();
+
+        assert_eq!(trade.price, dec!(150.25));
+        assert_eq!(trade.amount, dec!(100));
+        assert!(trade.side.is_none());
+        assert!(!trade.id.is_empty());
+    }
+
+    #[test]
+    fn tick_last_rejects_non_finite_price() {
+        let tick = make_tick_last(1700000000, f64::NAN, 100);
+        assert!(tick_last_to_public_trade(&tick).is_none());
+
+        let tick = make_tick_last(1700000000, f64::INFINITY, 100);
+        assert!(tick_last_to_public_trade(&tick).is_none());
+    }
+
+    #[test]
+    fn tick_last_generates_unique_ids() {
+        let tick1 = make_tick_last(1700000000, 150.25, 100);
+        let tick2 = make_tick_last(1700000001, 150.25, 100);
+        let tick3 = make_tick_last(1700000000, 150.26, 100);
+
+        let id1 = generate_tick_id(tick1.timestamp, tick1.price, tick1.size);
+        let id2 = generate_tick_id(tick2.timestamp, tick2.price, tick2.size);
+        let id3 = generate_tick_id(tick3.timestamp, tick3.price, tick3.size);
+
+        assert_ne!(id1, id2);
+        assert_ne!(id1, id3);
+        assert_ne!(id2, id3);
+    }
+
+    #[test]
+    fn tick_last_same_data_same_id() {
+        let tick1 = make_tick_last(1700000000, 150.25, 100);
+        let tick2 = make_tick_last(1700000000, 150.25, 100);
+
+        let id1 = generate_tick_id(tick1.timestamp, tick1.price, tick1.size);
+        let id2 = generate_tick_id(tick2.timestamp, tick2.price, tick2.size);
+
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn tick_bid_ask_converts_to_order_book_l1() {
+        use rust_decimal_macros::dec;
+
+        let tick = make_tick_bid_ask(1700000000, 150.00, 500, 150.05, 300);
+        let l1 = tick_bid_ask_to_order_book_l1(&tick).unwrap();
+
+        let bid = l1.best_bid.unwrap();
+        let ask = l1.best_ask.unwrap();
+
+        assert_eq!(bid.price, dec!(150.00));
+        assert_eq!(bid.amount, dec!(500));
+        assert_eq!(ask.price, dec!(150.05));
+        assert_eq!(ask.amount, dec!(300));
+        assert_eq!(l1.last_update_time.timestamp(), 1700000000);
+    }
+
+    #[test]
+    fn tick_bid_ask_rejects_non_finite_prices() {
+        let tick = make_tick_bid_ask(1700000000, f64::NAN, 500, 150.05, 300);
+        assert!(tick_bid_ask_to_order_book_l1(&tick).is_none());
+
+        let tick = make_tick_bid_ask(1700000000, 150.00, 500, f64::INFINITY, 300);
+        assert!(tick_bid_ask_to_order_book_l1(&tick).is_none());
+    }
+
+    #[test]
+    fn parse_tick_timestamp_converts_correctly() {
+        let ts = time::OffsetDateTime::from_unix_timestamp(1700000000).unwrap();
+        let dt = parse_tick_timestamp(ts).unwrap();
+
+        assert_eq!(dt.timestamp(), 1700000000);
+        assert_eq!(dt.timestamp_subsec_nanos(), 0);
+    }
+
+    #[test]
+    fn parse_tick_timestamp_preserves_subsecond_nanos() {
+        let ts =
+            time::OffsetDateTime::from_unix_timestamp_nanos(1_700_000_000_123_456_789).unwrap();
+        let dt = parse_tick_timestamp(ts).unwrap();
+
+        assert_eq!(dt.timestamp(), 1700000000);
+        assert_eq!(dt.timestamp_subsec_nanos(), 123_456_789);
     }
 }

--- a/rustrade-data/src/exchange/ibkr/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/mod.rs
@@ -45,7 +45,9 @@
 //! [`Candle`]: crate::subscription::candle::Candle
 
 pub mod depth;
+pub mod greeks;
 pub mod historical;
+pub mod options;
 pub mod quotes;
 pub mod subscription;
 pub mod trades;
@@ -56,7 +58,8 @@ use crate::{
 };
 use chrono::Utc;
 use depth::DepthAggregator;
-use ibapi::client::blocking::Client;
+use greeks::GreeksAggregator;
+use ibapi::{client::blocking::Client, contracts::SecurityType};
 use quotes::QuoteAggregator;
 use rust_decimal::Decimal;
 use rustrade_instrument::{exchange::ExchangeId, ibkr::ContractRegistry};
@@ -196,6 +199,12 @@ where
                     tx.clone(),
                 ),
                 IbkrSubscriptionKind::Trades => Self::run_trades_subscription(
+                    client.clone(),
+                    contract,
+                    sub.key.clone(),
+                    tx.clone(),
+                ),
+                IbkrSubscriptionKind::OptionGreeks => Self::run_option_greeks_subscription(
                     client.clone(),
                     contract,
                     sub.key.clone(),
@@ -429,6 +438,81 @@ where
                 }
             })
             .map_err(|e| DataError::Socket(format!("Failed to spawn trades thread: {e}")))?;
+        Ok(())
+    }
+
+    fn run_option_greeks_subscription(
+        client: Arc<Client>,
+        contract: ibapi::contracts::Contract,
+        key: K,
+        tx: mpsc::UnboundedSender<Result<MarketEvent<K, DataKind>, DataError>>,
+    ) -> Result<(), DataError> {
+        if contract.security_type != SecurityType::Option {
+            return Err(DataError::Socket(format!(
+                "option Greeks subscription requires SecurityType::Option, got {:?} for {}",
+                contract.security_type, contract.symbol
+            )));
+        }
+
+        let symbol = contract.symbol.to_string();
+        let symbol_clone = symbol.clone();
+        let tx_panic = tx.clone();
+
+        std::thread::Builder::new()
+            .name(format!("ibkr-greeks-{symbol}"))
+            .spawn(move || {
+                // Panic safety: parking_lot mutexes do not poison on panic, so shared state
+                // (ContractRegistry, etc.) remains usable. On panic the thread exits,
+                // tx is dropped, and the stream closes — caller observes EOF.
+                let result = catch_unwind(AssertUnwindSafe(|| {
+                    debug!(symbol = %symbol, "Starting option Greeks subscription");
+
+                    let sub = match client.market_data(&contract).subscribe() {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!(symbol = %symbol, error = %e, "Failed to subscribe to option Greeks");
+                            let _ = tx.send(Err(DataError::Socket(format!(
+                                "option Greeks subscription {symbol}: {e}"
+                            ))));
+                            return;
+                        }
+                    };
+
+                    let aggregator = GreeksAggregator::new();
+
+                    for tick in sub {
+                        if let Some(greeks) = aggregator.update(&tick) {
+                            let now = Utc::now();
+                            let event = MarketEvent {
+                                time_exchange: now,
+                                time_received: now,
+                                exchange: ExchangeId::Ibkr,
+                                instrument: key.clone(),
+                                kind: DataKind::OptionGreeks(greeks),
+                            };
+
+                            if tx.send(Ok(event)).is_err() {
+                                break;
+                            }
+                        }
+                    }
+
+                    debug!(symbol = %symbol, "Option Greeks subscription ended");
+                }));
+
+                if let Err(panic_info) = result {
+                    let msg = panic_info
+                        .downcast_ref::<&str>()
+                        .map(|s| s.to_string())
+                        .or_else(|| panic_info.downcast_ref::<String>().cloned())
+                        .unwrap_or_else(|| "unknown panic".to_string());
+                    error!(symbol = %symbol_clone, "Option Greeks worker panicked: {msg}");
+                    let _ = tx_panic.send(Err(DataError::Socket(format!(
+                        "option Greeks subscription {symbol_clone} panicked: {msg}"
+                    ))));
+                }
+            })
+            .map_err(|e| DataError::Socket(format!("Failed to spawn option Greeks thread: {e}")))?;
         Ok(())
     }
 }

--- a/rustrade-data/src/exchange/ibkr/options.rs
+++ b/rustrade-data/src/exchange/ibkr/options.rs
@@ -1,0 +1,188 @@
+//! Option Greeks and chain data types for Interactive Brokers.
+//!
+//! This module provides IBKR-specific functionality for option analytics:
+//!
+//! - Conversion from ibapi's `OptionComputation` to [`OptionGreeks`]
+//! - [`OptionChainEntry`] for option chain metadata
+//!
+//! The core [`OptionGreeks`] type is defined in [`subscription::greeks`] and
+//! re-exported here for convenience.
+//!
+//! # Calculator vs Real-Time
+//!
+//! IB provides two ways to get Greeks:
+//!
+//! 1. **Calculators** (Phase 5A): You provide volatility/price inputs, IB computes Greeks.
+//!    See [`IbkrHistoricalData::calculate_theoretical_greeks`] and
+//!    [`IbkrHistoricalData::calculate_implied_volatility`].
+//!
+//! 2. **Real-time ticks** (Phase 5B): Subscribe to option market data, receive
+//!    Greeks computed from live prices via `TickTypes::OptionComputation`.
+//!
+//! # Subscription Requirements
+//!
+//! Option Greeks require OPRA subscription ($1.50/mo) for US options.
+//!
+//! [`subscription::greeks`]: crate::subscription::greeks
+//! [`IbkrHistoricalData::calculate_theoretical_greeks`]: super::historical::IbkrHistoricalData::calculate_theoretical_greeks
+//! [`IbkrHistoricalData::calculate_implied_volatility`]: super::historical::IbkrHistoricalData::calculate_implied_volatility
+
+use chrono::NaiveDate;
+use ibapi::contracts::{OptionChain, OptionComputation};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+pub use crate::subscription::greeks::OptionGreeks;
+
+impl OptionGreeks {
+    /// Convert from ibapi's `OptionComputation` to [`OptionGreeks`].
+    pub(crate) fn from_ib(computation: &OptionComputation) -> Self {
+        Self {
+            delta: computation.delta,
+            gamma: computation.gamma,
+            theta: computation.theta,
+            vega: computation.vega,
+            implied_volatility: computation.implied_volatility,
+            theoretical_price: computation.option_price,
+            underlying_price: computation.underlying_price,
+        }
+    }
+}
+
+/// Option chain entry for a specific exchange.
+///
+/// Represents available option series for an underlying on a particular exchange.
+/// Use [`IbkrHistoricalData::fetch_option_chain`] to retrieve this data.
+///
+/// [`IbkrHistoricalData::fetch_option_chain`]: super::historical::IbkrHistoricalData::fetch_option_chain
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OptionChainEntry {
+    /// Contract ID of the underlying security.
+    pub underlying_contract_id: i32,
+    /// Option trading class (e.g., "AAPL" for standard, "AAPL7" for weekly).
+    pub trading_class: String,
+    /// Option multiplier (e.g., "100" for standard equity options).
+    pub multiplier: String,
+    /// Exchange where this option series trades.
+    pub exchange: String,
+    /// Available expiration dates.
+    pub expirations: Vec<NaiveDate>,
+    /// Available strike prices.
+    pub strikes: Vec<Decimal>,
+}
+
+impl OptionChainEntry {
+    /// Create OptionChainEntry from ibapi's OptionChain.
+    ///
+    /// Expirations that fail YYYYMMDD parsing and strike prices that fail
+    /// f64→Decimal conversion (NaN/Infinity/IB sentinel values) are skipped.
+    pub fn from_ib(chain: &OptionChain) -> Self {
+        Self {
+            underlying_contract_id: chain.underlying_contract_id,
+            trading_class: chain.trading_class.clone(),
+            multiplier: chain.multiplier.clone(),
+            exchange: chain.exchange.clone(),
+            expirations: chain
+                .expirations
+                .iter()
+                .filter_map(|s| NaiveDate::parse_from_str(s, "%Y%m%d").ok())
+                .collect(),
+            strikes: chain
+                .strikes
+                .iter()
+                .filter_map(|&s| super::decimal_from_f64(s))
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn option_greeks_from_ib_computation() {
+        use ibapi::contracts::{OptionComputation, tick_types::TickType};
+
+        let computation = OptionComputation {
+            field: TickType::ModelOption,
+            tick_attribute: Some(1),
+            delta: Some(0.55),
+            gamma: Some(0.02),
+            theta: Some(-0.05),
+            vega: Some(0.15),
+            implied_volatility: Some(0.25),
+            option_price: Some(5.50),
+            underlying_price: Some(150.0),
+            present_value_dividend: Some(0.0),
+        };
+
+        let greeks = OptionGreeks::from_ib(&computation);
+
+        assert_eq!(greeks.delta, Some(0.55));
+        assert_eq!(greeks.gamma, Some(0.02));
+        assert_eq!(greeks.theta, Some(-0.05));
+        assert_eq!(greeks.vega, Some(0.15));
+        assert_eq!(greeks.implied_volatility, Some(0.25));
+        assert_eq!(greeks.theoretical_price, Some(5.50));
+        assert_eq!(greeks.underlying_price, Some(150.0));
+        assert!(greeks.has_any_greek());
+    }
+
+    #[test]
+    fn option_greeks_empty_has_any_greek_false() {
+        let greeks = OptionGreeks::default();
+        assert!(!greeks.has_any_greek());
+    }
+
+    #[test]
+    fn option_chain_entry_from_ib() {
+        let chain = OptionChain {
+            underlying_contract_id: 265598,
+            trading_class: "AAPL".to_string(),
+            multiplier: "100".to_string(),
+            exchange: "SMART".to_string(),
+            expirations: vec!["20240119".to_string(), "20240216".to_string()],
+            strikes: vec![140.0, 145.0, 150.0, 155.0, 160.0],
+        };
+
+        let entry = OptionChainEntry::from_ib(&chain);
+
+        assert_eq!(entry.underlying_contract_id, 265598);
+        assert_eq!(entry.trading_class, "AAPL");
+        assert_eq!(entry.multiplier, "100");
+        assert_eq!(entry.exchange, "SMART");
+        assert_eq!(entry.expirations.len(), 2);
+        assert_eq!(
+            entry.expirations[0],
+            NaiveDate::from_ymd_opt(2024, 1, 19).unwrap()
+        );
+        assert_eq!(
+            entry.expirations[1],
+            NaiveDate::from_ymd_opt(2024, 2, 16).unwrap()
+        );
+        assert_eq!(entry.strikes.len(), 5);
+    }
+
+    #[test]
+    fn option_chain_entry_skips_invalid_expirations() {
+        let chain = OptionChain {
+            underlying_contract_id: 265598,
+            trading_class: "AAPL".to_string(),
+            multiplier: "100".to_string(),
+            exchange: "SMART".to_string(),
+            expirations: vec![
+                "20240119".to_string(),
+                "invalid".to_string(),
+                "20240216".to_string(),
+            ],
+            strikes: vec![150.0],
+        };
+
+        let entry = OptionChainEntry::from_ib(&chain);
+
+        assert_eq!(entry.expirations.len(), 2);
+    }
+}

--- a/rustrade-data/src/exchange/ibkr/subscription.rs
+++ b/rustrade-data/src/exchange/ibkr/subscription.rs
@@ -59,6 +59,22 @@ impl<K> IbkrSubscription<K> {
             kind: IbkrSubscriptionKind::Trades,
         }
     }
+
+    /// Create an option Greeks subscription.
+    ///
+    /// Use for option contracts to receive real-time Greeks (delta, gamma, theta,
+    /// vega, implied volatility) computed from live market prices.
+    ///
+    /// # Subscription Requirements
+    ///
+    /// Requires OPRA subscription ($1.50/mo) for US options.
+    pub fn option_greeks(key: K, instrument: InstrumentNameExchange) -> Self {
+        Self {
+            key,
+            instrument,
+            kind: IbkrSubscriptionKind::OptionGreeks,
+        }
+    }
 }
 
 /// Type of IBKR market data subscription.
@@ -73,6 +89,12 @@ pub enum IbkrSubscriptionKind {
     },
     /// Tick-by-tick trades via tick_by_tick()
     Trades,
+    /// Real-time option Greeks via market_data() with OptionComputation ticks.
+    ///
+    /// Use this for option contracts to receive live Greeks (delta, gamma, theta,
+    /// vega, IV) computed from market prices. Requires OPRA subscription for US
+    /// options.
+    OptionGreeks,
 }
 
 #[cfg(test)]

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -100,6 +100,10 @@
 // Silence unused_crate_dependencies for dev-dependencies used only in tests
 #[cfg(test)]
 use tracing_subscriber as _;
+// serial_test is only referenced by integration tests under the `massive` feature
+// (tests/massive_integration.rs), which compile as separate units.
+#[cfg(test)]
+use serial_test as _;
 
 use crate::{
     error::DataError,

--- a/rustrade-data/src/subscription/greeks.rs
+++ b/rustrade-data/src/subscription/greeks.rs
@@ -1,0 +1,100 @@
+//! Option Greeks subscription type.
+//!
+//! This module defines the [`OptionGreeks`] data type for option analytics
+//! (delta, gamma, theta, vega, implied volatility).
+//!
+//! Unlike other subscription types in this module, Greeks are typically
+//! computed by the exchange/broker from live market data rather than being
+//! raw market data themselves.
+
+use serde::{Deserialize, Serialize};
+
+/// Option Greeks values.
+///
+/// All fields are optional because the data source may not return all Greeks
+/// depending on the contract type, market state, or subscription level.
+///
+/// # Fields
+///
+/// - `delta`: Rate of change of option price with respect to underlying price
+/// - `gamma`: Rate of change of delta with respect to underlying price
+/// - `theta`: Rate of change of option price with respect to time (per day)
+/// - `vega`: Rate of change of option price with respect to volatility
+/// - `implied_volatility`: Market-implied volatility
+/// - `theoretical_price`: Model price computed by the exchange/broker
+/// - `underlying_price`: Current underlying price used in computation
+///
+/// # Note on Precision
+///
+/// Values are stored as `f64` rather than `Decimal` because Greeks are
+/// analytics (not monetary values) and the precision loss is acceptable.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct OptionGreeks {
+    pub delta: Option<f64>,
+    pub gamma: Option<f64>,
+    pub theta: Option<f64>,
+    pub vega: Option<f64>,
+    pub implied_volatility: Option<f64>,
+    pub theoretical_price: Option<f64>,
+    pub underlying_price: Option<f64>,
+}
+
+impl OptionGreeks {
+    /// Returns true if at least one first-order Greek (delta, gamma, theta,
+    /// vega, or implied volatility) is present.
+    ///
+    /// Does NOT consider `theoretical_price` or `underlying_price` — a tick
+    /// containing only those fields is treated as having no Greek data.
+    pub fn has_any_greek(&self) -> bool {
+        self.delta.is_some()
+            || self.gamma.is_some()
+            || self.theta.is_some()
+            || self.vega.is_some()
+            || self.implied_volatility.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn option_greeks_default_has_no_values() {
+        let greeks = OptionGreeks::default();
+        assert!(!greeks.has_any_greek());
+    }
+
+    #[test]
+    fn option_greeks_partial_has_any_greek() {
+        let greeks = OptionGreeks {
+            delta: Some(0.55),
+            ..Default::default()
+        };
+        assert!(greeks.has_any_greek());
+    }
+
+    #[test]
+    fn option_greeks_full_has_any_greek() {
+        let greeks = OptionGreeks {
+            delta: Some(0.55),
+            gamma: Some(0.02),
+            theta: Some(-0.05),
+            vega: Some(0.15),
+            implied_volatility: Some(0.25),
+            theoretical_price: Some(5.50),
+            underlying_price: Some(150.0),
+        };
+        assert!(greeks.has_any_greek());
+    }
+
+    #[test]
+    fn option_greeks_price_only_has_no_greek() {
+        let greeks = OptionGreeks {
+            theoretical_price: Some(5.50),
+            underlying_price: Some(150.0),
+            ..Default::default()
+        };
+        assert!(!greeks.has_any_greek());
+    }
+}

--- a/rustrade-data/src/subscription/mod.rs
+++ b/rustrade-data/src/subscription/mod.rs
@@ -20,6 +20,9 @@ pub mod book;
 /// Candle [`SubscriptionKind`] and the associated Barter output data model.
 pub mod candle;
 
+/// Option Greeks data model for options analytics.
+pub mod greeks;
+
 /// Liquidation [`SubscriptionKind`] and the associated Barter output data model.
 pub mod liquidation;
 

--- a/rustrade-data/tests/ibkr_integration.rs
+++ b/rustrade-data/tests/ibkr_integration.rs
@@ -31,7 +31,7 @@ use rustrade_data::{
     event::DataKind,
     exchange::ibkr::{
         IbkrMarketStream, IbkrStreamConfig,
-        historical::{HistoricalRequest, IbkrHistoricalData, ToDuration},
+        historical::{HistoricalRequest, HistoricalTickRequest, IbkrHistoricalData, ToDuration},
         subscription::{IbkrSubscription, IbkrSubscriptionKind},
     },
 };
@@ -348,6 +348,165 @@ async fn test_historical_from_shared_client() {
         "Expected at least one candle from shared client"
     );
     println!("Received {} candles from shared client", candles.len());
+}
+
+// ============================================================================
+// Historical Tick Data Tests (Task 13.4)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_historical_ticks_trade() {
+    init_logging();
+
+    let url = format!("127.0.0.1:{}", test_port());
+    let client_id = test_client_id_base() + 6;
+
+    let client = connect_historical(&url, client_id)
+        .await
+        .expect("connection failed");
+
+    let contract = aapl_contract();
+    let request = HistoricalTickRequest::recent(contract, 100);
+
+    println!("Fetching recent 100 AAPL trade ticks...");
+
+    let result = client.fetch_historical_ticks(request).await;
+
+    assert!(
+        result.is_ok(),
+        "fetch_historical_ticks failed: {:?}",
+        result.err()
+    );
+
+    let trades = result.unwrap();
+    println!("Received {} trade ticks", trades.len());
+
+    // May be empty outside market hours
+    if !trades.is_empty() {
+        for trade in trades.iter().take(5) {
+            println!(
+                "  Trade: id={} price={:.2} amount={} side={:?}",
+                trade.id, trade.price, trade.amount, trade.side
+            );
+        }
+
+        let first = &trades[0];
+        assert!(
+            !first.price.is_zero(),
+            "Trade price should be non-zero: {}",
+            first.price
+        );
+        assert!(
+            first.side.is_none(),
+            "IB historical ticks have no side info"
+        );
+    } else {
+        println!("No ticks available (normal outside market hours)");
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_historical_ticks_bid_ask() {
+    init_logging();
+
+    let url = format!("127.0.0.1:{}", test_port());
+    let client_id = test_client_id_base() + 7;
+
+    let client = connect_historical(&url, client_id)
+        .await
+        .expect("connection failed");
+
+    let contract = aapl_contract();
+    let request = HistoricalTickRequest::recent(contract, 100);
+
+    println!("Fetching recent 100 AAPL bid/ask ticks...");
+
+    let result = client.fetch_historical_bid_ask(request, false).await;
+
+    assert!(
+        result.is_ok(),
+        "fetch_historical_bid_ask failed: {:?}",
+        result.err()
+    );
+
+    let quotes = result.unwrap();
+    println!("Received {} bid/ask ticks", quotes.len());
+
+    // May be empty outside market hours
+    if !quotes.is_empty() {
+        for l1 in quotes.iter().take(5) {
+            let bid = l1.best_bid.as_ref().map(|b| format!("{:.2}", b.price));
+            let ask = l1.best_ask.as_ref().map(|a| format!("{:.2}", a.price));
+            println!(
+                "  L1: time={} bid={:?} ask={:?}",
+                l1.last_update_time.format("%H:%M:%S"),
+                bid,
+                ask
+            );
+        }
+
+        let first = &quotes[0];
+        assert!(
+            first.best_bid.is_some() && first.best_ask.is_some(),
+            "Expected both bid and ask to be present"
+        );
+
+        let bid = first.best_bid.as_ref().unwrap();
+        let ask = first.best_ask.as_ref().unwrap();
+        assert!(
+            bid.price < ask.price,
+            "Bid {:.4} should be less than ask {:.4}",
+            bid.price,
+            ask.price
+        );
+    } else {
+        println!("No ticks available (normal outside market hours)");
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_historical_ticks_with_time_range() {
+    use time::macros::datetime;
+
+    init_logging();
+
+    let url = format!("127.0.0.1:{}", test_port());
+    let client_id = test_client_id_base() + 8;
+
+    let client = connect_historical(&url, client_id)
+        .await
+        .expect("connection failed");
+
+    let contract = aapl_contract();
+
+    // Request ticks from a specific time (adjust date as needed for testing)
+    let request = HistoricalTickRequest {
+        contract,
+        start: Some(datetime!(2024-01-15 14:30 UTC)),
+        end: None,
+        number_of_ticks: 50,
+        regular_trading_hours_only: true,
+    };
+
+    println!("Fetching 50 AAPL trade ticks starting from 2024-01-15 14:30 UTC...");
+
+    let result = client.fetch_historical_ticks(request).await;
+
+    // This may fail if the date is too old or no data available
+    match result {
+        Ok(trades) => {
+            println!("Received {} trade ticks", trades.len());
+            for trade in trades.iter().take(3) {
+                println!("  Trade: price={:.2} amount={}", trade.price, trade.amount);
+            }
+        }
+        Err(e) => {
+            println!("Request failed (expected if date too old): {}", e);
+        }
+    }
 }
 
 // ============================================================================

--- a/rustrade-data/tests/ibkr_integration.rs
+++ b/rustrade-data/tests/ibkr_integration.rs
@@ -24,7 +24,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Integration tests: panics are the correct failure mode
 
 use ibapi::{
-    contracts::Contract,
+    contracts::{Contract, SecurityType},
     market_data::historical::{BarSize, WhatToShow},
 };
 use rustrade_data::{
@@ -814,4 +814,233 @@ async fn test_contract_resolution() {
             .get_name_by_con_id(first.contract.contract_id)
             .is_some()
     );
+}
+
+// ============================================================================
+// Option Greeks Calculator Tests (Phase 5A)
+// ============================================================================
+
+/// Create an AAPL call option contract for testing.
+///
+/// Uses a near-the-money strike with an expiration ~30 days out.
+/// Adjust expiration date to a valid future date when running tests.
+fn aapl_call_option() -> Contract {
+    // Note: Update expiration date to a valid future date before running
+    Contract::call("AAPL")
+        .strike(200.0)
+        .expires_on(2027, 6, 18) // Third Friday of June 2027
+        .build()
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_calculate_theoretical_greeks() {
+    init_logging();
+
+    let url = format!("127.0.0.1:{}", test_port());
+    let client_id = test_client_id_base() + 30;
+
+    let client = IbkrHistoricalData::connect(&url, client_id).expect("connection failed");
+
+    let option = aapl_call_option();
+
+    println!("Calculating theoretical Greeks for AAPL call option...");
+    println!("  Strike: {}", option.strike);
+    println!("  Using volatility: 25% (0.25)");
+    println!("  Using underlying price: $200.00");
+
+    let greeks = client
+        .calculate_theoretical_greeks(&option, 0.25, 200.0)
+        .await;
+
+    match greeks {
+        Ok(g) => {
+            println!("Theoretical Greeks:");
+            if let Some(delta) = g.delta {
+                println!("  Delta: {:.4}", delta);
+            }
+            if let Some(gamma) = g.gamma {
+                println!("  Gamma: {:.4}", gamma);
+            }
+            if let Some(theta) = g.theta {
+                println!("  Theta: {:.4}", theta);
+            }
+            if let Some(vega) = g.vega {
+                println!("  Vega: {:.4}", vega);
+            }
+            if let Some(price) = g.theoretical_price {
+                println!("  Theoretical Price: ${:.2}", price);
+            }
+
+            // For an ATM call with reasonable inputs, delta should be around 0.5
+            assert!(
+                g.has_any_greek(),
+                "Expected at least some Greeks to be computed"
+            );
+        }
+        Err(e) => panic!("calculate_theoretical_greeks failed: {e}"),
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_calculate_implied_volatility() {
+    init_logging();
+
+    let url = format!("127.0.0.1:{}", test_port());
+    let client_id = test_client_id_base() + 31;
+
+    let client = IbkrHistoricalData::connect(&url, client_id).expect("connection failed");
+
+    let option = aapl_call_option();
+
+    println!("Calculating implied volatility for AAPL call option...");
+    println!("  Strike: {}", option.strike);
+    println!("  Using option price: $10.00");
+    println!("  Using underlying price: $200.00");
+
+    let greeks = client
+        .calculate_implied_volatility(&option, 10.0, 200.0)
+        .await;
+
+    match greeks {
+        Ok(g) => {
+            println!("Implied Volatility Result:");
+            if let Some(iv) = g.implied_volatility {
+                println!("  IV: {:.2}%", iv * 100.0);
+            }
+            if let Some(delta) = g.delta {
+                println!("  Delta: {:.4}", delta);
+            }
+
+            assert!(g.implied_volatility.is_some(), "Expected IV to be computed");
+        }
+        Err(e) => panic!("calculate_implied_volatility failed: {e}"),
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_fetch_option_chain() {
+    init_logging();
+
+    let url = format!("127.0.0.1:{}", test_port());
+    let client_id = test_client_id_base() + 32;
+
+    let client = IbkrHistoricalData::connect(&url, client_id).expect("connection failed");
+
+    println!("Fetching option chain for AAPL...");
+
+    let chains = client
+        .fetch_option_chain("AAPL", "SMART", SecurityType::Stock, 0)
+        .await;
+
+    match chains {
+        Ok(entries) => {
+            println!("Received {} option chain entries:", entries.len());
+            for (i, entry) in entries.iter().take(3).enumerate() {
+                println!("Entry {}:", i + 1);
+                println!("  Exchange: {}", entry.exchange);
+                println!("  Trading Class: {}", entry.trading_class);
+                println!("  Multiplier: {}", entry.multiplier);
+                println!("  Expirations: {} available", entry.expirations.len());
+                if !entry.expirations.is_empty() {
+                    println!(
+                        "    First few: {:?}",
+                        &entry.expirations[..3.min(entry.expirations.len())]
+                    );
+                }
+                println!("  Strikes: {} available", entry.strikes.len());
+                if !entry.strikes.is_empty() {
+                    println!(
+                        "    First few: {:?}",
+                        &entry.strikes[..3.min(entry.strikes.len())]
+                    );
+                }
+            }
+
+            assert!(
+                !entries.is_empty(),
+                "Expected at least one option chain entry"
+            );
+        }
+        Err(e) => {
+            println!("Fetch failed: {}", e);
+            // Option chain data should be available for AAPL without special subscriptions
+            panic!("Option chain fetch failed: {}", e);
+        }
+    }
+}
+
+// ============================================================================
+// Real-Time Option Greeks Streaming Tests (Phase 5B)
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_option_greeks_stream() {
+    init_logging();
+
+    let config = IbkrStreamConfig {
+        host: "127.0.0.1".to_string(),
+        port: test_port(),
+        client_id: test_client_id_base() + 33,
+    };
+
+    let option = aapl_call_option();
+
+    let registry = ContractRegistry::new();
+    registry.register("AAPL_CALL".into(), option);
+    let registry = Arc::new(registry);
+
+    let subscriptions = vec![IbkrSubscription {
+        instrument: "AAPL_CALL".into(),
+        key: "AAPL_CALL".to_string(),
+        kind: IbkrSubscriptionKind::OptionGreeks,
+    }];
+
+    let result = IbkrMarketStream::init(config, registry, subscriptions);
+
+    match result {
+        Ok(mut stream) => {
+            println!("Option Greeks stream initialized");
+            println!("Waiting for Greeks updates (10 second timeout)...");
+            println!("Note: Requires OPRA subscription for live Greeks");
+
+            let timeout_result = tokio::time::timeout(Duration::from_secs(10), async {
+                let mut greeks_count = 0;
+                while let Some(result) = stream.next().await {
+                    match result {
+                        Ok(event) => {
+                            if let DataKind::OptionGreeks(g) = &event.kind {
+                                println!("Greeks update:");
+                                if let Some(delta) = g.delta {
+                                    println!("  Delta: {:.4}", delta);
+                                }
+                                if let Some(iv) = g.implied_volatility {
+                                    println!("  IV: {:.2}%", iv * 100.0);
+                                }
+                                greeks_count += 1;
+                                if greeks_count >= 3 {
+                                    break;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            println!("Stream error: {:?}", e);
+                            break;
+                        }
+                    }
+                }
+                greeks_count
+            })
+            .await;
+
+            match timeout_result {
+                Ok(count) => println!("Received {} Greeks updates", count),
+                Err(_) => println!("Timeout (requires OPRA subscription for live Greeks)"),
+            }
+        }
+        Err(e) => panic!("Stream init failed: {e}"),
+    }
 }

--- a/rustrade-data/tests/ibkr_integration.rs
+++ b/rustrade-data/tests/ibkr_integration.rs
@@ -2,10 +2,15 @@
 //!
 //! These tests require IB Gateway or TWS running on localhost:4002 (paper account).
 //!
+//! # Safety
+//!
+//! **All tests use paper trading accounts only.** Tests connect to port 4002 (Gateway paper)
+//! or 7497 (TWS paper). Never configure these tests to use a live trading account.
+//!
 //! # Prerequisites
 //!
 //! 1. IB Gateway or TWS running with API enabled
-//! 2. Market data subscriptions for test instruments (AAPL)
+//! 2. Market data subscriptions for test instruments (see tiers below)
 //! 3. Port 4002 (Gateway paper) or 7497 (TWS paper)
 //!
 //! # Running
@@ -19,6 +24,57 @@
 //! ```
 //!
 //! Tests are marked `#[ignore]` to avoid CI failures without IB connectivity.
+//!
+//! # Subscription Tiers
+//!
+//! Tests are organized by the market data subscriptions required to run them.
+//!
+//! ## Tier 0: Connection Only (FREE)
+//!
+//! No market data subscriptions needed.
+//!
+//! | Test | Description |
+//! |------|-------------|
+//! | `test_historical_connection` | Connect to IB for historical data |
+//! | `test_historical_from_shared_client` | Use shared ibapi client |
+//! | `test_market_stream_connection` | Initialize market stream |
+//! | `test_market_stream_unregistered_contract` | Verify rejection for unknown contract |
+//! | `test_contract_resolution` | Resolve contract details |
+//!
+//! ## Tier 1: US Real-Time Non-Consolidated (FREE with IBKR Pro)
+//!
+//! Included with IBKR Pro accounts. Provides IEX/Cboe data (not consolidated NBBO).
+//!
+//! | Test | Description |
+//! |------|-------------|
+//! | `test_historical_daily_bars` | Fetch daily OHLCV bars |
+//! | `test_historical_hourly_bars` | Fetch hourly bars |
+//! | `test_historical_minute_bars` | Fetch 1-minute bars |
+//! | `test_historical_midpoint_data` | Fetch midpoint bars |
+//! | `test_historical_ticks_trade` | Fetch historical trade ticks |
+//! | `test_historical_ticks_bid_ask` | Fetch historical bid/ask ticks |
+//! | `test_historical_ticks_with_time_range` | Fetch ticks with specific time range |
+//! | `test_market_stream_quotes` | Stream L1 quotes |
+//! | `test_market_stream_multiple_subscriptions` | Stream multiple symbols |
+//! | `test_calculate_theoretical_greeks` | Calculate option Greeks (calculator, no data) |
+//! | `test_calculate_implied_volatility` | Calculate IV (calculator, no data) |
+//! | `test_fetch_option_chain` | Fetch option chain structure |
+//!
+//! ## Tier 2: L2 Market Depth (PAID — varies by exchange)
+//!
+//! Requires exchange-specific L2 subscription.
+//!
+//! | Test | Description |
+//! |------|-------------|
+//! | `test_market_stream_depth` | Stream L2 order book depth |
+//!
+//! ## Tier 3: OPRA US Options ($1.50/mo)
+//!
+//! Required for real-time options quotes and Greeks.
+//!
+//! | Test | Description |
+//! |------|-------------|
+//! | `test_option_greeks_stream` | Stream real-time option Greeks |
 
 #![cfg(feature = "ibkr")]
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Integration tests: panics are the correct failure mode
@@ -92,7 +148,7 @@ async fn connect_raw_client(
 }
 
 // ============================================================================
-// Historical Data Tests (Task 3.3.5)
+// Historical Data Tests (Task 3.3.5) — Tier 0/1: Connection + US Real-Time (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -351,7 +407,7 @@ async fn test_historical_from_shared_client() {
 }
 
 // ============================================================================
-// Historical Tick Data Tests (Task 13.4)
+// Historical Tick Data Tests (Task 13.4) — Tier 1: US Real-Time (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -510,9 +566,10 @@ async fn test_historical_ticks_with_time_range() {
 }
 
 // ============================================================================
-// Market Data Stream Tests (Task 3.2.7)
+// Market Data Stream Tests (Task 3.2.7) — Tier 0/1/2: Varies by test
 // ============================================================================
 
+/// Tier 0: Connection Only (FREE)
 #[tokio::test]
 #[ignore]
 async fn test_market_stream_connection() {
@@ -545,6 +602,7 @@ async fn test_market_stream_connection() {
     println!("Market stream initialized successfully");
 }
 
+/// Tier 1: US Real-Time Non-Consolidated (FREE with IBKR Pro)
 #[tokio::test]
 #[ignore]
 async fn test_market_stream_quotes() {
@@ -609,6 +667,7 @@ async fn test_market_stream_quotes() {
     }
 }
 
+/// Tier 2: L2 Market Depth (PAID — varies by exchange)
 #[tokio::test]
 #[ignore]
 async fn test_market_stream_depth() {
@@ -666,6 +725,7 @@ async fn test_market_stream_depth() {
     }
 }
 
+/// Tier 0: Connection Only (FREE)
 #[tokio::test]
 #[ignore]
 async fn test_market_stream_unregistered_contract() {
@@ -697,6 +757,7 @@ async fn test_market_stream_unregistered_contract() {
     );
 }
 
+/// Tier 1: US Real-Time Non-Consolidated (FREE with IBKR Pro)
 #[tokio::test]
 #[ignore]
 async fn test_market_stream_multiple_subscriptions() {
@@ -764,7 +825,7 @@ async fn test_market_stream_multiple_subscriptions() {
 }
 
 // ============================================================================
-// Contract Registry Integration
+// Contract Registry Integration — Tier 0: Connection Only (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -817,8 +878,10 @@ async fn test_contract_resolution() {
 }
 
 // ============================================================================
-// Option Greeks Calculator Tests (Phase 5A)
+// Option Greeks Calculator Tests (Phase 5A) — Tier 1: US Real-Time (FREE)
 // ============================================================================
+// Note: These are calculator functions, not data fetches. They don't require
+// OPRA subscription — they compute Greeks from user-provided inputs.
 
 /// Create an AAPL call option contract for testing.
 ///
@@ -973,7 +1036,7 @@ async fn test_fetch_option_chain() {
 }
 
 // ============================================================================
-// Real-Time Option Greeks Streaming Tests (Phase 5B)
+// Real-Time Option Greeks Streaming Tests (Phase 5B) — Tier 3: OPRA ($1.50/mo)
 // ============================================================================
 
 #[tokio::test]

--- a/rustrade-execution/Cargo.toml
+++ b/rustrade-execution/Cargo.toml
@@ -111,3 +111,18 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 rust_decimal_macros = { workspace = true }
 # Serde round-trip tests (L2)
 serde_json = { workspace = true }
+
+# Examples that depend on optional features. Without `required-features`,
+# `cargo check --all-targets` (default features) fails to compile them.
+
+[[example]]
+name = "hyperliquid_execution"
+required-features = ["hyperliquid"]
+
+[[example]]
+name = "hyperliquid_spot_execution"
+required-features = ["hyperliquid"]
+
+[[example]]
+name = "ibkr_execution"
+required-features = ["ibkr"]

--- a/rustrade-execution/src/client/alpaca/mod.rs
+++ b/rustrade-execution/src/client/alpaca/mod.rs
@@ -1249,11 +1249,29 @@ impl AlpacaClient {
             }
         };
 
+        // Validate order kind — reject unsupported types early.
+        let order_type_str = match map_order_kind(kind) {
+            Some(s) => s,
+            None => {
+                return Some(Order {
+                    key: order_key,
+                    side,
+                    price,
+                    quantity,
+                    kind,
+                    time_in_force,
+                    state: OrderState::inactive(OrderError::UnsupportedOrderType(format!(
+                        "Alpaca connector does not yet support OrderKind::{kind:?}"
+                    ))),
+                });
+            }
+        };
+
         let body = AlpacaOrderRequest {
             symbol: instrument.name().as_str(),
             qty: quantity.to_string(),
             side: map_side(side),
-            order_type: map_order_kind(kind),
+            order_type: order_type_str,
             time_in_force: tif_str,
             limit_price: if matches!(kind, OrderKind::Limit) {
                 Some(price.to_string())
@@ -2629,10 +2647,16 @@ fn map_side(side: Side) -> &'static str {
     }
 }
 
-fn map_order_kind(kind: OrderKind) -> &'static str {
+fn map_order_kind(kind: OrderKind) -> Option<&'static str> {
     match kind {
-        OrderKind::Market => "market",
-        OrderKind::Limit => "limit",
+        OrderKind::Market => Some("market"),
+        OrderKind::Limit => Some("limit"),
+        // Alpaca supports stop, stop_limit, trailing_stop natively, but rustrade's
+        // Alpaca connector doesn't expose them yet. Return None to reject at open_order.
+        OrderKind::Stop { .. }
+        | OrderKind::StopLimit { .. }
+        | OrderKind::TrailingStop { .. }
+        | OrderKind::TrailingStopLimit { .. } => None,
     }
 }
 

--- a/rustrade-execution/src/client/alpaca/mod.rs
+++ b/rustrade-execution/src/client/alpaca/mod.rs
@@ -2679,6 +2679,14 @@ fn map_time_in_force(tif: TimeInForce) -> Result<&'static str, &'static str> {
         TimeInForce::GoodUntilEndOfDay => Ok("day"),
         TimeInForce::FillOrKill => Ok("fok"),
         TimeInForce::ImmediateOrCancel => Ok("ioc"),
+        TimeInForce::AtOpen => Ok("opg"),
+        TimeInForce::AtClose => Ok("cls"),
+        // Alpaca's `gtd` requires an `expired_at` timestamp on the order request,
+        // which this client does not currently surface. Reject to avoid silently
+        // dropping the expiry semantics.
+        TimeInForce::GoodTillDate { .. } => {
+            Err("Alpaca GoodTillDate is not yet wired through this client")
+        }
     }
 }
 

--- a/rustrade-execution/src/client/binance/mod.rs
+++ b/rustrade-execution/src/client/binance/mod.rs
@@ -2558,32 +2558,42 @@ fn convert_order_kind_tif(
 ) -> Option<(OrderPlaceTypeEnum, Option<OrderPlaceTimeInForceEnum>)> {
     match kind {
         OrderKind::Market => Some((OrderPlaceTypeEnum::Market, None)),
-        OrderKind::Limit => Some(match tif {
-            TimeInForce::GoodUntilCancelled { post_only: false } => (
+        OrderKind::Limit => match tif {
+            TimeInForce::GoodUntilCancelled { post_only: false } => Some((
                 OrderPlaceTypeEnum::Limit,
                 Some(OrderPlaceTimeInForceEnum::Gtc),
-            ),
+            )),
             TimeInForce::GoodUntilCancelled { post_only: true } => {
                 // LIMIT_MAKER is Binance's post-only order type (rejects if
                 // it would immediately match as taker)
-                (OrderPlaceTypeEnum::LimitMaker, None)
+                Some((OrderPlaceTypeEnum::LimitMaker, None))
             }
-            TimeInForce::FillOrKill => (
+            TimeInForce::FillOrKill => Some((
                 OrderPlaceTypeEnum::Limit,
                 Some(OrderPlaceTimeInForceEnum::Fok),
-            ),
-            TimeInForce::ImmediateOrCancel => (
+            )),
+            TimeInForce::ImmediateOrCancel => Some((
                 OrderPlaceTypeEnum::Limit,
                 Some(OrderPlaceTimeInForceEnum::Ioc),
-            ),
+            )),
             TimeInForce::GoodUntilEndOfDay => {
                 warn!("Binance Spot does not support GTD; coercing to GTC");
-                (
+                Some((
                     OrderPlaceTypeEnum::Limit,
                     Some(OrderPlaceTimeInForceEnum::Gtc),
-                )
+                ))
             }
-        }),
+            // Binance Spot does not support GTD/MOO/MOC. Surface as unsupported
+            // rather than silently coercing — these have venue-specific semantics
+            // that should not be lost.
+            TimeInForce::GoodTillDate { .. } | TimeInForce::AtOpen | TimeInForce::AtClose => {
+                warn!(
+                    time_in_force = ?tif,
+                    "Binance Spot does not support this TimeInForce"
+                );
+                None
+            }
+        },
         // TODO(TG13): Binance supports STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT,
         // TAKE_PROFIT_LIMIT, and TRAILING_STOP_MARKET. Add mapping in a future PR.
         OrderKind::Stop { .. }

--- a/rustrade-execution/src/client/binance/mod.rs
+++ b/rustrade-execution/src/client/binance/mod.rs
@@ -1154,7 +1154,22 @@ impl ExecutionClient for BinanceSpot {
             Side::Sell => OrderPlaceSideEnum::Sell,
         };
 
-        let (binance_type, binance_tif) = convert_order_kind_tif(kind, time_in_force);
+        let (binance_type, binance_tif) = match convert_order_kind_tif(kind, time_in_force) {
+            Some(converted) => converted,
+            None => {
+                return Some(Order {
+                    key: order_key,
+                    side,
+                    price,
+                    quantity,
+                    kind,
+                    time_in_force,
+                    state: OrderState::inactive(OrderError::UnsupportedOrderType(format!(
+                        "Binance Spot does not yet support OrderKind::{kind:?}"
+                    ))),
+                });
+            }
+        };
 
         // market BUY sends base quantity, not quoteOrderQty. Callers must
         // specify how much of the base asset they want, not how much quote to spend.
@@ -2366,9 +2381,23 @@ fn convert_new_order(
             warn!(%symbol, "BinanceSpot NEW market order missing price field (p), defaulting to 0");
             Decimal::ZERO
         }
-        (None, OrderKind::Limit) => {
-            warn!(%symbol, "BinanceSpot NEW limit order missing price (p), dropping");
+        (
+            None,
+            OrderKind::Limit | OrderKind::StopLimit { .. } | OrderKind::TrailingStopLimit { .. },
+        ) => {
+            warn!(%symbol, "BinanceSpot NEW limit-type order missing price (p), dropping");
             return None;
+        }
+        (
+            None,
+            OrderKind::Stop { trigger_price }
+            | OrderKind::TrailingStop {
+                offset: trigger_price,
+                ..
+            },
+        ) => {
+            // Stop orders without explicit price use trigger price as display price.
+            trigger_price
         }
     };
     let quantity = match report.q.as_deref() {
@@ -2526,10 +2555,10 @@ fn parse_time_in_force(tif: &str) -> TimeInForce {
 fn convert_order_kind_tif(
     kind: OrderKind,
     tif: TimeInForce,
-) -> (OrderPlaceTypeEnum, Option<OrderPlaceTimeInForceEnum>) {
+) -> Option<(OrderPlaceTypeEnum, Option<OrderPlaceTimeInForceEnum>)> {
     match kind {
-        OrderKind::Market => (OrderPlaceTypeEnum::Market, None),
-        OrderKind::Limit => match tif {
+        OrderKind::Market => Some((OrderPlaceTypeEnum::Market, None)),
+        OrderKind::Limit => Some(match tif {
             TimeInForce::GoodUntilCancelled { post_only: false } => (
                 OrderPlaceTypeEnum::Limit,
                 Some(OrderPlaceTimeInForceEnum::Gtc),
@@ -2554,7 +2583,19 @@ fn convert_order_kind_tif(
                     Some(OrderPlaceTimeInForceEnum::Gtc),
                 )
             }
-        },
+        }),
+        // TODO(TG13): Binance supports STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT,
+        // TAKE_PROFIT_LIMIT, and TRAILING_STOP_MARKET. Add mapping in a future PR.
+        OrderKind::Stop { .. }
+        | OrderKind::StopLimit { .. }
+        | OrderKind::TrailingStop { .. }
+        | OrderKind::TrailingStopLimit { .. } => {
+            warn!(
+                "Binance connector does not yet support OrderKind::{:?}",
+                kind
+            );
+            None
+        }
     }
 }
 
@@ -2680,6 +2721,7 @@ fn connectivity_error(e: anyhow::Error) -> UnindexedClientError {
 #[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
+    use crate::order::TrailingOffsetType;
 
     #[test]
     fn test_parse_side() {
@@ -2726,50 +2768,74 @@ mod tests {
 
     #[test]
     fn test_convert_order_kind_tif() {
+        use rust_decimal::Decimal;
+
         // binance-sdk enums don't derive PartialEq, so use matches!
         assert!(matches!(
             convert_order_kind_tif(OrderKind::Market, TimeInForce::ImmediateOrCancel),
-            (OrderPlaceTypeEnum::Market, None)
+            Some((OrderPlaceTypeEnum::Market, None))
         ));
         assert!(matches!(
             convert_order_kind_tif(
                 OrderKind::Limit,
                 TimeInForce::GoodUntilCancelled { post_only: false }
             ),
-            (
+            Some((
                 OrderPlaceTypeEnum::Limit,
                 Some(OrderPlaceTimeInForceEnum::Gtc)
-            )
+            ))
         ));
         assert!(matches!(
             convert_order_kind_tif(
                 OrderKind::Limit,
                 TimeInForce::GoodUntilCancelled { post_only: true }
             ),
-            (OrderPlaceTypeEnum::LimitMaker, None)
+            Some((OrderPlaceTypeEnum::LimitMaker, None))
         ));
         assert!(matches!(
             convert_order_kind_tif(OrderKind::Limit, TimeInForce::FillOrKill),
-            (
+            Some((
                 OrderPlaceTypeEnum::Limit,
                 Some(OrderPlaceTimeInForceEnum::Fok)
-            )
+            ))
         ));
         assert!(matches!(
             convert_order_kind_tif(OrderKind::Limit, TimeInForce::ImmediateOrCancel),
-            (
+            Some((
                 OrderPlaceTypeEnum::Limit,
                 Some(OrderPlaceTimeInForceEnum::Ioc)
-            )
+            ))
         ));
         // GoodUntilEndOfDay coerces to GTC on Binance Spot
         assert!(matches!(
             convert_order_kind_tif(OrderKind::Limit, TimeInForce::GoodUntilEndOfDay),
-            (
+            Some((
                 OrderPlaceTypeEnum::Limit,
                 Some(OrderPlaceTimeInForceEnum::Gtc)
-            )
+            ))
         ));
+
+        // Stop/Trailing order types return None (not yet supported)
+        assert!(
+            convert_order_kind_tif(
+                OrderKind::Stop {
+                    trigger_price: Decimal::from(100)
+                },
+                TimeInForce::GoodUntilCancelled { post_only: false }
+            )
+            .is_none()
+        );
+
+        assert!(
+            convert_order_kind_tif(
+                OrderKind::TrailingStop {
+                    offset: Decimal::from(5),
+                    offset_type: TrailingOffsetType::Percentage,
+                },
+                TimeInForce::GoodUntilCancelled { post_only: false }
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/rustrade-execution/src/client/hyperliquid/common.rs
+++ b/rustrade-execution/src/client/hyperliquid/common.rs
@@ -130,6 +130,13 @@ pub fn map_tif(tif: &TimeInForce) -> &'static str {
         TimeInForce::ImmediateOrCancel => "Ioc",
         TimeInForce::FillOrKill => "Ioc", // Hyperliquid doesn't have FOK, use IOC
         TimeInForce::GoodUntilEndOfDay => "Gtc", // No EOD on Hyperliquid
+        // Hyperliquid is a perpetuals DEX with no auction sessions and no native
+        // GTD. Coerce to GTC and surface the loss of semantics so downstream
+        // wrappers can decide whether to reject upstream.
+        TimeInForce::GoodTillDate { .. } | TimeInForce::AtOpen | TimeInForce::AtClose => {
+            warn!(time_in_force = ?tif, "Hyperliquid does not support this TimeInForce; coercing to Gtc");
+            "Gtc"
+        }
     }
 }
 

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -23,7 +23,8 @@
 //!
 //! # Limitations
 //!
-//! - **Order types**: Only Market and Limit supported (no Stop, Trailing, Algo)
+//! - **Order types**: Market, Limit, Stop, StopLimit, TrailingStop, TrailingStopLimit,
+//!   and Bracket (entry + take-profit + stop-loss) supported. No Algo orders.
 //! - **TimeInForce**: No `post_only` (IB has no maker-only orders)
 //! - **No auto-reconnect**: Caller responsibility per library philosophy
 //!
@@ -61,7 +62,11 @@ use ibapi::{
     accounts::{AccountSummaryResult, types::AccountGroup},
     client::blocking::Client,
 };
-use order::{OrderContext, OrderIdMap, PendingCancels, build_ib_order};
+pub use order::{BracketOrderRequest, BracketOrderResult};
+use order::{
+    OrderContext, OrderIdMap, PendingCancels, build_ib_bracket_with_oca, build_ib_order,
+    side_to_action, time_in_force_to_ib,
+};
 use parking_lot::Mutex;
 use rust_decimal::Decimal;
 use rustrade_instrument::{
@@ -230,14 +235,30 @@ impl IbkrClient {
     }
 
     /// Get the next order ID and increment the counter.
-    #[allow(clippy::expect_used)] // Panic is correct: i32::MAX orders means system is broken
     fn allocate_order_id(&self) -> i32 {
+        self.allocate_order_id_range(1)
+    }
+
+    /// Allocate a contiguous range of order IDs atomically.
+    ///
+    /// Returns the first ID in the range. Caller uses `base`, `base+1`, ..., `base+(count-1)`.
+    ///
+    /// This is essential for bracket orders which require consecutive IDs (parent=N,
+    /// take_profit=N+1, stop_loss=N+2). A single lock acquisition ensures no other
+    /// concurrent `open_order` call can grab an ID in the middle of the range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `count` exceeds `i32::MAX`, or if the resulting range would overflow `i32::MAX`.
+    #[allow(clippy::expect_used)] // Panic is correct: i32::MAX orders means system is broken
+    fn allocate_order_id_range(&self, count: u32) -> i32 {
+        let count_i32: i32 = count.try_into().expect("count exceeds i32::MAX");
         let mut id = self.next_order_id.lock();
-        let current = *id;
+        let base = *id;
         *id = id
-            .checked_add(1)
+            .checked_add(count_i32)
             .expect("order ID overflow: i32::MAX exceeded");
-        current
+        base
     }
 
     /// Register a contract for an instrument.
@@ -301,6 +322,474 @@ impl IbkrClient {
     /// remain indefinitely. Call this alongside other stale cleanup methods.
     pub fn clear_stale_pending_cancels(&self, max_age: std::time::Duration) -> usize {
         self.pending_cancels.clear_stale(max_age)
+    }
+
+    /// Place a bracket order (entry + take-profit + stop-loss) with OCA linking.
+    ///
+    /// A bracket order consists of three linked orders:
+    /// 1. **Entry**: Limit order to enter the position
+    /// 2. **Take Profit**: Limit order to exit at profit target (OCA-linked to SL)
+    /// 3. **Stop Loss**: Stop order to exit at loss limit (OCA-linked to TP)
+    ///
+    /// # OCA (One-Cancels-All) Behavior
+    ///
+    /// When either exit order fills, IB automatically cancels the other. This
+    /// prevents the dangerous scenario where take-profit fills but stop-loss
+    /// remains open, potentially opening an unintended opposing position.
+    ///
+    /// # All-or-Nothing Semantics
+    ///
+    /// If any leg is rejected by IB (e.g., insufficient margin, invalid price),
+    /// this method cancels all other legs and returns all three as `Inactive`.
+    /// You will never receive a mix of active and inactive legs.
+    ///
+    /// # Cancellation Safety
+    ///
+    /// This future registers order ID mappings before submitting to IB. If
+    /// cancelled mid-flight, orders may still be submitted and mappings will
+    /// leak. Avoid cancelling this future; use IB's native order timeout via
+    /// `TimeInForce` if timeout behavior is needed.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let request = BracketOrderRequest {
+    ///     instrument: "AAPL".into(),
+    ///     strategy: StrategyId::new("my-strategy"),
+    ///     parent_cid: ClientOrderId::new("bracket-001"),
+    ///     side: Side::Buy,
+    ///     quantity: dec!(100),
+    ///     entry_price: dec!(150.00),
+    ///     take_profit_price: dec!(160.00),  // +$10 profit target
+    ///     stop_loss_price: dec!(145.00),    // -$5 stop loss
+    ///     time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+    /// };
+    /// let result = client.open_bracket_order(request).await;
+    /// ```
+    pub async fn open_bracket_order(&self, request: BracketOrderRequest) -> BracketOrderResult {
+        let instrument = request.instrument.clone();
+
+        // Look up contract
+        let contract = match self.contracts.get_contract(&instrument) {
+            Some(c) => c,
+            None => {
+                return make_all_inactive_bracket(
+                    &request,
+                    OrderError::Rejected(ApiError::InstrumentInvalid(
+                        instrument,
+                        "contract not registered".to_string(),
+                    )),
+                );
+            }
+        };
+
+        // Convert quantity to f64
+        let quantity: f64 = match request.quantity.try_into() {
+            Ok(q) => q,
+            Err(_) => {
+                return make_all_inactive_bracket(
+                    &request,
+                    OrderError::Rejected(ApiError::OrderRejected(format!(
+                        "quantity {} exceeds f64 range",
+                        request.quantity
+                    ))),
+                );
+            }
+        };
+
+        // Convert prices to f64
+        let entry_price: f64 = match request.entry_price.try_into() {
+            Ok(p) => p,
+            Err(_) => {
+                return make_all_inactive_bracket(
+                    &request,
+                    OrderError::Rejected(ApiError::OrderRejected(format!(
+                        "entry_price {} exceeds f64 range",
+                        request.entry_price
+                    ))),
+                );
+            }
+        };
+        let tp_price: f64 = match request.take_profit_price.try_into() {
+            Ok(p) => p,
+            Err(_) => {
+                return make_all_inactive_bracket(
+                    &request,
+                    OrderError::Rejected(ApiError::OrderRejected(format!(
+                        "take_profit_price {} exceeds f64 range",
+                        request.take_profit_price
+                    ))),
+                );
+            }
+        };
+        let sl_price: f64 = match request.stop_loss_price.try_into() {
+            Ok(p) => p,
+            Err(_) => {
+                return make_all_inactive_bracket(
+                    &request,
+                    OrderError::Rejected(ApiError::OrderRejected(format!(
+                        "stop_loss_price {} exceeds f64 range",
+                        request.stop_loss_price
+                    ))),
+                );
+            }
+        };
+
+        // Validate time_in_force and convert to IB wire format
+        let ib_tif = match time_in_force_to_ib(&request.time_in_force) {
+            Ok(tif) => tif,
+            Err(e) => {
+                return make_all_inactive_bracket(
+                    &request,
+                    OrderError::Rejected(ApiError::OrderRejected(format!(
+                        "TIF not supported by IB: {e}"
+                    ))),
+                );
+            }
+        };
+
+        // Allocate 3 consecutive order IDs atomically
+        let parent_ib_id = self.allocate_order_id_range(3);
+        let tp_ib_id = parent_ib_id + 1;
+        let sl_ib_id = parent_ib_id + 2;
+
+        // Build bracket orders with OCA linking
+        let action = side_to_action(request.side);
+        let ib_orders = build_ib_bracket_with_oca(
+            parent_ib_id,
+            action,
+            quantity,
+            entry_price,
+            tp_price,
+            sl_price,
+            ib_tif,
+        );
+
+        // Generate client order IDs for children
+        let parent_cid = request.parent_cid.clone();
+        let (tp_cid, sl_cid) = derive_child_cids(&parent_cid);
+
+        // Determine opposite side for exit orders
+        let exit_side = match request.side {
+            Side::Buy => Side::Sell,
+            Side::Sell => Side::Buy,
+        };
+
+        // Register order contexts for all three legs
+        let parent_ctx = OrderContext {
+            instrument: instrument.clone(),
+            side: request.side,
+            price: request.entry_price,
+            quantity: request.quantity,
+            kind: OrderKind::Limit,
+            time_in_force: request.time_in_force,
+        };
+        let tp_ctx = OrderContext {
+            instrument: instrument.clone(),
+            side: exit_side,
+            price: request.take_profit_price,
+            quantity: request.quantity,
+            kind: OrderKind::Limit,
+            time_in_force: request.time_in_force,
+        };
+        let sl_ctx = OrderContext {
+            instrument: instrument.clone(),
+            side: exit_side,
+            price: request.stop_loss_price,
+            quantity: request.quantity,
+            kind: OrderKind::Stop {
+                trigger_price: request.stop_loss_price,
+            },
+            time_in_force: request.time_in_force,
+        };
+
+        self.order_ids
+            .register(parent_cid.clone(), parent_ib_id, parent_ctx);
+        self.order_ids.register(tp_cid.clone(), tp_ib_id, tp_ctx);
+        self.order_ids.register(sl_cid.clone(), sl_ib_id, sl_ctx);
+
+        // Place all three orders in spawn_blocking
+        let client = self.client.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            use ibapi::orders::PlaceOrder;
+
+            // Place parent (transmit=false, held until SL is sent)
+            let parent_sub = match client.place_order(parent_ib_id, &contract, &ib_orders[0]) {
+                Ok(s) => s,
+                Err(e) => return Err(format!("parent order failed: {e}")),
+            };
+
+            // Place take-profit (transmit=false)
+            let tp_sub = match client.place_order(tp_ib_id, &contract, &ib_orders[1]) {
+                Ok(s) => s,
+                Err(e) => {
+                    // Cancel parent before returning
+                    let _ = client.cancel_order(parent_ib_id, "");
+                    return Err(format!("take_profit order failed: {e}"));
+                }
+            };
+
+            // Place stop-loss (transmit=true, triggers all)
+            let sl_sub = match client.place_order(sl_ib_id, &contract, &ib_orders[2]) {
+                Ok(s) => s,
+                Err(e) => {
+                    // Cancel parent and TP before returning
+                    let _ = client.cancel_order(parent_ib_id, "");
+                    let _ = client.cancel_order(tp_ib_id, "");
+                    return Err(format!("stop_loss order failed: {e}"));
+                }
+            };
+
+            // Wait for first status from each subscription
+            let mut parent_status = None;
+            let mut tp_status = None;
+            let mut sl_status = None;
+
+            // Poll parent subscription
+            for event in parent_sub {
+                if let PlaceOrder::OrderStatus(status) = event {
+                    match status.status.as_str() {
+                        "Submitted" | "PreSubmitted" | "PendingSubmit" => {
+                            parent_status = Some(Ok(status.filled));
+                            break;
+                        }
+                        "Cancelled" | "Inactive" => {
+                            parent_status = Some(Err(status.status));
+                            break;
+                        }
+                        // Any other terminal status (e.g. "Filled", "ApiCancelled",
+                        // "PendingCancel") is treated as a rejection rather than
+                        // silently ignored — preserves observable failure semantics.
+                        other => {
+                            parent_status = Some(Err(format!("unexpected parent status: {other}")));
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Poll TP subscription
+            for event in tp_sub {
+                if let PlaceOrder::OrderStatus(status) = event {
+                    match status.status.as_str() {
+                        "Submitted" | "PreSubmitted" | "PendingSubmit" => {
+                            tp_status = Some(Ok(status.filled));
+                            break;
+                        }
+                        "Cancelled" | "Inactive" => {
+                            tp_status = Some(Err(status.status));
+                            break;
+                        }
+                        other => {
+                            tp_status =
+                                Some(Err(format!("unexpected take_profit status: {other}")));
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Poll SL subscription
+            for event in sl_sub {
+                if let PlaceOrder::OrderStatus(status) = event {
+                    match status.status.as_str() {
+                        "Submitted" | "PreSubmitted" | "PendingSubmit" => {
+                            sl_status = Some(Ok(status.filled));
+                            break;
+                        }
+                        "Cancelled" | "Inactive" => {
+                            sl_status = Some(Err(status.status));
+                            break;
+                        }
+                        other => {
+                            sl_status = Some(Err(format!("unexpected stop_loss status: {other}")));
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Verify all three legs reported a successful status. A `None` here
+            // means the subscription closed without producing a recognised event
+            // — surface that as an error rather than silently treating it as
+            // success. Any error or missing status cancels all legs.
+            match (parent_status, tp_status, sl_status) {
+                (Some(Ok(parent)), Some(Ok(tp)), Some(Ok(sl))) => Ok((parent, tp, sl)),
+                (parent, tp, sl) => {
+                    let _ = client.cancel_order(parent_ib_id, "");
+                    let _ = client.cancel_order(tp_ib_id, "");
+                    let _ = client.cancel_order(sl_ib_id, "");
+                    Err(format!(
+                        "bracket order rejected: parent={parent:?}, tp={tp:?}, sl={sl:?}"
+                    ))
+                }
+            }
+        })
+        .await;
+
+        match result {
+            Ok(Ok((parent_filled, tp_filled, sl_filled))) => {
+                let now = Utc::now();
+                let parent_filled_dec = parse_decimal_or_warn(parent_filled, "parent.filled");
+                let tp_filled_dec = parse_decimal_or_warn(tp_filled, "tp.filled");
+                let sl_filled_dec = parse_decimal_or_warn(sl_filled, "sl.filled");
+
+                BracketOrderResult {
+                    parent: Order {
+                        key: OrderKey {
+                            exchange: ExchangeId::Ibkr,
+                            instrument: instrument.clone(),
+                            strategy: request.strategy.clone(),
+                            cid: parent_cid,
+                        },
+                        side: request.side,
+                        price: request.entry_price,
+                        quantity: request.quantity,
+                        kind: OrderKind::Limit,
+                        time_in_force: request.time_in_force,
+                        state: OrderState::active(Open::new(
+                            OrderId::new(format_smolstr!("{}", parent_ib_id)),
+                            now,
+                            parent_filled_dec,
+                        )),
+                    },
+                    take_profit: Order {
+                        key: OrderKey {
+                            exchange: ExchangeId::Ibkr,
+                            instrument: instrument.clone(),
+                            strategy: request.strategy.clone(),
+                            cid: tp_cid,
+                        },
+                        side: exit_side,
+                        price: request.take_profit_price,
+                        quantity: request.quantity,
+                        kind: OrderKind::Limit,
+                        time_in_force: request.time_in_force,
+                        state: OrderState::active(Open::new(
+                            OrderId::new(format_smolstr!("{}", tp_ib_id)),
+                            now,
+                            tp_filled_dec,
+                        )),
+                    },
+                    stop_loss: Order {
+                        key: OrderKey {
+                            exchange: ExchangeId::Ibkr,
+                            instrument: instrument.clone(),
+                            strategy: request.strategy.clone(),
+                            cid: sl_cid,
+                        },
+                        side: exit_side,
+                        price: request.stop_loss_price,
+                        quantity: request.quantity,
+                        kind: OrderKind::Stop {
+                            trigger_price: request.stop_loss_price,
+                        },
+                        time_in_force: request.time_in_force,
+                        state: OrderState::active(Open::new(
+                            OrderId::new(format_smolstr!("{}", sl_ib_id)),
+                            now,
+                            sl_filled_dec,
+                        )),
+                    },
+                }
+            }
+            Ok(Err(err_msg)) => {
+                // Clean up order ID mappings
+                self.order_ids.remove_by_ib_id(parent_ib_id);
+                self.order_ids.remove_by_ib_id(tp_ib_id);
+                self.order_ids.remove_by_ib_id(sl_ib_id);
+
+                make_all_inactive_bracket(
+                    &request,
+                    OrderError::Rejected(ApiError::OrderRejected(err_msg)),
+                )
+            }
+            Err(join_err) => {
+                // Clean up order ID mappings
+                self.order_ids.remove_by_ib_id(parent_ib_id);
+                self.order_ids.remove_by_ib_id(tp_ib_id);
+                self.order_ids.remove_by_ib_id(sl_ib_id);
+
+                make_all_inactive_bracket(
+                    &request,
+                    OrderError::Rejected(ApiError::OrderRejected(format!(
+                        "task join error: {join_err}"
+                    ))),
+                )
+            }
+        }
+    }
+}
+
+/// Derive bracket child CIDs from the parent CID.
+///
+/// Convention: `{parent}_tp` for take-profit, `{parent}_sl` for stop-loss.
+/// All bracket call sites must use this helper to keep the naming consistent.
+fn derive_child_cids(parent_cid: &ClientOrderId) -> (ClientOrderId, ClientOrderId) {
+    (
+        ClientOrderId::new(format_smolstr!("{}_tp", parent_cid.0)),
+        ClientOrderId::new(format_smolstr!("{}_sl", parent_cid.0)),
+    )
+}
+
+/// Helper to create a BracketOrderResult with all legs inactive (same error).
+fn make_all_inactive_bracket(
+    request: &BracketOrderRequest,
+    error: OrderError<AssetNameExchange, InstrumentNameExchange>,
+) -> BracketOrderResult {
+    let exit_side = match request.side {
+        Side::Buy => Side::Sell,
+        Side::Sell => Side::Buy,
+    };
+
+    let parent_cid = request.parent_cid.clone();
+    let (tp_cid, sl_cid) = derive_child_cids(&parent_cid);
+
+    BracketOrderResult {
+        parent: Order {
+            key: OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: request.instrument.clone(),
+                strategy: request.strategy.clone(),
+                cid: parent_cid,
+            },
+            side: request.side,
+            price: request.entry_price,
+            quantity: request.quantity,
+            kind: OrderKind::Limit,
+            time_in_force: request.time_in_force,
+            state: OrderState::inactive(error.clone()),
+        },
+        take_profit: Order {
+            key: OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: request.instrument.clone(),
+                strategy: request.strategy.clone(),
+                cid: tp_cid,
+            },
+            side: exit_side,
+            price: request.take_profit_price,
+            quantity: request.quantity,
+            kind: OrderKind::Limit,
+            time_in_force: request.time_in_force,
+            state: OrderState::inactive(error.clone()),
+        },
+        stop_loss: Order {
+            key: OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: request.instrument.clone(),
+                strategy: request.strategy.clone(),
+                cid: sl_cid,
+            },
+            side: exit_side,
+            price: request.stop_loss_price,
+            quantity: request.quantity,
+            kind: OrderKind::Stop {
+                trigger_price: request.stop_loss_price,
+            },
+            time_in_force: request.time_in_force,
+            state: OrderState::inactive(error),
+        },
     }
 }
 

--- a/rustrade-execution/src/client/ibkr/order.rs
+++ b/rustrade-execution/src/client/ibkr/order.rs
@@ -1,4 +1,4 @@
-use crate::order::{OrderKind, TimeInForce, id::ClientOrderId};
+use crate::order::{OrderKind, TimeInForce, TrailingOffsetType, id::ClientOrderId};
 use fnv::FnvHashMap;
 use ibapi::orders::{Action, Order, TimeInForce as IbTimeInForce, order_builder};
 use parking_lot::{Mutex, RwLock};
@@ -238,6 +238,8 @@ pub enum OrderMappingError {
     PostOnlyNotSupported,
     /// Price conversion to f64 failed (overflow or invalid decimal).
     InvalidPrice(String),
+    /// Trailing offset type not supported by IBKR.
+    UnsupportedOffsetType(TrailingOffsetType),
 }
 
 impl std::fmt::Display for OrderMappingError {
@@ -245,6 +247,9 @@ impl std::fmt::Display for OrderMappingError {
         match self {
             Self::PostOnlyNotSupported => write!(f, "post_only not supported by IB"),
             Self::InvalidPrice(p) => write!(f, "invalid price for f64 conversion: {p}"),
+            Self::UnsupportedOffsetType(t) => {
+                write!(f, "trailing offset type {t:?} not supported by IBKR")
+            }
         }
     }
 }
@@ -267,7 +272,29 @@ pub fn time_in_force_to_ib(tif: &TimeInForce) -> Result<IbTimeInForce, OrderMapp
     }
 }
 
+/// Convert a Decimal to f64, returning an error if conversion fails.
+fn decimal_to_f64(value: rust_decimal::Decimal) -> Result<f64, OrderMappingError> {
+    value.try_into().or_else(|_| {
+        value
+            .to_string()
+            .parse()
+            .map_err(|_| OrderMappingError::InvalidPrice(value.to_string()))
+    })
+}
+
 /// Build an IB Order from rustrade order parameters.
+///
+/// # Order Type Mapping
+///
+/// - `Market` → IB "MKT"
+/// - `Limit` → IB "LMT" with `limit_price`
+/// - `Stop` → IB "STP" with `aux_price` as trigger
+/// - `StopLimit` → IB "STP LMT" with `aux_price` as trigger, `limit_price` from Order.price
+/// - `TrailingStop` (Percentage) → IB "TRAIL" with `trailing_percent`
+/// - `TrailingStop` (Absolute) → IB "TRAIL" with `aux_price`
+/// - `TrailingStopLimit` (Absolute) → IB "TRAIL LIMIT" with `aux_price`, `limit_price_offset`
+/// - `TrailingStopLimit` (Percentage) → IB "TRAIL LIMIT" with `trailing_percent`, `limit_price_offset`
+/// - `BasisPoints` offset type → Error (not supported by IBKR)
 pub fn build_ib_order(
     side: rustrade_instrument::Side,
     quantity: f64,
@@ -280,14 +307,98 @@ pub fn build_ib_order(
 
     let mut order = match kind {
         OrderKind::Market => order_builder::market_order(action, quantity),
+
         OrderKind::Limit => {
-            let price_f64: f64 = price.try_into().or_else(|_| {
-                price
-                    .to_string()
-                    .parse()
-                    .map_err(|_| OrderMappingError::InvalidPrice(price.to_string()))
-            })?;
+            let price_f64 = decimal_to_f64(price)?;
             order_builder::limit_order(action, quantity, price_f64)
+        }
+
+        OrderKind::Stop { trigger_price } => {
+            let trigger_f64 = decimal_to_f64(*trigger_price)?;
+            order_builder::stop(action, quantity, trigger_f64)
+        }
+
+        OrderKind::StopLimit { trigger_price } => {
+            let limit_f64 = decimal_to_f64(price)?;
+            let trigger_f64 = decimal_to_f64(*trigger_price)?;
+            order_builder::stop_limit(action, quantity, limit_f64, trigger_f64)
+        }
+
+        OrderKind::TrailingStop {
+            offset,
+            offset_type,
+        } => {
+            let offset_f64 = decimal_to_f64(*offset)?;
+            match offset_type {
+                TrailingOffsetType::Percentage => {
+                    // Use the builder for percentage-based trailing stop.
+                    // trail_stop_price is None, letting IB derive it from market price.
+                    Order {
+                        action,
+                        order_type: "TRAIL".to_owned(),
+                        total_quantity: quantity,
+                        trailing_percent: Some(offset_f64),
+                        trail_stop_price: None,
+                        ..Order::default()
+                    }
+                }
+                TrailingOffsetType::Absolute => {
+                    // Manual construction for absolute trailing stop.
+                    // aux_price holds the trailing amount.
+                    Order {
+                        action,
+                        order_type: "TRAIL".to_owned(),
+                        total_quantity: quantity,
+                        aux_price: Some(offset_f64),
+                        trail_stop_price: None,
+                        ..Order::default()
+                    }
+                }
+                TrailingOffsetType::BasisPoints => {
+                    return Err(OrderMappingError::UnsupportedOffsetType(
+                        TrailingOffsetType::BasisPoints,
+                    ));
+                }
+            }
+        }
+
+        OrderKind::TrailingStopLimit {
+            offset,
+            offset_type,
+            limit_offset,
+        } => {
+            let offset_f64 = decimal_to_f64(*offset)?;
+            let limit_offset_f64 = decimal_to_f64(*limit_offset)?;
+            match offset_type {
+                TrailingOffsetType::Absolute => {
+                    // Use builder for absolute trailing stop-limit.
+                    // aux_price = trailing_amount, limit_price_offset = limit offset from stop.
+                    order_builder::trailing_stop_limit(
+                        action,
+                        quantity,
+                        limit_offset_f64,
+                        offset_f64,
+                        0.0, // trail_stop_price: let IB derive from market
+                    )
+                }
+                TrailingOffsetType::Percentage => {
+                    // Manual construction for percentage-based trailing stop-limit.
+                    Order {
+                        action,
+                        order_type: "TRAIL LIMIT".to_owned(),
+                        total_quantity: quantity,
+                        trailing_percent: Some(offset_f64),
+                        limit_price_offset: Some(limit_offset_f64),
+                        trail_stop_price: None,
+                        ..Order::default()
+                    }
+                }
+                TrailingOffsetType::BasisPoints => {
+                    return Err(OrderMappingError::UnsupportedOffsetType(
+                        TrailingOffsetType::BasisPoints,
+                    ));
+                }
+            }
         }
     };
 
@@ -540,5 +651,178 @@ mod tests {
         assert_eq!(cancels.len(), 1);
         assert!(cancels.remove(42));
         assert!(cancels.is_empty());
+    }
+
+    #[test]
+    fn test_build_stop_order() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::Stop {
+                trigger_price: Decimal::from(45),
+            },
+            Decimal::ZERO,
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Sell);
+        assert_eq!(order.total_quantity, 100.0);
+        assert_eq!(order.order_type, "STP");
+        assert_eq!(order.aux_price, Some(45.0));
+        assert_eq!(order.limit_price, None);
+    }
+
+    #[test]
+    fn test_build_stop_limit_order() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::StopLimit {
+                trigger_price: Decimal::from(44),
+            },
+            Decimal::from(45), // limit price
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Sell);
+        assert_eq!(order.total_quantity, 100.0);
+        assert_eq!(order.order_type, "STP LMT");
+        assert_eq!(order.aux_price, Some(44.0)); // trigger/stop price
+        assert_eq!(order.limit_price, Some(45.0)); // limit price
+    }
+
+    #[test]
+    fn test_build_trailing_stop_percentage() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TrailingStop {
+                offset: Decimal::from(5),
+                offset_type: TrailingOffsetType::Percentage,
+            },
+            Decimal::ZERO,
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Sell);
+        assert_eq!(order.total_quantity, 100.0);
+        assert_eq!(order.order_type, "TRAIL");
+        assert_eq!(order.trailing_percent, Some(5.0));
+        assert_eq!(order.aux_price, None); // percentage uses trailing_percent, not aux_price
+        assert_eq!(order.trail_stop_price, None); // let IB derive from market
+    }
+
+    #[test]
+    fn test_build_trailing_stop_absolute() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TrailingStop {
+                offset: Decimal::from(2),
+                offset_type: TrailingOffsetType::Absolute,
+            },
+            Decimal::ZERO,
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Sell);
+        assert_eq!(order.total_quantity, 100.0);
+        assert_eq!(order.order_type, "TRAIL");
+        assert_eq!(order.aux_price, Some(2.0)); // absolute uses aux_price
+        assert_eq!(order.trailing_percent, None);
+        assert_eq!(order.trail_stop_price, None);
+    }
+
+    #[test]
+    fn test_build_trailing_stop_limit_absolute() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TrailingStopLimit {
+                offset: Decimal::from(2),
+                offset_type: TrailingOffsetType::Absolute,
+                limit_offset: Decimal::try_from(0.5).unwrap(),
+            },
+            Decimal::ZERO,
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Sell);
+        assert_eq!(order.total_quantity, 100.0);
+        assert_eq!(order.order_type, "TRAIL LIMIT");
+        assert_eq!(order.aux_price, Some(2.0)); // trailing amount
+        assert_eq!(order.limit_price_offset, Some(0.5)); // limit offset from stop
+        assert_eq!(order.trailing_percent, None);
+    }
+
+    #[test]
+    fn test_build_trailing_stop_limit_percentage() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TrailingStopLimit {
+                offset: Decimal::from(5),
+                offset_type: TrailingOffsetType::Percentage,
+                limit_offset: Decimal::try_from(0.5).unwrap(),
+            },
+            Decimal::ZERO,
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Sell);
+        assert_eq!(order.total_quantity, 100.0);
+        assert_eq!(order.order_type, "TRAIL LIMIT");
+        assert_eq!(order.trailing_percent, Some(5.0));
+        assert_eq!(order.limit_price_offset, Some(0.5));
+        assert_eq!(order.aux_price, None); // percentage doesn't use aux_price
+    }
+
+    #[test]
+    fn test_build_trailing_stop_basis_points_unsupported() {
+        let result = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TrailingStop {
+                offset: Decimal::from(50), // 50 basis points
+                offset_type: TrailingOffsetType::BasisPoints,
+            },
+            Decimal::ZERO,
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        );
+
+        assert!(matches!(
+            result,
+            Err(OrderMappingError::UnsupportedOffsetType(
+                TrailingOffsetType::BasisPoints
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_build_trailing_stop_limit_basis_points_unsupported() {
+        let result = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TrailingStopLimit {
+                offset: Decimal::from(50),
+                offset_type: TrailingOffsetType::BasisPoints,
+                limit_offset: Decimal::try_from(0.5).unwrap(),
+            },
+            Decimal::ZERO,
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        );
+
+        assert!(matches!(
+            result,
+            Err(OrderMappingError::UnsupportedOffsetType(
+                TrailingOffsetType::BasisPoints
+            ))
+        ));
     }
 }

--- a/rustrade-execution/src/client/ibkr/order.rs
+++ b/rustrade-execution/src/client/ibkr/order.rs
@@ -1,10 +1,77 @@
-use crate::order::{OrderKind, TimeInForce, TrailingOffsetType, id::ClientOrderId};
+use crate::order::{
+    Order as RustradeOrder, OrderKind, TimeInForce, TrailingOffsetType,
+    id::{ClientOrderId, StrategyId},
+    state::UnindexedOrderState,
+};
 use fnv::FnvHashMap;
-use ibapi::orders::{Action, Order, TimeInForce as IbTimeInForce, order_builder};
+use ibapi::orders::{Action, OcaType, Order, TimeInForce as IbTimeInForce, order_builder};
 use parking_lot::{Mutex, RwLock};
 use rust_decimal::Decimal;
-use rustrade_instrument::{Side, instrument::name::InstrumentNameExchange};
+use rustrade_instrument::{Side, exchange::ExchangeId, instrument::name::InstrumentNameExchange};
 use std::{sync::Arc, time::Instant};
+
+// ============================================================================
+// Bracket Order Types
+// ============================================================================
+
+/// Request to place a bracket order (entry + take-profit + stop-loss).
+///
+/// A bracket order consists of three linked orders:
+/// 1. **Entry**: Limit order to enter the position
+/// 2. **Take Profit**: Limit order to exit at profit target
+/// 3. **Stop Loss**: Stop order to exit at loss limit
+///
+/// The entry order is submitted with `transmit=false`, holding all orders until
+/// the stop-loss (with `transmit=true`) triggers atomic submission of all three.
+///
+/// Take-profit and stop-loss are linked via OCA (One-Cancels-All) group, so when
+/// one fills, IB automatically cancels the other.
+#[derive(Debug, Clone)]
+pub struct BracketOrderRequest {
+    /// Instrument to trade.
+    pub instrument: InstrumentNameExchange,
+    /// Strategy identifier for order correlation.
+    pub strategy: StrategyId,
+    /// Client order ID for the parent (entry) order.
+    /// Child orders will have IDs derived from this (parent_cid + "_tp", parent_cid + "_sl").
+    pub parent_cid: ClientOrderId,
+    /// Buy or Sell for the entry order (exits use opposite side).
+    pub side: Side,
+    /// Number of shares/contracts.
+    pub quantity: Decimal,
+    /// Entry limit price.
+    pub entry_price: Decimal,
+    /// Take profit limit price.
+    pub take_profit_price: Decimal,
+    /// Stop loss trigger price.
+    pub stop_loss_price: Decimal,
+    /// Time-in-force for all three orders.
+    pub time_in_force: TimeInForce,
+}
+
+/// Result of placing a bracket order.
+///
+/// Contains the three orders with their states. Use the `ClientOrderId` from each
+/// order's key to cancel individual legs or correlate stream events.
+///
+/// # Invariant
+///
+/// Either all three orders are `Active(Open)` or all three are `Inactive`.
+/// Partial success (some active, some inactive) is prevented by the all-or-nothing
+/// error handling in `open_bracket_order`.
+#[derive(Debug, Clone)]
+pub struct BracketOrderResult {
+    /// Parent (entry) order.
+    pub parent: RustradeOrder<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
+    /// Take profit order (opposite side, limit).
+    pub take_profit: RustradeOrder<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
+    /// Stop loss order (opposite side, stop).
+    pub stop_loss: RustradeOrder<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
+}
+
+// ============================================================================
+// Order Context
+// ============================================================================
 
 /// Order context stored when placing orders.
 ///
@@ -225,7 +292,7 @@ impl Default for PendingCancels {
 }
 
 /// Convert rustrade Side to IB Action.
-pub fn side_to_action(side: rustrade_instrument::Side) -> Action {
+pub(crate) fn side_to_action(side: rustrade_instrument::Side) -> Action {
     match side {
         rustrade_instrument::Side::Buy => Action::Buy,
         rustrade_instrument::Side::Sell => Action::Sell,
@@ -405,6 +472,76 @@ pub fn build_ib_order(
     order.tif = tif_ib;
 
     Ok(order)
+}
+
+/// Build a bracket order with proper OCA linking.
+///
+/// ibapi's `order_builder::bracket_order()` sets `parent_id` on child orders (TP/SL
+/// wait for entry fill) but does NOT set `oca_group` or `oca_type`. Without OCA
+/// linking, if take-profit fills, stop-loss stays open — dangerous position exposure.
+///
+/// This function wraps `bracket_order()` and adds OCA group linking so that when
+/// either child order fills, the other is automatically cancelled by IB.
+///
+/// # Arguments
+///
+/// * `parent_order_id` - The IB order ID for the parent (entry) order
+/// * `action` - Buy or Sell for the entry order (children use opposite action)
+/// * `quantity` - Number of shares/contracts
+/// * `limit_price` - Entry limit price
+/// * `take_profit_price` - Take profit limit price (above entry for Buy, below for Sell)
+/// * `stop_loss_price` - Stop loss trigger price (below entry for Buy, above for Sell)
+///
+/// # Returns
+///
+/// Vec of 3 orders: `[parent, take_profit, stop_loss]` with:
+/// - `parent_id` set on children (IB's bracket linkage)
+/// - `oca_group` set on children (OCA linkage between TP and SL)
+/// - `oca_type = CancelWithBlock` (safest: one at a time, cancel remaining)
+/// - `transmit` flags: parent=false, TP=false, SL=true (atomic submission)
+///
+/// # Order ID Convention
+///
+/// ibapi's `bracket_order()` assigns consecutive IDs: parent=N, TP=N+1, SL=N+2.
+/// Caller must ensure these IDs are reserved atomically via `allocate_order_id_range(3)`.
+pub fn build_ib_bracket_with_oca(
+    parent_order_id: i32,
+    action: Action,
+    quantity: f64,
+    limit_price: f64,
+    take_profit_price: f64,
+    stop_loss_price: f64,
+    tif: IbTimeInForce,
+) -> Vec<Order> {
+    let mut orders = order_builder::bracket_order(
+        parent_order_id,
+        action,
+        quantity,
+        limit_price,
+        take_profit_price,
+        stop_loss_price,
+    );
+    assert_eq!(
+        orders.len(),
+        3,
+        "ibapi bracket_order must return exactly 3 orders (parent, TP, SL)"
+    );
+
+    // ibapi's bracket_order() defaults all legs to TimeInForce::Day; override
+    // with the caller-specified TIF so it actually reaches the wire.
+    orders[0].tif = tif.clone();
+    orders[1].tif = tif.clone();
+    orders[2].tif = tif;
+
+    // Link TP and SL via OCA group so one cancels the other.
+    // CancelWithBlock provides overfill protection by routing only one child at a time.
+    let oca_group = format!("bracket_{}", parent_order_id);
+    orders[1].oca_group = oca_group.clone();
+    orders[1].oca_type = OcaType::CancelWithBlock;
+    orders[2].oca_group = oca_group;
+    orders[2].oca_type = OcaType::CancelWithBlock;
+
+    orders
 }
 
 #[cfg(test)]
@@ -824,5 +961,166 @@ mod tests {
                 TrailingOffsetType::BasisPoints
             ))
         ));
+    }
+
+    // =========================================================================
+    // Bracket Order Tests (Phase 3)
+    // =========================================================================
+
+    #[test]
+    fn test_build_ib_bracket_with_oca_sets_oca_fields() {
+        let orders = build_ib_bracket_with_oca(
+            1000,
+            Action::Buy,
+            10.0,
+            150.0,
+            160.0,
+            140.0,
+            IbTimeInForce::Day,
+        );
+
+        assert_eq!(orders.len(), 3);
+
+        // OCA group must be non-empty on both child orders
+        assert!(!orders[1].oca_group.is_empty());
+        assert_eq!(orders[1].oca_group, orders[2].oca_group);
+
+        // Both children must use CancelWithBlock
+        assert_eq!(orders[1].oca_type, OcaType::CancelWithBlock);
+        assert_eq!(orders[2].oca_type, OcaType::CancelWithBlock);
+
+        // Parent must NOT be in OCA group (only children are linked)
+        assert!(orders[0].oca_group.is_empty());
+        assert_eq!(orders[0].oca_type, OcaType::None);
+    }
+
+    #[test]
+    fn test_build_ib_bracket_with_oca_parent_id_linkage() {
+        let orders = build_ib_bracket_with_oca(
+            1000,
+            Action::Buy,
+            10.0,
+            150.0,
+            160.0,
+            140.0,
+            IbTimeInForce::Day,
+        );
+
+        // Children must reference parent via parent_id
+        assert_eq!(orders[1].parent_id, 1000); // TP waits for parent fill
+        assert_eq!(orders[2].parent_id, 1000); // SL waits for parent fill
+
+        // Parent has no parent
+        assert_eq!(orders[0].parent_id, 0);
+    }
+
+    #[test]
+    fn test_build_ib_bracket_with_oca_transmit_flags() {
+        let orders = build_ib_bracket_with_oca(
+            1000,
+            Action::Buy,
+            10.0,
+            150.0,
+            160.0,
+            140.0,
+            IbTimeInForce::Day,
+        );
+
+        // Only the last order triggers transmission of all three
+        assert!(!orders[0].transmit); // Parent: don't transmit yet
+        assert!(!orders[1].transmit); // TP: don't transmit yet
+        assert!(orders[2].transmit); // SL: transmit all
+    }
+
+    #[test]
+    fn test_build_ib_bracket_with_oca_order_ids_are_consecutive() {
+        let orders = build_ib_bracket_with_oca(
+            500,
+            Action::Sell,
+            5.0,
+            100.0,
+            90.0,
+            110.0,
+            IbTimeInForce::Day,
+        );
+
+        assert_eq!(orders[0].order_id, 500); // Parent
+        assert_eq!(orders[1].order_id, 501); // Take profit
+        assert_eq!(orders[2].order_id, 502); // Stop loss
+    }
+
+    #[test]
+    fn test_build_ib_bracket_with_oca_group_name_contains_parent_id() {
+        let orders =
+            build_ib_bracket_with_oca(42, Action::Buy, 1.0, 10.0, 12.0, 8.0, IbTimeInForce::Day);
+
+        assert!(orders[1].oca_group.contains("42"));
+        assert!(orders[2].oca_group.contains("42"));
+    }
+
+    #[test]
+    fn test_build_ib_bracket_with_oca_order_types() {
+        let orders = build_ib_bracket_with_oca(
+            1000,
+            Action::Buy,
+            100.0,
+            150.0,
+            160.0,
+            140.0,
+            IbTimeInForce::Day,
+        );
+
+        // Parent is limit order
+        assert_eq!(orders[0].order_type, "LMT");
+        assert_eq!(orders[0].limit_price, Some(150.0));
+
+        // Take profit is limit order
+        assert_eq!(orders[1].order_type, "LMT");
+        assert_eq!(orders[1].limit_price, Some(160.0));
+
+        // Stop loss is stop order
+        assert_eq!(orders[2].order_type, "STP");
+        assert_eq!(orders[2].aux_price, Some(140.0));
+    }
+
+    #[test]
+    fn test_build_ib_bracket_with_oca_actions_reversed_for_children() {
+        // Buy bracket: entry=Buy, exits=Sell
+        let buy_orders =
+            build_ib_bracket_with_oca(100, Action::Buy, 10.0, 50.0, 55.0, 45.0, IbTimeInForce::Day);
+        assert_eq!(buy_orders[0].action, Action::Buy);
+        assert_eq!(buy_orders[1].action, Action::Sell);
+        assert_eq!(buy_orders[2].action, Action::Sell);
+
+        // Sell bracket: entry=Sell, exits=Buy
+        let sell_orders = build_ib_bracket_with_oca(
+            200,
+            Action::Sell,
+            10.0,
+            50.0,
+            45.0,
+            55.0,
+            IbTimeInForce::Day,
+        );
+        assert_eq!(sell_orders[0].action, Action::Sell);
+        assert_eq!(sell_orders[1].action, Action::Buy);
+        assert_eq!(sell_orders[2].action, Action::Buy);
+    }
+
+    #[test]
+    fn test_build_ib_bracket_with_oca_applies_tif_to_all_legs() {
+        let orders = build_ib_bracket_with_oca(
+            1000,
+            Action::Buy,
+            10.0,
+            150.0,
+            160.0,
+            140.0,
+            IbTimeInForce::GoodTilCanceled,
+        );
+
+        assert_eq!(orders[0].tif, IbTimeInForce::GoodTilCanceled);
+        assert_eq!(orders[1].tif, IbTimeInForce::GoodTilCanceled);
+        assert_eq!(orders[2].tif, IbTimeInForce::GoodTilCanceled);
     }
 }

--- a/rustrade-execution/src/client/ibkr/order.rs
+++ b/rustrade-execution/src/client/ibkr/order.rs
@@ -307,6 +307,13 @@ pub enum OrderMappingError {
     InvalidPrice(String),
     /// Trailing offset type not supported by IBKR.
     UnsupportedOffsetType(TrailingOffsetType),
+    /// AtClose TIF only valid with Market or Limit orders (becomes MOC/LOC).
+    /// Stop orders cannot be combined with at-close execution.
+    UnsupportedOrderKindForAtClose(OrderKind),
+    /// AtClose TIF reached `time_in_force_to_ib` directly. AtClose changes the
+    /// order TYPE (MOC/LOC), not just the TIF; callers must route through
+    /// `build_ib_order` which handles the type promotion.
+    AtCloseRequiresOrderTypeChange,
 }
 
 impl std::fmt::Display for OrderMappingError {
@@ -317,6 +324,17 @@ impl std::fmt::Display for OrderMappingError {
             Self::UnsupportedOffsetType(t) => {
                 write!(f, "trailing offset type {t:?} not supported by IBKR")
             }
+            Self::UnsupportedOrderKindForAtClose(k) => {
+                write!(
+                    f,
+                    "AtClose TIF only valid with Market or Limit orders, got {k:?}"
+                )
+            }
+            Self::AtCloseRequiresOrderTypeChange => write!(
+                f,
+                "AtClose TIF must be routed through build_ib_order, which promotes \
+                 the order to MOC/LOC; time_in_force_to_ib cannot map it directly"
+            ),
         }
     }
 }
@@ -324,6 +342,12 @@ impl std::fmt::Display for OrderMappingError {
 impl std::error::Error for OrderMappingError {}
 
 /// Convert rustrade TimeInForce to IB TimeInForce.
+///
+/// Returns [`OrderMappingError::AtCloseRequiresOrderTypeChange`] for
+/// [`TimeInForce::AtClose`]: AtClose changes the order TYPE (MOC/LOC), not
+/// just the TIF, and is handled by [`build_ib_order`] which promotes the
+/// order type. Callers needing AtClose support should route through
+/// [`build_ib_order`] rather than this helper.
 pub fn time_in_force_to_ib(tif: &TimeInForce) -> Result<IbTimeInForce, OrderMappingError> {
     match tif {
         TimeInForce::GoodUntilCancelled { post_only } => {
@@ -336,6 +360,12 @@ pub fn time_in_force_to_ib(tif: &TimeInForce) -> Result<IbTimeInForce, OrderMapp
         TimeInForce::GoodUntilEndOfDay => Ok(IbTimeInForce::Day),
         TimeInForce::FillOrKill => Ok(IbTimeInForce::FillOrKill),
         TimeInForce::ImmediateOrCancel => Ok(IbTimeInForce::ImmediateOrCancel),
+        TimeInForce::GoodTillDate { .. } => Ok(IbTimeInForce::GoodTilDate),
+        TimeInForce::AtOpen => Ok(IbTimeInForce::OnOpen),
+        // AtClose changes the order TYPE to MOC/LOC, not just the TIF.
+        // `build_ib_order` intercepts AtClose; surfacing Err here lets other
+        // callers (e.g. the bracket-order path) reject gracefully.
+        TimeInForce::AtClose => Err(OrderMappingError::AtCloseRequiresOrderTypeChange),
     }
 }
 
@@ -362,6 +392,13 @@ fn decimal_to_f64(value: rust_decimal::Decimal) -> Result<f64, OrderMappingError
 /// - `TrailingStopLimit` (Absolute) → IB "TRAIL LIMIT" with `aux_price`, `limit_price_offset`
 /// - `TrailingStopLimit` (Percentage) → IB "TRAIL LIMIT" with `trailing_percent`, `limit_price_offset`
 /// - `BasisPoints` offset type → Error (not supported by IBKR)
+///
+/// # Time-in-Force Special Cases
+///
+/// - `AtClose` + `Market` → IB "MOC" (Market-on-Close)
+/// - `AtClose` + `Limit` → IB "LOC" (Limit-on-Close)
+/// - `AtClose` + Stop/Trailing → Error (not supported by IBKR)
+/// - `GoodTillDate` → Sets both TIF and `good_till_date` field
 pub fn build_ib_order(
     side: rustrade_instrument::Side,
     quantity: f64,
@@ -370,6 +407,12 @@ pub fn build_ib_order(
     tif: &TimeInForce,
 ) -> Result<Order, OrderMappingError> {
     let action = side_to_action(side);
+
+    // Handle AtClose specially - it changes the order TYPE, not just TIF
+    if matches!(tif, TimeInForce::AtClose) {
+        return build_at_close_order(action, quantity, kind, price);
+    }
+
     let tif_ib = time_in_force_to_ib(tif)?;
 
     let mut order = match kind {
@@ -471,7 +514,41 @@ pub fn build_ib_order(
 
     order.tif = tif_ib;
 
+    // Handle GoodTillDate: set the good_till_date string field
+    if let TimeInForce::GoodTillDate { expiry } = tif {
+        order.good_till_date = format_gtd_datetime(expiry);
+    }
+
     Ok(order)
+}
+
+/// Format a DateTime<Utc> for IB's good_till_date field.
+///
+/// IB accepts format: "yyyyMMdd HH:mm:ss" with optional timezone suffix.
+/// We use UTC format "yyyyMMdd-HH:mm:ss" which IB interprets as UTC.
+fn format_gtd_datetime(dt: &chrono::DateTime<chrono::Utc>) -> String {
+    dt.format("%Y%m%d-%H:%M:%S").to_string()
+}
+
+/// Build an at-close order (MOC or LOC).
+///
+/// Only Market and Limit orders can be combined with at-close execution.
+/// Stop orders cannot execute at close due to IBKR's order model constraints.
+fn build_at_close_order(
+    action: Action,
+    quantity: f64,
+    kind: &OrderKind,
+    price: rust_decimal::Decimal,
+) -> Result<Order, OrderMappingError> {
+    match kind {
+        OrderKind::Market => Ok(order_builder::market_on_close(action, quantity)),
+        OrderKind::Limit => {
+            let price_f64 = decimal_to_f64(price)?;
+            Ok(order_builder::limit_on_close(action, quantity, price_f64))
+        }
+        // Stop orders cannot be combined with at-close execution
+        _ => Err(OrderMappingError::UnsupportedOrderKindForAtClose(*kind)),
+    }
 }
 
 /// Build a bracket order with proper OCA linking.
@@ -630,6 +707,36 @@ mod tests {
         assert_eq!(
             time_in_force_to_ib(&TimeInForce::ImmediateOrCancel),
             Ok(IbTimeInForce::ImmediateOrCancel)
+        );
+    }
+
+    #[test]
+    fn test_time_in_force_conversion_good_till_date() {
+        use chrono::{TimeZone, Utc};
+
+        let expiry = Utc.with_ymd_and_hms(2025, 6, 30, 23, 59, 59).unwrap();
+        assert_eq!(
+            time_in_force_to_ib(&TimeInForce::GoodTillDate { expiry }),
+            Ok(IbTimeInForce::GoodTilDate)
+        );
+    }
+
+    #[test]
+    fn test_time_in_force_conversion_at_open() {
+        assert_eq!(
+            time_in_force_to_ib(&TimeInForce::AtOpen),
+            Ok(IbTimeInForce::OnOpen)
+        );
+    }
+
+    #[test]
+    fn test_time_in_force_conversion_at_close_returns_err() {
+        // AtClose changes the order TYPE (MOC/LOC), so callers must route
+        // through build_ib_order. Other callers (e.g. bracket orders) get a
+        // graceful Err that they can surface as an order rejection.
+        assert_eq!(
+            time_in_force_to_ib(&TimeInForce::AtClose),
+            Err(OrderMappingError::AtCloseRequiresOrderTypeChange)
         );
     }
 
@@ -961,6 +1068,212 @@ mod tests {
                 TrailingOffsetType::BasisPoints
             ))
         ));
+    }
+
+    // =========================================================================
+    // Extended Time-in-Force Tests (Phase 6)
+    // =========================================================================
+
+    #[test]
+    fn test_build_market_order_at_open() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Buy,
+            100.0,
+            &OrderKind::Market,
+            Decimal::ZERO,
+            &TimeInForce::AtOpen,
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Buy);
+        assert_eq!(order.total_quantity, 100.0);
+        assert_eq!(order.order_type, "MKT");
+        assert_eq!(order.tif, IbTimeInForce::OnOpen);
+    }
+
+    #[test]
+    fn test_build_limit_order_at_open() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            50.0,
+            &OrderKind::Limit,
+            Decimal::from(150),
+            &TimeInForce::AtOpen,
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Sell);
+        assert_eq!(order.total_quantity, 50.0);
+        assert_eq!(order.order_type, "LMT");
+        assert_eq!(order.limit_price, Some(150.0));
+        assert_eq!(order.tif, IbTimeInForce::OnOpen);
+    }
+
+    #[test]
+    fn test_build_stop_order_at_open() {
+        // Stop orders can use AtOpen TIF
+        let order = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::Stop {
+                trigger_price: Decimal::from(45),
+            },
+            Decimal::ZERO,
+            &TimeInForce::AtOpen,
+        )
+        .unwrap();
+
+        assert_eq!(order.order_type, "STP");
+        assert_eq!(order.aux_price, Some(45.0));
+        assert_eq!(order.tif, IbTimeInForce::OnOpen);
+    }
+
+    #[test]
+    fn test_build_market_on_close() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Buy,
+            100.0,
+            &OrderKind::Market,
+            Decimal::ZERO,
+            &TimeInForce::AtClose,
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Buy);
+        assert_eq!(order.total_quantity, 100.0);
+        assert_eq!(order.order_type, "MOC");
+    }
+
+    #[test]
+    fn test_build_limit_on_close() {
+        let order = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            50.0,
+            &OrderKind::Limit,
+            Decimal::from(150),
+            &TimeInForce::AtClose,
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Sell);
+        assert_eq!(order.total_quantity, 50.0);
+        assert_eq!(order.order_type, "LOC");
+        assert_eq!(order.limit_price, Some(150.0));
+    }
+
+    #[test]
+    fn test_build_stop_at_close_unsupported() {
+        let result = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::Stop {
+                trigger_price: Decimal::from(45),
+            },
+            Decimal::ZERO,
+            &TimeInForce::AtClose,
+        );
+
+        assert!(matches!(
+            result,
+            Err(OrderMappingError::UnsupportedOrderKindForAtClose(
+                OrderKind::Stop { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_build_stop_limit_at_close_unsupported() {
+        let result = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::StopLimit {
+                trigger_price: Decimal::from(44),
+            },
+            Decimal::from(45),
+            &TimeInForce::AtClose,
+        );
+
+        assert!(matches!(
+            result,
+            Err(OrderMappingError::UnsupportedOrderKindForAtClose(
+                OrderKind::StopLimit { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_build_trailing_stop_at_close_unsupported() {
+        let result = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TrailingStop {
+                offset: Decimal::from(5),
+                offset_type: TrailingOffsetType::Percentage,
+            },
+            Decimal::ZERO,
+            &TimeInForce::AtClose,
+        );
+
+        assert!(matches!(
+            result,
+            Err(OrderMappingError::UnsupportedOrderKindForAtClose(
+                OrderKind::TrailingStop { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_build_trailing_stop_limit_at_close_unsupported() {
+        let result = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TrailingStopLimit {
+                offset: Decimal::from(5),
+                offset_type: TrailingOffsetType::Absolute,
+                limit_offset: Decimal::from(1),
+            },
+            Decimal::ZERO,
+            &TimeInForce::AtClose,
+        );
+
+        assert!(matches!(
+            result,
+            Err(OrderMappingError::UnsupportedOrderKindForAtClose(
+                OrderKind::TrailingStopLimit { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_build_good_till_date_order() {
+        use chrono::{TimeZone, Utc};
+
+        let expiry = Utc.with_ymd_and_hms(2025, 6, 30, 23, 59, 59).unwrap();
+        let order = build_ib_order(
+            rustrade_instrument::Side::Buy,
+            100.0,
+            &OrderKind::Limit,
+            Decimal::from(150),
+            &TimeInForce::GoodTillDate { expiry },
+        )
+        .unwrap();
+
+        assert_eq!(order.action, Action::Buy);
+        assert_eq!(order.total_quantity, 100.0);
+        assert_eq!(order.order_type, "LMT");
+        assert_eq!(order.tif, IbTimeInForce::GoodTilDate);
+        assert_eq!(order.good_till_date, "20250630-23:59:59");
+    }
+
+    #[test]
+    fn test_format_gtd_datetime() {
+        use chrono::{TimeZone, Utc};
+
+        let dt = Utc.with_ymd_and_hms(2024, 12, 25, 14, 30, 0).unwrap();
+        assert_eq!(format_gtd_datetime(&dt), "20241225-14:30:00");
+
+        let dt2 = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        assert_eq!(format_gtd_datetime(&dt2), "20250101-00:00:00");
     }
 
     // =========================================================================

--- a/rustrade-execution/src/error.rs
+++ b/rustrade-execution/src/error.rs
@@ -287,6 +287,13 @@ pub enum OrderError<AssetKey = AssetIndex, InstrumentKey = InstrumentIndex> {
     /// [`ApiError::RateLimit`] is transient; other variants are not.
     #[error("order rejected: {0}")]
     Rejected(#[from] ApiError<AssetKey, InstrumentKey>),
+
+    /// The order type is not supported by this connector.
+    ///
+    /// Non-transient — the connector does not support this order type (e.g.,
+    /// trailing stop orders on a connector that only supports market/limit).
+    #[error("unsupported order type: {0}")]
+    UnsupportedOrderType(String),
 }
 
 impl<AssetKey, InstrumentKey> OrderError<AssetKey, InstrumentKey> {
@@ -304,6 +311,7 @@ impl<AssetKey, InstrumentKey> OrderError<AssetKey, InstrumentKey> {
             Self::Connectivity(e) => e.is_transient(),
             Self::Rejected(ApiError::RateLimit) => true,
             Self::Rejected(_) => false,
+            Self::UnsupportedOrderType(_) => false,
         }
     }
 }

--- a/rustrade-execution/src/exchange/mock/mod.rs
+++ b/rustrade-execution/src/exchange/mock/mod.rs
@@ -325,11 +325,18 @@ impl MockExchange {
                 request.state.side,
                 match request.state.kind {
                     // unreachable: validate_order_kind_supported (called above) already
-                    // rejects Limit orders with Err, so this arm is never reached.
-                    // Kept for exhaustiveness; passes the limit price so fill models that
-                    // gain Limit support in future behave correctly without a separate change.
-                    OrderKind::Limit => Some(request.state.price),
+                    // rejects non-Market orders with Err, so these arms are never reached.
+                    // Kept for exhaustiveness; passes the limit/trigger price so fill models
+                    // that gain support in future behave correctly without a separate change.
                     OrderKind::Market => None,
+                    OrderKind::Limit
+                    | OrderKind::StopLimit { .. }
+                    | OrderKind::TrailingStopLimit { .. } => Some(request.state.price),
+                    OrderKind::Stop { trigger_price }
+                    | OrderKind::TrailingStop {
+                        offset: trigger_price,
+                        ..
+                    } => Some(trigger_price),
                 },
                 market_prices.best_bid,
                 market_prices.best_ask,
@@ -488,7 +495,7 @@ impl MockExchange {
             Ok(())
         } else {
             Err(UnindexedOrderError::Rejected(ApiError::OrderRejected(
-                format!("MockExchange does not supported OrderKind: {order_kind}"),
+                format!("MockExchange does not support OrderKind::{order_kind:?}"),
             )))
         }
     }

--- a/rustrade-execution/src/indexer.rs
+++ b/rustrade-execution/src/indexer.rs
@@ -208,6 +208,9 @@ impl AccountEventIndexer {
                     OrderError::Connectivity(error) => {
                         OrderState::inactive(OrderError::Connectivity(error))
                     }
+                    OrderError::UnsupportedOrderType(msg) => {
+                        OrderState::inactive(OrderError::UnsupportedOrderType(msg))
+                    }
                 },
                 InactiveOrderState::Cancelled(cancelled) => OrderState::inactive(cancelled),
                 InactiveOrderState::FullyFilled(filled) => OrderState::fully_filled(filled),
@@ -271,6 +274,7 @@ impl AccountEventIndexer {
         Ok(match error {
             UnindexedOrderError::Connectivity(error) => OrderError::Connectivity(error),
             UnindexedOrderError::Rejected(error) => OrderError::Rejected(self.api_error(error)?),
+            UnindexedOrderError::UnsupportedOrderType(msg) => OrderError::UnsupportedOrderType(msg),
         })
     }
 

--- a/rustrade-execution/src/order/mod.rs
+++ b/rustrade-execution/src/order/mod.rs
@@ -3,6 +3,7 @@ use crate::order::{
     request::{OrderRequestCancel, OrderRequestOpen, RequestCancel, RequestOpen},
     state::UnindexedOrderState,
 };
+use chrono::{DateTime, Utc};
 use derive_more::{Constructor, Display};
 use id::ClientOrderId;
 use rust_decimal::Decimal;
@@ -206,10 +207,21 @@ pub enum OrderKind {
     Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Display,
 )]
 pub enum TimeInForce {
-    GoodUntilCancelled { post_only: bool },
+    GoodUntilCancelled {
+        post_only: bool,
+    },
     GoodUntilEndOfDay,
     FillOrKill,
     ImmediateOrCancel,
+    /// Good until a specific date/time. Order expires if not filled by the specified time.
+    #[display("GoodTillDate({expiry})")]
+    GoodTillDate {
+        expiry: DateTime<Utc>,
+    },
+    /// Execute at market open (OPG). Valid for various order types.
+    AtOpen,
+    /// Execute at market close. Only valid with Market (→ MOC) or Limit (→ LOC) orders.
+    AtClose,
 }
 
 impl<ExchangeKey, InstrumentKey> From<&OrderRequestOpen<ExchangeKey, InstrumentKey>>

--- a/rustrade-execution/src/order/mod.rs
+++ b/rustrade-execution/src/order/mod.rs
@@ -152,12 +152,54 @@ where
     }
 }
 
+/// Specifies how the trailing offset is measured for trailing stop orders.
+///
+/// Different exchanges support different offset types:
+/// - IBKR: Absolute (dollar amount) and Percentage
+/// - Binance: BasisPoints (1/100th of 1%)
+/// - Alpaca/Coinbase: Do not support trailing stops
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Display,
+)]
+pub enum TrailingOffsetType {
+    /// Absolute dollar/currency amount (e.g., $2.00 trailing distance).
+    Absolute,
+    /// Percentage of the current price (e.g., 5% trailing distance).
+    Percentage,
+    /// Basis points (1/100th of 1%). Used by Binance.
+    BasisPoints,
+}
+
 #[derive(
     Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Display,
 )]
 pub enum OrderKind {
     Market,
     Limit,
+    /// Stop (market) order - triggers a market order when trigger_price is reached.
+    #[display("Stop({trigger_price})")]
+    Stop {
+        trigger_price: Decimal,
+    },
+    /// Stop-limit order - triggers a limit order at Order.price when trigger_price is reached.
+    #[display("StopLimit({trigger_price})")]
+    StopLimit {
+        trigger_price: Decimal,
+    },
+    /// Trailing stop order - stop price trails the market by a specified offset.
+    #[display("TrailingStop({offset}, {offset_type})")]
+    TrailingStop {
+        offset: Decimal,
+        offset_type: TrailingOffsetType,
+    },
+    /// Trailing stop-limit order - when triggered, submits a limit order offset from the stop.
+    #[display("TrailingStopLimit({offset}, {offset_type}, {limit_offset})")]
+    TrailingStopLimit {
+        offset: Decimal,
+        offset_type: TrailingOffsetType,
+        /// Offset from the triggered stop price to set the limit price.
+        limit_offset: Decimal,
+    },
 }
 
 #[derive(

--- a/rustrade-execution/tests/ibkr_execution.rs
+++ b/rustrade-execution/tests/ibkr_execution.rs
@@ -1051,3 +1051,230 @@ async fn test_place_and_cancel_trailing_stop_limit_absolute() {
         }
     }
 }
+
+// ============================================================================
+// Bracket Order Tests (TG13 Phase 3)
+// ============================================================================
+
+/// Test placing and cancelling a bracket order with OCA linkage.
+///
+/// Places a bracket order with:
+/// - Entry: Buy limit at $1 (won't fill since AAPL >> $1)
+/// - Take Profit: Sell limit at $2
+/// - Stop Loss: Sell stop at $0.50
+///
+/// Verifies all three legs are accepted, then cancels the parent which
+/// should cascade to cancel the children.
+#[tokio::test]
+#[ignore]
+async fn test_place_and_cancel_bracket_order() {
+    use rustrade_execution::client::ibkr::BracketOrderRequest;
+
+    init_logging();
+
+    let config = test_config(16);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let strategy = StrategyId::new("test-bracket-order");
+    let parent_cid =
+        ClientOrderId::new(format!("bracket-{}", chrono::Utc::now().timestamp_millis()));
+
+    let request = BracketOrderRequest {
+        instrument: aapl_name.clone(),
+        strategy: strategy.clone(),
+        parent_cid: parent_cid.clone(),
+        side: Side::Buy,
+        quantity: dec!(1),
+        entry_price: dec!(1.00),       // Entry at $1 (won't fill)
+        take_profit_price: dec!(2.00), // TP at $2
+        stop_loss_price: dec!(0.50),   // SL at $0.50
+        time_in_force: TimeInForce::GoodUntilEndOfDay,
+    };
+
+    println!("Placing bracket order: BUY 1 AAPL @ $1.00 entry, $2.00 TP, $0.50 SL");
+
+    let result = client.open_bracket_order(request).await;
+
+    // Check parent order
+    match &result.parent.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Parent order placed successfully!");
+            println!("  Client Order ID: {}", result.parent.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+        }
+        OrderState::Inactive(e) => {
+            panic!("Parent order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected parent order state: {:?}", other);
+        }
+    }
+
+    // Check take profit order
+    match &result.take_profit.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Take profit order placed successfully!");
+            println!("  Client Order ID: {}", result.take_profit.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+        }
+        OrderState::Inactive(e) => {
+            panic!("Take profit order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected take profit order state: {:?}", other);
+        }
+    }
+
+    // Check stop loss order
+    match &result.stop_loss.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Stop loss order placed successfully!");
+            println!("  Client Order ID: {}", result.stop_loss.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+        }
+        OrderState::Inactive(e) => {
+            panic!("Stop loss order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected stop loss order state: {:?}", other);
+        }
+    }
+
+    // Brief delay before cancel
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Cancel the parent order - this should cascade to children via IB's parent_id linkage
+    if let OrderState::Active(ActiveOrderState::Open(open_state)) = &result.parent.state {
+        let cancel_key = OrderKey {
+            exchange: ExchangeId::Ibkr,
+            instrument: &aapl_name,
+            strategy: result.parent.key.strategy.clone(),
+            cid: result.parent.key.cid.clone(),
+        };
+
+        let cancel_request = rustrade_execution::order::OrderEvent {
+            key: cancel_key,
+            state: rustrade_execution::order::request::RequestCancel {
+                id: Some(open_state.id.clone()),
+            },
+        };
+
+        println!("Canceling bracket order (parent)...");
+        let cancel_response = client.cancel_order(cancel_request).await;
+
+        assert!(cancel_response.is_some(), "Expected cancel response");
+        let cancel_response = cancel_response.unwrap();
+
+        match &cancel_response.state {
+            Ok(_cancelled) => {
+                println!("Bracket order canceled successfully!");
+                println!("  (Children should be auto-cancelled by IB via parent_id linkage)");
+            }
+            Err(e) => {
+                panic!("Cancel rejected: {:?}", e);
+            }
+        }
+    }
+}
+
+/// Test that bracket order OCA group is set correctly.
+///
+/// This test verifies the OCA linkage by checking that when we fetch open orders,
+/// the TP and SL orders share the same OCA group identifier.
+#[tokio::test]
+#[ignore]
+async fn test_bracket_order_oca_group_linkage() {
+    use rustrade_execution::client::ibkr::BracketOrderRequest;
+
+    init_logging();
+
+    let config = test_config(17);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let strategy = StrategyId::new("test-bracket-oca");
+    let parent_cid = ClientOrderId::new(format!(
+        "bracket-oca-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let request = BracketOrderRequest {
+        instrument: aapl_name.clone(),
+        strategy: strategy.clone(),
+        parent_cid: parent_cid.clone(),
+        side: Side::Buy,
+        quantity: dec!(1),
+        entry_price: dec!(1.00),
+        take_profit_price: dec!(2.00),
+        stop_loss_price: dec!(0.50),
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+    };
+
+    println!("Placing bracket order to verify OCA linkage...");
+    let result = client.open_bracket_order(request).await;
+
+    // Verify all three are active
+    assert!(
+        matches!(result.parent.state, OrderState::Active(_)),
+        "Parent should be active"
+    );
+    assert!(
+        matches!(result.take_profit.state, OrderState::Active(_)),
+        "TP should be active"
+    );
+    assert!(
+        matches!(result.stop_loss.state, OrderState::Active(_)),
+        "SL should be active"
+    );
+
+    println!("All three legs placed successfully.");
+    println!("  Parent CID: {}", result.parent.key.cid);
+    println!(
+        "  TP CID: {} (should end with _tp)",
+        result.take_profit.key.cid
+    );
+    println!(
+        "  SL CID: {} (should end with _sl)",
+        result.stop_loss.key.cid
+    );
+
+    // Verify CID naming convention
+    assert!(
+        result.take_profit.key.cid.0.ends_with("_tp"),
+        "TP CID should end with _tp"
+    );
+    assert!(
+        result.stop_loss.key.cid.0.ends_with("_sl"),
+        "SL CID should end with _sl"
+    );
+
+    // Brief delay before cleanup
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Cleanup: cancel the parent
+    if let OrderState::Active(ActiveOrderState::Open(open_state)) = &result.parent.state {
+        let cancel_key = OrderKey {
+            exchange: ExchangeId::Ibkr,
+            instrument: &aapl_name,
+            strategy: result.parent.key.strategy.clone(),
+            cid: result.parent.key.cid.clone(),
+        };
+
+        let cancel_request = rustrade_execution::order::OrderEvent {
+            key: cancel_key,
+            state: rustrade_execution::order::request::RequestCancel {
+                id: Some(open_state.id.clone()),
+            },
+        };
+
+        let _ = client.cancel_order(cancel_request).await;
+        println!("Cleanup: bracket order cancelled.");
+    }
+}

--- a/rustrade-execution/tests/ibkr_execution.rs
+++ b/rustrade-execution/tests/ibkr_execution.rs
@@ -31,7 +31,7 @@ use rustrade_execution::{
         ibkr::{IbkrClient, IbkrConfig, contract::stock_contract},
     },
     order::{
-        OrderKey, OrderKind, TimeInForce,
+        OrderKey, OrderKind, TimeInForce, TrailingOffsetType,
         id::{ClientOrderId, StrategyId},
         request::RequestOpen,
         state::{ActiveOrderState, InactiveOrderState, OrderState},
@@ -637,5 +637,417 @@ async fn test_cancel_produces_cancelled_not_expired() {
         panic!("FAILURE: Order state is Expired (should be Cancelled for user-initiated cancel)");
     } else {
         println!("WARNING: No terminal state observed in stream (cancel_order response was OK)");
+    }
+}
+
+// ============================================================================
+// Stop and Trailing Stop Order Tests (TG13 Phase 1 & 2)
+// ============================================================================
+
+/// Test placing and cancelling a Stop order.
+///
+/// Uses a Sell Stop with trigger at $0.01 - since AAPL trades far above this,
+/// the stop will never trigger and the order remains open for cancellation.
+#[tokio::test]
+#[ignore]
+async fn test_place_and_cancel_stop_order() {
+    init_logging();
+
+    let config = test_config(12);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let strategy = StrategyId::new("test-stop-order");
+    let order_cid = ClientOrderId::new(format!(
+        "stop-order-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Sell Stop at $0.01 trigger - won't trigger since AAPL >> $0.01
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: dec!(0.00), // Not used for Stop (market) orders
+        quantity: dec!(1),
+        kind: OrderKind::Stop {
+            trigger_price: dec!(0.01),
+        },
+        time_in_force: TimeInForce::GoodUntilEndOfDay,
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing Stop order: SELL 1 AAPL @ Stop $0.01 (won't trigger)");
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Stop order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: &aapl_name,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling Stop order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            let cancel_response = cancel_response.unwrap();
+
+            match &cancel_response.state {
+                Ok(_cancelled) => {
+                    println!("Stop order canceled successfully!");
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("Stop order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}
+
+/// Test placing and cancelling a Stop-Limit order.
+///
+/// Uses a Sell StopLimit with trigger at $0.01 and limit at $0.01 -
+/// since AAPL trades far above this, the stop will never trigger.
+#[tokio::test]
+#[ignore]
+async fn test_place_and_cancel_stop_limit_order() {
+    init_logging();
+
+    let config = test_config(13);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let strategy = StrategyId::new("test-stop-limit-order");
+    let order_cid = ClientOrderId::new(format!(
+        "stop-limit-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Sell StopLimit: trigger at $0.01, limit at $0.01 - won't trigger
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: dec!(0.01), // Limit price (used when stop triggers)
+        quantity: dec!(1),
+        kind: OrderKind::StopLimit {
+            trigger_price: dec!(0.01),
+        },
+        time_in_force: TimeInForce::GoodUntilEndOfDay,
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing StopLimit order: SELL 1 AAPL @ Stop $0.01, Limit $0.01 (won't trigger)");
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("StopLimit order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: &aapl_name,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling StopLimit order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            let cancel_response = cancel_response.unwrap();
+
+            match &cancel_response.state {
+                Ok(_cancelled) => {
+                    println!("StopLimit order canceled successfully!");
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("StopLimit order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}
+
+/// Test placing and cancelling a TrailingStop order with percentage offset.
+///
+/// Uses a Sell TrailingStop with 50% trail - the stop price trails 50% below
+/// the highest price seen. Since this creates a very wide trail, the order
+/// won't trigger and remains open for cancellation.
+#[tokio::test]
+#[ignore]
+async fn test_place_and_cancel_trailing_stop_percentage() {
+    init_logging();
+
+    let config = test_config(14);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let strategy = StrategyId::new("test-trailing-stop-pct");
+    let order_cid = ClientOrderId::new(format!(
+        "trail-stop-pct-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Sell TrailingStop with 50% percentage offset - won't trigger
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: dec!(0.00), // Not used for trailing stop (market) orders
+        quantity: dec!(1),
+        kind: OrderKind::TrailingStop {
+            offset: dec!(50), // 50% trailing offset
+            offset_type: TrailingOffsetType::Percentage,
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing TrailingStop order: SELL 1 AAPL @ 50% trail (won't trigger)");
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("TrailingStop (percentage) order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: &aapl_name,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling TrailingStop order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            let cancel_response = cancel_response.unwrap();
+
+            match &cancel_response.state {
+                Ok(_cancelled) => {
+                    println!("TrailingStop (percentage) order canceled successfully!");
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("TrailingStop order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}
+
+/// Test placing and cancelling a TrailingStopLimit order with absolute offset.
+///
+/// Uses a Sell TrailingStopLimit with $500 absolute trail and $1 limit offset -
+/// the stop price trails $500 below the highest price seen. A $500 trailing
+/// distance is far wider than typical intraday AAPL moves, so the stop won't
+/// trigger and the order remains open for cancellation.
+#[tokio::test]
+#[ignore]
+async fn test_place_and_cancel_trailing_stop_limit_absolute() {
+    init_logging();
+
+    let config = test_config(15);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let strategy = StrategyId::new("test-trailing-stop-limit-abs");
+    let order_cid = ClientOrderId::new(format!(
+        "trail-stop-limit-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Sell TrailingStopLimit: $500 absolute trail, $1 limit offset from stop
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: dec!(0.00), // Not used directly; limit_offset determines limit price
+        quantity: dec!(1),
+        kind: OrderKind::TrailingStopLimit {
+            offset: dec!(500), // $500 trailing amount
+            offset_type: TrailingOffsetType::Absolute,
+            limit_offset: dec!(1), // Limit price = stop price - $1
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!(
+        "Placing TrailingStopLimit order: SELL 1 AAPL @ $500 trail, $1 limit offset (won't trigger)"
+    );
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("TrailingStopLimit (absolute) order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: &aapl_name,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling TrailingStopLimit order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            let cancel_response = cancel_response.unwrap();
+
+            match &cancel_response.state {
+                Ok(_cancelled) => {
+                    println!("TrailingStopLimit (absolute) order canceled successfully!");
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("TrailingStopLimit order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
     }
 }

--- a/rustrade-execution/tests/ibkr_execution.rs
+++ b/rustrade-execution/tests/ibkr_execution.rs
@@ -2,6 +2,12 @@
 //!
 //! These tests require IB Gateway or TWS running on localhost:4002 (paper account).
 //!
+//! # Safety
+//!
+//! **All tests use paper trading accounts only.** The `IBKR_PAPER_ACCOUNT` env var is required
+//! and tests connect to port 4002 (Gateway paper) or 7497 (TWS paper). Never configure these
+//! tests to use a live trading account.
+//!
 //! # Prerequisites
 //!
 //! 1. IB Gateway or TWS running with API enabled
@@ -19,6 +25,38 @@
 //! ```
 //!
 //! Tests are marked `#[ignore]` to avoid CI failures without IB connectivity.
+//!
+//! # Subscription Tiers
+//!
+//! Tests are organized by the market data subscriptions required to run them.
+//!
+//! ## Tier 0: Paper Account Only (FREE)
+//!
+//! No market data subscriptions needed — just a paper trading account.
+//!
+//! | Test | Description |
+//! |------|-------------|
+//! | `test_connection` | Connect to IB Gateway |
+//! | `test_contract_registration` | Register contracts in local registry |
+//! | `test_fetch_balances` | Fetch account balances |
+//! | `test_account_snapshot` | Fetch full account snapshot |
+//! | `test_fetch_open_orders` | Fetch currently open orders |
+//! | `test_account_stream` | Stream account events |
+//! | `test_fetch_trades` | Fetch historical trades |
+//! | `test_order_id_mapping_cleanup` | Test stale order cleanup |
+//! | `test_place_and_cancel_limit_order` | Place and cancel limit order |
+//! | `test_order_without_registered_contract` | Verify rejection for unknown contract |
+//! | `test_cancel_nonexistent_order` | Verify rejection for unknown order |
+//! | `test_cancel_produces_cancelled_not_expired` | Verify Cancelled vs Expired state |
+//! | `test_place_and_cancel_stop_order` | Stop order lifecycle |
+//! | `test_place_and_cancel_stop_limit_order` | Stop-limit order lifecycle |
+//! | `test_place_and_cancel_trailing_stop_percentage` | Trailing stop (%) lifecycle |
+//! | `test_place_and_cancel_trailing_stop_limit_absolute` | Trailing stop-limit ($) lifecycle |
+//! | `test_place_and_cancel_bracket_order` | Bracket order with OCA |
+//! | `test_bracket_order_oca_group_linkage` | Verify OCA group linkage |
+//! | `test_place_and_cancel_gtd_order` | Good-Till-Date order |
+//! | `test_place_moo_order_premarket` | Market-on-Open (timing-sensitive) |
+//! | `test_place_loo_order_premarket` | Limit-on-Open (timing-sensitive) |
 
 #![cfg(feature = "ibkr")]
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Integration tests: panics are the correct failure mode
@@ -87,7 +125,7 @@ async fn connect_client(config: IbkrConfig) -> Result<IbkrClient, String> {
 }
 
 // ============================================================================
-// Connection Tests
+// Connection Tests — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -128,7 +166,7 @@ async fn test_contract_registration() {
 }
 
 // ============================================================================
-// Account Snapshot Tests
+// Account Snapshot Tests — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -180,7 +218,7 @@ async fn test_account_snapshot() {
 }
 
 // ============================================================================
-// Open Orders Tests
+// Open Orders Tests — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -215,7 +253,7 @@ async fn test_fetch_open_orders() {
 }
 
 // ============================================================================
-// Order Lifecycle Tests
+// Order Lifecycle Tests — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -314,7 +352,7 @@ async fn test_place_and_cancel_limit_order() {
 }
 
 // ============================================================================
-// Account Stream Tests
+// Account Stream Tests — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -360,7 +398,7 @@ async fn test_account_stream() {
 }
 
 // ============================================================================
-// Historical Trades Tests
+// Historical Trades Tests — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -397,7 +435,7 @@ async fn test_fetch_trades() {
 }
 
 // ============================================================================
-// Order ID Mapping Tests
+// Order ID Mapping Tests — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -418,7 +456,7 @@ async fn test_order_id_mapping_cleanup() {
 }
 
 // ============================================================================
-// Edge Case Tests
+// Edge Case Tests — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 #[tokio::test]
@@ -504,7 +542,7 @@ async fn test_cancel_nonexistent_order() {
 }
 
 // ============================================================================
-// Cancelled vs Expired Differentiation Tests
+// Cancelled vs Expired Differentiation Tests — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 /// Verifies that user-initiated cancel produces `Cancelled` state, not `Expired`.
@@ -641,7 +679,7 @@ async fn test_cancel_produces_cancelled_not_expired() {
 }
 
 // ============================================================================
-// Stop and Trailing Stop Order Tests (TG13 Phase 1 & 2)
+// Stop and Trailing Stop Order Tests (TG13 Phase 1 & 2) — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 /// Test placing and cancelling a Stop order.
@@ -1053,7 +1091,7 @@ async fn test_place_and_cancel_trailing_stop_limit_absolute() {
 }
 
 // ============================================================================
-// Bracket Order Tests (TG13 Phase 3)
+// Bracket Order Tests (TG13 Phase 3) — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 /// Test placing and cancelling a bracket order with OCA linkage.
@@ -1280,7 +1318,7 @@ async fn test_bracket_order_oca_group_linkage() {
 }
 
 // ============================================================================
-// Extended Time-in-Force Tests (TG13 Phase 6)
+// Extended Time-in-Force Tests (TG13 Phase 6) — Tier 0: Paper Account Only (FREE)
 // ============================================================================
 
 /// Test placing and cancelling a Good-Till-Date (GTD) order.

--- a/rustrade-execution/tests/ibkr_execution.rs
+++ b/rustrade-execution/tests/ibkr_execution.rs
@@ -1278,3 +1278,298 @@ async fn test_bracket_order_oca_group_linkage() {
         println!("Cleanup: bracket order cancelled.");
     }
 }
+
+// ============================================================================
+// Extended Time-in-Force Tests (TG13 Phase 6)
+// ============================================================================
+
+/// Test placing and cancelling a Good-Till-Date (GTD) order.
+///
+/// Uses a limit order with expiry set to tomorrow. The order won't fill at $1
+/// and will be cancelled before expiry.
+#[tokio::test]
+#[ignore]
+async fn test_place_and_cancel_gtd_order() {
+    init_logging();
+
+    let config = test_config(18);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let strategy = StrategyId::new("test-gtd-order");
+    let order_cid = ClientOrderId::new(format!(
+        "gtd-order-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // GTD order expiring tomorrow at 23:59:59 UTC
+    let expiry = chrono::Utc::now() + chrono::Duration::days(1);
+    let request_open = RequestOpen {
+        side: Side::Buy,
+        price: dec!(1.00),
+        quantity: dec!(1),
+        kind: OrderKind::Limit,
+        time_in_force: TimeInForce::GoodTillDate { expiry },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!(
+        "Placing GTD limit order: BUY 1 AAPL @ $1.00, expires {}",
+        expiry.format("%Y-%m-%d %H:%M:%S UTC")
+    );
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("GTD order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: &aapl_name,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling GTD order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            let cancel_response = cancel_response.unwrap();
+
+            match &cancel_response.state {
+                Ok(_cancelled) => {
+                    println!("GTD order canceled successfully!");
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("GTD order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}
+
+/// Test placing a Market-on-Open (MOO) order during pre-market.
+///
+/// Note: This test is timing-sensitive - it should be run during pre-market hours
+/// (before 9:30 AM ET) for the order to be accepted. Running during regular hours
+/// will result in rejection.
+#[tokio::test]
+#[ignore]
+async fn test_place_moo_order_premarket() {
+    init_logging();
+
+    let config = test_config(19);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let strategy = StrategyId::new("test-moo-order");
+    let order_cid = ClientOrderId::new(format!(
+        "moo-order-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Market-on-Open order - only valid during pre-market
+    let request_open = RequestOpen {
+        side: Side::Buy,
+        price: dec!(0.00), // Not used for market orders
+        quantity: dec!(1),
+        kind: OrderKind::Market,
+        time_in_force: TimeInForce::AtOpen,
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing MOO order: BUY 1 AAPL at market open");
+    println!("Note: This test should be run during pre-market hours");
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("MOO order placed successfully (pre-market)!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+
+            // Cancel immediately to avoid execution at open
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: &aapl_name,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling MOO order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            match &cancel_response.unwrap().state {
+                Ok(_) => println!("MOO order canceled successfully!"),
+                Err(e) => panic!("Cancel rejected: {:?}", e),
+            }
+        }
+        OrderState::Inactive(e) => {
+            // This is expected if running outside pre-market hours
+            println!("MOO order rejected (expected if not pre-market): {:?}", e);
+            println!("Test is timing-sensitive - run during pre-market for success");
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}
+
+/// Test placing a Limit-on-Open (LOO) order during pre-market.
+///
+/// Similar to MOO but with a limit price. The order will only fill if the
+/// opening price is at or below the limit.
+#[tokio::test]
+#[ignore]
+async fn test_place_loo_order_premarket() {
+    init_logging();
+
+    let config = test_config(20);
+    let client = connect_client(config).await.expect("connection failed");
+
+    let aapl_name = aapl_instrument();
+    let aapl_contract = stock_contract("AAPL", "SMART", "USD");
+    client.register_contract(aapl_name.clone(), aapl_contract);
+
+    let strategy = StrategyId::new("test-loo-order");
+    let order_cid = ClientOrderId::new(format!(
+        "loo-order-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::Ibkr,
+        instrument: &aapl_name,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Limit-on-Open at $1 - won't fill
+    let request_open = RequestOpen {
+        side: Side::Buy,
+        price: dec!(1.00),
+        quantity: dec!(1),
+        kind: OrderKind::Limit,
+        time_in_force: TimeInForce::AtOpen,
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing LOO order: BUY 1 AAPL @ $1.00 at market open");
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("LOO order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::Ibkr,
+                instrument: &aapl_name,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling LOO order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            match &cancel_response.unwrap().state {
+                Ok(_) => println!("LOO order canceled successfully!"),
+                Err(e) => panic!("Cancel rejected: {:?}", e),
+            }
+        }
+        OrderState::Inactive(e) => {
+            println!("LOO order rejected (may be timing-related): {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `OrderKind::Stop`, `StopLimit`, `TrailingStop`, and `TrailingStopLimit` variants with `trigger_price`, `offset`, and `limit_offset` fields
- Add `TrailingOffsetType` enum (`Absolute`, `Percentage`, `BasisPoints`) for trailing order configuration
- Add `OrderError::UnsupportedOrderType` for connectors that don't support certain order types
- Full IBKR support: Maps to ibapi `stop()`, `stop_limit()`, `trailing_stop()`, `trailing_stop_limit()` builders
- Binance/Alpaca: Return `UnsupportedOrderType` error (native support planned for future PR)

Implements TG13 Phase 1 (Stop/Stop-Limit) and Phase 2 (Trailing Stop) from `docs/current_task.md`.

## Test plan

- [x] All 20 IBKR order tests pass
- [x] All 36 Binance tests pass
- [x] Clippy clean
- [ ] Integration tests require live IBKR connection (marked `#[ignore]`)