### PR TITLE
feat(alpaca): Options market data and advanced order types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `AlpacaIex`: Free IEX feed for US equities
   - `AlpacaSip`: Paid consolidated SIP feed for US equities
   - `AlpacaCrypto`: Crypto market data
+- **Alpaca options market data**: REST-based option discovery and Greeks snapshots
+  - `AlpacaOptionsClient`: Options market data client with rate limiting and pagination
+  - `AlpacaOptionContractQuery`: Builder for filtering contracts by underlying, expiration, strike, type, style
+  - `fetch_contracts(query)`: Discover option contracts via `GET /v2/options/contracts`
+  - `AlpacaOptionSnapshot`: Option snapshot with quote and Greeks data
+  - `fetch_snapshots(symbols, feed)`: Fetch snapshots with Greeks via `GET /v1beta1/options/snapshots`
+  - `fetch_chain_snapshots(underlying, feed)`: Convenience method for entire option chains
+  - `AlpacaOptionFeed`: `Opra` (real-time, paid) or `Indicative` (15-min delayed, free)
+  - **Note**: Greeks streaming is NOT available — Alpaca only provides REST snapshots for Greeks data
 - **Quotes subscription kind**: Generic top-of-book quotes (`SubKind::Quotes`)
 - `ExchangeId::AlpacaBroker`: Dedicated variant for Alpaca execution client
   (distinct from market data feed identifiers)

--- a/rustrade-data/src/exchange/alpaca/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/mod.rs
@@ -50,6 +50,7 @@ use url::Url;
 
 pub mod channel;
 pub mod market;
+pub mod options;
 pub mod quote;
 pub mod subscription;
 pub mod trade;

--- a/rustrade-data/src/exchange/alpaca/options/contracts.rs
+++ b/rustrade-data/src/exchange/alpaca/options/contracts.rs
@@ -1,0 +1,592 @@
+//! Option contract discovery types and methods.
+//!
+//! Implements `GET /v2/options/contracts` for querying available option contracts.
+
+use super::{AlpacaOptionsClient, AlpacaOptionsError};
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+use rustrade_instrument::instrument::kind::option::{OptionExercise, OptionKind};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use tracing::debug;
+
+/// Maximum contracts per page (Alpaca API limit).
+const MAX_PAGE_SIZE: usize = 10_000;
+
+/// Default page size for contract queries.
+const DEFAULT_PAGE_SIZE: usize = 1_000;
+
+/// Maximum pages to fetch before stopping (safety limit).
+const MAX_PAGES: usize = 100;
+
+/// Query parameters for option contract discovery.
+///
+/// Use builder methods to construct the query, then pass to
+/// [`AlpacaOptionsClient::fetch_contracts`].
+///
+/// # Example
+///
+/// ```
+/// use rustrade_data::exchange::alpaca::options::AlpacaOptionContractQuery;
+/// use chrono::NaiveDate;
+/// use rust_decimal_macros::dec;
+///
+/// let query = AlpacaOptionContractQuery::new(vec!["AAPL".into(), "TSLA".into()])
+///     .expiration_gte(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap())
+///     .expiration_lte(NaiveDate::from_ymd_opt(2024, 3, 31).unwrap())
+///     .strike_gte(dec!(100))
+///     .strike_lte(dec!(200))
+///     .call_only();
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct AlpacaOptionContractQuery {
+    /// Filter by underlying symbols (e.g., ["AAPL", "TSLA"]).
+    pub underlying_symbols: Vec<String>,
+    /// Minimum expiration date (inclusive).
+    pub expiration_date_gte: Option<NaiveDate>,
+    /// Maximum expiration date (inclusive).
+    pub expiration_date_lte: Option<NaiveDate>,
+    /// Minimum strike price (inclusive).
+    pub strike_price_gte: Option<Decimal>,
+    /// Maximum strike price (inclusive).
+    pub strike_price_lte: Option<Decimal>,
+    /// Filter by option type (call or put).
+    pub option_type: Option<OptionKind>,
+    /// Filter by exercise style (american or european).
+    pub style: Option<OptionExercise>,
+    /// Page size (default 1000, max 10000).
+    pub limit: Option<usize>,
+}
+
+impl AlpacaOptionContractQuery {
+    /// Create a new query for the given underlying symbols.
+    pub fn new(underlying_symbols: Vec<String>) -> Self {
+        Self {
+            underlying_symbols,
+            ..Default::default()
+        }
+    }
+
+    /// Filter contracts expiring on or after this date.
+    #[must_use]
+    pub fn expiration_gte(mut self, date: NaiveDate) -> Self {
+        self.expiration_date_gte = Some(date);
+        self
+    }
+
+    /// Filter contracts expiring on or before this date.
+    #[must_use]
+    pub fn expiration_lte(mut self, date: NaiveDate) -> Self {
+        self.expiration_date_lte = Some(date);
+        self
+    }
+
+    /// Filter contracts with strike price at or above this value.
+    #[must_use]
+    pub fn strike_gte(mut self, strike: Decimal) -> Self {
+        self.strike_price_gte = Some(strike);
+        self
+    }
+
+    /// Filter contracts with strike price at or below this value.
+    #[must_use]
+    pub fn strike_lte(mut self, strike: Decimal) -> Self {
+        self.strike_price_lte = Some(strike);
+        self
+    }
+
+    /// Filter to call options only.
+    #[must_use]
+    pub fn call_only(mut self) -> Self {
+        self.option_type = Some(OptionKind::Call);
+        self
+    }
+
+    /// Filter to put options only.
+    #[must_use]
+    pub fn put_only(mut self) -> Self {
+        self.option_type = Some(OptionKind::Put);
+        self
+    }
+
+    /// Filter by option type.
+    #[must_use]
+    pub fn option_type(mut self, kind: OptionKind) -> Self {
+        self.option_type = Some(kind);
+        self
+    }
+
+    /// Filter by exercise style.
+    #[must_use]
+    pub fn style(mut self, style: OptionExercise) -> Self {
+        self.style = Some(style);
+        self
+    }
+
+    /// Set page size (max 10000).
+    #[must_use]
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit.min(MAX_PAGE_SIZE));
+        self
+    }
+
+    /// Build query parameters for the API request.
+    fn to_query_params(&self) -> Vec<(&'static str, String)> {
+        let mut params = Vec::new();
+
+        if !self.underlying_symbols.is_empty() {
+            params.push(("underlying_symbols", self.underlying_symbols.join(",")));
+        }
+        if let Some(date) = self.expiration_date_gte {
+            params.push(("expiration_date_gte", date.format("%Y-%m-%d").to_string()));
+        }
+        if let Some(date) = self.expiration_date_lte {
+            params.push(("expiration_date_lte", date.format("%Y-%m-%d").to_string()));
+        }
+        if let Some(strike) = self.strike_price_gte {
+            params.push(("strike_price_gte", strike.to_string()));
+        }
+        if let Some(strike) = self.strike_price_lte {
+            params.push(("strike_price_lte", strike.to_string()));
+        }
+        if let Some(kind) = self.option_type {
+            params.push((
+                "type",
+                match kind {
+                    OptionKind::Call => "call",
+                    OptionKind::Put => "put",
+                }
+                .to_string(),
+            ));
+        }
+        if let Some(style) = self.style {
+            // Alpaca only supports American and European styles; Bermudan is silently
+            // omitted from the request (the API would reject it).
+            let style_str = match style {
+                OptionExercise::American => Some("american"),
+                OptionExercise::European => Some("european"),
+                OptionExercise::Bermudan => None,
+            };
+            if let Some(s) = style_str {
+                params.push(("style", s.to_string()));
+            }
+        }
+
+        let limit = self.limit.unwrap_or(DEFAULT_PAGE_SIZE).min(MAX_PAGE_SIZE);
+        params.push(("limit", limit.to_string()));
+
+        // Only return active contracts
+        params.push(("status", "active".to_string()));
+
+        params
+    }
+}
+
+/// Alpaca option contract from the API response.
+///
+/// Represents a single option contract with its metadata.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AlpacaOptionContract {
+    /// Unique contract identifier.
+    pub id: String,
+    /// OCC symbol (e.g., "AAPL240119C00150000").
+    pub symbol: String,
+    /// Human-readable name (e.g., "AAPL Jan 19 2024 150 Call").
+    pub name: String,
+    /// Contract status ("active" or "inactive").
+    pub status: String,
+    /// Whether the contract is tradable.
+    pub tradable: bool,
+    /// Expiration date.
+    #[serde(with = "date_format")]
+    pub expiration_date: NaiveDate,
+    /// Root symbol (e.g., "AAPL").
+    pub root_symbol: String,
+    /// Underlying symbol.
+    pub underlying_symbol: String,
+    /// Underlying asset ID.
+    pub underlying_asset_id: String,
+    /// Option type ("call" or "put").
+    #[serde(rename = "type")]
+    pub option_type: String,
+    /// Exercise style ("american" or "european").
+    pub style: String,
+    /// Strike price.
+    #[serde(deserialize_with = "deserialize_decimal_string")]
+    pub strike_price: Decimal,
+    /// Contract multiplier (e.g., "100").
+    #[serde(deserialize_with = "deserialize_decimal_string")]
+    pub size: Decimal,
+    /// Open interest (number of outstanding contracts).
+    #[serde(default, deserialize_with = "deserialize_option_decimal_string")]
+    pub open_interest: Option<Decimal>,
+    /// Date of open interest data.
+    #[serde(default, with = "option_date_format")]
+    pub open_interest_date: Option<NaiveDate>,
+    /// Previous close price.
+    #[serde(default, deserialize_with = "deserialize_option_decimal_string")]
+    pub close_price: Option<Decimal>,
+    /// Date of close price.
+    #[serde(default, with = "option_date_format")]
+    pub close_price_date: Option<NaiveDate>,
+}
+
+impl AlpacaOptionContract {
+    /// Get the option kind (Call or Put).
+    pub fn kind(&self) -> Option<OptionKind> {
+        match self.option_type.as_str() {
+            "call" => Some(OptionKind::Call),
+            "put" => Some(OptionKind::Put),
+            _ => None,
+        }
+    }
+
+    /// Get the exercise style (American or European).
+    pub fn exercise(&self) -> Option<OptionExercise> {
+        match self.style.as_str() {
+            "american" => Some(OptionExercise::American),
+            "european" => Some(OptionExercise::European),
+            _ => None,
+        }
+    }
+}
+
+/// API response wrapper for option contracts.
+#[derive(Debug, Deserialize)]
+struct ContractsResponse {
+    option_contracts: Option<Vec<AlpacaOptionContract>>,
+    #[serde(default)]
+    next_page_token: Option<String>,
+}
+
+impl AlpacaOptionsClient {
+    /// Fetch option contracts matching the query.
+    ///
+    /// Automatically paginates through all results up to the safety limit.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - Query parameters for filtering contracts
+    ///
+    /// # Returns
+    ///
+    /// Vector of matching option contracts.
+    ///
+    /// # Errors
+    ///
+    /// Returns error on network failure, API error, or invalid response.
+    pub async fn fetch_contracts(
+        &self,
+        query: &AlpacaOptionContractQuery,
+    ) -> Result<Vec<AlpacaOptionContract>, AlpacaOptionsError> {
+        let mut all_contracts = Vec::new();
+        let mut page_token: Option<String> = None;
+        let mut pages = 0usize;
+
+        loop {
+            if pages >= MAX_PAGES {
+                debug!(
+                    pages,
+                    contracts = all_contracts.len(),
+                    "reached max pages limit"
+                );
+                break;
+            }
+            pages += 1;
+
+            let mut params = query.to_query_params();
+            if let Some(ref token) = page_token {
+                params.push(("page_token", token.clone()));
+            }
+
+            let url = format!("{}/v2/options/contracts", self.broker_base);
+            let request = self.http.get(&url).query(&params);
+
+            let response: ContractsResponse = self.request_with_retry(request).await?;
+
+            let contracts = response.option_contracts.unwrap_or_default();
+            let count = contracts.len();
+            all_contracts.extend(contracts);
+
+            debug!(
+                page = pages,
+                count,
+                total = all_contracts.len(),
+                "fetched contracts page"
+            );
+
+            match response.next_page_token {
+                Some(token) if !token.is_empty() => {
+                    page_token = Some(token);
+                }
+                _ => break,
+            }
+        }
+
+        Ok(all_contracts)
+    }
+}
+
+// Custom deserializer for decimal strings
+fn deserialize_decimal_string<'de, D>(deserializer: D) -> Result<Decimal, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    Decimal::from_str(&s).map_err(serde::de::Error::custom)
+}
+
+fn deserialize_option_decimal_string<'de, D>(deserializer: D) -> Result<Option<Decimal>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    match opt {
+        Some(s) if !s.is_empty() => Decimal::from_str(&s)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        _ => Ok(None),
+    }
+}
+
+mod date_format {
+    use chrono::NaiveDate;
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub(super) const FORMAT: &str = "%Y-%m-%d";
+
+    pub fn serialize<S>(date: &NaiveDate, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&date.format(FORMAT).to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<NaiveDate, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        NaiveDate::parse_from_str(&s, FORMAT).map_err(serde::de::Error::custom)
+    }
+}
+
+mod option_date_format {
+    use chrono::NaiveDate;
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    use super::date_format::FORMAT;
+
+    pub fn serialize<S>(date: &Option<NaiveDate>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match date {
+            Some(d) => serializer.serialize_some(&d.format(FORMAT).to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<NaiveDate>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt: Option<String> = Option::deserialize(deserializer)?;
+        match opt {
+            Some(s) if !s.is_empty() => NaiveDate::parse_from_str(&s, FORMAT)
+                .map(Some)
+                .map_err(serde::de::Error::custom),
+            _ => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn query_builder_basic() {
+        let query = AlpacaOptionContractQuery::new(vec!["AAPL".into()]);
+        let params = query.to_query_params();
+
+        assert!(
+            params
+                .iter()
+                .any(|(k, v)| *k == "underlying_symbols" && v == "AAPL")
+        );
+        assert!(params.iter().any(|(k, v)| *k == "status" && v == "active"));
+    }
+
+    #[test]
+    fn query_builder_full() {
+        let query = AlpacaOptionContractQuery::new(vec!["AAPL".into(), "TSLA".into()])
+            .expiration_gte(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap())
+            .expiration_lte(NaiveDate::from_ymd_opt(2024, 3, 31).unwrap())
+            .strike_gte(dec!(100))
+            .strike_lte(dec!(200))
+            .call_only()
+            .style(OptionExercise::American)
+            .limit(500);
+
+        let params = query.to_query_params();
+
+        assert!(
+            params
+                .iter()
+                .any(|(k, v)| *k == "underlying_symbols" && v == "AAPL,TSLA")
+        );
+        assert!(
+            params
+                .iter()
+                .any(|(k, v)| *k == "expiration_date_gte" && v == "2024-01-01")
+        );
+        assert!(
+            params
+                .iter()
+                .any(|(k, v)| *k == "expiration_date_lte" && v == "2024-03-31")
+        );
+        assert!(
+            params
+                .iter()
+                .any(|(k, v)| *k == "strike_price_gte" && v == "100")
+        );
+        assert!(
+            params
+                .iter()
+                .any(|(k, v)| *k == "strike_price_lte" && v == "200")
+        );
+        assert!(params.iter().any(|(k, v)| *k == "type" && v == "call"));
+        assert!(params.iter().any(|(k, v)| *k == "style" && v == "american"));
+        assert!(params.iter().any(|(k, v)| *k == "limit" && v == "500"));
+    }
+
+    #[test]
+    fn query_bermudan_style_skips_style_param() {
+        // Alpaca does not support Bermudan; the builder must omit the `style` filter
+        // while preserving `limit` and `status` (regression guard for #65).
+        let query =
+            AlpacaOptionContractQuery::new(vec!["AAPL".into()]).style(OptionExercise::Bermudan);
+        let params = query.to_query_params();
+
+        assert!(!params.iter().any(|(k, _)| *k == "style"));
+        assert!(params.iter().any(|(k, _)| *k == "limit"));
+        assert!(params.iter().any(|(k, v)| *k == "status" && v == "active"));
+    }
+
+    #[test]
+    fn query_limit_capped_at_max() {
+        let query = AlpacaOptionContractQuery::new(vec!["AAPL".into()]).limit(999_999);
+        let params = query.to_query_params();
+
+        let limit = params
+            .iter()
+            .find(|(k, _)| *k == "limit")
+            .map(|(_, v)| v.as_str())
+            .unwrap();
+        assert_eq!(limit, "10000");
+    }
+
+    #[test]
+    fn contract_deserialize() {
+        let json = r#"{
+            "id": "test-id",
+            "symbol": "AAPL240119C00150000",
+            "name": "AAPL Jan 19 2024 150 Call",
+            "status": "active",
+            "tradable": true,
+            "expiration_date": "2024-01-19",
+            "root_symbol": "AAPL",
+            "underlying_symbol": "AAPL",
+            "underlying_asset_id": "asset-id",
+            "type": "call",
+            "style": "american",
+            "strike_price": "150.00",
+            "size": "100",
+            "open_interest": "1234",
+            "open_interest_date": "2024-01-18",
+            "close_price": "5.50",
+            "close_price_date": "2024-01-18"
+        }"#;
+
+        let contract: AlpacaOptionContract = serde_json::from_str(json).unwrap();
+
+        assert_eq!(contract.symbol, "AAPL240119C00150000");
+        assert_eq!(contract.strike_price, dec!(150.00));
+        assert_eq!(contract.size, dec!(100));
+        assert_eq!(contract.kind(), Some(OptionKind::Call));
+        assert_eq!(contract.exercise(), Some(OptionExercise::American));
+        assert_eq!(
+            contract.expiration_date,
+            NaiveDate::from_ymd_opt(2024, 1, 19).unwrap()
+        );
+    }
+
+    #[test]
+    fn contract_deserialize_minimal() {
+        let json = r#"{
+            "id": "test-id",
+            "symbol": "AAPL240119P00150000",
+            "name": "AAPL Jan 19 2024 150 Put",
+            "status": "active",
+            "tradable": true,
+            "expiration_date": "2024-01-19",
+            "root_symbol": "AAPL",
+            "underlying_symbol": "AAPL",
+            "underlying_asset_id": "asset-id",
+            "type": "put",
+            "style": "european",
+            "strike_price": "150",
+            "size": "100"
+        }"#;
+
+        let contract: AlpacaOptionContract = serde_json::from_str(json).unwrap();
+
+        assert_eq!(contract.kind(), Some(OptionKind::Put));
+        assert_eq!(contract.exercise(), Some(OptionExercise::European));
+        assert!(contract.open_interest.is_none());
+        assert!(contract.close_price.is_none());
+    }
+
+    #[test]
+    fn contracts_response_deserialize() {
+        let json = r#"{
+            "option_contracts": [
+                {
+                    "id": "test-id",
+                    "symbol": "AAPL240119C00150000",
+                    "name": "AAPL Jan 19 2024 150 Call",
+                    "status": "active",
+                    "tradable": true,
+                    "expiration_date": "2024-01-19",
+                    "root_symbol": "AAPL",
+                    "underlying_symbol": "AAPL",
+                    "underlying_asset_id": "asset-id",
+                    "type": "call",
+                    "style": "american",
+                    "strike_price": "150",
+                    "size": "100"
+                }
+            ],
+            "next_page_token": "abc123"
+        }"#;
+
+        let response: ContractsResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(response.option_contracts.unwrap().len(), 1);
+        assert_eq!(response.next_page_token, Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn contracts_response_empty() {
+        let json = r#"{}"#;
+
+        let response: ContractsResponse = serde_json::from_str(json).unwrap();
+
+        assert!(response.option_contracts.is_none());
+        assert!(response.next_page_token.is_none());
+    }
+}

--- a/rustrade-data/src/exchange/alpaca/options/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/options/mod.rs
@@ -1,0 +1,279 @@
+//! Alpaca options market data client.
+//!
+//! Provides REST-based option contract discovery and chain snapshots with Greeks.
+//!
+//! # Endpoints
+//!
+//! - [`AlpacaOptionsClient::fetch_contracts`]: `GET /v2/options/contracts` — discover available contracts
+//! - [`AlpacaOptionsClient::fetch_snapshots`]: `GET /v1beta1/options/snapshots` — chain snapshots with Greeks
+//!
+//! # Authentication
+//!
+//! Requires `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` environment variables.
+//!
+//! # Data Feeds
+//!
+//! - [`AlpacaOptionFeed::Opra`]: Real-time OPRA feed (requires paid subscription)
+//! - [`AlpacaOptionFeed::Indicative`]: 15-minute delayed feed (free)
+//!
+//! # Example
+//!
+//! ```ignore
+//! use rustrade_data::exchange::alpaca::options::{
+//!     AlpacaOptionsClient, AlpacaOptionContractQuery, AlpacaOptionFeed,
+//! };
+//! use chrono::NaiveDate;
+//!
+//! let client = AlpacaOptionsClient::from_env()?;
+//!
+//! // Discover AAPL options expiring in next 30 days
+//! let query = AlpacaOptionContractQuery::new(vec!["AAPL".into()])
+//!     .expiration_gte(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap())
+//!     .expiration_lte(NaiveDate::from_ymd_opt(2024, 1, 31).unwrap());
+//!
+//! let contracts = client.fetch_contracts(&query).await?;
+//!
+//! // Fetch snapshots with Greeks (using free delayed feed)
+//! let symbols: Vec<_> = contracts.iter().map(|c| c.symbol.clone()).collect();
+//! let snapshots = client.fetch_snapshots(&symbols, AlpacaOptionFeed::Indicative).await?;
+//! ```
+//!
+//! # Limitations
+//!
+//! - **REST only**: Greeks streaming is NOT available via WebSocket. Use snapshots for
+//!   point-in-time Greeks data.
+//! - **Rate limits**: Alpaca applies rate limits; the client handles 429 responses with retry.
+
+mod contracts;
+mod snapshots;
+
+pub use contracts::{AlpacaOptionContract, AlpacaOptionContractQuery};
+pub use snapshots::{AlpacaOptionFeed, AlpacaOptionQuote, AlpacaOptionSnapshot, AlpacaOptionTrade};
+
+use reqwest::header::{HeaderMap, HeaderValue};
+use std::{env, time::Duration};
+use thiserror::Error;
+use tracing::{debug, warn};
+
+/// Base URL for Alpaca Broker API (trading + options contracts).
+const BROKER_API_BASE: &str = "https://api.alpaca.markets";
+
+/// Base URL for Alpaca Data API (market data including options snapshots).
+const DATA_API_BASE: &str = "https://data.alpaca.markets";
+
+/// Paper trading base URL.
+const PAPER_API_BASE: &str = "https://paper-api.alpaca.markets";
+
+/// Default timeout for REST requests.
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Maximum retry attempts for rate-limited requests.
+const MAX_RETRY_ATTEMPTS: u32 = 3;
+
+/// Default delay when rate-limited (if no Retry-After header).
+const DEFAULT_RATE_LIMIT_DELAY_SECS: u64 = 60;
+
+/// Errors from Alpaca options API operations.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum AlpacaOptionsError {
+    /// Environment variable not set or invalid.
+    #[error("environment variable error: {0}")]
+    EnvVar(String),
+
+    /// HTTP client error.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// API returned an error response.
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+
+    /// Rate limit exceeded after retries.
+    #[error("rate limit exceeded after {attempts} attempts")]
+    RateLimitExceeded { attempts: u32 },
+
+    /// Invalid response format.
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+/// Alpaca options market data client.
+///
+/// Provides access to option contract discovery and chain snapshots via REST API.
+/// The client handles authentication, rate limiting, and pagination automatically.
+///
+/// # Construction
+///
+/// Use [`AlpacaOptionsClient::from_env`] to create a client using environment variables,
+/// or [`AlpacaOptionsClient::new`] for explicit credentials.
+#[derive(Clone)]
+pub struct AlpacaOptionsClient {
+    http: reqwest::Client,
+    broker_base: String,
+    data_base: String,
+}
+
+impl std::fmt::Debug for AlpacaOptionsClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AlpacaOptionsClient")
+            .field("broker_base", &self.broker_base)
+            .field("data_base", &self.data_base)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AlpacaOptionsClient {
+    /// Create a new client with explicit credentials.
+    ///
+    /// # Arguments
+    ///
+    /// * `api_key` - Alpaca API key
+    /// * `api_secret` - Alpaca API secret
+    /// * `paper` - Use paper trading endpoint if true
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the HTTP client cannot be built (invalid headers).
+    pub fn new(api_key: &str, api_secret: &str, paper: bool) -> Result<Self, AlpacaOptionsError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "APCA-API-KEY-ID",
+            HeaderValue::from_str(api_key)
+                .map_err(|e| AlpacaOptionsError::EnvVar(format!("invalid API key: {e}")))?,
+        );
+        headers.insert(
+            "APCA-API-SECRET-KEY",
+            HeaderValue::from_str(api_secret)
+                .map_err(|e| AlpacaOptionsError::EnvVar(format!("invalid API secret: {e}")))?,
+        );
+
+        let http = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()?;
+
+        let broker_base = if paper {
+            PAPER_API_BASE.to_string()
+        } else {
+            BROKER_API_BASE.to_string()
+        };
+
+        Ok(Self {
+            http,
+            broker_base,
+            data_base: DATA_API_BASE.to_string(),
+        })
+    }
+
+    /// Create a client from environment variables.
+    ///
+    /// Reads:
+    /// - `ALPACA_API_KEY` - API key (required)
+    /// - `ALPACA_SECRET_KEY` - API secret (required)
+    /// - `ALPACA_PAPER` - Set to "true" for paper trading (optional, defaults to false)
+    ///
+    /// # Errors
+    ///
+    /// Returns error if required environment variables are missing.
+    pub fn from_env() -> Result<Self, AlpacaOptionsError> {
+        let api_key = env::var("ALPACA_API_KEY")
+            .map_err(|e| AlpacaOptionsError::EnvVar(format!("ALPACA_API_KEY: {e}")))?;
+        let api_secret = env::var("ALPACA_SECRET_KEY")
+            .map_err(|e| AlpacaOptionsError::EnvVar(format!("ALPACA_SECRET_KEY: {e}")))?;
+        let paper = env::var("ALPACA_PAPER")
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        Self::new(&api_key, &api_secret, paper)
+    }
+
+    /// Execute a request with rate limit retry.
+    async fn request_with_retry<T>(
+        &self,
+        request: reqwest::RequestBuilder,
+    ) -> Result<T, AlpacaOptionsError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let mut attempts = 0u32;
+
+        loop {
+            attempts += 1;
+
+            // `try_clone` returns `None` only for streaming bodies; safe for these GET requests.
+            let response = request
+                .try_clone()
+                .ok_or_else(|| {
+                    AlpacaOptionsError::InvalidResponse(
+                        "request body is not cloneable; cannot retry".into(),
+                    )
+                })?
+                .send()
+                .await?;
+
+            let status = response.status();
+
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                if attempts >= MAX_RETRY_ATTEMPTS {
+                    return Err(AlpacaOptionsError::RateLimitExceeded { attempts });
+                }
+
+                let delay = parse_retry_after(response.headers())
+                    .unwrap_or(Duration::from_secs(DEFAULT_RATE_LIMIT_DELAY_SECS));
+
+                warn!(
+                    attempt = attempts,
+                    delay_secs = delay.as_secs(),
+                    "Alpaca rate limited, retrying"
+                );
+                tokio::time::sleep(delay).await;
+                continue;
+            }
+
+            if !status.is_success() {
+                let message = response.text().await.unwrap_or_default();
+                return Err(AlpacaOptionsError::Api {
+                    status: status.as_u16(),
+                    message,
+                });
+            }
+
+            let body = response.text().await?;
+            debug!(len = body.len(), "Alpaca response received");
+
+            return serde_json::from_str(&body).map_err(|e| {
+                AlpacaOptionsError::InvalidResponse(format!("JSON parse error: {e}"))
+            });
+        }
+    }
+}
+
+/// Parse the `Retry-After` header (delay in seconds).
+///
+/// `x-ratelimit-reset` is intentionally not used as a fallback because it carries
+/// a Unix epoch timestamp, not a duration; mis-interpreting it would produce
+/// sleeps measured in years.
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::AlpacaOptionsClient;
+
+    #[test]
+    fn client_debug_hides_credentials() {
+        let client = AlpacaOptionsClient::new("test-key-id", "test-secret-value", true)
+            .expect("client construction with ASCII credentials should succeed");
+        let debug_str = format!("{client:?}");
+
+        assert!(!debug_str.contains("test-key-id"));
+        assert!(!debug_str.contains("test-secret-value"));
+    }
+}

--- a/rustrade-data/src/exchange/alpaca/options/snapshots.rs
+++ b/rustrade-data/src/exchange/alpaca/options/snapshots.rs
@@ -1,0 +1,468 @@
+//! Option chain snapshots with Greeks.
+//!
+//! Implements `GET /v1beta1/options/snapshots` for fetching option snapshots with Greeks.
+
+use super::{AlpacaOptionsClient, AlpacaOptionsError};
+use crate::subscription::greeks::OptionGreeks;
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tracing::debug;
+
+/// Maximum symbols per snapshot request (Alpaca API limit).
+const MAX_SYMBOLS_PER_REQUEST: usize = 100;
+
+/// Maximum pages to fetch before stopping (safety limit).
+const MAX_PAGES: usize = 100;
+
+/// Alpaca options data feed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AlpacaOptionFeed {
+    /// Real-time OPRA feed (requires paid subscription).
+    Opra,
+    /// 15-minute delayed indicative feed (free).
+    #[default]
+    Indicative,
+}
+
+impl AlpacaOptionFeed {
+    /// Wire value sent in `feed=` query strings and emitted by the `Serialize` impl.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Opra => "opra",
+            Self::Indicative => "indicative",
+        }
+    }
+}
+
+/// Option quote data (bid/ask).
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AlpacaOptionQuote {
+    /// Quote timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Ask exchange code.
+    #[serde(rename = "ax")]
+    pub ask_exchange: String,
+    /// Ask price.
+    #[serde(rename = "ap")]
+    pub ask_price: Decimal,
+    /// Ask size (number of contracts).
+    #[serde(rename = "as")]
+    pub ask_size: u32,
+    /// Bid exchange code.
+    #[serde(rename = "bx")]
+    pub bid_exchange: String,
+    /// Bid price.
+    #[serde(rename = "bp")]
+    pub bid_price: Decimal,
+    /// Bid size (number of contracts).
+    #[serde(rename = "bs")]
+    pub bid_size: u32,
+}
+
+/// Option trade data.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AlpacaOptionTrade {
+    /// Trade timestamp.
+    #[serde(rename = "t")]
+    pub timestamp: DateTime<Utc>,
+    /// Exchange code.
+    #[serde(rename = "x")]
+    pub exchange: String,
+    /// Trade price.
+    #[serde(rename = "p")]
+    pub price: Decimal,
+    /// Trade size (number of contracts).
+    #[serde(rename = "s")]
+    pub size: u32,
+}
+
+/// Greeks data from Alpaca API.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Deserialize)]
+struct AlpacaGreeks {
+    #[serde(default)]
+    delta: Option<f64>,
+    #[serde(default)]
+    gamma: Option<f64>,
+    #[serde(default)]
+    theta: Option<f64>,
+    #[serde(default)]
+    vega: Option<f64>,
+    #[serde(default)]
+    rho: Option<f64>,
+}
+
+impl From<AlpacaGreeks> for OptionGreeks {
+    fn from(g: AlpacaGreeks) -> Self {
+        // `rho` is intentionally dropped — `OptionGreeks` does not expose it.
+        Self {
+            delta: g.delta,
+            gamma: g.gamma,
+            theta: g.theta,
+            vega: g.vega,
+            implied_volatility: None,
+            theoretical_price: None,
+            underlying_price: None,
+        }
+    }
+}
+
+/// Option snapshot with quote and Greeks.
+///
+/// Contains point-in-time market data for an option contract.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AlpacaOptionSnapshot {
+    /// OCC symbol (e.g., "AAPL240119C00150000").
+    /// Note: This is populated from the HashMap key, not deserialized from JSON.
+    #[serde(default)]
+    pub symbol: String,
+    /// Latest quote (bid/ask).
+    #[serde(default)]
+    pub latest_quote: Option<AlpacaOptionQuote>,
+    /// Latest trade.
+    #[serde(default)]
+    pub latest_trade: Option<AlpacaOptionTrade>,
+    /// Option Greeks.
+    #[serde(default, skip_serializing)]
+    greeks: Option<AlpacaGreeks>,
+    /// Implied volatility.
+    #[serde(default)]
+    pub implied_volatility: Option<f64>,
+}
+
+impl AlpacaOptionSnapshot {
+    /// Get option Greeks in the standard format.
+    ///
+    /// Returns [`OptionGreeks`] with delta, gamma, theta, vega populated from the
+    /// Alpaca response. Implied volatility is stored separately in [`Self::implied_volatility`].
+    pub fn greeks(&self) -> OptionGreeks {
+        let mut greeks: OptionGreeks = self.greeks.unwrap_or_default().into();
+        greeks.implied_volatility = self.implied_volatility;
+        greeks
+    }
+
+    /// Check if this snapshot has any Greek data.
+    pub fn has_greeks(&self) -> bool {
+        self.greeks.is_some() || self.implied_volatility.is_some()
+    }
+}
+
+/// API response wrapper for snapshots.
+#[derive(Debug, Deserialize)]
+struct SnapshotsResponse {
+    snapshots: Option<HashMap<String, AlpacaOptionSnapshot>>,
+    #[serde(default)]
+    next_page_token: Option<String>,
+}
+
+impl AlpacaOptionsClient {
+    /// Fetch option snapshots with Greeks for the given symbols.
+    ///
+    /// Automatically batches requests if more than 100 symbols are provided,
+    /// and paginates through all results.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbols` - OCC symbols to fetch (e.g., ["AAPL240119C00150000"])
+    /// * `feed` - Data feed to use (OPRA for real-time, Indicative for delayed)
+    ///
+    /// # Returns
+    ///
+    /// Vector of option snapshots with quote and Greeks data.
+    ///
+    /// # Errors
+    ///
+    /// Returns error on network failure, API error, or invalid response.
+    ///
+    /// # Note
+    ///
+    /// Greeks streaming is NOT available via WebSocket. This method provides
+    /// point-in-time snapshot data only.
+    pub async fn fetch_snapshots(
+        &self,
+        symbols: &[String],
+        feed: AlpacaOptionFeed,
+    ) -> Result<Vec<AlpacaOptionSnapshot>, AlpacaOptionsError> {
+        if symbols.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut all_snapshots = Vec::new();
+
+        // Batch symbols into chunks of MAX_SYMBOLS_PER_REQUEST
+        for chunk in symbols.chunks(MAX_SYMBOLS_PER_REQUEST) {
+            let chunk_snapshots = self.fetch_snapshots_batch(chunk, feed).await?;
+            all_snapshots.extend(chunk_snapshots);
+        }
+
+        Ok(all_snapshots)
+    }
+
+    /// Fetch snapshots for a single batch of symbols (max 100).
+    async fn fetch_snapshots_batch(
+        &self,
+        symbols: &[String],
+        feed: AlpacaOptionFeed,
+    ) -> Result<Vec<AlpacaOptionSnapshot>, AlpacaOptionsError> {
+        let mut all_snapshots = Vec::new();
+        let mut page_token: Option<String> = None;
+        let mut pages = 0usize;
+
+        let symbols_param = symbols.join(",");
+
+        loop {
+            if pages >= MAX_PAGES {
+                debug!(
+                    pages,
+                    snapshots = all_snapshots.len(),
+                    "reached max pages limit"
+                );
+                break;
+            }
+            pages += 1;
+
+            let mut params: Vec<(&str, &str)> =
+                vec![("symbols", &symbols_param), ("feed", feed.as_str())];
+
+            // `token_string` is hoisted to outlive `params` (which borrows it).
+            let token_string;
+            if let Some(ref token) = page_token {
+                token_string = token.clone();
+                params.push(("page_token", &token_string));
+            }
+
+            let url = format!("{}/v1beta1/options/snapshots", self.data_base);
+            let request = self.http.get(&url).query(&params);
+
+            let response: SnapshotsResponse = self.request_with_retry(request).await?;
+
+            if let Some(snapshots_map) = response.snapshots {
+                let count = snapshots_map.len();
+                all_snapshots.extend(snapshots_map.into_iter().map(|(symbol, mut snapshot)| {
+                    snapshot.symbol = symbol;
+                    snapshot
+                }));
+
+                debug!(
+                    page = pages,
+                    count,
+                    total = all_snapshots.len(),
+                    "fetched snapshots page"
+                );
+            }
+
+            match response.next_page_token {
+                Some(token) if !token.is_empty() => {
+                    page_token = Some(token);
+                }
+                _ => break,
+            }
+        }
+
+        Ok(all_snapshots)
+    }
+
+    /// Fetch snapshots for all options of an underlying symbol.
+    ///
+    /// This is a convenience method that first fetches all contracts for the
+    /// underlying, then fetches snapshots for those contracts.
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying` - Underlying symbol (e.g., "AAPL")
+    /// * `feed` - Data feed to use
+    ///
+    /// # Returns
+    ///
+    /// Vector of option snapshots for all active contracts of the underlying.
+    pub async fn fetch_chain_snapshots(
+        &self,
+        underlying: &str,
+        feed: AlpacaOptionFeed,
+    ) -> Result<Vec<AlpacaOptionSnapshot>, AlpacaOptionsError> {
+        use super::AlpacaOptionContractQuery;
+
+        // First, fetch all contracts for this underlying
+        let query = AlpacaOptionContractQuery::new(vec![underlying.to_string()]);
+        let contracts = self.fetch_contracts(&query).await?;
+
+        if contracts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        debug!(
+            underlying,
+            contracts = contracts.len(),
+            "fetching snapshots for chain"
+        );
+
+        // Extract symbols and fetch snapshots
+        let symbols: Vec<String> = contracts.iter().map(|c| c.symbol.clone()).collect();
+        self.fetch_snapshots(&symbols, feed).await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn feed_as_str() {
+        assert_eq!(AlpacaOptionFeed::Opra.as_str(), "opra");
+        assert_eq!(AlpacaOptionFeed::Indicative.as_str(), "indicative");
+    }
+
+    #[test]
+    fn quote_deserialize() {
+        let json = r#"{
+            "t": "2024-01-15T14:27:51.742904322Z",
+            "ax": "C",
+            "ap": 2.95,
+            "as": 50,
+            "bx": "N",
+            "bp": 2.85,
+            "bs": 75
+        }"#;
+
+        let quote: AlpacaOptionQuote = serde_json::from_str(json).unwrap();
+
+        assert_eq!(quote.ask_exchange, "C");
+        assert_eq!(quote.ask_price, dec!(2.95));
+        assert_eq!(quote.ask_size, 50);
+        assert_eq!(quote.bid_exchange, "N");
+        assert_eq!(quote.bid_price, dec!(2.85));
+        assert_eq!(quote.bid_size, 75);
+    }
+
+    #[test]
+    fn trade_deserialize() {
+        let json = r#"{
+            "t": "2024-01-15T14:25:48.889796106Z",
+            "x": "N",
+            "p": 2.84,
+            "s": 100
+        }"#;
+
+        let trade: AlpacaOptionTrade = serde_json::from_str(json).unwrap();
+
+        assert_eq!(trade.exchange, "N");
+        assert_eq!(trade.price, dec!(2.84));
+        assert_eq!(trade.size, 100);
+    }
+
+    #[test]
+    fn snapshot_deserialize_full() {
+        let json = r#"{
+            "symbol": "AAPL240119C00150000",
+            "latest_quote": {
+                "t": "2024-01-15T14:27:51.742904322Z",
+                "ax": "C",
+                "ap": 2.95,
+                "as": 50,
+                "bx": "N",
+                "bp": 2.85,
+                "bs": 75
+            },
+            "latest_trade": {
+                "t": "2024-01-15T14:25:48.889796106Z",
+                "x": "N",
+                "p": 2.84,
+                "s": 100
+            },
+            "greeks": {
+                "delta": 0.6234,
+                "gamma": 0.0412,
+                "theta": -0.0285,
+                "vega": 0.3156,
+                "rho": 0.1829
+            },
+            "implied_volatility": 0.287
+        }"#;
+
+        let snapshot: AlpacaOptionSnapshot = serde_json::from_str(json).unwrap();
+
+        assert_eq!(snapshot.symbol, "AAPL240119C00150000");
+        assert!(snapshot.latest_quote.is_some());
+        assert!(snapshot.latest_trade.is_some());
+        assert!(snapshot.has_greeks());
+
+        let greeks = snapshot.greeks();
+        assert_eq!(greeks.delta, Some(0.6234));
+        assert_eq!(greeks.gamma, Some(0.0412));
+        assert_eq!(greeks.theta, Some(-0.0285));
+        assert_eq!(greeks.vega, Some(0.3156));
+        assert_eq!(greeks.implied_volatility, Some(0.287));
+    }
+
+    #[test]
+    fn snapshot_deserialize_minimal() {
+        let json = r#"{
+            "symbol": "AAPL240119C00150000"
+        }"#;
+
+        let snapshot: AlpacaOptionSnapshot = serde_json::from_str(json).unwrap();
+
+        assert_eq!(snapshot.symbol, "AAPL240119C00150000");
+        assert!(snapshot.latest_quote.is_none());
+        assert!(snapshot.latest_trade.is_none());
+        assert!(!snapshot.has_greeks());
+    }
+
+    #[test]
+    fn greeks_conversion() {
+        let alpaca_greeks = AlpacaGreeks {
+            delta: Some(0.55),
+            gamma: Some(0.02),
+            theta: Some(-0.05),
+            vega: Some(0.15),
+            rho: Some(0.10),
+        };
+
+        let greeks: OptionGreeks = alpaca_greeks.into();
+
+        assert_eq!(greeks.delta, Some(0.55));
+        assert_eq!(greeks.gamma, Some(0.02));
+        assert_eq!(greeks.theta, Some(-0.05));
+        assert_eq!(greeks.vega, Some(0.15));
+        // rho is not in OptionGreeks, so it's dropped
+        // implied_volatility comes from snapshot, not greeks struct
+        assert!(greeks.implied_volatility.is_none());
+    }
+
+    #[test]
+    fn snapshots_response_deserialize() {
+        let json = r#"{
+            "snapshots": {
+                "AAPL240119C00150000": {
+                    "symbol": "",
+                    "implied_volatility": 0.25
+                }
+            },
+            "next_page_token": "abc123"
+        }"#;
+
+        let response: SnapshotsResponse = serde_json::from_str(json).unwrap();
+
+        assert!(response.snapshots.is_some());
+        assert_eq!(response.snapshots.unwrap().len(), 1);
+        assert_eq!(response.next_page_token, Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn snapshots_response_empty() {
+        let json = r#"{}"#;
+
+        let response: SnapshotsResponse = serde_json::from_str(json).unwrap();
+
+        assert!(response.snapshots.is_none());
+        assert!(response.next_page_token.is_none());
+    }
+}

--- a/rustrade-data/src/exchange/ibkr/options.rs
+++ b/rustrade-data/src/exchange/ibkr/options.rs
@@ -30,6 +30,7 @@
 use chrono::NaiveDate;
 use ibapi::contracts::{OptionChain, OptionComputation};
 use rust_decimal::Decimal;
+use rustrade_instrument::{exchange::ExchangeId, instrument::market_data::OptionChainDescriptor};
 use serde::{Deserialize, Serialize};
 
 pub use crate::subscription::greeks::OptionGreeks;
@@ -95,10 +96,34 @@ impl OptionChainEntry {
                 .collect(),
         }
     }
+
+    /// Convert to unified [`OptionChainDescriptor`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`rust_decimal::Error`] if the multiplier string cannot be parsed
+    /// as a decimal. Surfacing the parse error lets callers log the offending
+    /// value instead of silently dropping the entry.
+    ///
+    /// # Notes
+    ///
+    /// - `exercise` is `None` because IBKR does not return exercise style in chain data
+    /// - `exchange` is always `ExchangeId::Ibkr` (the IBKR-specific exchange string is not mapped)
+    pub fn to_descriptor(&self) -> Result<OptionChainDescriptor, rust_decimal::Error> {
+        let multiplier = self.multiplier.parse::<Decimal>()?;
+
+        Ok(OptionChainDescriptor::new(
+            ExchangeId::Ibkr,
+            multiplier,
+            self.expirations.clone(),
+            self.strikes.clone(),
+            None,
+        ))
+    }
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 
@@ -184,5 +209,44 @@ mod tests {
         let entry = OptionChainEntry::from_ib(&chain);
 
         assert_eq!(entry.expirations.len(), 2);
+    }
+
+    #[test]
+    fn option_chain_entry_to_descriptor() {
+        use rust_decimal_macros::dec;
+
+        let entry = OptionChainEntry {
+            underlying_contract_id: 265598,
+            trading_class: "AAPL".to_string(),
+            multiplier: "100".to_string(),
+            exchange: "SMART".to_string(),
+            expirations: vec![
+                NaiveDate::from_ymd_opt(2024, 1, 19).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 2, 16).unwrap(),
+            ],
+            strikes: vec![dec!(145), dec!(150), dec!(155)],
+        };
+
+        let descriptor = entry.to_descriptor().unwrap();
+
+        assert_eq!(descriptor.exchange, ExchangeId::Ibkr);
+        assert_eq!(descriptor.multiplier, dec!(100));
+        assert_eq!(descriptor.expirations.len(), 2);
+        assert_eq!(descriptor.strikes.len(), 3);
+        assert!(descriptor.exercise.is_none());
+    }
+
+    #[test]
+    fn option_chain_entry_to_descriptor_invalid_multiplier() {
+        let entry = OptionChainEntry {
+            underlying_contract_id: 265598,
+            trading_class: "AAPL".to_string(),
+            multiplier: "not_a_number".to_string(),
+            exchange: "SMART".to_string(),
+            expirations: vec![],
+            strikes: vec![],
+        };
+
+        assert!(entry.to_descriptor().is_err());
     }
 }

--- a/rustrade-data/tests/alpaca_data.rs
+++ b/rustrade-data/tests/alpaca_data.rs
@@ -451,3 +451,221 @@ async fn test_iex_quote_stream_receives_data() {
          If outside US market hours (9:30 AM - 4:00 PM ET), this is expected."
     );
 }
+
+// ============================================================================
+// Options Market Data Tests (REST API - available 24/7)
+// ============================================================================
+
+use chrono::Utc;
+use rustrade_data::exchange::alpaca::options::{
+    AlpacaOptionContractQuery, AlpacaOptionFeed, AlpacaOptionsClient,
+};
+
+/// Test fetching AAPL option contracts.
+///
+/// Verifies that we can discover option contracts with various filters.
+#[tokio::test]
+#[ignore]
+async fn test_fetch_aapl_option_contracts() {
+    init_logging();
+
+    let client = AlpacaOptionsClient::from_env().expect("Failed to create options client");
+
+    // Query AAPL options expiring in the next 60 days
+    let today = Utc::now().date_naive();
+    let sixty_days = today + chrono::Duration::days(60);
+
+    let query = AlpacaOptionContractQuery::new(vec!["AAPL".into()])
+        .expiration_gte(today)
+        .expiration_lte(sixty_days)
+        .limit(100);
+
+    let contracts = client
+        .fetch_contracts(&query)
+        .await
+        .expect("Failed to fetch contracts");
+
+    tracing::info!(count = contracts.len(), "Fetched AAPL option contracts");
+
+    assert!(!contracts.is_empty(), "No AAPL options found");
+
+    // Verify contract data quality
+    for contract in contracts.iter().take(5) {
+        tracing::info!(
+            symbol = %contract.symbol,
+            expiration = %contract.expiration_date,
+            strike = %contract.strike_price,
+            option_type = %contract.option_type,
+            style = %contract.style,
+            "Contract"
+        );
+
+        assert!(
+            contract.symbol.starts_with("AAPL"),
+            "Symbol should start with AAPL"
+        );
+        assert!(
+            contract.expiration_date >= today,
+            "Expiration should be >= today"
+        );
+        assert!(
+            contract.expiration_date <= sixty_days,
+            "Expiration should be <= 60 days out"
+        );
+        assert!(
+            contract.strike_price > Decimal::ZERO,
+            "Strike should be positive"
+        );
+        assert!(
+            contract.option_type == "call" || contract.option_type == "put",
+            "Option type should be call or put"
+        );
+        assert!(
+            contract.style == "american" || contract.style == "european",
+            "Style should be american or european"
+        );
+    }
+}
+
+/// Test fetching option contracts with call-only filter.
+#[tokio::test]
+#[ignore]
+async fn test_fetch_call_options_only() {
+    init_logging();
+
+    let client = AlpacaOptionsClient::from_env().expect("Failed to create options client");
+
+    let today = Utc::now().date_naive();
+    let thirty_days = today + chrono::Duration::days(30);
+
+    let query = AlpacaOptionContractQuery::new(vec!["AAPL".into()])
+        .expiration_gte(today)
+        .expiration_lte(thirty_days)
+        .call_only()
+        .limit(50);
+
+    let contracts = client
+        .fetch_contracts(&query)
+        .await
+        .expect("Failed to fetch call options");
+
+    tracing::info!(count = contracts.len(), "Fetched AAPL call options");
+
+    assert!(!contracts.is_empty(), "No AAPL call options found");
+
+    // Verify all are calls
+    for contract in &contracts {
+        assert_eq!(
+            contract.option_type, "call",
+            "Expected call option, got {}",
+            contract.option_type
+        );
+    }
+}
+
+/// Test fetching option chain snapshots with Greeks.
+///
+/// Uses the indicative (delayed) feed which is free.
+#[tokio::test]
+#[ignore]
+async fn test_fetch_aapl_chain_snapshot_with_greeks() {
+    init_logging();
+
+    let client = AlpacaOptionsClient::from_env().expect("Failed to create options client");
+
+    // First get some contracts
+    let today = Utc::now().date_naive();
+    let thirty_days = today + chrono::Duration::days(30);
+
+    let query = AlpacaOptionContractQuery::new(vec!["AAPL".into()])
+        .expiration_gte(today)
+        .expiration_lte(thirty_days)
+        .limit(10);
+
+    let contracts = client
+        .fetch_contracts(&query)
+        .await
+        .expect("Failed to fetch contracts");
+
+    assert!(!contracts.is_empty(), "No contracts to fetch snapshots for");
+
+    // Fetch snapshots for these contracts
+    let symbols: Vec<String> = contracts.iter().map(|c| c.symbol.clone()).collect();
+
+    let snapshots = client
+        .fetch_snapshots(&symbols, AlpacaOptionFeed::Indicative)
+        .await
+        .expect("Failed to fetch snapshots");
+
+    tracing::info!(
+        requested = symbols.len(),
+        received = snapshots.len(),
+        "Fetched option snapshots"
+    );
+
+    // We might not get snapshots for all symbols (some may not have recent activity)
+    // but we should get at least some
+    assert!(!snapshots.is_empty(), "No snapshots received");
+
+    // Log snapshot details
+    let mut greeks_count = 0;
+    for snapshot in &snapshots {
+        if snapshot.has_greeks() {
+            greeks_count += 1;
+            let greeks = snapshot.greeks();
+            tracing::info!(
+                symbol = %snapshot.symbol,
+                delta = ?greeks.delta,
+                gamma = ?greeks.gamma,
+                theta = ?greeks.theta,
+                vega = ?greeks.vega,
+                iv = ?greeks.implied_volatility,
+                "Snapshot with Greeks"
+            );
+        }
+
+        if let Some(ref quote) = snapshot.latest_quote {
+            tracing::info!(
+                symbol = %snapshot.symbol,
+                bid = %quote.bid_price,
+                ask = %quote.ask_price,
+                "Snapshot quote"
+            );
+            assert!(
+                quote.bid_price >= Decimal::ZERO,
+                "Bid should be non-negative"
+            );
+            assert!(
+                quote.ask_price >= Decimal::ZERO,
+                "Ask should be non-negative"
+            );
+        }
+    }
+
+    tracing::info!(
+        total = snapshots.len(),
+        with_greeks = greeks_count,
+        "Snapshot summary"
+    );
+}
+
+/// Test the convenience method for fetching entire chain snapshots.
+#[tokio::test]
+#[ignore]
+async fn test_fetch_chain_snapshots_convenience() {
+    init_logging();
+
+    let client = AlpacaOptionsClient::from_env().expect("Failed to create options client");
+
+    // SPY has a large active option chain (50k+ contracts) — a good stress test
+    // for pagination and the 100-symbol batch limit.
+    let snapshots = client
+        .fetch_chain_snapshots("SPY", AlpacaOptionFeed::Indicative)
+        .await
+        .expect("Failed to fetch chain snapshots");
+
+    tracing::info!(count = snapshots.len(), "Fetched SPY chain snapshots");
+
+    // SPY has many options, we should get a substantial number
+    assert!(!snapshots.is_empty(), "No SPY chain snapshots received");
+}

--- a/rustrade-data/tests/alpaca_data.rs
+++ b/rustrade-data/tests/alpaca_data.rs
@@ -40,7 +40,7 @@
 use futures_util::StreamExt;
 use rust_decimal::Decimal;
 use rustrade_data::{
-    exchange::alpaca::{AlpacaCrypto, AlpacaIex},
+    exchange::alpaca::{AlpacaCrypto, AlpacaIex, AlpacaSip},
     streams::{
         Streams,
         reconnect::{Event, stream::ReconnectingStream},
@@ -453,6 +453,170 @@ async fn test_iex_quote_stream_receives_data() {
 }
 
 // ============================================================================
+// SIP Equity Stream Tests (requires SIP subscription)
+// ============================================================================
+
+/// Test SIP trade stream connection.
+///
+/// NOTE: Requires SIP subscription. Will fail with auth error without subscription.
+#[tokio::test]
+#[ignore]
+async fn test_sip_trade_stream_connection() {
+    init_logging();
+
+    let streams = Streams::<PublicTrades>::builder()
+        .subscribe([(
+            AlpacaSip::default(),
+            "spy",
+            "usd",
+            MarketDataInstrumentKind::Spot,
+            PublicTrades,
+        )])
+        .init()
+        .await;
+
+    assert!(
+        streams.is_ok(),
+        "Failed to connect to SIP trade stream: {:?}",
+        streams.err()
+    );
+    tracing::info!("SIP trade stream connected and subscribed");
+}
+
+/// Test SIP quote stream connection.
+///
+/// NOTE: Requires SIP subscription.
+#[tokio::test]
+#[ignore]
+async fn test_sip_quote_stream_connection() {
+    init_logging();
+
+    let streams = Streams::<Quotes>::builder()
+        .subscribe([(
+            AlpacaSip::default(),
+            "aapl",
+            "usd",
+            MarketDataInstrumentKind::Spot,
+            Quotes,
+        )])
+        .init()
+        .await;
+
+    assert!(
+        streams.is_ok(),
+        "Failed to connect to SIP quote stream: {:?}",
+        streams.err()
+    );
+    tracing::info!("SIP quote stream connected and subscribed");
+}
+
+/// Test receiving trade data from SIP (consolidated tape).
+///
+/// NOTE: Requires SIP subscription. May timeout outside US market hours.
+#[tokio::test]
+#[ignore]
+async fn test_sip_trade_stream_receives_data() {
+    init_logging();
+
+    let streams = Streams::<PublicTrades>::builder()
+        .subscribe([(
+            AlpacaSip::default(),
+            "spy",
+            "usd",
+            MarketDataInstrumentKind::Spot,
+            PublicTrades,
+        )])
+        .init()
+        .await
+        .expect("Failed to init SIP stream");
+
+    let mut stream = streams
+        .select_all()
+        .with_error_handler(|e| tracing::warn!(?e, "Stream error"));
+
+    tracing::info!("Waiting for SIP trade data (consolidated tape)...");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+
+    while tokio::time::Instant::now() < deadline {
+        let timeout = tokio::time::timeout(Duration::from_secs(30), stream.next()).await;
+
+        match timeout {
+            Ok(Some(Event::Item(trade))) => {
+                tracing::info!(?trade, "Received SIP trade");
+                assert!(trade.kind.price > Decimal::ZERO, "Invalid trade price");
+                assert!(trade.kind.amount > Decimal::ZERO, "Invalid trade amount");
+                return;
+            }
+            Ok(Some(_)) => continue,
+            Ok(None) => panic!("Stream ended unexpectedly"),
+            Err(_) => {
+                tracing::warn!("Timeout waiting for SIP data - may be outside market hours");
+                continue;
+            }
+        }
+    }
+
+    panic!(
+        "No SIP trade events received within timeout. \
+         If outside US market hours (9:30 AM - 4:00 PM ET), this is expected."
+    );
+}
+
+/// Test receiving quote data from SIP (consolidated NBBO).
+///
+/// NOTE: Requires SIP subscription. May timeout outside US market hours.
+#[tokio::test]
+#[ignore]
+async fn test_sip_quote_stream_receives_data() {
+    init_logging();
+
+    let streams = Streams::<Quotes>::builder()
+        .subscribe([(
+            AlpacaSip::default(),
+            "spy",
+            "usd",
+            MarketDataInstrumentKind::Spot,
+            Quotes,
+        )])
+        .init()
+        .await
+        .expect("Failed to init SIP quote stream");
+
+    let mut stream = streams
+        .select_all()
+        .with_error_handler(|e| tracing::warn!(?e, "Stream error"));
+
+    tracing::info!("Waiting for SIP quote data (consolidated NBBO)...");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+
+    while tokio::time::Instant::now() < deadline {
+        let timeout = tokio::time::timeout(Duration::from_secs(30), stream.next()).await;
+
+        match timeout {
+            Ok(Some(Event::Item(quote))) => {
+                tracing::info!(?quote, "Received SIP quote (NBBO)");
+                assert!(quote.kind.bid_price > Decimal::ZERO, "Invalid bid price");
+                assert!(quote.kind.ask_price > Decimal::ZERO, "Invalid ask price");
+                return;
+            }
+            Ok(Some(_)) => continue,
+            Ok(None) => panic!("Stream ended unexpectedly"),
+            Err(_) => {
+                tracing::warn!("Timeout waiting for SIP quote - may be outside market hours");
+                continue;
+            }
+        }
+    }
+
+    panic!(
+        "No SIP quote events received within timeout. \
+         If outside US market hours (9:30 AM - 4:00 PM ET), this is expected."
+    );
+}
+
+// ============================================================================
 // Options Market Data Tests (REST API - available 24/7)
 // ============================================================================
 
@@ -668,4 +832,98 @@ async fn test_fetch_chain_snapshots_convenience() {
 
     // SPY has many options, we should get a substantial number
     assert!(!snapshots.is_empty(), "No SPY chain snapshots received");
+}
+
+// ============================================================================
+// OPRA Options Tests (requires OPRA subscription)
+// ============================================================================
+
+/// Test fetching option snapshots with real-time OPRA feed.
+///
+/// NOTE: Requires OPRA subscription. Will return empty or error without subscription.
+#[tokio::test]
+#[ignore]
+async fn test_fetch_opra_snapshots() {
+    init_logging();
+
+    let client = AlpacaOptionsClient::from_env().expect("Failed to create options client");
+
+    // Get some AAPL contracts
+    let today = Utc::now().date_naive();
+    let thirty_days = today + chrono::Duration::days(30);
+
+    let query = AlpacaOptionContractQuery::new(vec!["AAPL".into()])
+        .expiration_gte(today)
+        .expiration_lte(thirty_days)
+        .limit(10);
+
+    let contracts = client
+        .fetch_contracts(&query)
+        .await
+        .expect("Failed to fetch contracts");
+
+    assert!(!contracts.is_empty(), "No contracts to fetch snapshots for");
+
+    let symbols: Vec<String> = contracts.iter().map(|c| c.symbol.clone()).collect();
+
+    // Fetch with OPRA (real-time) feed
+    let snapshots = client
+        .fetch_snapshots(&symbols, AlpacaOptionFeed::Opra)
+        .await
+        .expect("Failed to fetch OPRA snapshots");
+
+    tracing::info!(
+        requested = symbols.len(),
+        received = snapshots.len(),
+        "Fetched OPRA option snapshots"
+    );
+
+    assert!(!snapshots.is_empty(), "No OPRA snapshots received");
+
+    // Verify we got real-time data with Greeks
+    let mut greeks_count = 0;
+    for snapshot in &snapshots {
+        if snapshot.has_greeks() {
+            greeks_count += 1;
+            let greeks = snapshot.greeks();
+            tracing::info!(
+                symbol = %snapshot.symbol,
+                delta = ?greeks.delta,
+                gamma = ?greeks.gamma,
+                theta = ?greeks.theta,
+                vega = ?greeks.vega,
+                iv = ?greeks.implied_volatility,
+                "OPRA snapshot with Greeks"
+            );
+        }
+    }
+
+    tracing::info!(
+        total = snapshots.len(),
+        with_greeks = greeks_count,
+        "OPRA snapshot summary"
+    );
+}
+
+/// Test fetching entire chain with OPRA feed.
+///
+/// NOTE: Requires OPRA subscription.
+#[tokio::test]
+#[ignore]
+async fn test_fetch_opra_chain_snapshots() {
+    init_logging();
+
+    let client = AlpacaOptionsClient::from_env().expect("Failed to create options client");
+
+    let snapshots = client
+        .fetch_chain_snapshots("AAPL", AlpacaOptionFeed::Opra)
+        .await
+        .expect("Failed to fetch OPRA chain snapshots");
+
+    tracing::info!(count = snapshots.len(), "Fetched AAPL OPRA chain snapshots");
+
+    assert!(
+        !snapshots.is_empty(),
+        "No AAPL OPRA chain snapshots received"
+    );
 }

--- a/rustrade-execution/Cargo.toml
+++ b/rustrade-execution/Cargo.toml
@@ -111,6 +111,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 rust_decimal_macros = { workspace = true }
 # Serde round-trip tests (L2)
 serde_json = { workspace = true }
+# Serial test execution for integration tests that share exchange state
+serial_test = { workspace = true }
 
 # Examples that depend on optional features. Without `required-features`,
 # `cargo check --all-targets` (default features) fails to compile them.

--- a/rustrade-execution/src/client/alpaca/mod.rs
+++ b/rustrade-execution/src/client/alpaca/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     client::ExecutionClient,
     error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     order::{
-        Order, OrderKey, OrderKind, TimeInForce,
+        Order, OrderKey, OrderKind, TimeInForce, TrailingOffsetType,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
         state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
@@ -444,6 +444,9 @@ struct AlpacaOrderResponse {
     order_type: String,
     time_in_force: String,
     limit_price: Option<String>,
+    stop_price: Option<String>,
+    trail_percent: Option<String>,
+    trail_price: Option<String>,
     created_at: String,
 }
 
@@ -484,6 +487,103 @@ pub enum AlpacaPositionIntent {
 }
 
 // ---------------------------------------------------------------------------
+// Bracket order types
+// ---------------------------------------------------------------------------
+
+/// Take-profit parameters for Alpaca bracket orders.
+///
+/// The take-profit leg is always a limit order at the specified price.
+#[derive(Debug, Serialize)]
+struct TakeProfitParams {
+    limit_price: String,
+}
+
+/// Stop-loss parameters for Alpaca bracket orders.
+///
+/// When `limit_price` is `None`, the stop-loss is a stop (market) order.
+/// When `limit_price` is `Some`, the stop-loss becomes a stop-limit order.
+#[derive(Debug, Serialize)]
+struct StopLossParams {
+    stop_price: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limit_price: Option<String>,
+}
+
+/// Request to place a bracket order (entry + take-profit + stop-loss).
+///
+/// A bracket order consists of three linked orders submitted in a single request:
+/// 1. **Entry**: Limit order to enter the position
+/// 2. **Take Profit**: Limit order to exit at profit target
+/// 3. **Stop Loss**: Stop or stop-limit order to exit at loss limit
+///
+/// When either the take-profit or stop-loss fills, Alpaca automatically cancels
+/// the other leg.
+///
+/// # Constraints
+///
+/// - `time_in_force` must be `Day` or `GoodUntilCancelled` (no extended hours)
+/// - Entry order type is always `Limit`
+/// - Take-profit is always a `Limit` order
+/// - Stop-loss is a `Stop` order (or `StopLimit` if `stop_loss_limit_price` is set)
+///
+/// # Example
+///
+/// ```ignore
+/// let request = AlpacaBracketOrderRequest {
+///     instrument: "AAPL".into(),
+///     strategy: StrategyId::new("momentum"),
+///     cid: ClientOrderId::new("bracket-001"),
+///     side: Side::Buy,
+///     quantity: dec!(10),
+///     entry_price: dec!(150.00),
+///     take_profit_price: dec!(160.00),
+///     stop_loss_price: dec!(145.00),
+///     stop_loss_limit_price: None,  // Simple stop, or Some(dec!(144.00)) for stop-limit
+///     time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+/// };
+/// let result = client.open_bracket_order(request).await;
+/// ```
+#[derive(Debug, Clone)]
+pub struct AlpacaBracketOrderRequest {
+    /// Instrument to trade.
+    pub instrument: InstrumentNameExchange,
+    /// Strategy identifier for order correlation.
+    pub strategy: StrategyId,
+    /// Client order ID for the parent (entry) order.
+    pub cid: ClientOrderId,
+    /// Buy or Sell for the entry order (exits use opposite side).
+    pub side: Side,
+    /// Number of shares/contracts.
+    pub quantity: Decimal,
+    /// Entry limit price.
+    pub entry_price: Decimal,
+    /// Take-profit limit price.
+    pub take_profit_price: Decimal,
+    /// Stop-loss trigger price.
+    pub stop_loss_price: Decimal,
+    /// Optional stop-loss limit price. When set, makes the stop-loss a stop-limit order.
+    pub stop_loss_limit_price: Option<Decimal>,
+    /// Time-in-force for all legs. Must be `Day` or `GoodUntilCancelled`.
+    pub time_in_force: TimeInForce,
+}
+
+/// Result of placing an Alpaca bracket order.
+///
+/// Contains the parent order with its state. The take-profit and stop-loss legs
+/// are managed by Alpaca and their status can be queried via `fetch_open_orders`.
+///
+/// # Note
+///
+/// Unlike IBKR which returns three separate orders, Alpaca's bracket API returns
+/// a single parent order. The child legs (TP/SL) are implicitly created and linked
+/// by Alpaca. Use `fetch_open_orders` to retrieve all legs after placement.
+#[derive(Debug, Clone)]
+pub struct AlpacaBracketOrderResult {
+    /// Parent (entry) order with its current state.
+    pub parent: Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>,
+}
+
+// ---------------------------------------------------------------------------
 // REST order request body
 // ---------------------------------------------------------------------------
 
@@ -498,12 +598,26 @@ struct AlpacaOrderRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     limit_price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    stop_price: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trail_percent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trail_price: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     client_order_id: Option<&'a str>,
     // position_intent: heuristic mapping (buy→buy_to_open, sell→sell_to_close).
     // Correct for directional long-only strategies. Omit for exchanges/asset
     // classes that don't require it (stocks/crypto ignore this field).
     #[serde(skip_serializing_if = "Option::is_none")]
     position_intent: Option<AlpacaPositionIntent>,
+    // Bracket order fields (order_class, take_profit, stop_loss).
+    // Set order_class to "bracket" and populate TP/SL for bracket orders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    order_class: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    take_profit: Option<TakeProfitParams>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop_loss: Option<StopLossParams>,
 }
 
 // ---------------------------------------------------------------------------
@@ -571,6 +685,12 @@ struct AlpacaOrderWs<'a> {
     time_in_force: SmolStr,
     #[serde(borrow)]
     limit_price: Option<&'a str>,
+    #[serde(borrow)]
+    stop_price: Option<&'a str>,
+    #[serde(borrow)]
+    trail_percent: Option<&'a str>,
+    #[serde(borrow)]
+    trail_price: Option<&'a str>,
     status: SmolStr,
 }
 
@@ -1211,6 +1331,247 @@ impl AlpacaClient {
         self.open_order_inner(request, intent).await
     }
 
+    /// Place a bracket order (entry + take-profit + stop-loss) in a single request.
+    ///
+    /// A bracket order consists of three linked orders:
+    /// 1. **Entry**: Limit order to enter the position
+    /// 2. **Take Profit**: Limit order to exit at profit target
+    /// 3. **Stop Loss**: Stop (or stop-limit) order to exit at loss limit
+    ///
+    /// When the entry order fills, Alpaca activates both exit legs. When either
+    /// exit leg fills, Alpaca automatically cancels the other.
+    ///
+    /// # Constraints
+    ///
+    /// - `time_in_force` must be `Day` or `GoodUntilCancelled` (Alpaca rejects others)
+    /// - No extended hours trading with bracket orders
+    /// - Entry is always a limit order
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let request = AlpacaBracketOrderRequest {
+    ///     instrument: "AAPL".into(),
+    ///     strategy: StrategyId::new("momentum"),
+    ///     cid: ClientOrderId::new("bracket-001"),
+    ///     side: Side::Buy,
+    ///     quantity: dec!(10),
+    ///     entry_price: dec!(150.00),
+    ///     take_profit_price: dec!(160.00),
+    ///     stop_loss_price: dec!(145.00),
+    ///     stop_loss_limit_price: None,
+    ///     time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+    /// };
+    /// let result = client.open_bracket_order(request).await;
+    /// ```
+    pub async fn open_bracket_order(
+        &self,
+        request: AlpacaBracketOrderRequest,
+    ) -> AlpacaBracketOrderResult {
+        let order_key = crate::order::OrderKey::new(
+            ExchangeId::AlpacaBroker,
+            request.instrument.clone(),
+            request.strategy.clone(),
+            request.cid.clone(),
+        );
+
+        // Validate time_in_force: bracket orders only support day or gtc
+        let tif_str = match request.time_in_force {
+            TimeInForce::GoodUntilEndOfDay => "day",
+            TimeInForce::GoodUntilCancelled { post_only } => {
+                if post_only {
+                    return AlpacaBracketOrderResult {
+                        parent: Order {
+                            key: order_key,
+                            side: request.side,
+                            price: Some(request.entry_price),
+                            quantity: request.quantity,
+                            kind: OrderKind::Limit,
+                            time_in_force: request.time_in_force,
+                            state: OrderState::inactive(OrderError::Rejected(
+                                ApiError::OrderRejected(
+                                    "Alpaca does not support post_only for bracket orders"
+                                        .to_string(),
+                                ),
+                            )),
+                        },
+                    };
+                }
+                "gtc"
+            }
+            other => {
+                return AlpacaBracketOrderResult {
+                    parent: Order {
+                        key: order_key,
+                        side: request.side,
+                        price: Some(request.entry_price),
+                        quantity: request.quantity,
+                        kind: OrderKind::Limit,
+                        time_in_force: request.time_in_force,
+                        state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
+                            format!(
+                                "Alpaca bracket orders only support Day or GTC time_in_force, got {:?}",
+                                other
+                            ),
+                        ))),
+                    },
+                };
+            }
+        };
+
+        // Validate price ordering. Alpaca rejects mis-ordered brackets with a
+        // generic 422; surface a structured local error before round-trip.
+        let price_ordering_ok = match request.side {
+            Side::Buy => {
+                request.stop_loss_price < request.entry_price
+                    && request.entry_price < request.take_profit_price
+            }
+            Side::Sell => {
+                request.take_profit_price < request.entry_price
+                    && request.entry_price < request.stop_loss_price
+            }
+        };
+        if !price_ordering_ok {
+            return AlpacaBracketOrderResult {
+                parent: Order {
+                    key: order_key,
+                    side: request.side,
+                    price: Some(request.entry_price),
+                    quantity: request.quantity,
+                    kind: OrderKind::Limit,
+                    time_in_force: request.time_in_force,
+                    state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
+                        format!(
+                            "Invalid bracket price ordering for {:?} side: entry={}, take_profit={}, stop_loss={}",
+                            request.side,
+                            request.entry_price,
+                            request.take_profit_price,
+                            request.stop_loss_price,
+                        ),
+                    ))),
+                },
+            };
+        }
+
+        // Validate stop-loss limit price if provided. For a Buy bracket, the SL
+        // is a sell stop(-limit); the limit must be at or below the trigger so
+        // the order can fill if price gaps down. Reverse for Sell brackets.
+        if let Some(sl_limit) = request.stop_loss_limit_price {
+            let sl_limit_ok = match request.side {
+                Side::Buy => sl_limit <= request.stop_loss_price,
+                Side::Sell => sl_limit >= request.stop_loss_price,
+            };
+            if !sl_limit_ok {
+                return AlpacaBracketOrderResult {
+                    parent: Order {
+                        key: order_key,
+                        side: request.side,
+                        price: Some(request.entry_price),
+                        quantity: request.quantity,
+                        kind: OrderKind::Limit,
+                        time_in_force: request.time_in_force,
+                        state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
+                            format!(
+                                "Invalid stop-loss limit price for {:?} bracket: \
+                                 stop_loss_price={}, stop_loss_limit_price={}",
+                                request.side, request.stop_loss_price, sl_limit,
+                            ),
+                        ))),
+                    },
+                };
+            }
+        }
+
+        // Build the bracket order request
+        let body = AlpacaOrderRequest {
+            symbol: request.instrument.name().as_str(),
+            qty: request.quantity.to_string(),
+            side: map_side(request.side),
+            order_type: "limit",
+            time_in_force: tif_str,
+            limit_price: Some(request.entry_price.to_string()),
+            stop_price: None,
+            trail_percent: None,
+            trail_price: None,
+            client_order_id: Some(request.cid.0.as_str()),
+            position_intent: if is_options_or_equity_symbol(request.instrument.name().as_str()) {
+                Some(map_position_intent(request.side, false))
+            } else {
+                None
+            },
+            order_class: Some("bracket"),
+            take_profit: Some(TakeProfitParams {
+                limit_price: request.take_profit_price.to_string(),
+            }),
+            stop_loss: Some(StopLossParams {
+                stop_price: request.stop_loss_price.to_string(),
+                limit_price: request.stop_loss_limit_price.map(|p| p.to_string()),
+            }),
+        };
+
+        let base = self.base_url();
+        let http = self.http.clone();
+        let rl = &self.rate_limiter;
+        let orders_url = format!("{base}/v2/orders");
+
+        let result: Result<AlpacaOrderResponse, UnindexedClientError> =
+            rest_with_retry(rl, || http.post(&orders_url).json(&body)).await;
+
+        match result {
+            Ok(resp) => {
+                let exchange_order_id = OrderId(SmolStr::new(&resp.id));
+                let time_exchange = parse_timestamp(&resp.created_at).unwrap_or_else(Utc::now);
+                let filled_qty = Decimal::from_str(&resp.filled_qty).unwrap_or(Decimal::ZERO);
+
+                let state = if filled_qty >= request.quantity {
+                    OrderState::fully_filled(Filled::new(
+                        exchange_order_id,
+                        time_exchange,
+                        filled_qty,
+                        None,
+                    ))
+                } else {
+                    OrderState::active(Open::new(exchange_order_id, time_exchange, filled_qty))
+                };
+
+                AlpacaBracketOrderResult {
+                    parent: Order {
+                        key: order_key,
+                        side: request.side,
+                        price: Some(request.entry_price),
+                        quantity: request.quantity,
+                        kind: OrderKind::Limit,
+                        time_in_force: request.time_in_force,
+                        state,
+                    },
+                }
+            }
+            Err(e) => {
+                let order_err = match e {
+                    UnindexedClientError::Connectivity(ce) => OrderError::Connectivity(ce),
+                    UnindexedClientError::Api(ae) => OrderError::Rejected(ae),
+                    UnindexedClientError::TaskFailed(_)
+                    | UnindexedClientError::Internal(_)
+                    | UnindexedClientError::Truncated { .. }
+                    | UnindexedClientError::TruncatedSnapshot { .. } => {
+                        unreachable!("rest_with_retry (order path) does not produce these variants")
+                    }
+                };
+                AlpacaBracketOrderResult {
+                    parent: Order {
+                        key: order_key,
+                        side: request.side,
+                        price: Some(request.entry_price),
+                        quantity: request.quantity,
+                        kind: OrderKind::Limit,
+                        time_in_force: request.time_in_force,
+                        state: OrderState::inactive(order_err),
+                    },
+                }
+            }
+        }
+    }
+
     async fn open_order_inner(
         &self,
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
@@ -1267,17 +1628,74 @@ impl AlpacaClient {
             }
         };
 
+        // Validate trailing stop offset type — Alpaca only supports percent and absolute.
+        if let OrderKind::TrailingStop {
+            offset_type: TrailingOffsetType::BasisPoints,
+            ..
+        } = kind
+        {
+            return Some(Order {
+                key: order_key,
+                side,
+                price,
+                quantity,
+                kind,
+                time_in_force,
+                state: OrderState::inactive(OrderError::UnsupportedOrderType(
+                    "Alpaca does not support TrailingOffsetType::BasisPoints; \
+                     use Percentage or Absolute"
+                        .to_string(),
+                )),
+            });
+        }
+
+        // StopLimit requires Order.price (the limit price applied once trigger fires).
+        // Guard locally to avoid a wire round-trip producing a generic 422.
+        if matches!(kind, OrderKind::StopLimit { .. }) && price.is_none() {
+            return Some(Order {
+                key: order_key,
+                side,
+                price,
+                quantity,
+                kind,
+                time_in_force,
+                state: OrderState::inactive(OrderError::Rejected(ApiError::OrderRejected(
+                    "StopLimit order requires Order.price (the limit price) to be set".to_string(),
+                ))),
+            });
+        }
+
+        // Extract stop/trailing parameters based on order kind.
+        let (stop_price, trail_percent, trail_price) = match kind {
+            OrderKind::Stop { trigger_price } | OrderKind::StopLimit { trigger_price } => {
+                (Some(trigger_price.to_string()), None, None)
+            }
+            OrderKind::TrailingStop {
+                offset,
+                offset_type,
+            } => match offset_type {
+                TrailingOffsetType::Percentage => (None, Some(offset.to_string()), None),
+                TrailingOffsetType::Absolute => (None, None, Some(offset.to_string())),
+                TrailingOffsetType::BasisPoints => unreachable!("validated above"),
+            },
+            OrderKind::Market | OrderKind::Limit | OrderKind::TrailingStopLimit { .. } => {
+                (None, None, None)
+            }
+        };
+
         let body = AlpacaOrderRequest {
             symbol: instrument.name().as_str(),
             qty: quantity.to_string(),
             side: map_side(side),
             order_type: order_type_str,
             time_in_force: tif_str,
-            limit_price: if matches!(kind, OrderKind::Limit) {
-                price.map(|p| p.to_string())
-            } else {
-                None
+            limit_price: match kind {
+                OrderKind::Limit | OrderKind::StopLimit { .. } => price.map(|p| p.to_string()),
+                _ => None,
             },
+            stop_price,
+            trail_percent,
+            trail_price,
             client_order_id: Some(cid.0.as_str()),
             // position_intent is required for options orders and valid (but optional)
             // for equities. It is NOT a valid field for crypto orders and must be
@@ -1289,6 +1707,10 @@ impl AlpacaClient {
             } else {
                 None
             },
+            // Non-bracket order: no bracket fields
+            order_class: None,
+            take_profit: None,
+            stop_loss: None,
         };
 
         let base = self.base_url();
@@ -2346,7 +2768,12 @@ fn convert_open_order(
         .as_deref()
         .and_then(|s| Decimal::from_str(s).ok());
     let filled_qty = Decimal::from_str(&o.filled_qty).unwrap_or(Decimal::ZERO);
-    let kind = parse_order_kind(&o.order_type)?;
+    let kind = parse_order_kind(
+        &o.order_type,
+        o.stop_price.as_deref(),
+        o.trail_percent.as_deref(),
+        o.trail_price.as_deref(),
+    )?;
     let time_in_force = parse_time_in_force(&o.time_in_force);
     let time_exchange = parse_timestamp(&o.created_at).unwrap_or_else(Utc::now);
 
@@ -2505,7 +2932,12 @@ fn convert_trade_update(update: AlpacaTradeUpdate<'_>) -> Option<UnindexedAccoun
             let price = order.limit_price.and_then(|s| Decimal::from_str(s).ok());
             let filled_qty =
                 Decimal::from_str(order.filled_qty.unwrap_or("0")).unwrap_or(Decimal::ZERO);
-            let kind = parse_order_kind(&order.order_type)?;
+            let kind = parse_order_kind(
+                &order.order_type,
+                order.stop_price,
+                order.trail_percent,
+                order.trail_price,
+            )?;
             let time_in_force = parse_time_in_force(&order.time_in_force);
             let time_exchange = update
                 .timestamp
@@ -2604,13 +3036,41 @@ fn parse_side(s: &str) -> Option<Side> {
     }
 }
 
-fn parse_order_kind(s: &str) -> Option<OrderKind> {
-    match s {
+fn parse_order_kind(
+    order_type: &str,
+    stop_price: Option<&str>,
+    trail_percent: Option<&str>,
+    trail_price: Option<&str>,
+) -> Option<OrderKind> {
+    match order_type {
         "market" | "Market" => Some(OrderKind::Market),
         "limit" | "Limit" => Some(OrderKind::Limit),
+        "stop" | "Stop" => {
+            let trigger_price = stop_price.and_then(|s| Decimal::from_str(s).ok())?;
+            Some(OrderKind::Stop { trigger_price })
+        }
+        "stop_limit" | "Stop_limit" => {
+            let trigger_price = stop_price.and_then(|s| Decimal::from_str(s).ok())?;
+            Some(OrderKind::StopLimit { trigger_price })
+        }
+        "trailing_stop" | "Trailing_stop" => {
+            // Alpaca returns either trail_percent or trail_price, not both.
+            if let Some(pct) = trail_percent.and_then(|s| Decimal::from_str(s).ok()) {
+                Some(OrderKind::TrailingStop {
+                    offset: pct,
+                    offset_type: TrailingOffsetType::Percentage,
+                })
+            } else if let Some(price) = trail_price.and_then(|s| Decimal::from_str(s).ok()) {
+                Some(OrderKind::TrailingStop {
+                    offset: price,
+                    offset_type: TrailingOffsetType::Absolute,
+                })
+            } else {
+                trace!("Alpaca: trailing_stop missing trail_percent and trail_price");
+                None
+            }
+        }
         other => {
-            // stop, stop_limit, trailing_stop — not in rustrade's OrderKind enum.
-            // Return None to skip the order; the consumer never placed these via rustrade.
             trace!(%other, "Alpaca: unsupported order type, skipping");
             None
         }
@@ -2647,12 +3107,11 @@ fn map_order_kind(kind: OrderKind) -> Option<&'static str> {
     match kind {
         OrderKind::Market => Some("market"),
         OrderKind::Limit => Some("limit"),
-        // Alpaca supports stop, stop_limit, trailing_stop natively, but rustrade's
-        // Alpaca connector doesn't expose them yet. Return None to reject at open_order.
-        OrderKind::Stop { .. }
-        | OrderKind::StopLimit { .. }
-        | OrderKind::TrailingStop { .. }
-        | OrderKind::TrailingStopLimit { .. } => None,
+        OrderKind::Stop { .. } => Some("stop"),
+        OrderKind::StopLimit { .. } => Some("stop_limit"),
+        OrderKind::TrailingStop { .. } => Some("trailing_stop"),
+        // Alpaca does not support trailing stop-limit orders.
+        OrderKind::TrailingStopLimit { .. } => None,
     }
 }
 
@@ -2800,9 +3259,97 @@ mod tests {
 
     #[test]
     fn test_parse_order_kind() {
-        assert_eq!(parse_order_kind("market"), Some(OrderKind::Market));
-        assert_eq!(parse_order_kind("limit"), Some(OrderKind::Limit));
-        assert_eq!(parse_order_kind("stop"), None);
+        // Market and Limit don't need extra params
+        assert_eq!(
+            parse_order_kind("market", None, None, None),
+            Some(OrderKind::Market)
+        );
+        assert_eq!(
+            parse_order_kind("limit", None, None, None),
+            Some(OrderKind::Limit)
+        );
+
+        // Stop requires stop_price
+        assert_eq!(
+            parse_order_kind("stop", Some("150.00"), None, None),
+            Some(OrderKind::Stop {
+                trigger_price: Decimal::from_str("150.00").unwrap()
+            })
+        );
+        assert_eq!(parse_order_kind("stop", None, None, None), None);
+
+        // StopLimit requires stop_price
+        assert_eq!(
+            parse_order_kind("stop_limit", Some("145.00"), None, None),
+            Some(OrderKind::StopLimit {
+                trigger_price: Decimal::from_str("145.00").unwrap()
+            })
+        );
+
+        // TrailingStop with percentage
+        assert_eq!(
+            parse_order_kind("trailing_stop", None, Some("5.0"), None),
+            Some(OrderKind::TrailingStop {
+                offset: Decimal::from_str("5.0").unwrap(),
+                offset_type: TrailingOffsetType::Percentage,
+            })
+        );
+
+        // TrailingStop with absolute price
+        assert_eq!(
+            parse_order_kind("trailing_stop", None, None, Some("2.50")),
+            Some(OrderKind::TrailingStop {
+                offset: Decimal::from_str("2.50").unwrap(),
+                offset_type: TrailingOffsetType::Absolute,
+            })
+        );
+
+        // TrailingStop without either offset returns None
+        assert_eq!(parse_order_kind("trailing_stop", None, None, None), None);
+
+        // Unknown type returns None
+        assert_eq!(parse_order_kind("unknown", None, None, None), None);
+    }
+
+    #[test]
+    fn test_map_order_kind() {
+        assert_eq!(map_order_kind(OrderKind::Market), Some("market"));
+        assert_eq!(map_order_kind(OrderKind::Limit), Some("limit"));
+        assert_eq!(
+            map_order_kind(OrderKind::Stop {
+                trigger_price: Decimal::from_str("150.00").unwrap()
+            }),
+            Some("stop")
+        );
+        assert_eq!(
+            map_order_kind(OrderKind::StopLimit {
+                trigger_price: Decimal::from_str("145.00").unwrap()
+            }),
+            Some("stop_limit")
+        );
+        assert_eq!(
+            map_order_kind(OrderKind::TrailingStop {
+                offset: Decimal::from_str("5.0").unwrap(),
+                offset_type: TrailingOffsetType::Percentage,
+            }),
+            Some("trailing_stop")
+        );
+        assert_eq!(
+            map_order_kind(OrderKind::TrailingStop {
+                offset: Decimal::from_str("2.50").unwrap(),
+                offset_type: TrailingOffsetType::Absolute,
+            }),
+            Some("trailing_stop")
+        );
+        // TrailingStopLimit is not supported by Alpaca
+        assert_eq!(
+            map_order_kind(OrderKind::TrailingStopLimit {
+                offset: Decimal::from_str("5.0").unwrap(),
+                offset_type: TrailingOffsetType::Percentage,
+                limit_offset: Decimal::from_str("1.0").unwrap(),
+            }),
+            None
+        );
     }
 
     #[test]
@@ -2821,6 +3368,230 @@ mod tests {
         let result = map_time_in_force(TimeInForce::GoodUntilCancelled { post_only: true });
         assert!(result.is_err(), "post_only must be rejected");
         assert!(result.unwrap_err().contains("post_only"));
+    }
+
+    // =========================================================================
+    // Bracket Order Serialization Tests
+    // =========================================================================
+
+    #[test]
+    fn test_bracket_order_serializes_with_stop_loss_stop_order() {
+        // Bracket order with stop-loss as a simple stop order (no limit_price)
+        let body = AlpacaOrderRequest {
+            symbol: "AAPL",
+            qty: "10".to_string(),
+            side: "buy",
+            order_type: "limit",
+            time_in_force: "gtc",
+            limit_price: Some("150.00".to_string()),
+            stop_price: None,
+            trail_percent: None,
+            trail_price: None,
+            client_order_id: Some("bracket-001"),
+            position_intent: Some(AlpacaPositionIntent::BuyToOpen),
+            order_class: Some("bracket"),
+            take_profit: Some(TakeProfitParams {
+                limit_price: "160.00".to_string(),
+            }),
+            stop_loss: Some(StopLossParams {
+                stop_price: "145.00".to_string(),
+                limit_price: None,
+            }),
+        };
+
+        let json = serde_json::to_value(&body).unwrap();
+
+        assert_eq!(json["symbol"], "AAPL");
+        assert_eq!(json["qty"], "10");
+        assert_eq!(json["side"], "buy");
+        assert_eq!(json["type"], "limit");
+        assert_eq!(json["time_in_force"], "gtc");
+        assert_eq!(json["limit_price"], "150.00");
+        assert_eq!(json["order_class"], "bracket");
+
+        // Take profit should have limit_price
+        assert_eq!(json["take_profit"]["limit_price"], "160.00");
+
+        // Stop loss should have stop_price but NO limit_price
+        assert_eq!(json["stop_loss"]["stop_price"], "145.00");
+        assert!(
+            json["stop_loss"].get("limit_price").is_none(),
+            "stop_loss.limit_price should be omitted when None"
+        );
+    }
+
+    #[test]
+    fn test_bracket_order_serializes_with_stop_loss_stop_limit_order() {
+        // Bracket order with stop-loss as a stop-limit order (has limit_price)
+        let body = AlpacaOrderRequest {
+            symbol: "SPY",
+            qty: "5".to_string(),
+            side: "sell",
+            order_type: "limit",
+            time_in_force: "day",
+            limit_price: Some("450.00".to_string()),
+            stop_price: None,
+            trail_percent: None,
+            trail_price: None,
+            client_order_id: Some("bracket-002"),
+            position_intent: Some(AlpacaPositionIntent::SellToClose),
+            order_class: Some("bracket"),
+            take_profit: Some(TakeProfitParams {
+                limit_price: "440.00".to_string(),
+            }),
+            stop_loss: Some(StopLossParams {
+                stop_price: "455.00".to_string(),
+                limit_price: Some("456.00".to_string()),
+            }),
+        };
+
+        let json = serde_json::to_value(&body).unwrap();
+
+        assert_eq!(json["symbol"], "SPY");
+        assert_eq!(json["side"], "sell");
+        assert_eq!(json["time_in_force"], "day");
+        assert_eq!(json["order_class"], "bracket");
+
+        // Take profit
+        assert_eq!(json["take_profit"]["limit_price"], "440.00");
+
+        // Stop loss with limit_price (stop-limit order)
+        assert_eq!(json["stop_loss"]["stop_price"], "455.00");
+        assert_eq!(
+            json["stop_loss"]["limit_price"], "456.00",
+            "stop_loss.limit_price should be present for stop-limit orders"
+        );
+    }
+
+    // =========================================================================
+    // Bracket Order Validation Tests
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_open_bracket_order_rejects_invalid_tif() {
+        use rust_decimal_macros::dec;
+        use rustrade_instrument::instrument::name::InstrumentNameExchange;
+
+        // Create a minimal client with dummy credentials (no network call will be made)
+        let config = AlpacaConfig::new("dummy_key".into(), "dummy_secret".into(), true);
+        let client = AlpacaClient::new(config);
+
+        let request = AlpacaBracketOrderRequest {
+            instrument: InstrumentNameExchange::new("SPY"),
+            strategy: crate::order::id::StrategyId::new("test"),
+            cid: crate::order::id::ClientOrderId::new("test-tif"),
+            side: Side::Buy,
+            quantity: dec!(1),
+            entry_price: dec!(100.00),
+            take_profit_price: dec!(120.00),
+            stop_loss_price: dec!(90.00),
+            stop_loss_limit_price: None,
+            time_in_force: TimeInForce::ImmediateOrCancel, // Invalid for brackets
+        };
+
+        let result = client.open_bracket_order(request).await;
+
+        assert!(
+            result.parent.state.is_failed(),
+            "Bracket order with IOC TIF should be rejected locally"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_open_bracket_order_rejects_invalid_price_ordering() {
+        use rust_decimal_macros::dec;
+        use rustrade_instrument::instrument::name::InstrumentNameExchange;
+
+        let config = AlpacaConfig::new("dummy_key".into(), "dummy_secret".into(), true);
+        let client = AlpacaClient::new(config);
+
+        // Buy bracket with SL > entry (invalid)
+        let request = AlpacaBracketOrderRequest {
+            instrument: InstrumentNameExchange::new("SPY"),
+            strategy: crate::order::id::StrategyId::new("test"),
+            cid: crate::order::id::ClientOrderId::new("test-price"),
+            side: Side::Buy,
+            quantity: dec!(1),
+            entry_price: dec!(100.00),
+            take_profit_price: dec!(120.00),
+            stop_loss_price: dec!(105.00), // Invalid: SL > entry for buy
+            stop_loss_limit_price: None,
+            time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        };
+
+        let result = client.open_bracket_order(request).await;
+
+        assert!(
+            result.parent.state.is_failed(),
+            "Bracket order with invalid price ordering should be rejected locally"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_open_bracket_order_rejects_invalid_sl_limit_price() {
+        use rust_decimal_macros::dec;
+        use rustrade_instrument::instrument::name::InstrumentNameExchange;
+
+        let config = AlpacaConfig::new("dummy_key".into(), "dummy_secret".into(), true);
+        let client = AlpacaClient::new(config);
+
+        // Buy bracket with SL limit > SL trigger (invalid for sell stop-limit)
+        let request = AlpacaBracketOrderRequest {
+            instrument: InstrumentNameExchange::new("SPY"),
+            strategy: crate::order::id::StrategyId::new("test"),
+            cid: crate::order::id::ClientOrderId::new("test-sl-limit"),
+            side: Side::Buy,
+            quantity: dec!(1),
+            entry_price: dec!(100.00),
+            take_profit_price: dec!(120.00),
+            stop_loss_price: dec!(90.00),
+            stop_loss_limit_price: Some(dec!(95.00)), // Invalid: limit > trigger for sell SL
+            time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        };
+
+        let result = client.open_bracket_order(request).await;
+
+        assert!(
+            result.parent.state.is_failed(),
+            "Bracket order with invalid SL limit price should be rejected locally"
+        );
+    }
+
+    #[test]
+    fn test_non_bracket_order_omits_bracket_fields() {
+        // Regular limit order should not have bracket fields
+        let body = AlpacaOrderRequest {
+            symbol: "AAPL",
+            qty: "1".to_string(),
+            side: "buy",
+            order_type: "limit",
+            time_in_force: "gtc",
+            limit_price: Some("150.00".to_string()),
+            stop_price: None,
+            trail_percent: None,
+            trail_price: None,
+            client_order_id: Some("regular-001"),
+            position_intent: Some(AlpacaPositionIntent::BuyToOpen),
+            order_class: None,
+            take_profit: None,
+            stop_loss: None,
+        };
+
+        let json = serde_json::to_value(&body).unwrap();
+
+        assert_eq!(json["symbol"], "AAPL");
+        assert!(
+            json.get("order_class").is_none(),
+            "order_class should be omitted for non-bracket orders"
+        );
+        assert!(
+            json.get("take_profit").is_none(),
+            "take_profit should be omitted for non-bracket orders"
+        );
+        assert!(
+            json.get("stop_loss").is_none(),
+            "stop_loss should be omitted for non-bracket orders"
+        );
     }
 
     #[test]
@@ -3002,6 +3773,9 @@ mod tests {
             order_type: SmolStr::new("limit"),
             time_in_force: SmolStr::new("day"),
             limit_price: Some("100.00"),
+            stop_price: None,
+            trail_percent: None,
+            trail_price: None,
             status: SmolStr::new("partially_filled"),
         }
     }
@@ -3052,6 +3826,9 @@ mod tests {
                 order_type: SmolStr::new("limit"),
                 time_in_force: SmolStr::new("day"),
                 limit_price: Some("150.00"),
+                stop_price: None,
+                trail_percent: None,
+                trail_price: None,
                 status: SmolStr::new("new"),
             },
             price: None,
@@ -3108,6 +3885,9 @@ mod tests {
             order_type: "market".to_string(),
             time_in_force: "day".to_string(),
             limit_price: None,
+            stop_price: None,
+            trail_percent: None,
+            trail_price: None,
             created_at: "2025-04-18T14:30:00Z".to_string(),
         };
         assert!(convert_open_order(&order).is_none());
@@ -3180,6 +3960,9 @@ mod tests {
             order_type: "limit".to_string(),
             time_in_force: "day".to_string(),
             limit_price: Some("100.00".to_string()),
+            stop_price: None,
+            trail_percent: None,
+            trail_price: None,
             created_at: "2025-04-18T14:30:00Z".to_string(),
         }
     }
@@ -3327,6 +4110,9 @@ mod tests {
                 order_type: SmolStr::new("market"),
                 time_in_force: SmolStr::new("day"),
                 limit_price: None,
+                stop_price: None,
+                trail_percent: None,
+                trail_price: None,
                 status: SmolStr::new("filled"),
             },
             price: Some("100.00"),
@@ -3348,6 +4134,9 @@ mod tests {
                 order_type: SmolStr::new("market"),
                 time_in_force: SmolStr::new("day"),
                 limit_price: None,
+                stop_price: None,
+                trail_percent: None,
+                trail_price: None,
                 status: SmolStr::new("filled"),
             },
             price: Some("100.00"),
@@ -3369,6 +4158,9 @@ mod tests {
                 order_type: SmolStr::new("market"),
                 time_in_force: SmolStr::new("day"),
                 limit_price: None,
+                stop_price: None,
+                trail_percent: None,
+                trail_price: None,
                 status: SmolStr::new("filled"),
             },
             price: Some("100.00"),

--- a/rustrade-execution/tests/alpaca_integration.rs
+++ b/rustrade-execution/tests/alpaca_integration.rs
@@ -44,7 +44,7 @@ use rustrade_execution::{
         alpaca::{AlpacaClient, AlpacaConfig},
     },
     order::{
-        OrderKey, OrderKind, TimeInForce,
+        OrderKey, OrderKind, TimeInForce, TrailingOffsetType,
         id::{ClientOrderId, StrategyId},
         request::RequestOpen,
         state::{ActiveOrderState, InactiveOrderState, OrderState},
@@ -54,6 +54,7 @@ use rustrade_instrument::{
     Side, asset::name::AssetNameExchange, exchange::ExchangeId,
     instrument::name::InstrumentNameExchange,
 };
+use serial_test::serial;
 use std::time::Duration;
 use tokio_stream::StreamExt;
 use tracing_subscriber::{EnvFilter, fmt};
@@ -224,6 +225,7 @@ async fn test_fetch_open_orders() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_and_cancel_limit_order() {
     init_logging();
 
@@ -321,6 +323,7 @@ async fn test_place_and_cancel_limit_order() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_crypto_limit_order() {
     init_logging();
 
@@ -408,6 +411,7 @@ async fn test_place_crypto_limit_order() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_account_stream() {
     init_logging();
 
@@ -459,6 +463,7 @@ async fn test_account_stream() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_account_stream_with_order() {
     init_logging();
 
@@ -579,5 +584,404 @@ async fn test_account_stream_with_order() {
             })
             .await;
         println!("Cleanup complete");
+    }
+}
+
+// ============================================================================
+// Stop Order Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_place_and_cancel_stop_order() {
+    init_logging();
+
+    let config = test_config();
+    let client = AlpacaClient::new(config);
+
+    let instrument = spy_instrument();
+    let strategy = StrategyId::new("test-strategy");
+    let order_cid = ClientOrderId::new(format!(
+        "test-stop-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::AlpacaBroker,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Stop order: triggers a market order when SPY drops to $1.00
+    // This price is unrealistically low so the order will never trigger
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: None,
+        quantity: dec!(1),
+        kind: OrderKind::Stop {
+            trigger_price: dec!(1.00),
+        },
+        time_in_force: TimeInForce::GoodUntilEndOfDay,
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing stop order: SELL 1 SPY @ stop $1.00 (won't trigger - price too low)");
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Stop order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+            println!("  Kind: {:?}", response.kind);
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::AlpacaBroker,
+                instrument: &instrument,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling stop order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            let cancel_response = cancel_response.unwrap();
+
+            match &cancel_response.state {
+                Ok(cancelled) => {
+                    println!("Stop order canceled successfully!");
+                    println!("  Exchange Order ID: {:?}", cancelled.id);
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("Stop order rejected: {:?}", e);
+        }
+        OrderState::Active(other) => {
+            panic!("Unexpected active state: {:?}", other);
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_place_and_cancel_trailing_stop_order() {
+    init_logging();
+
+    let config = test_config();
+    let client = AlpacaClient::new(config);
+
+    let instrument = spy_instrument();
+    let strategy = StrategyId::new("test-strategy");
+    let order_cid = ClientOrderId::new(format!(
+        "test-trail-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::AlpacaBroker,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+    };
+
+    // Trailing stop order with 5% trail distance
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: None,
+        quantity: dec!(1),
+        kind: OrderKind::TrailingStop {
+            offset: dec!(5.0),
+            offset_type: TrailingOffsetType::Percentage,
+        },
+        time_in_force: TimeInForce::GoodUntilEndOfDay,
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing trailing stop order: SELL 1 SPY with 5% trail");
+
+    let response = client.open_order(open_request).await;
+
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Trailing stop order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+            println!("  Kind: {:?}", response.kind);
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::AlpacaBroker,
+                instrument: &instrument,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling trailing stop order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            let cancel_response = cancel_response.unwrap();
+
+            match &cancel_response.state {
+                Ok(cancelled) => {
+                    println!("Trailing stop order canceled successfully!");
+                    println!("  Exchange Order ID: {:?}", cancelled.id);
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("Trailing stop order rejected: {:?}", e);
+        }
+        OrderState::Active(other) => {
+            panic!("Unexpected active state: {:?}", other);
+        }
+    }
+}
+
+// ============================================================================
+// Bracket Order Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_place_and_cancel_bracket_order_with_stop() {
+    use rustrade_execution::client::alpaca::{AlpacaBracketOrderRequest, AlpacaBracketOrderResult};
+
+    init_logging();
+
+    let config = test_config();
+    let client = AlpacaClient::new(config);
+
+    let instrument = spy_instrument();
+    let strategy = StrategyId::new("test-bracket");
+    let order_cid = ClientOrderId::new(format!(
+        "test-bracket-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    // Bracket order with stop-loss as a simple stop order
+    // Entry at $100 (way below market ~$580+, won't fill), TP at $120, SL at $90
+    let request = AlpacaBracketOrderRequest {
+        instrument: instrument.clone(),
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+        side: Side::Buy,
+        quantity: dec!(1),
+        entry_price: dec!(100.00),
+        take_profit_price: dec!(120.00),
+        stop_loss_price: dec!(90.00),
+        stop_loss_limit_price: None, // Simple stop order
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+    };
+
+    println!("Placing bracket order: BUY 1 SPY @ $100 entry, $120 TP, $90 SL (stop)");
+
+    let result: AlpacaBracketOrderResult = client.open_bracket_order(request).await;
+
+    match &result.parent.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Bracket order placed successfully!");
+            println!("  Client Order ID: {}", result.parent.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+            println!("  Entry Price: {:?}", result.parent.price);
+
+            // Verify the order is on the book
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Fetch open orders to see all legs
+            let instruments: Vec<InstrumentNameExchange> = vec![instrument.clone()];
+            let open_orders = client.fetch_open_orders(&instruments).await;
+            match open_orders {
+                Ok(orders) => {
+                    println!("Open orders after bracket placement: {}", orders.len());
+                    for order in &orders {
+                        println!(
+                            "  {:?} {} {} @ {:?} (kind: {:?})",
+                            order.side,
+                            order.quantity,
+                            order.key.instrument,
+                            order.price,
+                            order.kind
+                        );
+                    }
+                    // Bracket order should create 3 legs (entry, TP, SL)
+                    // but we only assert >= 1 since entry might be the only one visible before fill
+                    assert!(
+                        !orders.is_empty(),
+                        "Expected at least the entry order to be visible"
+                    );
+                }
+                Err(e) => {
+                    println!("Warning: fetch_open_orders failed: {:?}", e);
+                }
+            }
+
+            // Cancel the bracket order (canceling parent cancels all legs)
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::AlpacaBroker,
+                instrument: &instrument,
+                strategy: result.parent.key.strategy.clone(),
+                cid: result.parent.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling bracket order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            match &cancel_response.unwrap().state {
+                Ok(cancelled) => {
+                    println!("Bracket order canceled successfully!");
+                    println!("  Exchange Order ID: {:?}", cancelled.id);
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("Bracket order rejected: {:?}", e);
+        }
+        OrderState::Active(other) => {
+            panic!("Unexpected active state: {:?}", other);
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_place_and_cancel_bracket_order_with_stop_limit() {
+    use rustrade_execution::client::alpaca::{AlpacaBracketOrderRequest, AlpacaBracketOrderResult};
+
+    init_logging();
+
+    let config = test_config();
+    let client = AlpacaClient::new(config);
+
+    let instrument = spy_instrument();
+    let strategy = StrategyId::new("test-bracket-sl");
+    let order_cid = ClientOrderId::new(format!(
+        "test-bracket-sl-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    // Bracket order with stop-loss as a stop-limit order
+    // Entry at $100 (way below market, won't fill), TP at $120, SL triggers at $90, limit at $88
+    let request = AlpacaBracketOrderRequest {
+        instrument: instrument.clone(),
+        strategy: strategy.clone(),
+        cid: order_cid.clone(),
+        side: Side::Buy,
+        quantity: dec!(1),
+        entry_price: dec!(100.00),
+        take_profit_price: dec!(120.00),
+        stop_loss_price: dec!(90.00),
+        stop_loss_limit_price: Some(dec!(88.00)), // Stop-limit order
+        time_in_force: TimeInForce::GoodUntilEndOfDay,
+    };
+
+    println!("Placing bracket order: BUY 1 SPY @ $100 entry, $120 TP, $90/$88 SL (stop-limit)");
+
+    let result: AlpacaBracketOrderResult = client.open_bracket_order(request).await;
+
+    match &result.parent.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Bracket order (stop-limit SL) placed successfully!");
+            println!("  Client Order ID: {}", result.parent.key.cid);
+            println!("  Exchange Order ID: {:?}", open_state.id);
+            println!("  Entry Price: {:?}", result.parent.price);
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Cancel the bracket order
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::AlpacaBroker,
+                instrument: &instrument,
+                strategy: result.parent.key.strategy.clone(),
+                cid: result.parent.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling bracket order (stop-limit)...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            match &cancel_response.unwrap().state {
+                Ok(cancelled) => {
+                    println!("Bracket order (stop-limit) canceled successfully!");
+                    println!("  Exchange Order ID: {:?}", cancelled.id);
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("Bracket order (stop-limit) rejected: {:?}", e);
+        }
+        OrderState::Active(other) => {
+            panic!("Unexpected active state: {:?}", other);
+        }
     }
 }

--- a/rustrade-instrument/src/instrument/market_data/mod.rs
+++ b/rustrade-instrument/src/instrument/market_data/mod.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 pub mod kind;
+pub mod option_chain;
+
+pub use option_chain::{OptionChainDescriptor, OptionChainError};
 
 /// Barter representation of an `MarketDataInstrument`. Used to uniquely identify a `base_quote`
 /// pair, and it's associated instrument type.

--- a/rustrade-instrument/src/instrument/market_data/option_chain.rs
+++ b/rustrade-instrument/src/instrument/market_data/option_chain.rs
@@ -1,0 +1,339 @@
+//! Option chain discovery types for cross-exchange option chain enumeration.
+//!
+//! [`OptionChainDescriptor`] represents the available option contracts for an underlying,
+//! providing a unified view across exchanges with different API capabilities.
+//!
+//! # Exchange API Divergence
+//!
+//! | Field | IBKR | Alpaca |
+//! |-------|------|--------|
+//! | `exchange` | always `ExchangeId::Ibkr` (per-chain string ignored) | ✓ |
+//! | `multiplier` | ✓ | ✓ (`size` field) |
+//! | `expirations` | ✓ | ✓ |
+//! | `strikes` | ✓ | ✓ |
+//! | `exercise` | ✗ (caller must know) | ✓ (`style` field) |
+//!
+//! # Example
+//!
+//! ```
+//! use chrono::NaiveDate;
+//! use rust_decimal_macros::dec;
+//! use rustrade_instrument::{
+//!     exchange::ExchangeId,
+//!     instrument::{
+//!         kind::option::OptionExercise,
+//!         market_data::option_chain::OptionChainDescriptor,
+//!     },
+//! };
+//!
+//! let descriptor = OptionChainDescriptor::new(
+//!     ExchangeId::Ibkr,
+//!     dec!(100),
+//!     vec![
+//!         NaiveDate::from_ymd_opt(2024, 1, 19).unwrap(),
+//!         NaiveDate::from_ymd_opt(2024, 2, 16).unwrap(),
+//!     ],
+//!     vec![dec!(145), dec!(150), dec!(155)],
+//!     None, // IBKR doesn't provide exercise style
+//! );
+//!
+//! // Expand to contracts (US equity = American)
+//! let contracts = descriptor
+//!     .to_contracts(Some(OptionExercise::American))
+//!     .unwrap();
+//!
+//! // 2 expirations × 3 strikes × 2 (Call + Put) = 12 contracts
+//! assert_eq!(contracts.len(), 12);
+//! ```
+
+use crate::{
+    exchange::ExchangeId,
+    instrument::{
+        kind::option::{OptionExercise, OptionKind},
+        market_data::kind::MarketDataOptionContract,
+    },
+};
+use chrono::{NaiveDate, NaiveTime};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use thiserror::Error;
+
+/// Error when expanding an [`OptionChainDescriptor`] to contracts.
+#[non_exhaustive]
+#[derive(Debug, Clone, Error)]
+pub enum OptionChainError {
+    /// Exercise style required but not provided.
+    ///
+    /// Occurs when `OptionChainDescriptor::exercise` is `None` and no
+    /// `exercise` parameter is passed to `to_contracts()`.
+    #[error("exercise style required: descriptor has no exercise field and none provided")]
+    ExerciseRequired,
+}
+
+/// Option chain descriptor for cross-exchange option discovery.
+///
+/// Represents the matrix of available option contracts (expirations × strikes)
+/// for an underlying on a specific exchange. Use [`to_contracts`](Self::to_contracts)
+/// to expand into individual [`MarketDataOptionContract`] instances.
+///
+/// # API Divergence
+///
+/// The `exercise` field documents exchange API differences (per [#70] pattern):
+/// - **Alpaca**: Returns `style` ("american"/"european") per contract — stored in `exercise`
+/// - **IBKR**: Does not return exercise style — `exercise` is `None`, caller provides it
+///
+/// # Construction
+///
+/// Use [`OptionChainDescriptor::new`] to create instances. Outside this crate,
+/// direct struct literal syntax is not available due to `#[non_exhaustive]`.
+///
+/// [#70]: https://github.com/Niqnil/rustrade/issues/70
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct OptionChainDescriptor {
+    /// Exchange where this option chain trades.
+    pub exchange: ExchangeId,
+
+    /// Contract multiplier (e.g., 100 for standard equity options).
+    pub multiplier: Decimal,
+
+    /// Available expiration dates, sorted ascending.
+    pub expirations: Vec<NaiveDate>,
+
+    /// Available strike prices, sorted ascending.
+    pub strikes: Vec<Decimal>,
+
+    /// Exercise style when provided by the exchange API.
+    ///
+    /// - `Some(style)`: API returned exercise style (Alpaca)
+    /// - `None`: API does not provide it (IBKR) — caller must supply to [`to_contracts`](Self::to_contracts)
+    pub exercise: Option<OptionExercise>,
+}
+
+impl OptionChainDescriptor {
+    /// Create a new option chain descriptor.
+    ///
+    /// # Arguments
+    ///
+    /// * `exchange` - Exchange where this option chain trades
+    /// * `multiplier` - Contract multiplier (e.g., 100 for standard equity options)
+    /// * `expirations` - Available expiration dates
+    /// * `strikes` - Available strike prices
+    /// * `exercise` - Exercise style if known, `None` if API doesn't provide it
+    pub fn new(
+        exchange: ExchangeId,
+        multiplier: Decimal,
+        expirations: Vec<NaiveDate>,
+        strikes: Vec<Decimal>,
+        exercise: Option<OptionExercise>,
+    ) -> Self {
+        Self {
+            exchange,
+            multiplier,
+            expirations,
+            strikes,
+            exercise,
+        }
+    }
+
+    /// Expand to all option contracts (expirations × strikes × {Call, Put}).
+    ///
+    /// # Arguments
+    ///
+    /// * `exercise` - Exercise style override. If `Some`, uses this value.
+    ///   If `None`, uses `self.exercise`. Returns error if both are `None`.
+    ///
+    /// # Returns
+    ///
+    /// Vector of [`MarketDataOptionContract`] for each combination of
+    /// expiration, strike, and option kind (Call/Put). Results are ordered:
+    /// for each expiration, for each strike, Call then Put.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OptionChainError::ExerciseRequired`] if no exercise style
+    /// is available (both `self.exercise` and `exercise` param are `None`).
+    pub fn to_contracts(
+        &self,
+        exercise: Option<OptionExercise>,
+    ) -> Result<Vec<MarketDataOptionContract>, OptionChainError> {
+        let exercise = exercise
+            .or(self.exercise)
+            .ok_or(OptionChainError::ExerciseRequired)?;
+
+        let mut contracts = Vec::with_capacity(self.contract_count());
+
+        for expiration in &self.expirations {
+            let expiry = expiration.and_time(NaiveTime::MIN).and_utc();
+
+            for &strike in &self.strikes {
+                contracts.push(MarketDataOptionContract {
+                    kind: OptionKind::Call,
+                    exercise,
+                    expiry,
+                    strike,
+                });
+                contracts.push(MarketDataOptionContract {
+                    kind: OptionKind::Put,
+                    exercise,
+                    expiry,
+                    strike,
+                });
+            }
+        }
+
+        Ok(contracts)
+    }
+
+    /// Number of contracts this descriptor would expand to.
+    ///
+    /// Returns `expirations.len() × strikes.len() × 2` (Call + Put for each),
+    /// saturating at `usize::MAX` to defend against adversarial deserialized input.
+    pub fn contract_count(&self) -> usize {
+        self.expirations
+            .len()
+            .saturating_mul(self.strikes.len())
+            .saturating_mul(2)
+    }
+}
+
+impl fmt::Display for OptionChainDescriptor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OptionChain({}: {} expirations × {} strikes, multiplier={})",
+            self.exchange,
+            self.expirations.len(),
+            self.strikes.len(),
+            self.multiplier
+        )
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use chrono::Timelike;
+    use rust_decimal_macros::dec;
+
+    fn sample_descriptor() -> OptionChainDescriptor {
+        OptionChainDescriptor::new(
+            ExchangeId::Ibkr,
+            dec!(100),
+            vec![
+                NaiveDate::from_ymd_opt(2024, 1, 19).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 2, 16).unwrap(),
+            ],
+            vec![dec!(145), dec!(150), dec!(155)],
+            None,
+        )
+    }
+
+    #[test]
+    fn to_contracts_with_exercise_param() {
+        let descriptor = sample_descriptor();
+        let contracts = descriptor
+            .to_contracts(Some(OptionExercise::American))
+            .unwrap();
+
+        // 2 expirations × 3 strikes × 2 kinds = 12
+        assert_eq!(contracts.len(), 12);
+        assert_eq!(descriptor.contract_count(), 12);
+
+        // First expiration, first strike: Call then Put
+        assert_eq!(contracts[0].kind, OptionKind::Call);
+        assert_eq!(contracts[0].strike, dec!(145));
+        assert_eq!(contracts[0].exercise, OptionExercise::American);
+
+        assert_eq!(contracts[1].kind, OptionKind::Put);
+        assert_eq!(contracts[1].strike, dec!(145));
+    }
+
+    #[test]
+    fn to_contracts_uses_stored_exercise() {
+        let mut descriptor = sample_descriptor();
+        descriptor.exercise = Some(OptionExercise::European);
+
+        // Pass None — should use stored exercise
+        let contracts = descriptor.to_contracts(None).unwrap();
+
+        assert_eq!(contracts[0].exercise, OptionExercise::European);
+    }
+
+    #[test]
+    fn to_contracts_param_overrides_stored() {
+        let mut descriptor = sample_descriptor();
+        descriptor.exercise = Some(OptionExercise::European);
+
+        // Pass American — should override stored European
+        let contracts = descriptor
+            .to_contracts(Some(OptionExercise::American))
+            .unwrap();
+
+        assert_eq!(contracts[0].exercise, OptionExercise::American);
+    }
+
+    #[test]
+    fn to_contracts_error_when_no_exercise() {
+        let descriptor = sample_descriptor(); // exercise: None
+
+        let result = descriptor.to_contracts(None);
+
+        assert!(matches!(result, Err(OptionChainError::ExerciseRequired)));
+    }
+
+    #[test]
+    fn to_contracts_expiry_is_midnight_utc() {
+        let descriptor = sample_descriptor();
+        let contracts = descriptor
+            .to_contracts(Some(OptionExercise::American))
+            .unwrap();
+
+        let expiry = contracts[0].expiry;
+        assert_eq!(expiry.hour(), 0);
+        assert_eq!(expiry.minute(), 0);
+        assert_eq!(expiry.second(), 0);
+        assert_eq!(
+            expiry.date_naive(),
+            NaiveDate::from_ymd_opt(2024, 1, 19).unwrap()
+        );
+    }
+
+    #[test]
+    fn empty_chain_produces_no_contracts() {
+        let descriptor = OptionChainDescriptor::new(
+            ExchangeId::AlpacaBroker,
+            dec!(100),
+            vec![],
+            vec![dec!(150)],
+            Some(OptionExercise::American),
+        );
+
+        let contracts = descriptor.to_contracts(None).unwrap();
+        assert!(contracts.is_empty());
+        assert_eq!(descriptor.contract_count(), 0);
+    }
+
+    #[test]
+    fn display_format() {
+        let descriptor = sample_descriptor();
+        let display = format!("{}", descriptor);
+        assert!(display.contains("Ibkr"));
+        assert!(display.contains("2 expirations"));
+        assert!(display.contains("3 strikes"));
+        assert!(display.contains("100"));
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        let mut descriptor = sample_descriptor();
+        descriptor.exercise = Some(OptionExercise::American);
+
+        let json = serde_json::to_string(&descriptor).unwrap();
+        let parsed: OptionChainDescriptor = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(descriptor, parsed);
+    }
+}


### PR DESCRIPTION
## Summary
- Add bracket orders, stop orders, and trailing stops for Alpaca execution
- Introduce unified `OptionChainDescriptor` for cross-exchange options discovery
- Add REST-based Alpaca options market data (contracts, snapshots, Greeks)

## Test plan
- [ ] Run `cargo test --test alpaca_integration` with credentials
- [ ] Run `cargo test --test alpaca_data` with credentials
- [ ] Verify contract discovery filters work correctly
- [ ] Verify snapshot fetching with chunking for large symbol sets