### PR TITLE
ci(alpaca): Add integration test workflows for GitHub Actions

### DIFF
--- a/.github/workflows/alpaca-integration.yml
+++ b/.github/workflows/alpaca-integration.yml
@@ -1,0 +1,60 @@
+name: "Alpaca Integration"
+
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+    branches: ["main", "develop"]
+  pull_request:
+    paths-ignore:
+      - "**.md"
+    branches: ["main", "develop"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MOLD_VERSION: "2.35.1"
+  ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
+  ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+  ALPACA_PAPER: "true"
+
+jobs:
+  alpaca-tests:
+    name: Alpaca integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Only run on same-repo PRs and pushes (prevents secret exfiltration from forks)
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install mold linker
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
+        with:
+          mold-version: ${{ env.MOLD_VERSION }}
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: "rustrade-ci-test"
+
+      - name: Execution tests
+        id: exec-tests
+        continue-on-error: true
+        run: cargo test -p rustrade-execution --test alpaca_integration -- --ignored
+
+      - name: Market data tests (skip IEX, SIP, OPRA)
+        id: data-tests
+        continue-on-error: true
+        run: cargo test -p rustrade-data --test alpaca_data -- --ignored --skip iex --skip sip --skip opra
+
+      - name: Check test results
+        if: steps.exec-tests.outcome == 'failure' || steps.data-tests.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/alpaca-weekly.yml
+++ b/.github/workflows/alpaca-weekly.yml
@@ -1,0 +1,48 @@
+name: "Alpaca Weekly"
+
+on:
+  schedule:
+    # Wednesday 11:00 AM ET (15:00 UTC) - during US market hours
+    - cron: "0 15 * * 3"
+  workflow_dispatch:
+
+env:
+  MOLD_VERSION: "2.35.1"
+  ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
+  ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+  ALPACA_PAPER: "true"
+
+jobs:
+  alpaca-tests:
+    name: Alpaca full integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install mold linker
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
+        with:
+          mold-version: ${{ env.MOLD_VERSION }}
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: "rustrade-ci-test"
+
+      - name: Execution tests
+        id: exec-tests
+        continue-on-error: true
+        run: cargo test -p rustrade-execution --test alpaca_integration -- --ignored
+
+      - name: Market data tests (includes IEX, skip SIP/OPRA)
+        id: data-tests
+        continue-on-error: true
+        run: cargo test -p rustrade-data --test alpaca_data -- --ignored --skip sip --skip opra
+
+      - name: Check test results
+        if: steps.exec-tests.outcome == 'failure' || steps.data-tests.outcome == 'failure'
+        run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,12 +52,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `DatabentoLive<K>`: Real-time WebSocket streaming with `PitSymbolMap` symbol resolution
   - `ExchangeId` variants: `DatabentoGlbx`, `DatabentoXnas`, `DatabentoXnys`, `DatabentoDbeq`, `DatabentoOpra`
   - Nanosecond-precision timestamps and lossless Decimal price conversion
-  - **Note**: Live data integration is NOT TESTED — Databento does not offer development/sandbox keys and we do not have a subscription.
-    Offline fixture tests verify transformation logic; network integration is unverified.
+  - **Testing**: NOT TESTED in CI; offline fixture tests verified locally; live integration untested (requires paid subscription)
 - **Alpaca market data connector**: Real-time trades and quotes via WebSocket
   - `AlpacaIex`: Free IEX feed for US equities
   - `AlpacaSip`: Paid consolidated SIP feed for US equities
   - `AlpacaCrypto`: Crypto market data
+  - **Testing**: IEX and crypto feeds are tested with paper credentials; SIP requires Algo Trader Plus (paid subscription) and is NOT TESTED
 - **Alpaca options market data**: REST-based option discovery and Greeks snapshots
   - `AlpacaOptionsClient`: Options market data client with rate limiting and pagination
   - `AlpacaOptionContractQuery`: Builder for filtering contracts by underlying, expiration, strike, type, style
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `fetch_snapshots(symbols, feed)`: Fetch snapshots with Greeks via `GET /v1beta1/options/snapshots`
   - `fetch_chain_snapshots(underlying, feed)`: Convenience method for entire option chains
   - `AlpacaOptionFeed`: `Opra` (real-time, paid) or `Indicative` (15-min delayed, free)
+  - **Testing**: Indicative feed is tested; OPRA requires Algo Trader Plus (paid subscription) and is NOT TESTED
   - **Note**: Greeks streaming is NOT available — Alpaca only provides REST snapshots for Greeks data
 - **Quotes subscription kind**: Generic top-of-book quotes (`SubKind::Quotes`)
 - `ExchangeId::AlpacaBroker`: Dedicated variant for Alpaca execution client

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A Rust ecosystem for building high-performance algorithmic trading systems.
 [![MIT licensed][mit-badge]][mit-url]
 [![Crates.io][crates-badge]][crates-url]
 [![docs.rs][docs-badge]][docs-url]
+[![Alpaca Integration][alpaca-badge]][alpaca-url]
+[![Alpaca Weekly][alpaca-weekly-badge]][alpaca-weekly-url]
 
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: https://github.com/Niqnil/rustrade/blob/main/LICENSE
@@ -12,6 +14,10 @@ A Rust ecosystem for building high-performance algorithmic trading systems.
 [crates-url]: https://crates.io/crates/rustrade
 [docs-badge]: https://img.shields.io/docsrs/rustrade
 [docs-url]: https://docs.rs/rustrade
+[alpaca-badge]: https://github.com/Niqnil/rustrade/actions/workflows/alpaca-integration.yml/badge.svg
+[alpaca-url]: https://github.com/Niqnil/rustrade/actions/workflows/alpaca-integration.yml
+[alpaca-weekly-badge]: https://github.com/Niqnil/rustrade/actions/workflows/alpaca-weekly.yml/badge.svg
+[alpaca-weekly-url]: https://github.com/Niqnil/rustrade/actions/workflows/alpaca-weekly.yml
 
 ## Overview
 

--- a/rustrade-data/src/exchange/alpaca/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/mod.rs
@@ -5,6 +5,15 @@
 //! - SIP: `wss://stream.data.alpaca.markets/v2/sip` (paid, consolidated tape)
 //! - Crypto: `wss://stream.data.alpaca.markets/v1beta3/crypto/us`
 //!
+//! # Testing Status
+//!
+//! **Tested locally, CI planned (free tier — paper trading allowed):**
+//! - Crypto streaming: trades and quotes (24/7)
+//! - IEX equity streaming: trades and quotes (market hours only)
+//!
+//! **NOT tested (requires Algo Trader Plus subscription):**
+//! - SIP equity streaming — implemented but unverified against real endpoints
+//!
 //! # Authentication
 //!
 //! Requires `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` environment variables.

--- a/rustrade-data/src/exchange/alpaca/options/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/options/mod.rs
@@ -38,6 +38,15 @@
 //! let snapshots = client.fetch_snapshots(&symbols, AlpacaOptionFeed::Indicative).await?;
 //! ```
 //!
+//! # Testing Status
+//!
+//! **Tested locally, CI planned (free tier — paper trading allowed):**
+//! - Contract discovery via `fetch_contracts()`
+//! - Indicative feed (15-min delayed) via `fetch_snapshots()`
+//!
+//! **NOT tested (requires OPRA subscription via Algo Trader Plus):**
+//! - OPRA real-time feed — implemented but unverified against real endpoints
+//!
 //! # Limitations
 //!
 //! - **REST only**: Greeks streaming is NOT available via WebSocket. Use snapshots for

--- a/rustrade-data/src/exchange/databento/mod.rs
+++ b/rustrade-data/src/exchange/databento/mod.rs
@@ -22,15 +22,16 @@
 //! Requires `DATABENTO_API_KEY` environment variable from an active Databento
 //! subscription.
 //!
-//! # Testing
+//! # Testing Status
 //!
-//! **Live data integration is NOT TESTED** — Databento does not offer development/sandbox
-//! keys and we do not have a subscription.
+//! **NOT tested in CI** — no permission to use credentials for CI.
 //!
-//! - **Offline tests** (`databento_transformer.rs`): Verify DBN-to-rustrade
-//!   transformation using fixture files. Runs in CI.
-//! - **Integration tests** (`databento_integration.rs`): Written but not run.
-//!   Network calls (auth, API, WebSocket) are unverified.
+//! **Tested locally:**
+//! - Offline fixture tests (`databento_transformer.rs`): DBN-to-rustrade transformation
+//!
+//! **NOT tested locally (no subscription, no sandbox keys):**
+//! - Historical API (`databento_integration.rs`): authentication, queries
+//! - Live streaming (`databento_integration.rs`): WebSocket connection, data reception
 //!
 //! # Datasets
 //!

--- a/rustrade-data/src/exchange/ibkr/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/mod.rs
@@ -2,6 +2,21 @@
 //!
 //! Provides streaming market data from IB TWS/Gateway via the `ibapi` crate.
 //!
+//! # Testing Status
+//!
+//! **NOT TESTED in CI.** IBKR has not confirmed permission to use credentials
+//! for CI, and requires IB Gateway/TWS running locally.
+//!
+//! **Tested locally (free subscriptions via IBKR Pro):**
+//! - Tier 0: Connection, contract resolution
+//! - Tier 1: Historical bars/ticks, L1 quotes, Greeks calculator, option chains
+//!
+//! **NOT tested locally (paid subscriptions):**
+//! - Tier 2: L2 Market Depth — exchange-specific fees
+//! - Tier 3: OPRA US Options — paid subscription
+//!
+//! Tests are organized by subscription tier (see `ibkr_integration.rs`).
+//!
 //! # Connection
 //!
 //! Requires TWS or IB Gateway running locally with API enabled:

--- a/rustrade-data/src/exchange/ibkr/options.rs
+++ b/rustrade-data/src/exchange/ibkr/options.rs
@@ -21,7 +21,7 @@
 //!
 //! # Subscription Requirements
 //!
-//! Option Greeks require OPRA subscription ($1.50/mo) for US options.
+//! Option Greeks require OPRA subscription (paid) for US options.
 //!
 //! [`subscription::greeks`]: crate::subscription::greeks
 //! [`IbkrHistoricalData::calculate_theoretical_greeks`]: super::historical::IbkrHistoricalData::calculate_theoretical_greeks

--- a/rustrade-data/src/exchange/ibkr/subscription.rs
+++ b/rustrade-data/src/exchange/ibkr/subscription.rs
@@ -67,7 +67,7 @@ impl<K> IbkrSubscription<K> {
     ///
     /// # Subscription Requirements
     ///
-    /// Requires OPRA subscription ($1.50/mo) for US options.
+    /// Requires OPRA subscription (paid) for US options.
     pub fn option_greeks(key: K, instrument: InstrumentNameExchange) -> Self {
         Self {
             key,

--- a/rustrade-data/tests/alpaca_data.rs
+++ b/rustrade-data/tests/alpaca_data.rs
@@ -2,9 +2,20 @@
 //!
 //! These tests verify connectivity and data reception from Alpaca market data streams.
 //!
+//! # Status
+//!
+//! **Tested locally, CI planned (paper trading allowed by Alpaca):**
+//! - Crypto streaming: trades and quotes (24/7, free)
+//! - IEX equity streaming: trades and quotes (market hours, free)
+//!
+//! **NOT tested (requires Algo Trader Plus subscription):**
+//! - SIP equity streaming (`test_sip_*`) — implemented but unverified
+//!
+//! Tests are marked `#[ignore]` to avoid CI failures without credentials.
+//!
 //! # Prerequisites
 //!
-//! 1. Alpaca account (https://app.alpaca.markets)
+//! 1. Alpaca paper trading account (https://app.alpaca.markets)
 //! 2. Environment variables set (see .env.template):
 //!    - ALPACA_API_KEY: API key
 //!    - ALPACA_SECRET_KEY: Secret key
@@ -21,8 +32,6 @@
 //! # Run specific test
 //! cargo test --test alpaca_data --features alpaca test_crypto_trade_stream -- --ignored
 //! ```
-//!
-//! Tests are marked `#[ignore]` to avoid CI failures without credentials.
 //!
 //! # Market Hours Note
 //!

--- a/rustrade-data/tests/databento_integration.rs
+++ b/rustrade-data/tests/databento_integration.rs
@@ -4,11 +4,13 @@
 //!
 //! # Status
 //!
-//! **Live data integration is NOT TESTED.** Databento does not offer sandbox or
-//! development API keys, and we do not have a subscription. The transformation
-//! logic (DBN → rustrade events) is tested via fixtures in
-//! `databento_transformer.rs`, but the network integration (authentication,
-//! API calls, WebSocket streaming) has not been verified against real endpoints.
+//! **NOT tested in CI** — no permission to use credentials for CI.
+//!
+//! **NOT tested locally (no subscription, no sandbox keys):**
+//! - All tests in this file — network integration (authentication, API calls,
+//!   WebSocket streaming) has not been verified against real endpoints
+//!
+//! Offline fixture tests (`databento_transformer.rs`) verify transformation logic locally.
 //!
 //! # Prerequisites
 //!

--- a/rustrade-data/tests/ibkr_integration.rs
+++ b/rustrade-data/tests/ibkr_integration.rs
@@ -2,6 +2,14 @@
 //!
 //! These tests require IB Gateway or TWS running on localhost:4002 (paper account).
 //!
+//! # Status
+//!
+//! **NOT TESTED in CI.** IBKR has not confirmed permission to use credentials
+//! for CI, and requires IB Gateway/TWS running locally.
+//!
+//! **Tested locally:** Tier 0 (connection) and Tier 1 (free IBKR Pro subscriptions).
+//! **NOT tested locally:** Tier 2 (L2 depth) and Tier 3 (OPRA) — paid subscriptions.
+//!
 //! # Safety
 //!
 //! **All tests use paper trading accounts only.** Tests connect to port 4002 (Gateway paper)
@@ -22,8 +30,6 @@
 //! # Run specific test
 //! cargo test --test ibkr_integration --features ibkr test_historical_daily_bars -- --ignored
 //! ```
-//!
-//! Tests are marked `#[ignore]` to avoid CI failures without IB connectivity.
 //!
 //! # Subscription Tiers
 //!
@@ -68,7 +74,7 @@
 //! |------|-------------|
 //! | `test_market_stream_depth` | Stream L2 order book depth |
 //!
-//! ## Tier 3: OPRA US Options ($1.50/mo)
+//! ## Tier 3: OPRA US Options (PAID)
 //!
 //! Required for real-time options quotes and Greeks.
 //!
@@ -1055,7 +1061,7 @@ async fn test_fetch_option_chain() {
 }
 
 // ============================================================================
-// Real-Time Option Greeks Streaming Tests (Phase 5B) — Tier 3: OPRA ($1.50/mo)
+// Real-Time Option Greeks Streaming Tests (Phase 5B) — Tier 3: OPRA (PAID)
 // ============================================================================
 
 #[serial]

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -3,6 +3,14 @@
 //! Uses the `ibapi` crate for IB TWS/Gateway connectivity. Supports equities,
 //! futures, options, and forex.
 //!
+//! # Testing Status
+//!
+//! **NOT TESTED in CI.** IBKR has not confirmed permission to use credentials
+//! for CI, and requires IB Gateway/TWS running locally.
+//!
+//! **Tested locally:** All execution tests (connection, orders, account streaming)
+//! run on paper trading accounts — no market data subscriptions required.
+//!
 //! # Connection
 //!
 //! Requires TWS or IB Gateway running locally with API enabled:

--- a/rustrade-execution/tests/alpaca_integration.rs
+++ b/rustrade-execution/tests/alpaca_integration.rs
@@ -2,6 +2,16 @@
 //!
 //! These tests require Alpaca paper trading API credentials.
 //!
+//! # Status
+//!
+//! **Tested locally, CI planned (paper trading allowed by Alpaca):**
+//! - All order types: market, limit, stop, stop-limit, trailing stop
+//! - Bracket orders with TP/SL legs
+//! - Account snapshots, balances, positions
+//! - Account event streaming via WebSocket
+//!
+//! Tests are marked `#[ignore]` to avoid CI failures without credentials.
+//!
 //! # Prerequisites
 //!
 //! 1. Alpaca paper trading account (https://app.alpaca.markets)
@@ -22,8 +32,6 @@
 //! # Run specific test
 //! cargo test --test alpaca_integration --features alpaca test_account_snapshot -- --ignored
 //! ```
-//!
-//! Tests are marked `#[ignore]` to avoid CI failures without credentials.
 //!
 //! # Market Hours Note
 //!

--- a/rustrade-execution/tests/ibkr_execution.rs
+++ b/rustrade-execution/tests/ibkr_execution.rs
@@ -2,6 +2,14 @@
 //!
 //! These tests require IB Gateway or TWS running on localhost:4002 (paper account).
 //!
+//! # Status
+//!
+//! **NOT TESTED in CI.** IBKR has not confirmed permission to use credentials
+//! for CI, and requires IB Gateway/TWS running locally.
+//!
+//! **Tested locally:** All execution tests (Tier 0) run on paper trading accounts
+//! — no market data subscriptions needed.
+//!
 //! # Safety
 //!
 //! **All tests use paper trading accounts only.** The `IBKR_PAPER_ACCOUNT` env var is required
@@ -23,8 +31,6 @@
 //! # Run specific test
 //! IBKR_PAPER_ACCOUNT=<account_id> cargo test --test ibkr_execution --features ibkr test_connection -- --ignored
 //! ```
-//!
-//! Tests are marked `#[ignore]` to avoid CI failures without IB connectivity.
 //!
 //! # Subscription Tiers
 //!


### PR DESCRIPTION
## Summary

- Add `alpaca-integration.yml` workflow for PR/push to main/develop (runs crypto + options tests 24/7)
- Add `alpaca-weekly.yml` workflow for Wednesday 11 AM ET (includes IEX equity tests during market hours)
- Add workflow status badges to README
- Fork PRs blocked from accessing secrets to prevent exfiltration

## Test plan

- [x] Verify `alpaca-integration.yml` triggers on this PR
- [ ] Manually trigger `alpaca-weekly.yml` via Actions tab during market hours
- [ ] Confirm fork PRs skip the integration test job