### PR TITLE
deps(ibkr): bump ibapi from 2.11.4 to 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **deps(ibkr)**: Bump `ibapi` from 2.11.4 to 2.12.0 — fixes TWS error surfacing on
+  subscription channels ([rust-ibapi#567](https://github.com/wboayue/rust-ibapi/pull/567),
+  closes [#78](https://github.com/Niqnil/rustrade/issues/78))
 - **perf(alpaca)**: Pre-allocate `/v2/orders` endpoint URL at `AlpacaClient` construction,
   eliminating 2 heap allocations per order placement (`open_order_inner`, `open_bracket_order`).
 - **BREAKING**: `PublicTrade::side` changed from `Side` to `Option<Side>`.

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -67,7 +67,7 @@ vecmap-rs = { workspace = true }
 fnv = { workspace = true }
 
 # IBKR (optional, behind "ibkr" feature)
-ibapi = { version = "=2.11.4", optional = true, default-features = false, features = ["sync"] }
+ibapi = { version = "=2.12.0", optional = true, default-features = false, features = ["sync"] }
 time = { version = "0.3", optional = true, features = ["macros"] }
 
 # Hyperliquid (optional, behind "hyperliquid" feature)

--- a/rustrade-execution/Cargo.toml
+++ b/rustrade-execution/Cargo.toml
@@ -89,7 +89,7 @@ lru = { workspace = true, optional = true }         # Event deduplication cache 
 parking_lot = { workspace = true, optional = true } # Lighter mutex for dedup cache (no poisoning, no OS thread park)
 
 # IBKR (optional, behind "ibkr" feature)
-ibapi = { version = "=2.11.4", optional = true, default-features = false, features = [
+ibapi = { version = "=2.12.0", optional = true, default-features = false, features = [
     "sync",
 ] }
 chrono-tz = { workspace = true, optional = true }

--- a/rustrade-instrument/Cargo.toml
+++ b/rustrade-instrument/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true }
 
 [dependencies]
 # IBKR (optional, behind "ibkr" feature)
-ibapi = { version = "=2.11.4", optional = true, default-features = false, features = ["sync"] }
+ibapi = { version = "=2.12.0", optional = true, default-features = false, features = ["sync"] }
 fnv = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 # SerDe


### PR DESCRIPTION
## Summary

- Bump `ibapi` from 2.11.4 to 2.12.0 across all crates
- v2.12.0 fixes TWS error surfacing on subscription channels ([rust-ibapi#567](https://github.com/wboayue/rust-ibapi/pull/567))

### Supply Chain Security Review

| Review | Status | Findings |
|--------|--------|----------|
| Security | ✅ PASS | No unsafe code, network only to user-provided TWS/Gateway, no suspicious patterns |
| Dependencies | ✅ PASS | 46 crates, all trusted ecosystem (`time-tz` less mainstream but low-risk) |
| Diff (2.11.4→2.12.0) | ✅ PASS | Bugfix only: TWS error surfacing, exchange default fix. No new deps/unsafe/I/O |

Closes #78

## Test plan

- [x] `cargo check -p rustrade-data --features ibkr` passes