### PR TITLE
Remove ExchangeId::Alpaca in favor of specific variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,12 +93,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     compiler-enforced invariant.)
   - Migration: For `Limit`, `StopLimit`, and `TrailingStopLimit` orders, wrap the
     limit price in `Some()`. For `Market`, `Stop`, and `TrailingStop` orders, use `None`.
-
-### Deprecated
-
-- `ExchangeId::Alpaca`: Use `AlpacaIex`, `AlpacaSip`, or `AlpacaCrypto` instead.
-  The bare `Alpaca` variant will be removed in the next major version.
-  Migration: Replace `ExchangeId::Alpaca` with `ExchangeId::AlpacaIex` for US equities.
+- **BREAKING**: Removed `ExchangeId::Alpaca`.
+  - Use `AlpacaIex`, `AlpacaSip`, or `AlpacaCrypto` for market data feeds
+  - Use `AlpacaBroker` for execution
+  - Migration: Replace `ExchangeId::Alpaca` with the appropriate specific variant
 
 ## [0.1.0] - 2026-05-01
 

--- a/rustrade-instrument/src/exchange.rs
+++ b/rustrade-instrument/src/exchange.rs
@@ -34,11 +34,6 @@ pub enum ExchangeId {
     Other,
     Simulated,
     Mock,
-    #[deprecated(
-        since = "0.2.0",
-        note = "Use AlpacaIex, AlpacaSip, or AlpacaCrypto instead"
-    )]
-    Alpaca,
     BinanceFuturesCoin,
     BinanceFuturesUsd,
     BinanceOptions,
@@ -110,12 +105,10 @@ pub enum ExchangeId {
 impl ExchangeId {
     /// Return the &str representation of this [`ExchangeId`]
     pub fn as_str(&self) -> &'static str {
-        #[allow(deprecated)] // Alpaca variant retained for serialization until removal
         match self {
             ExchangeId::Other => "other",
             ExchangeId::Simulated => "simulated",
             ExchangeId::Mock => "mock",
-            ExchangeId::Alpaca => "alpaca",
             ExchangeId::AlpacaBroker => "alpaca_broker",
             ExchangeId::AlpacaCrypto => "alpaca_crypto",
             ExchangeId::AlpacaIex => "alpaca_iex",


### PR DESCRIPTION
## Summary

- Remove deprecated `ExchangeId::Alpaca` variant entirely (breaking change)
- Users should use `AlpacaIex`, `AlpacaSip`, `AlpacaCrypto`, or `AlpacaBroker` instead
- Since 0.2.0 already has multiple breaking changes, no need to deprecate first

## Test plan

- [x] `cargo check -p rustrade-instrument` passes
- [x] `cargo clippy` clean