### PR TITLE
feat(subscriber): Implement stateful Subscriber trait for credential injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: Stateful `Subscriber` trait for credential injection** ([#43](https://github.com/Niqnil/rustrade/issues/43))
+  - `Subscriber::subscribe` now takes `&self` instead of being a static method
+  - `Subscriber` trait requires `Clone + Send + Sync` bounds
+  - `StreamBuilder::subscribe()` now requires a subscriber instance as first argument:
+    - Unauthenticated: `.subscribe(WebSocketSubscriber, [...])`
+    - Authenticated (Alpaca): `.subscribe(AlpacaSubscriber::from_env()?, [...])`
+  - `init_market_stream()` now takes subscriber as second argument
+  - `AlpacaSubscriber` is now stateful with `AlpacaCredentials`:
+    - `AlpacaSubscriber::new(credentials)`: Create with explicit credentials
+    - `AlpacaSubscriber::from_env()`: Load from `ALPACA_API_KEY`/`ALPACA_SECRET_KEY`
+    - `AlpacaCredentials::new(key, secret)`: Create credentials explicitly
+    - `AlpacaCredentials::from_env()`: Load from environment
+  - Auth errors now fail at construction time (fast fail) instead of first reconnect
+  - Credentials are cloned into reconnect closure, available on every reconnect
+
 ### Added
 
 - **BracketOrderClient supertrait**: Unified trait for bracket orders

--- a/rustrade-data/examples/hyperliquid_market_data.rs
+++ b/rustrade-data/examples/hyperliquid_market_data.rs
@@ -12,6 +12,7 @@ use futures_util::StreamExt;
 use rustrade_data::{
     exchange::hyperliquid::Hyperliquid,
     streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscriber::WebSocketSubscriber,
     subscription::{book::OrderBooksL2, trade::PublicTrades},
 };
 use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
@@ -25,42 +26,51 @@ async fn main() {
 
     // Subscribe to BTC and ETH trades on separate connections (high volume)
     let trades = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            Hyperliquid,
-            "btc",
-            "usdc",
-            MarketDataInstrumentKind::Perpetual,
-            PublicTrades,
-        )])
-        .subscribe([(
-            Hyperliquid,
-            "eth",
-            "usdc",
-            MarketDataInstrumentKind::Perpetual,
-            PublicTrades,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                Hyperliquid,
+                "btc",
+                "usdc",
+                MarketDataInstrumentKind::Perpetual,
+                PublicTrades,
+            )],
+        )
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                Hyperliquid,
+                "eth",
+                "usdc",
+                MarketDataInstrumentKind::Perpetual,
+                PublicTrades,
+            )],
+        )
         .init()
         .await
         .unwrap();
 
     // Subscribe to L2 order book snapshots
     let books = Streams::<OrderBooksL2>::builder()
-        .subscribe([
-            (
-                Hyperliquid,
-                "btc",
-                "usdc",
-                MarketDataInstrumentKind::Perpetual,
-                OrderBooksL2,
-            ),
-            (
-                Hyperliquid,
-                "eth",
-                "usdc",
-                MarketDataInstrumentKind::Perpetual,
-                OrderBooksL2,
-            ),
-        ])
+        .subscribe(
+            WebSocketSubscriber,
+            [
+                (
+                    Hyperliquid,
+                    "btc",
+                    "usdc",
+                    MarketDataInstrumentKind::Perpetual,
+                    OrderBooksL2,
+                ),
+                (
+                    Hyperliquid,
+                    "eth",
+                    "usdc",
+                    MarketDataInstrumentKind::Perpetual,
+                    OrderBooksL2,
+                ),
+            ],
+        )
         .init()
         .await
         .unwrap();

--- a/rustrade-data/examples/hyperliquid_spot_market_data.rs
+++ b/rustrade-data/examples/hyperliquid_spot_market_data.rs
@@ -21,6 +21,7 @@ use futures_util::StreamExt;
 use rustrade_data::{
     exchange::hyperliquid::{HyperliquidSpot, resolve_spot_pair},
     streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscriber::WebSocketSubscriber,
     subscription::{book::OrderBooksL2, trade::PublicTrades},
 };
 use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
@@ -42,26 +43,32 @@ async fn main() {
 
     // Subscribe to HYPE/USDC spot trades
     let trades = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            HyperliquidSpot,
-            hype_usdc.as_str(),
-            "usdc",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                HyperliquidSpot,
+                hype_usdc.as_str(),
+                "usdc",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await
         .unwrap();
 
     // Subscribe to HYPE/USDC spot L2 order book
     let books = Streams::<OrderBooksL2>::builder()
-        .subscribe([(
-            HyperliquidSpot,
-            hype_usdc.as_str(),
-            "usdc",
-            MarketDataInstrumentKind::Spot,
-            OrderBooksL2,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                HyperliquidSpot,
+                hype_usdc.as_str(),
+                "usdc",
+                MarketDataInstrumentKind::Spot,
+                OrderBooksL2,
+            )],
+        )
         .init()
         .await
         .unwrap();

--- a/rustrade-data/examples/multi_stream_multi_exchange.rs
+++ b/rustrade-data/examples/multi_stream_multi_exchange.rs
@@ -7,6 +7,7 @@ use rustrade_data::{
         okx::Okx,
     },
     streams::{Streams, consumer::MarketStreamResult, reconnect::stream::ReconnectingStream},
+    subscriber::WebSocketSubscriber,
     subscription::{
         book::{OrderBooksL1, OrderBooksL2},
         trade::PublicTrades,
@@ -34,13 +35,13 @@ async fn main() {
 
         // Add PublicTrades Streams for various exchanges
         .add(Streams::<PublicTrades>::builder()
-            .subscribe([
+            .subscribe(WebSocketSubscriber, [
                 (BinanceSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
             ])
-            .subscribe([
+            .subscribe(WebSocketSubscriber, [
                 (BinanceFuturesUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
             ])
-            .subscribe([
+            .subscribe(WebSocketSubscriber, [
                 (Okx, "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
                 (Okx, "btc", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
             ])
@@ -48,20 +49,20 @@ async fn main() {
 
         // Add OrderBooksL1 Stream for various exchanges
         .add(Streams::<OrderBooksL1>::builder()
-            .subscribe([
+            .subscribe(WebSocketSubscriber, [
                 (BinanceSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL1),
             ])
-            .subscribe([
+            .subscribe(WebSocketSubscriber, [
                 (BinanceFuturesUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, OrderBooksL1),
             ])
         )
 
         // Add OrderBooksL2 Stream for various exchanges
         .add(Streams::<OrderBooksL2>::builder()
-            .subscribe([
+            .subscribe(WebSocketSubscriber, [
                 (BinanceSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL2),
             ])
-            .subscribe([
+            .subscribe(WebSocketSubscriber, [
                 (BinanceFuturesUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, OrderBooksL2),
             ])
         )

--- a/rustrade-data/examples/order_books_l1_streams.rs
+++ b/rustrade-data/examples/order_books_l1_streams.rs
@@ -3,6 +3,7 @@
 use rustrade_data::{
     exchange::binance::spot::BinanceSpot,
     streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscriber::WebSocketSubscriber,
     subscription::book::OrderBooksL1,
 };
 use rustrade_instrument::{
@@ -22,17 +23,17 @@ async fn main() {
     let mut streams = Streams::<OrderBooksL1>::builder()
 
         // Separate WebSocket connection for BTC_USDT stream since it's very high volume
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL1),
         ])
 
         // Separate WebSocket connection for ETH_USDT stream since it's very high volume
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceSpot::default(), "eth", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL1),
         ])
 
         // Lower volume Instruments can share a WebSocket connection
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceSpot::default(), "xrp", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL1),
             (BinanceSpot::default(), "sol", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL1),
             (BinanceSpot::default(), "avax", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL1),

--- a/rustrade-data/examples/order_books_l1_streams_multi_exchange.rs
+++ b/rustrade-data/examples/order_books_l1_streams_multi_exchange.rs
@@ -4,6 +4,7 @@ use futures::StreamExt;
 use rustrade_data::{
     exchange::binance::{futures::BinanceFuturesUsd, spot::BinanceSpot},
     streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscriber::WebSocketSubscriber,
     subscription::book::OrderBooksL1,
 };
 use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
@@ -18,11 +19,11 @@ async fn main() {
     // Initialise OrderBooksL1 Streams for various exchanges
     // '--> each call to StreamBuilder::subscribe() initialises a separate WebSocket connection
     let streams = Streams::<OrderBooksL1>::builder()
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL1),
             (BinanceSpot::default(), "eth", "usd", MarketDataInstrumentKind::Spot, OrderBooksL1),
         ])
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceFuturesUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, OrderBooksL1),
             (BinanceFuturesUsd::default(), "eth", "usd", MarketDataInstrumentKind::Perpetual, OrderBooksL1),
         ])

--- a/rustrade-data/examples/order_books_l2_streams.rs
+++ b/rustrade-data/examples/order_books_l2_streams.rs
@@ -4,6 +4,7 @@ use futures_util::StreamExt;
 use rustrade_data::{
     exchange::binance::spot::BinanceSpot,
     streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscriber::WebSocketSubscriber,
     subscription::book::OrderBooksL2,
 };
 use rustrade_instrument::{
@@ -22,17 +23,17 @@ async fn main() {
     let mut streams = Streams::<OrderBooksL2>::builder()
 
         // Separate WebSocket connection for BTC_USDT stream since it's very high volume
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL2),
         ])
 
         // Separate WebSocket connection for ETH_USDT stream since it's very high volume
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceSpot::default(), "eth", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL2),
         ])
 
         // Lower volume Instruments can share a WebSocket connection
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceSpot::default(), "xrp", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL2),
             (BinanceSpot::default(), "sol", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL2),
             (BinanceSpot::default(), "avax", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL2),

--- a/rustrade-data/examples/public_trades_streams.rs
+++ b/rustrade-data/examples/public_trades_streams.rs
@@ -4,6 +4,7 @@ use futures_util::StreamExt;
 use rustrade_data::{
     exchange::binance::futures::BinanceFuturesUsd,
     streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscriber::WebSocketSubscriber,
     subscription::trade::PublicTrades,
 };
 use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
@@ -20,17 +21,17 @@ async fn main() {
     let streams = Streams::<PublicTrades>::builder()
 
         // Separate WebSocket connection for BTC_USDT stream since it's very high volume
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceFuturesUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
         ])
 
         // Separate WebSocket connection for ETH_USDT stream since it's very high volume
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceFuturesUsd::default(), "eth", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
         ])
 
         // Lower volume Instruments can share a WebSocket connection
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceFuturesUsd::default(), "xrp", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
             (BinanceFuturesUsd::default(), "sol", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
             (BinanceFuturesUsd::default(), "avax", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),

--- a/rustrade-data/examples/public_trades_streams_multi_exchange.rs
+++ b/rustrade-data/examples/public_trades_streams_multi_exchange.rs
@@ -15,6 +15,7 @@ use rustrade_data::{
         okx::Okx,
     },
     streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscriber::WebSocketSubscriber,
     subscription::trade::PublicTrades,
 };
 use rustrade_instrument::instrument::{
@@ -34,49 +35,49 @@ async fn main() {
     // Initialise PublicTrades Streams for various exchanges
     // '--> each call to StreamBuilder::subscribe() creates a separate WebSocket connection
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
             (BinanceSpot::default(), "eth", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
         ])
 
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BinanceFuturesUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
             (BinanceFuturesUsd::default(), "eth", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
         ])
 
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (GateioSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
         ])
 
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (GateioPerpetualsUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
         ])
 
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (GateioPerpetualsBtc::default(), "btc", "usd", MarketDataInstrumentKind::Perpetual, PublicTrades),
         ])
 
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (GateioOptions::default(), "btc", "usdt", MarketDataInstrumentKind::Option(put_contract()), PublicTrades),
         ])
 
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (Okx, "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
             (Okx, "btc", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
             (Okx, "btc", "usd", MarketDataInstrumentKind::Future(future_contract_expiry()), PublicTrades),
             (Okx, "btc", "usd", MarketDataInstrumentKind::Option(call_contract()), PublicTrades),
         ])
 
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BybitSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
             (BybitSpot::default(), "eth", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
         ])
 
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (BybitPerpetualsUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
         ])
 
-        .subscribe([
+        .subscribe(WebSocketSubscriber, [
             (Bitmex, "xbt", "usd", MarketDataInstrumentKind::Perpetual, PublicTrades)
         ])
 

--- a/rustrade-data/src/books/manager.rs
+++ b/rustrade-data/src/books/manager.rs
@@ -8,6 +8,7 @@ use crate::{
     exchange::StreamSelector,
     instrument::InstrumentData,
     streams::{Streams, consumer::MarketStreamEvent, reconnect::stream::ReconnectingStream},
+    subscriber::WebSocketSubscriber,
     subscription::{
         Subscription,
         book::{OrderBookEvent, OrderBooksL2},
@@ -82,7 +83,12 @@ where
     SubBatchIter: IntoIterator<Item = SubIter>,
     SubIter: IntoIterator<Item = Sub>,
     Sub: Into<Subscription<Exchange, Instrument, OrderBooksL2>>,
-    Exchange: StreamSelector<Instrument, OrderBooksL2> + Ord + Display + Send + Sync + 'static,
+    Exchange: StreamSelector<Instrument, OrderBooksL2, Subscriber = WebSocketSubscriber>
+        + Ord
+        + Display
+        + Send
+        + Sync
+        + 'static,
     Instrument: InstrumentData + Ord + Display + 'static,
     Instrument::Key: Eq + Hash + Send + 'static,
     Subscription<Exchange, Instrument, OrderBooksL2>:
@@ -102,7 +108,7 @@ where
                 subscription
             });
 
-            let builder = builder.subscribe(batch);
+            let builder = builder.subscribe(WebSocketSubscriber, batch);
             (builder, books)
         },
     );

--- a/rustrade-data/src/exchange/alpaca/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/mod.rs
@@ -16,8 +16,27 @@
 //!
 //! # Authentication
 //!
-//! Requires `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` environment variables.
+//! Alpaca requires authentication via [`AlpacaCredentials`]. Credentials can be:
+//! - Loaded from environment variables via [`AlpacaCredentials::from_env()`]
+//! - Provided explicitly via [`AlpacaCredentials::new()`]
+//!
 //! Auth message is sent immediately after WebSocket connection, before subscriptions.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use rustrade_data::exchange::alpaca::{AlpacaCredentials, AlpacaSubscriber, AlpacaIex};
+//! use rustrade_data::streams::Streams;
+//! use rustrade_data::subscription::trade::PublicTrades;
+//!
+//! // Load credentials at construction time (fails fast if env vars missing)
+//! let subscriber = AlpacaSubscriber::from_env()?;
+//!
+//! let streams = Streams::<PublicTrades>::builder()
+//!     .subscribe(subscriber, [(AlpacaIex::default(), "AAPL", "USD", PublicTrades)])
+//!     .init()
+//!     .await?;
+//! ```
 //!
 //! # Connectors
 //!
@@ -53,7 +72,7 @@ use rustrade_integration::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::{env, fmt::Debug, marker::PhantomData, time::Duration};
+use std::{env, fmt, fmt::Debug, marker::PhantomData, time::Duration};
 use tracing::debug;
 use url::Url;
 
@@ -222,17 +241,95 @@ where
     }
 }
 
+/// Credentials for authenticating to Alpaca market data WebSocket.
+///
+/// `Debug` is implemented manually to redact `api_secret`, preventing accidental
+/// exposure of the secret in tracing or panic output.
+#[derive(Clone)]
+pub struct AlpacaCredentials {
+    api_key: String,
+    api_secret: String,
+}
+
+impl fmt::Debug for AlpacaCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AlpacaCredentials")
+            .field("api_key", &self.api_key)
+            .field("api_secret", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl AlpacaCredentials {
+    /// Create credentials from explicit values.
+    pub fn new(api_key: impl Into<String>, api_secret: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            api_secret: api_secret.into(),
+        }
+    }
+
+    /// Load credentials from environment variables.
+    ///
+    /// Reads `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` from environment.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if either environment variable is not set.
+    pub fn from_env() -> Result<Self, SocketError> {
+        let api_key = env::var("ALPACA_API_KEY")
+            .map_err(|e| SocketError::Subscribe(format!("ALPACA_API_KEY: {e}")))?;
+        let api_secret = env::var("ALPACA_SECRET_KEY")
+            .map_err(|e| SocketError::Subscribe(format!("ALPACA_SECRET_KEY: {e}")))?;
+        Ok(Self {
+            api_key,
+            api_secret,
+        })
+    }
+}
+
 /// Alpaca WebSocket subscriber with authentication.
 ///
 /// Handles the auth → subscribe flow required by Alpaca market data streams.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
-pub struct AlpacaSubscriber;
+///
+/// # Example
+///
+/// ```ignore
+/// use rustrade_data::exchange::alpaca::{AlpacaCredentials, AlpacaSubscriber};
+///
+/// // Load credentials at construction time (fails fast if env vars missing)
+/// let credentials = AlpacaCredentials::from_env()?;
+/// let subscriber = AlpacaSubscriber::new(credentials);
+///
+/// // Or with explicit credentials
+/// let subscriber = AlpacaSubscriber::new(AlpacaCredentials::new("key", "secret"));
+/// ```
+#[derive(Clone, Debug)]
+pub struct AlpacaSubscriber {
+    credentials: AlpacaCredentials,
+}
+
+impl AlpacaSubscriber {
+    /// Create a new subscriber with the provided credentials.
+    pub fn new(credentials: AlpacaCredentials) -> Self {
+        Self { credentials }
+    }
+
+    /// Create a new subscriber using credentials from environment variables.
+    ///
+    /// Equivalent to `AlpacaSubscriber::new(AlpacaCredentials::from_env()?)`.
+    /// See [`AlpacaCredentials::from_env`] for the variables read and error conditions.
+    pub fn from_env() -> Result<Self, SocketError> {
+        Ok(Self::new(AlpacaCredentials::from_env()?))
+    }
+}
 
 #[async_trait]
 impl crate::subscriber::Subscriber for AlpacaSubscriber {
     type SubMapper = crate::subscriber::mapper::WebSocketSubMapper;
 
     async fn subscribe<Exchange, Instrument, Kind>(
+        &self,
         subscriptions: &[crate::subscription::Subscription<Exchange, Instrument, Kind>],
     ) -> Result<crate::subscriber::Subscribed<Instrument::Key>, SocketError>
     where
@@ -249,7 +346,7 @@ impl crate::subscriber::Subscriber for AlpacaSubscriber {
         let mut websocket = connect(url).await?;
         debug!(%exchange, "connected to Alpaca WebSocket, sending auth");
 
-        alpaca_authenticate(&mut websocket).await?;
+        alpaca_authenticate(&mut websocket, &self.credentials).await?;
         debug!(%exchange, "Alpaca auth successful");
 
         let crate::subscription::SubscriptionMeta {
@@ -281,24 +378,15 @@ impl crate::subscriber::Subscriber for AlpacaSubscriber {
     }
 }
 
-/// Authenticate to Alpaca WebSocket using env credentials.
-///
-/// # Note
-/// Reads `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` from environment.
-/// This is a Phase 2 expedient — other market data connectors use unauthenticated
-/// public streams. A proper credential-injection mechanism should be designed
-/// when another authenticated market data connector is added.
-// FIXME: Design credential-injection mechanism for Subscriber trait instead of env::var
-async fn alpaca_authenticate(ws: &mut WebSocket) -> Result<(), SocketError> {
-    let api_key = env::var("ALPACA_API_KEY")
-        .map_err(|e| SocketError::Subscribe(format!("ALPACA_API_KEY: {e}")))?;
-    let api_secret = env::var("ALPACA_SECRET_KEY")
-        .map_err(|e| SocketError::Subscribe(format!("ALPACA_SECRET_KEY: {e}")))?;
-
+/// Authenticate to Alpaca WebSocket using the provided credentials.
+async fn alpaca_authenticate(
+    ws: &mut WebSocket,
+    credentials: &AlpacaCredentials,
+) -> Result<(), SocketError> {
     let auth_msg = json!({
         "action": "auth",
-        "key": api_key,
-        "secret": api_secret,
+        "key": credentials.api_key,
+        "secret": credentials.api_secret,
     })
     .to_string();
 

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -47,6 +47,7 @@
 //!         okx::Okx,
 //!     },
 //!     streams::{Streams, reconnect::stream::ReconnectingStream},
+//!     subscriber::WebSocketSubscriber,
 //!     subscription::trade::PublicTrades,
 //! };
 //! use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
@@ -59,23 +60,23 @@
 //!     // '--> each call to StreamBuilder::subscribe() initialises a separate WebSocket connection
 //!
 //!     let streams = Streams::<PublicTrades>::builder()
-//!         .subscribe([
+//!         .subscribe(WebSocketSubscriber, [
 //!             (BinanceSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
 //!             (BinanceSpot::default(), "eth", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
 //!         ])
-//!         .subscribe([
+//!         .subscribe(WebSocketSubscriber, [
 //!             (BinanceFuturesUsd::default(), "btc", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
 //!             (BinanceFuturesUsd::default(), "eth", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
 //!         ])
-//!         .subscribe([
+//!         .subscribe(WebSocketSubscriber, [
 //!             (Coinbase, "btc", "usd", MarketDataInstrumentKind::Spot, PublicTrades),
 //!             (Coinbase, "eth", "usd", MarketDataInstrumentKind::Spot, PublicTrades),
 //!         ])
-//!         .subscribe([
+//!         .subscribe(WebSocketSubscriber, [
 //!             (GateioSpot::default(), "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
 //!             (GateioSpot::default(), "eth", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
 //!         ])
-//!         .subscribe([
+//!         .subscribe(WebSocketSubscriber, [
 //!             (Okx, "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
 //!             (Okx, "eth", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
 //!             (Okx, "btc", "usdt", MarketDataInstrumentKind::Perpetual, PublicTrades),
@@ -200,6 +201,7 @@ where
     Kind: SubscriptionKind,
 {
     async fn init<SnapFetcher>(
+        subscriber: &Exchange::Subscriber,
         subscriptions: &[Subscription<Exchange, Instrument, Kind>],
     ) -> Result<Self, DataError>
     where
@@ -239,6 +241,7 @@ where
     Parser: StreamParser<Transformer::Input, Message = WsMessage, Error = WsError> + Send,
 {
     async fn init<SnapFetcher>(
+        subscriber: &Exchange::Subscriber,
         subscriptions: &[Subscription<Exchange, Instrument, Kind>],
     ) -> Result<Self, DataError>
     where
@@ -251,7 +254,7 @@ where
             websocket,
             map: instrument_map,
             buffered_websocket_events,
-        } = Exchange::Subscriber::subscribe(subscriptions).await?;
+        } = subscriber.subscribe(subscriptions).await?;
 
         // Fetch any required initial MarketEvent snapshots
         let initial_snapshots = SnapFetcher::fetch_snapshots(subscriptions).await?;

--- a/rustrade-data/src/streams/builder/dynamic/mod.rs
+++ b/rustrade-data/src/streams/builder/dynamic/mod.rs
@@ -22,6 +22,7 @@ use crate::{
         consumer::{MarketStreamResult, STREAM_RECONNECTION_POLICY, init_market_stream},
         reconnect::stream::ReconnectingStream,
     },
+    subscriber::WebSocketSubscriber,
     subscription::{
         SubKind, Subscription,
         book::{OrderBookEvent, OrderBookL1, OrderBooksL1, OrderBooksL2},
@@ -131,6 +132,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BinanceSpot, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -151,6 +153,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BinanceSpot, SubKind::OrderBooksL1) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -171,6 +174,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BinanceSpot, SubKind::OrderBooksL2) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -191,6 +195,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BinanceFuturesUsd, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -211,6 +216,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BinanceFuturesUsd, SubKind::OrderBooksL1) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::<_, Instrument, _>::new(
@@ -231,6 +237,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BinanceFuturesUsd, SubKind::OrderBooksL2) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::<_, Instrument, _>::new(
@@ -251,6 +258,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BinanceFuturesUsd, SubKind::Liquidations) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::<_, Instrument, _>::new(
@@ -271,6 +279,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::Bitfinex, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -291,6 +300,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::Bitmex, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -311,6 +321,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BybitSpot, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -331,6 +342,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BybitSpot, SubKind::OrderBooksL1) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -351,6 +363,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BybitSpot, SubKind::OrderBooksL2) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -371,6 +384,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BybitPerpetualsUsd, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -391,6 +405,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BybitPerpetualsUsd, SubKind::OrderBooksL1) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -411,6 +426,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::BybitPerpetualsUsd, SubKind::OrderBooksL2) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -431,6 +447,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::Coinbase, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -451,6 +468,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::GateioSpot, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -471,6 +489,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::GateioFuturesUsd, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -491,6 +510,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::GateioFuturesBtc, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -511,6 +531,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::GateioPerpetualsUsd, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -531,6 +552,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::GateioPerpetualsBtc, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -551,6 +573,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::GateioOptions, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -571,6 +594,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::Kraken, SubKind::PublicTrades) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -591,6 +615,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     (ExchangeId::Kraken, SubKind::OrderBooksL1) => {
                                         init_market_stream(
                                             STREAM_RECONNECTION_POLICY,
+                                            WebSocketSubscriber,
                                             subs.into_iter()
                                                 .map(|sub| {
                                                     Subscription::new(
@@ -610,6 +635,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
                                     }
                                     (ExchangeId::Okx, SubKind::PublicTrades) => init_market_stream(
                                         STREAM_RECONNECTION_POLICY,
+                                        WebSocketSubscriber,
                                         subs.into_iter()
                                             .map(|sub| {
                                                 Subscription::new(Okx, sub.instrument, PublicTrades)

--- a/rustrade-data/src/streams/builder/mod.rs
+++ b/rustrade-data/src/streams/builder/mod.rs
@@ -72,9 +72,17 @@ where
     /// Add a collection of [`Subscription`]s to the [`StreamBuilder`] that will be actioned on
     /// a distinct [`WebSocket`](rustrade_integration::protocol::websocket::WebSocket) connection.
     ///
+    /// The `subscriber` handles the WebSocket connection and authentication.
+    /// For unauthenticated exchanges, use [`WebSocketSubscriber`](crate::subscriber::WebSocketSubscriber).
+    /// For authenticated exchanges like Alpaca, use the exchange-specific subscriber with credentials.
+    ///
     /// Note that [`Subscription`]s are not actioned until the
     /// [`init()`](StreamBuilder::init()) method is invoked.
-    pub fn subscribe<SubIter, Sub, Exchange, Instrument>(mut self, subscriptions: SubIter) -> Self
+    pub fn subscribe<SubIter, Sub, Exchange, Instrument>(
+        mut self,
+        subscriber: Exchange::Subscriber,
+        subscriptions: SubIter,
+    ) -> Self
     where
         SubIter: IntoIterator<Item = Sub>,
         Sub: Into<Subscription<Exchange, Instrument, Kind>>,
@@ -106,7 +114,8 @@ where
             subscriptions.dedup();
 
             // Initialise a MarketEvent `ReconnectingStream`
-            let stream = init_market_stream(STREAM_RECONNECTION_POLICY, subscriptions).await?;
+            let stream =
+                init_market_stream(STREAM_RECONNECTION_POLICY, subscriber, subscriptions).await?;
 
             // Forward MarketEvents to ExchangeTx
             tokio::spawn(stream.forward_to(exchange_tx));

--- a/rustrade-data/src/streams/consumer.rs
+++ b/rustrade-data/src/streams/consumer.rs
@@ -41,8 +41,12 @@ pub type MarketStreamEvent<InstrumentKey, Kind> =
 ///
 /// The provided [`ReconnectionBackoffPolicy`] dictates how the exponential backoff scales
 /// between reconnections.
+///
+/// The `subscriber` is cloned into the reconnect closure, so authenticated subscribers
+/// will have their credentials available on reconnection.
 pub async fn init_market_stream<Exchange, Instrument, Kind>(
     policy: ReconnectionBackoffPolicy,
+    subscriber: Exchange::Subscriber,
     subscriptions: Vec<Subscription<Exchange, Instrument, Kind>>,
 ) -> Result<impl Stream<Item = MarketStreamResult<Instrument::Key, Kind::Event>>, DataError>
 where
@@ -69,14 +73,19 @@ where
         "MarketStream with auto reconnect initialising"
     );
 
-    Ok(init_reconnecting_stream(move || {
-        let subscriptions = subscriptions.clone();
-        async move { Exchange::Stream::init::<Exchange::SnapFetcher>(&subscriptions).await }
-    })
-    .await?
-    .with_reconnect_backoff(policy, stream_key)
-    .with_termination_on_error(|error| error.is_terminal(), stream_key)
-    .with_reconnection_events(exchange))
+    Ok(
+        init_reconnecting_stream(move || {
+            let subscriber = subscriber.clone();
+            let subscriptions = subscriptions.clone();
+            async move {
+                Exchange::Stream::init::<Exchange::SnapFetcher>(&subscriber, &subscriptions).await
+            }
+        })
+        .await?
+        .with_reconnect_backoff(policy, stream_key)
+        .with_termination_on_error(|error| error.is_terminal(), stream_key)
+        .with_reconnection_events(exchange),
+    )
 }
 
 #[derive(

--- a/rustrade-data/src/subscriber/mod.rs
+++ b/rustrade-data/src/subscriber/mod.rs
@@ -27,11 +27,16 @@ pub mod mapper;
 pub mod validator;
 
 /// Defines how to connect to a socket and subscribe to market data streams.
+///
+/// Subscribers may carry state such as authentication credentials.
+/// The trait requires `Clone` to support reconnection (subscribers are cloned
+/// into the reconnect closure).
 #[async_trait]
-pub trait Subscriber {
+pub trait Subscriber: Clone + Send + Sync {
     type SubMapper: SubscriptionMapper;
 
     async fn subscribe<Exchange, Instrument, Kind>(
+        &self,
         subscriptions: &[Subscription<Exchange, Instrument, Kind>],
     ) -> Result<Subscribed<Instrument::Key>, SocketError>
     where
@@ -50,7 +55,11 @@ pub struct Subscribed<InstrumentKey> {
 }
 
 /// Standard [`Subscriber`] for [`WebSocket`]s suitable for most exchanges.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+///
+/// This is a stateless subscriber for unauthenticated market data streams.
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Deserialize, Serialize,
+)]
 pub struct WebSocketSubscriber;
 
 #[async_trait]
@@ -58,6 +67,7 @@ impl Subscriber for WebSocketSubscriber {
     type SubMapper = WebSocketSubMapper;
 
     async fn subscribe<Exchange, Instrument, Kind>(
+        &self,
         subscriptions: &[Subscription<Exchange, Instrument, Kind>],
     ) -> Result<Subscribed<Instrument::Key>, SocketError>
     where

--- a/rustrade-data/tests/alpaca_data.rs
+++ b/rustrade-data/tests/alpaca_data.rs
@@ -49,7 +49,7 @@
 use futures_util::StreamExt;
 use rust_decimal::Decimal;
 use rustrade_data::{
-    exchange::alpaca::{AlpacaCrypto, AlpacaIex, AlpacaSip},
+    exchange::alpaca::{AlpacaCrypto, AlpacaIex, AlpacaSip, AlpacaSubscriber},
     streams::{
         Streams,
         reconnect::{Event, stream::ReconnectingStream},
@@ -80,13 +80,16 @@ async fn test_crypto_trade_stream_connection() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            AlpacaCrypto::default(),
-            "btc",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaCrypto::default(),
+                "btc",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await;
 
@@ -104,13 +107,16 @@ async fn test_crypto_trade_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            AlpacaCrypto::default(),
-            "btc",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaCrypto::default(),
+                "btc",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init crypto stream");
@@ -145,13 +151,16 @@ async fn test_crypto_quote_stream_connection() {
     init_logging();
 
     let streams = Streams::<Quotes>::builder()
-        .subscribe([(
-            AlpacaCrypto::default(),
-            "btc",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            Quotes,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaCrypto::default(),
+                "btc",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                Quotes,
+            )],
+        )
         .init()
         .await;
 
@@ -169,13 +178,16 @@ async fn test_crypto_quote_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<Quotes>::builder()
-        .subscribe([(
-            AlpacaCrypto::default(),
-            "btc",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            Quotes,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaCrypto::default(),
+                "btc",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                Quotes,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init crypto quote stream");
@@ -214,22 +226,25 @@ async fn test_crypto_multiple_symbols() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([
-            (
-                AlpacaCrypto::default(),
-                "btc",
-                "usd",
-                MarketDataInstrumentKind::Spot,
-                PublicTrades,
-            ),
-            (
-                AlpacaCrypto::default(),
-                "eth",
-                "usd",
-                MarketDataInstrumentKind::Spot,
-                PublicTrades,
-            ),
-        ])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [
+                (
+                    AlpacaCrypto::default(),
+                    "btc",
+                    "usd",
+                    MarketDataInstrumentKind::Spot,
+                    PublicTrades,
+                ),
+                (
+                    AlpacaCrypto::default(),
+                    "eth",
+                    "usd",
+                    MarketDataInstrumentKind::Spot,
+                    PublicTrades,
+                ),
+            ],
+        )
         .init()
         .await;
 
@@ -279,13 +294,16 @@ async fn test_iex_trade_stream_connection() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            AlpacaIex::default(),
-            "spy",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaIex::default(),
+                "spy",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await;
 
@@ -303,13 +321,16 @@ async fn test_iex_quote_stream_connection() {
     init_logging();
 
     let streams = Streams::<Quotes>::builder()
-        .subscribe([(
-            AlpacaIex::default(),
-            "aapl",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            Quotes,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaIex::default(),
+                "aapl",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                Quotes,
+            )],
+        )
         .init()
         .await;
 
@@ -327,22 +348,25 @@ async fn test_iex_multiple_symbols_subscription() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([
-            (
-                AlpacaIex::default(),
-                "spy",
-                "usd",
-                MarketDataInstrumentKind::Spot,
-                PublicTrades,
-            ),
-            (
-                AlpacaIex::default(),
-                "aapl",
-                "usd",
-                MarketDataInstrumentKind::Spot,
-                PublicTrades,
-            ),
-        ])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [
+                (
+                    AlpacaIex::default(),
+                    "spy",
+                    "usd",
+                    MarketDataInstrumentKind::Spot,
+                    PublicTrades,
+                ),
+                (
+                    AlpacaIex::default(),
+                    "aapl",
+                    "usd",
+                    MarketDataInstrumentKind::Spot,
+                    PublicTrades,
+                ),
+            ],
+        )
         .init()
         .await;
 
@@ -364,13 +388,16 @@ async fn test_iex_trade_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            AlpacaIex::default(),
-            "spy",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaIex::default(),
+                "spy",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init IEX stream");
@@ -417,13 +444,16 @@ async fn test_iex_quote_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<Quotes>::builder()
-        .subscribe([(
-            AlpacaIex::default(),
-            "spy",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            Quotes,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaIex::default(),
+                "spy",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                Quotes,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init IEX quote stream");
@@ -474,13 +504,16 @@ async fn test_sip_trade_stream_connection() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            AlpacaSip::default(),
-            "spy",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaSip::default(),
+                "spy",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await;
 
@@ -501,13 +534,16 @@ async fn test_sip_quote_stream_connection() {
     init_logging();
 
     let streams = Streams::<Quotes>::builder()
-        .subscribe([(
-            AlpacaSip::default(),
-            "aapl",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            Quotes,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaSip::default(),
+                "aapl",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                Quotes,
+            )],
+        )
         .init()
         .await;
 
@@ -528,13 +564,16 @@ async fn test_sip_trade_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            AlpacaSip::default(),
-            "spy",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaSip::default(),
+                "spy",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init SIP stream");
@@ -581,13 +620,16 @@ async fn test_sip_quote_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<Quotes>::builder()
-        .subscribe([(
-            AlpacaSip::default(),
-            "spy",
-            "usd",
-            MarketDataInstrumentKind::Spot,
-            Quotes,
-        )])
+        .subscribe(
+            AlpacaSubscriber::from_env().unwrap(),
+            [(
+                AlpacaSip::default(),
+                "spy",
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                Quotes,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init SIP quote stream");

--- a/rustrade-data/tests/hyperliquid_data.rs
+++ b/rustrade-data/tests/hyperliquid_data.rs
@@ -30,6 +30,7 @@ use rustrade_data::{
         Streams,
         reconnect::{Event, stream::ReconnectingStream},
     },
+    subscriber::WebSocketSubscriber,
     subscription::{book::OrderBooksL2, trade::PublicTrades},
 };
 use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
@@ -165,13 +166,16 @@ async fn test_trade_stream_connection() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            Hyperliquid,
-            "btc",
-            "usdc",
-            MarketDataInstrumentKind::Perpetual,
-            PublicTrades,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                Hyperliquid,
+                "btc",
+                "usdc",
+                MarketDataInstrumentKind::Perpetual,
+                PublicTrades,
+            )],
+        )
         .init()
         .await;
 
@@ -189,13 +193,16 @@ async fn test_trade_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            Hyperliquid,
-            "btc",
-            "usdc",
-            MarketDataInstrumentKind::Perpetual,
-            PublicTrades,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                Hyperliquid,
+                "btc",
+                "usdc",
+                MarketDataInstrumentKind::Perpetual,
+                PublicTrades,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init stream");
@@ -230,13 +237,16 @@ async fn test_l2_book_stream_connection() {
     init_logging();
 
     let streams = Streams::<OrderBooksL2>::builder()
-        .subscribe([(
-            Hyperliquid,
-            "btc",
-            "usdc",
-            MarketDataInstrumentKind::Perpetual,
-            OrderBooksL2,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                Hyperliquid,
+                "btc",
+                "usdc",
+                MarketDataInstrumentKind::Perpetual,
+                OrderBooksL2,
+            )],
+        )
         .init()
         .await;
 
@@ -254,13 +264,16 @@ async fn test_l2_book_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<OrderBooksL2>::builder()
-        .subscribe([(
-            Hyperliquid,
-            "btc",
-            "usdc",
-            MarketDataInstrumentKind::Perpetual,
-            OrderBooksL2,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                Hyperliquid,
+                "btc",
+                "usdc",
+                MarketDataInstrumentKind::Perpetual,
+                OrderBooksL2,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init stream");
@@ -285,22 +298,25 @@ async fn test_multiple_symbols_stream() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([
-            (
-                Hyperliquid,
-                "btc",
-                "usdc",
-                MarketDataInstrumentKind::Perpetual,
-                PublicTrades,
-            ),
-            (
-                Hyperliquid,
-                "eth",
-                "usdc",
-                MarketDataInstrumentKind::Perpetual,
-                PublicTrades,
-            ),
-        ])
+        .subscribe(
+            WebSocketSubscriber,
+            [
+                (
+                    Hyperliquid,
+                    "btc",
+                    "usdc",
+                    MarketDataInstrumentKind::Perpetual,
+                    PublicTrades,
+                ),
+                (
+                    Hyperliquid,
+                    "eth",
+                    "usdc",
+                    MarketDataInstrumentKind::Perpetual,
+                    PublicTrades,
+                ),
+            ],
+        )
         .init()
         .await;
 

--- a/rustrade-data/tests/hyperliquid_spot_data.rs
+++ b/rustrade-data/tests/hyperliquid_spot_data.rs
@@ -34,6 +34,7 @@ use rustrade_data::{
         Streams,
         reconnect::{Event, stream::ReconnectingStream},
     },
+    subscriber::WebSocketSubscriber,
     subscription::{book::OrderBooksL2, trade::PublicTrades},
 };
 use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
@@ -60,13 +61,16 @@ async fn test_spot_trade_stream_connection() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            HyperliquidSpot,
-            "@107",
-            "usdc",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                HyperliquidSpot,
+                "@107",
+                "usdc",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await;
 
@@ -84,13 +88,16 @@ async fn test_spot_trade_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            HyperliquidSpot,
-            "@107",
-            "usdc",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                HyperliquidSpot,
+                "@107",
+                "usdc",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init stream");
@@ -139,13 +146,16 @@ async fn test_spot_l2_book_stream_connection() {
     init_logging();
 
     let streams = Streams::<OrderBooksL2>::builder()
-        .subscribe([(
-            HyperliquidSpot,
-            "@107",
-            "usdc",
-            MarketDataInstrumentKind::Spot,
-            OrderBooksL2,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                HyperliquidSpot,
+                "@107",
+                "usdc",
+                MarketDataInstrumentKind::Spot,
+                OrderBooksL2,
+            )],
+        )
         .init()
         .await;
 
@@ -163,13 +173,16 @@ async fn test_spot_l2_book_stream_receives_data() {
     init_logging();
 
     let streams = Streams::<OrderBooksL2>::builder()
-        .subscribe([(
-            HyperliquidSpot,
-            "@107",
-            "usdc",
-            MarketDataInstrumentKind::Spot,
-            OrderBooksL2,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                HyperliquidSpot,
+                "@107",
+                "usdc",
+                MarketDataInstrumentKind::Spot,
+                OrderBooksL2,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init stream");
@@ -196,25 +209,31 @@ async fn test_spot_combined_streams() {
 
     // Subscribe to both trades and books for BTC/USDC spot
     let trades = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            HyperliquidSpot,
-            "@107",
-            "usdc",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                HyperliquidSpot,
+                "@107",
+                "usdc",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init trade stream");
 
     let books = Streams::<OrderBooksL2>::builder()
-        .subscribe([(
-            HyperliquidSpot,
-            "@107",
-            "usdc",
-            MarketDataInstrumentKind::Spot,
-            OrderBooksL2,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                HyperliquidSpot,
+                "@107",
+                "usdc",
+                MarketDataInstrumentKind::Spot,
+                OrderBooksL2,
+            )],
+        )
         .init()
         .await
         .expect("Failed to init book stream");
@@ -265,13 +284,16 @@ async fn test_spot_invalid_pair_handling() {
 
     // Try to subscribe to a non-existent spot pair
     let result = Streams::<PublicTrades>::builder()
-        .subscribe([(
-            HyperliquidSpot,
-            "invalidcoin",
-            "usdc",
-            MarketDataInstrumentKind::Spot,
-            PublicTrades,
-        )])
+        .subscribe(
+            WebSocketSubscriber,
+            [(
+                HyperliquidSpot,
+                "invalidcoin",
+                "usdc",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            )],
+        )
         .init()
         .await;
 


### PR DESCRIPTION
## Summary

Refactor Subscriber trait to be stateful, enabling secure credential management and fast-fail authentication. This resolves the architectural issue of how to pass credentials through reconnects without relying on environment variables.

- Make Subscriber trait stateful: requires `&self`, `Clone + Send + Sync` bounds
- Add `AlpacaCredentials` struct with `new()` and `from_env()` constructors (redacts secrets in Debug)
- Refactor `AlpacaSubscriber` from zero-sized to stateful, carrying credentials
- Update StreamBuilder API: `subscribe()` now requires subscriber instance
- Update all examples (10) and tests (3) to pass subscriber instances

## Test plan

- [x] All examples updated and compile
- [x] All integration tests updated
- [x] `cargo check` passes
- [x] `cargo clippy` passes

Closes #43