### PR TITLE
fix(ibkr): Clean up zombie connections in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use `AlpacaBroker` for execution
   - Migration: Replace `ExchangeId::Alpaca` with the appropriate specific variant
 
+### Fixed
+
+- **IBKR integration tests no longer leave zombie connections** ([#63](https://github.com/Niqnil/rustrade/issues/63)):
+  - Added `disconnect()` method to `IbkrHistoricalData`, `IbkrMarketStream`, and `IbkrClient`
+    for explicit connection cleanup
+  - Added `Drop` implementations that call `disconnect()` to ensure IB Gateway releases
+    client IDs even when tests panic or exit abruptly
+  - Added `#[serial]` attribute to all IBKR integration tests to prevent parallel execution
+    conflicts when sharing IB Gateway connections
+  - Previously, repeated test runs would fail with "client id already in use" until IB Gateway
+    was restarted
+
 ## [0.1.0] - 2026-05-01
 
 Initial release of rustrade, a fork of [barter-rs](https://github.com/barter-rs/barter-rs).

--- a/rustrade-data/src/exchange/ibkr/historical.rs
+++ b/rustrade-data/src/exchange/ibkr/historical.rs
@@ -138,6 +138,23 @@ impl IbkrHistoricalData {
         Self { client }
     }
 
+    /// Disconnect from IB Gateway.
+    ///
+    /// Signals the ibapi client to shut down and releases the client ID for reuse.
+    /// When constructed via [`Self::connect`], `Drop` already calls this automatically
+    /// once this is the sole owner of the `Arc<Client>` — explicit calls are typically
+    /// unnecessary.
+    ///
+    /// When constructed via [`Self::from_client`] with a shared `Arc<Client>`, calling
+    /// `disconnect()` **terminates the connection for all owners** (other
+    /// [`IbkrHistoricalData`] instances or external holders of the same `Arc`).
+    ///
+    /// This is idempotent — calling it multiple times is safe.
+    pub fn disconnect(&self) {
+        debug!("Disconnecting IbkrHistoricalData");
+        self.client.disconnect();
+    }
+
     /// Fetch historical candles for the given request.
     ///
     /// # Arguments
@@ -611,6 +628,23 @@ impl IbkrHistoricalData {
         })??;
 
         Ok(chains)
+    }
+}
+
+impl Drop for IbkrHistoricalData {
+    fn drop(&mut self) {
+        // Only disconnect when we are the sole owner of the Arc<Client>.
+        // `from_client(Arc<Client>)` lets callers share the client; disconnecting
+        // here would terminate the connection for other owners too.
+        //
+        // `Arc::strong_count` is approximate under concurrent clone/drop on other
+        // threads. A spurious skip is harmless (ibapi's own `Client::Drop` will
+        // eventually run when the last Arc drops); a spurious disconnect is also
+        // benign because `disconnect()` is idempotent.
+        if Arc::strong_count(&self.client) == 1 {
+            debug!("Dropping IbkrHistoricalData (sole owner), disconnecting client");
+            self.client.disconnect();
+        }
     }
 }
 

--- a/rustrade-data/src/exchange/ibkr/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/mod.rs
@@ -128,6 +128,7 @@ impl Default for IbkrStreamConfig {
 #[derive(Debug)]
 pub struct IbkrMarketStream<K> {
     rx: mpsc::UnboundedReceiver<Result<MarketEvent<K, DataKind>, DataError>>,
+    client: Arc<Client>,
 }
 
 impl<K> futures::Stream for IbkrMarketStream<K> {
@@ -226,7 +227,21 @@ where
             ));
         }
 
-        Ok(Self { rx })
+        Ok(Self { rx, client })
+    }
+
+    /// Disconnect from IB Gateway.
+    ///
+    /// Signals the client to shut down, which will cause worker threads to exit
+    /// when they next attempt an IB operation. This releases the client ID for reuse.
+    ///
+    /// Call this before dropping to ensure IB Gateway releases the connection promptly.
+    /// Worker threads will terminate when they observe the disconnected state.
+    ///
+    /// This is idempotent — calling it multiple times is safe.
+    pub fn disconnect(&self) {
+        debug!("Disconnecting IbkrMarketStream");
+        self.client.disconnect();
     }
 
     fn run_quotes_subscription(
@@ -514,6 +529,13 @@ where
             })
             .map_err(|e| DataError::Socket(format!("Failed to spawn option Greeks thread: {e}")))?;
         Ok(())
+    }
+}
+
+impl<K> Drop for IbkrMarketStream<K> {
+    fn drop(&mut self) {
+        debug!("Dropping IbkrMarketStream, disconnecting client");
+        self.client.disconnect();
     }
 }
 

--- a/rustrade-data/tests/ibkr_integration.rs
+++ b/rustrade-data/tests/ibkr_integration.rs
@@ -92,6 +92,7 @@ use rustrade_data::{
     },
 };
 use rustrade_instrument::ibkr::ContractRegistry;
+use serial_test::serial;
 use std::{sync::Arc, time::Duration};
 use tokio_stream::StreamExt;
 use tracing_subscriber::{EnvFilter, fmt};
@@ -153,20 +154,22 @@ async fn connect_raw_client(
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_historical_connection() {
     init_logging();
 
     let url = format!("127.0.0.1:{}", test_port());
     let client_id = test_client_id_base();
 
-    let result = connect_historical(&url, client_id).await;
+    let client = connect_historical(&url, client_id).await;
 
-    assert!(result.is_ok(), "Failed to connect: {:?}", result.err());
+    assert!(client.is_ok(), "Failed to connect: {:?}", client.err());
     println!("Connected to IB for historical data");
 }
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_historical_daily_bars() {
     init_logging();
 
@@ -245,6 +248,7 @@ async fn test_historical_daily_bars() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_historical_hourly_bars() {
     init_logging();
 
@@ -294,6 +298,7 @@ async fn test_historical_hourly_bars() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_historical_minute_bars() {
     init_logging();
 
@@ -328,6 +333,7 @@ async fn test_historical_minute_bars() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_historical_midpoint_data() {
     init_logging();
 
@@ -374,6 +380,7 @@ async fn test_historical_midpoint_data() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_historical_from_shared_client() {
     init_logging();
 
@@ -412,6 +419,7 @@ async fn test_historical_from_shared_client() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_historical_ticks_trade() {
     init_logging();
 
@@ -464,6 +472,7 @@ async fn test_historical_ticks_trade() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_historical_ticks_bid_ask() {
     init_logging();
 
@@ -524,6 +533,7 @@ async fn test_historical_ticks_bid_ask() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_historical_ticks_with_time_range() {
     use time::macros::datetime;
 
@@ -572,6 +582,7 @@ async fn test_historical_ticks_with_time_range() {
 /// Tier 0: Connection Only (FREE)
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_market_stream_connection() {
     init_logging();
 
@@ -605,6 +616,7 @@ async fn test_market_stream_connection() {
 /// Tier 1: US Real-Time Non-Consolidated (FREE with IBKR Pro)
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_market_stream_quotes() {
     init_logging();
 
@@ -670,6 +682,7 @@ async fn test_market_stream_quotes() {
 /// Tier 2: L2 Market Depth (PAID — varies by exchange)
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_market_stream_depth() {
     init_logging();
 
@@ -728,6 +741,7 @@ async fn test_market_stream_depth() {
 /// Tier 0: Connection Only (FREE)
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_market_stream_unregistered_contract() {
     init_logging();
 
@@ -760,6 +774,7 @@ async fn test_market_stream_unregistered_contract() {
 /// Tier 1: US Real-Time Non-Consolidated (FREE with IBKR Pro)
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_market_stream_multiple_subscriptions() {
     init_logging();
 
@@ -830,6 +845,7 @@ async fn test_market_stream_multiple_subscriptions() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_contract_resolution() {
     init_logging();
 
@@ -897,6 +913,7 @@ fn aapl_call_option() -> Contract {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_calculate_theoretical_greeks() {
     init_logging();
 
@@ -947,6 +964,7 @@ async fn test_calculate_theoretical_greeks() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_calculate_implied_volatility() {
     init_logging();
 
@@ -984,6 +1002,7 @@ async fn test_calculate_implied_volatility() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_fetch_option_chain() {
     init_logging();
 
@@ -1041,6 +1060,7 @@ async fn test_fetch_option_chain() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_option_greeks_stream() {
     init_logging();
 

--- a/rustrade-data/tests/ibkr_integration.rs
+++ b/rustrade-data/tests/ibkr_integration.rs
@@ -152,9 +152,9 @@ async fn connect_raw_client(
 // Historical Data Tests (Task 3.3.5) — Tier 0/1: Connection + US Real-Time (FREE)
 // ============================================================================
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_historical_connection() {
     init_logging();
 
@@ -167,9 +167,9 @@ async fn test_historical_connection() {
     println!("Connected to IB for historical data");
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_historical_daily_bars() {
     init_logging();
 
@@ -246,9 +246,9 @@ async fn test_historical_daily_bars() {
     );
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_historical_hourly_bars() {
     init_logging();
 
@@ -296,9 +296,9 @@ async fn test_historical_hourly_bars() {
     }
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_historical_minute_bars() {
     init_logging();
 
@@ -331,9 +331,9 @@ async fn test_historical_minute_bars() {
     assert!(!candles.is_empty(), "Expected at least one 1-minute candle");
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_historical_midpoint_data() {
     init_logging();
 
@@ -378,9 +378,9 @@ async fn test_historical_midpoint_data() {
     }
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_historical_from_shared_client() {
     init_logging();
 
@@ -417,9 +417,9 @@ async fn test_historical_from_shared_client() {
 // Historical Tick Data Tests (Task 13.4) — Tier 1: US Real-Time (FREE)
 // ============================================================================
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_historical_ticks_trade() {
     init_logging();
 
@@ -470,9 +470,9 @@ async fn test_historical_ticks_trade() {
     }
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_historical_ticks_bid_ask() {
     init_logging();
 
@@ -531,9 +531,9 @@ async fn test_historical_ticks_bid_ask() {
     }
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_historical_ticks_with_time_range() {
     use time::macros::datetime;
 
@@ -580,9 +580,9 @@ async fn test_historical_ticks_with_time_range() {
 // ============================================================================
 
 /// Tier 0: Connection Only (FREE)
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_market_stream_connection() {
     init_logging();
 
@@ -614,9 +614,9 @@ async fn test_market_stream_connection() {
 }
 
 /// Tier 1: US Real-Time Non-Consolidated (FREE with IBKR Pro)
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_market_stream_quotes() {
     init_logging();
 
@@ -680,9 +680,9 @@ async fn test_market_stream_quotes() {
 }
 
 /// Tier 2: L2 Market Depth (PAID — varies by exchange)
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_market_stream_depth() {
     init_logging();
 
@@ -739,9 +739,9 @@ async fn test_market_stream_depth() {
 }
 
 /// Tier 0: Connection Only (FREE)
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_market_stream_unregistered_contract() {
     init_logging();
 
@@ -772,9 +772,9 @@ async fn test_market_stream_unregistered_contract() {
 }
 
 /// Tier 1: US Real-Time Non-Consolidated (FREE with IBKR Pro)
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_market_stream_multiple_subscriptions() {
     init_logging();
 
@@ -843,9 +843,9 @@ async fn test_market_stream_multiple_subscriptions() {
 // Contract Registry Integration — Tier 0: Connection Only (FREE)
 // ============================================================================
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_contract_resolution() {
     init_logging();
 
@@ -911,9 +911,9 @@ fn aapl_call_option() -> Contract {
         .build()
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_calculate_theoretical_greeks() {
     init_logging();
 
@@ -962,9 +962,9 @@ async fn test_calculate_theoretical_greeks() {
     }
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_calculate_implied_volatility() {
     init_logging();
 
@@ -1000,9 +1000,9 @@ async fn test_calculate_implied_volatility() {
     }
 }
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_fetch_option_chain() {
     init_logging();
 
@@ -1058,9 +1058,9 @@ async fn test_fetch_option_chain() {
 // Real-Time Option Greeks Streaming Tests (Phase 5B) — Tier 3: OPRA ($1.50/mo)
 // ============================================================================
 
+#[serial]
 #[tokio::test]
 #[ignore]
-#[serial]
 async fn test_option_greeks_stream() {
     init_logging();
 

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -324,6 +324,24 @@ impl IbkrClient {
         self.pending_cancels.clear_stale(max_age)
     }
 
+    /// Disconnect from IB Gateway.
+    ///
+    /// Signals the ibapi client to shut down and releases the client ID for reuse.
+    ///
+    /// [`IbkrClient`] implements [`Clone`] and has no `Drop` impl: the underlying
+    /// connection is released automatically when the last `Arc<Client>` reference
+    /// is dropped. Calling `disconnect()` explicitly terminates the connection
+    /// **immediately for all clones** sharing this client.
+    ///
+    /// Any active `account_stream()` iterators will receive errors on their
+    /// next iteration attempt.
+    ///
+    /// This is idempotent — calling it multiple times is safe.
+    pub fn disconnect(&self) {
+        debug!("Disconnecting IbkrClient");
+        self.client.disconnect();
+    }
+
     /// Place a bracket order (entry + take-profit + stop-loss) with OCA linking.
     ///
     /// A bracket order consists of three linked orders:

--- a/rustrade-execution/src/lib.rs
+++ b/rustrade-execution/src/lib.rs
@@ -30,6 +30,8 @@
 
 // Silence unused_crate_dependencies for dev-dependencies used only in tests
 #[cfg(test)]
+use serial_test as _;
+#[cfg(test)]
 use tracing_subscriber as _;
 #[cfg(test)]
 use wiremock as _;

--- a/rustrade-execution/tests/ibkr_execution.rs
+++ b/rustrade-execution/tests/ibkr_execution.rs
@@ -79,6 +79,7 @@ use rustrade_instrument::{
     Side, asset::name::AssetNameExchange, exchange::ExchangeId,
     instrument::name::InstrumentNameExchange,
 };
+use serial_test::serial;
 use std::time::Duration;
 use tokio_stream::StreamExt;
 use tracing_subscriber::{EnvFilter, fmt};
@@ -130,6 +131,7 @@ async fn connect_client(config: IbkrConfig) -> Result<IbkrClient, String> {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_connection() {
     init_logging();
 
@@ -145,6 +147,7 @@ async fn test_connection() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_contract_registration() {
     init_logging();
 
@@ -171,6 +174,7 @@ async fn test_contract_registration() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_fetch_balances() {
     init_logging();
 
@@ -194,6 +198,7 @@ async fn test_fetch_balances() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_account_snapshot() {
     init_logging();
 
@@ -223,6 +228,7 @@ async fn test_account_snapshot() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_fetch_open_orders() {
     init_logging();
 
@@ -258,6 +264,7 @@ async fn test_fetch_open_orders() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_and_cancel_limit_order() {
     init_logging();
 
@@ -357,6 +364,7 @@ async fn test_place_and_cancel_limit_order() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_account_stream() {
     init_logging();
 
@@ -403,6 +411,7 @@ async fn test_account_stream() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_fetch_trades() {
     init_logging();
 
@@ -440,6 +449,7 @@ async fn test_fetch_trades() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_order_id_mapping_cleanup() {
     init_logging();
 
@@ -461,6 +471,7 @@ async fn test_order_id_mapping_cleanup() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_order_without_registered_contract() {
     init_logging();
 
@@ -507,6 +518,7 @@ async fn test_order_without_registered_contract() {
 
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_cancel_nonexistent_order() {
     init_logging();
 
@@ -552,6 +564,7 @@ async fn test_cancel_nonexistent_order() {
 /// - DAY orders expired at market close → Expired (not in pending_cancels)
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_cancel_produces_cancelled_not_expired() {
     init_logging();
 
@@ -688,6 +701,7 @@ async fn test_cancel_produces_cancelled_not_expired() {
 /// the stop will never trigger and the order remains open for cancellation.
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_and_cancel_stop_order() {
     init_logging();
 
@@ -788,6 +802,7 @@ async fn test_place_and_cancel_stop_order() {
 /// since AAPL trades far above this, the stop will never trigger.
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_and_cancel_stop_limit_order() {
     init_logging();
 
@@ -889,6 +904,7 @@ async fn test_place_and_cancel_stop_limit_order() {
 /// won't trigger and remains open for cancellation.
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_and_cancel_trailing_stop_percentage() {
     init_logging();
 
@@ -992,6 +1008,7 @@ async fn test_place_and_cancel_trailing_stop_percentage() {
 /// trigger and the order remains open for cancellation.
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_and_cancel_trailing_stop_limit_absolute() {
     init_logging();
 
@@ -1105,6 +1122,7 @@ async fn test_place_and_cancel_trailing_stop_limit_absolute() {
 /// should cascade to cancel the children.
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_and_cancel_bracket_order() {
     use rustrade_execution::client::ibkr::BracketOrderRequest;
 
@@ -1225,6 +1243,7 @@ async fn test_place_and_cancel_bracket_order() {
 /// the TP and SL orders share the same OCA group identifier.
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_bracket_order_oca_group_linkage() {
     use rustrade_execution::client::ibkr::BracketOrderRequest;
 
@@ -1327,6 +1346,7 @@ async fn test_bracket_order_oca_group_linkage() {
 /// and will be cancelled before expiry.
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_and_cancel_gtd_order() {
     init_logging();
 
@@ -1430,6 +1450,7 @@ async fn test_place_and_cancel_gtd_order() {
 /// will result in rejection.
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_moo_order_premarket() {
     init_logging();
 
@@ -1526,6 +1547,7 @@ async fn test_place_moo_order_premarket() {
 /// opening price is at or below the limit.
 #[tokio::test]
 #[ignore]
+#[serial]
 async fn test_place_loo_order_premarket() {
     init_logging();
 


### PR DESCRIPTION
## Summary
- Add explicit `disconnect()` methods to IBKR types with proper `Arc` reference counting
- Implement `Drop` traits for automatic cleanup (prevents lingering connections on panic)
- Add `#[serial]` to all 21 IBKR integration tests to eliminate client ID race conditions

Closes #63

## Test plan
- [x] Run IBKR integration tests multiple times without restarting IB Gateway
- [x] Verify no "client id already in use" errors