### PR TITLE
feat(databento): Add streaming APIs and structured error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Databento streaming variants** ([#46](https://github.com/Niqnil/rustrade/issues/46))
+  - `DatabentoHistorical::fetch_trades_stream()`: Stream trades without collecting into memory
+  - `DatabentoHistorical::fetch_quotes_stream()`: Stream quotes without collecting into memory
+  - Avoids memory spikes for large historical queries (millions of records)
+
 ### Changed
+
+- **Databento structured error types** ([#47](https://github.com/Niqnil/rustrade/issues/47))
+  - New `DatabentoErrorKind` enum: `Authentication`, `RateLimit`, `Network`, `Decode`, `Api`
+  - New `DataError::Databento { kind, context, message }` variant for programmatic error handling
+  - Enables proper retry logic: don't retry auth errors, backoff on rate limits, retry network errors
+  - All Databento errors now use structured types instead of `DataError::Socket(String)`
+
+- **Databento `Arc<K>` performance documentation** ([#45](https://github.com/Niqnil/rustrade/issues/45))
+  - Documented that instrument keys are cloned per record
+  - Recommended `Arc<K>` for high-frequency scenarios to avoid per-record heap allocations
+  - Added examples in rustdoc for `fetch_trades`, `fetch_quotes`, and `DatabentoLive`
 
 - **BREAKING: Stateful `Subscriber` trait for credential injection** ([#43](https://github.com/Niqnil/rustrade/issues/43))
   - `Subscriber::subscribe` now takes `&self` instead of being a static method

--- a/rustrade-data/src/error.rs
+++ b/rustrade-data/src/error.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "databento")]
+use crate::exchange::databento::DatabentoErrorKind;
 use crate::subscription::SubKind;
 use rustrade_instrument::{exchange::ExchangeId, index::error::IndexError};
 use rustrade_integration::{error::SocketError, subscription::SubscriptionId};
@@ -24,6 +26,15 @@ pub enum DataError {
 
     #[error("SocketError: {0}")]
     Socket(String),
+
+    /// Databento-specific error with categorized kind for programmatic handling.
+    #[cfg(feature = "databento")]
+    #[error("Databento {kind} error ({context}): {message}")]
+    Databento {
+        kind: DatabentoErrorKind,
+        context: String,
+        message: String,
+    },
 
     #[error("unsupported dynamic Subscription for exchange: {exchange}, kind: {sub_kind}")]
     Unsupported {

--- a/rustrade-data/src/exchange/databento/error.rs
+++ b/rustrade-data/src/exchange/databento/error.rs
@@ -1,16 +1,48 @@
 //! Error types and conversions for Databento integration.
 
 use crate::error::DataError;
+use serde::{Deserialize, Serialize};
 use std::error::Error as StdError;
 use std::fmt;
 
-/// Databento-specific error wrapper.
+/// Categorized Databento error for programmatic handling.
 ///
-/// Provides context for errors from the databento crate while preserving
-/// the original error's source chain via [`std::error::Error::source`].
-/// Convertible to the library's [`DataError`] type.
+/// Enables callers to implement proper retry logic:
+/// - [`Authentication`](DatabentoErrorKind::Authentication): Don't retry, fix credentials
+/// - [`RateLimit`](DatabentoErrorKind::RateLimit): Retry with exponential backoff
+/// - [`Network`](DatabentoErrorKind::Network): Retry with backoff
+/// - [`Decode`](DatabentoErrorKind::Decode): Skip record or abort depending on context
+/// - [`Api`](DatabentoErrorKind::Api): Check message for details
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum DatabentoErrorKind {
+    /// API key missing, invalid, or expired.
+    Authentication,
+    /// Request throttled due to rate limits.
+    RateLimit,
+    /// Connection or network-level failure.
+    Network,
+    /// Failed to decode DBN record or response.
+    Decode,
+    /// Other API error (check message for details).
+    Api,
+}
+
+impl fmt::Display for DatabentoErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Authentication => write!(f, "authentication"),
+            Self::RateLimit => write!(f, "rate limit"),
+            Self::Network => write!(f, "network"),
+            Self::Decode => write!(f, "decode"),
+            Self::Api => write!(f, "API"),
+        }
+    }
+}
+
+/// Internal error wrapper that preserves the source error chain.
 #[derive(Debug)]
 pub(crate) struct DatabentoError {
+    pub(crate) kind: DatabentoErrorKind,
     context: &'static str,
     source: Box<dyn StdError + Send + Sync + 'static>,
 }
@@ -20,7 +52,9 @@ impl DatabentoError {
         context: &'static str,
         source: impl StdError + Send + Sync + 'static,
     ) -> Self {
+        let kind = classify_error(&source);
         Self {
+            kind,
             context,
             source: Box::new(source),
         }
@@ -41,8 +75,48 @@ impl StdError for DatabentoError {
 
 impl From<DatabentoError> for DataError {
     fn from(err: DatabentoError) -> Self {
-        DataError::Socket(err.to_string())
+        DataError::Databento {
+            kind: err.kind,
+            context: err.context.to_string(),
+            message: err.source.to_string(),
+        }
     }
+}
+
+/// Classify an error into a [`DatabentoErrorKind`] based on error message heuristics.
+fn classify_error(err: &(impl StdError + ?Sized)) -> DatabentoErrorKind {
+    let mut msg = err.to_string();
+    msg.make_ascii_lowercase();
+
+    if msg.contains("api key")
+        || msg.contains("apikey")
+        || msg.contains("unauthorized")
+        || msg.contains("authentication")
+        || msg.contains("invalid key")
+        || msg.contains("expired")
+    {
+        return DatabentoErrorKind::Authentication;
+    }
+
+    if msg.contains("rate limit") || msg.contains("too many requests") || msg.contains("throttl") {
+        return DatabentoErrorKind::RateLimit;
+    }
+
+    if msg.contains("connect")
+        || msg.contains("timeout")
+        || msg.contains("network")
+        || msg.contains("dns")
+        || msg.contains("socket")
+        || msg.contains("unexpected end of file")
+    {
+        return DatabentoErrorKind::Network;
+    }
+
+    if msg.contains("decode") || msg.contains("parse") || msg.contains("invalid record") {
+        return DatabentoErrorKind::Decode;
+    }
+
+    DatabentoErrorKind::Api
 }
 
 /// Extension trait for adding context to databento errors. Crate-internal
@@ -54,5 +128,14 @@ pub(crate) trait DatabentoResultExt<T> {
 impl<T, E: StdError + Send + Sync + 'static> DatabentoResultExt<T> for Result<T, E> {
     fn with_context(self, ctx: &'static str) -> Result<T, DatabentoError> {
         self.map_err(|e| DatabentoError::new(ctx, e))
+    }
+}
+
+/// Create a decode error from a message (for use in iterator/stream contexts).
+pub(crate) fn decode_error(message: impl Into<String>) -> DataError {
+    DataError::Databento {
+        kind: DatabentoErrorKind::Decode,
+        context: "decoding DBN record".to_string(),
+        message: message.into(),
     }
 }

--- a/rustrade-data/src/exchange/databento/historical.rs
+++ b/rustrade-data/src/exchange/databento/historical.rs
@@ -21,7 +21,7 @@
 //! let trades = client.fetch_trades(&params, ExchangeId::DatabentoGlbx, "ES").await?;
 //! ```
 
-use super::error::DatabentoResultExt;
+use super::error::{DatabentoResultExt, decode_error};
 use super::transformer::{dbn_mbp1_to_quote, dbn_trade_to_public_trade};
 use crate::error::DataError;
 use crate::event::MarketEvent;
@@ -32,6 +32,7 @@ use databento::dbn::decode::DynDecoder;
 use databento::dbn::enums::VersionUpgradePolicy;
 use databento::dbn::{self, decode::DecodeRecord};
 use databento::historical::timeseries::GetRangeParams;
+use futures::Stream;
 use rustrade_instrument::exchange::ExchangeId;
 use std::path::Path;
 use tracing::{debug, info};
@@ -81,11 +82,25 @@ impl DatabentoHistorical {
 
     /// Fetch historical trades for the given parameters.
     ///
+    /// Collects all records into memory before returning. For large queries
+    /// (millions of records), consider [`fetch_trades_stream`](Self::fetch_trades_stream)
+    /// to process records incrementally.
+    ///
     /// # Arguments
     ///
     /// * `params` - Query parameters (dataset, symbols, time range)
     /// * `exchange` - ExchangeId to tag events with (should match dataset)
     /// * `instrument` - Instrument key to tag events with
+    ///
+    /// # Performance
+    ///
+    /// The instrument key is cloned for each record. For high-frequency data,
+    /// use [`Arc<K>`](std::sync::Arc) to avoid per-record heap allocations:
+    ///
+    /// ```ignore
+    /// let instrument = Arc::new("ES".to_string());
+    /// let trades = client.fetch_trades(&params, exchange, instrument).await?;
+    /// ```
     ///
     /// # Returns
     ///
@@ -135,13 +150,20 @@ impl DatabentoHistorical {
 
     /// Fetch historical quotes (top-of-book) for the given parameters.
     ///
-    /// Uses MBP-1 (Market By Price level 1) schema.
+    /// Uses MBP-1 (Market By Price level 1) schema. Collects all records into
+    /// memory before returning. For large queries, consider
+    /// [`fetch_quotes_stream`](Self::fetch_quotes_stream).
     ///
     /// # Arguments
     ///
     /// * `params` - Query parameters (dataset, symbols, time range). Schema should be Mbp1.
     /// * `exchange` - ExchangeId to tag events with
     /// * `instrument` - Instrument key to tag events with
+    ///
+    /// # Performance
+    ///
+    /// The instrument key is cloned for each record. For high-frequency data,
+    /// use [`Arc<K>`](std::sync::Arc) to avoid per-record heap allocations.
     ///
     /// Each event's `time_received` is stamped at decode time on the local machine.
     pub async fn fetch_quotes<K: Clone>(
@@ -186,6 +208,152 @@ impl DatabentoHistorical {
         Ok(quotes)
     }
 
+    /// Stream historical trades without collecting into memory.
+    ///
+    /// Unlike [`fetch_trades`](Self::fetch_trades), this returns a stream that
+    /// yields records as they're decoded, avoiding memory spikes for large queries.
+    ///
+    /// # Arguments
+    ///
+    /// * `params` - Query parameters (dataset, symbols, time range)
+    /// * `exchange` - ExchangeId to tag events with
+    /// * `instrument` - Instrument key to tag events with (use `Arc<K>` for efficiency)
+    ///
+    /// # Errors
+    ///
+    /// The outer `Result` returns [`DataError::Databento`] if the initial
+    /// `get_range` request fails (e.g. authentication, network, or invalid
+    /// params).
+    ///
+    /// Per-item errors are yielded as `Err` items on the stream and indicate
+    /// a DBN decode failure. After a decode error the underlying decoder is
+    /// in an unspecified state; callers should drop the stream rather than
+    /// continue polling for more records. Records that successfully decode
+    /// but fail conversion to [`PublicTrade`] are logged at `debug` and
+    /// skipped silently.
+    pub async fn fetch_trades_stream<K: Clone + Send + 'static>(
+        &mut self,
+        params: &GetRangeParams,
+        exchange: ExchangeId,
+        instrument: K,
+    ) -> Result<impl Stream<Item = Result<MarketEvent<K, PublicTrade>, DataError>>, DataError> {
+        debug!(?params, "Streaming historical trades from Databento");
+
+        let decoder = self
+            .client
+            .timeseries()
+            .get_range(params)
+            .await
+            .with_context("fetching trades")?;
+
+        Ok(futures::stream::unfold(
+            TradeStreamState {
+                decoder,
+                exchange,
+                instrument,
+            },
+            |mut state| async move {
+                loop {
+                    match state.decoder.decode_record::<dbn::TradeMsg>().await {
+                        Ok(Some(record)) => match dbn_trade_to_public_trade(record) {
+                            Ok((time_exchange, trade)) => {
+                                let event = MarketEvent {
+                                    time_exchange,
+                                    time_received: Utc::now(),
+                                    exchange: state.exchange,
+                                    instrument: state.instrument.clone(),
+                                    kind: trade,
+                                };
+                                return Some((Ok(event), state));
+                            }
+                            Err(e) => {
+                                debug!(error = %e, "Skipping invalid trade record");
+                                continue;
+                            }
+                        },
+                        Ok(None) => return None,
+                        Err(e) => {
+                            return Some((Err(decode_error(e.to_string())), state));
+                        }
+                    }
+                }
+            },
+        ))
+    }
+
+    /// Stream historical quotes without collecting into memory.
+    ///
+    /// Unlike [`fetch_quotes`](Self::fetch_quotes), this returns a stream that
+    /// yields records as they're decoded, avoiding memory spikes for large queries.
+    ///
+    /// # Arguments
+    ///
+    /// * `params` - Query parameters (dataset, symbols, time range). Schema should be Mbp1.
+    /// * `exchange` - ExchangeId to tag events with
+    /// * `instrument` - Instrument key to tag events with (use `Arc<K>` for efficiency)
+    ///
+    /// # Errors
+    ///
+    /// The outer `Result` returns [`DataError::Databento`] if the initial
+    /// `get_range` request fails (e.g. authentication, network, or invalid
+    /// params).
+    ///
+    /// Per-item errors are yielded as `Err` items on the stream and indicate
+    /// a DBN decode failure. After a decode error the underlying decoder is
+    /// in an unspecified state; callers should drop the stream rather than
+    /// continue polling for more records. Records that successfully decode
+    /// but fail conversion to [`Quote`] are logged at `debug` and skipped
+    /// silently.
+    pub async fn fetch_quotes_stream<K: Clone + Send + 'static>(
+        &mut self,
+        params: &GetRangeParams,
+        exchange: ExchangeId,
+        instrument: K,
+    ) -> Result<impl Stream<Item = Result<MarketEvent<K, Quote>, DataError>>, DataError> {
+        debug!(?params, "Streaming historical quotes from Databento");
+
+        let decoder = self
+            .client
+            .timeseries()
+            .get_range(params)
+            .await
+            .with_context("fetching quotes")?;
+
+        Ok(futures::stream::unfold(
+            QuoteStreamState {
+                decoder,
+                exchange,
+                instrument,
+            },
+            |mut state| async move {
+                loop {
+                    match state.decoder.decode_record::<dbn::Mbp1Msg>().await {
+                        Ok(Some(record)) => match dbn_mbp1_to_quote(record) {
+                            Ok((time_exchange, quote)) => {
+                                let event = MarketEvent {
+                                    time_exchange,
+                                    time_received: Utc::now(),
+                                    exchange: state.exchange,
+                                    instrument: state.instrument.clone(),
+                                    kind: quote,
+                                };
+                                return Some((Ok(event), state));
+                            }
+                            Err(e) => {
+                                debug!(error = %e, "Skipping invalid quote record");
+                                continue;
+                            }
+                        },
+                        Ok(None) => return None,
+                        Err(e) => {
+                            return Some((Err(decode_error(e.to_string())), state));
+                        }
+                    }
+                }
+            },
+        ))
+    }
+
     /// Returns the underlying client for advanced use cases.
     pub fn client(&self) -> &HistoricalClient {
         &self.client
@@ -206,19 +374,19 @@ impl DatabentoHistorical {
 ///
 /// * `path` - Path to `.dbn` or `.dbn.zst` file
 /// * `exchange` - ExchangeId to tag events with
-/// * `instrument` - Instrument key to tag events with
+/// * `instrument` - Instrument key to tag events with (use `Arc<K>` for efficiency)
 ///
 /// # Errors
 ///
-/// Returns [`DataError::Socket`] if the file cannot be opened or the DBN
+/// Returns [`DataError::Databento`] if the file cannot be opened or the DBN
 /// header is invalid.
 pub fn load_trades_from_dbn<K: Clone>(
     path: &Path,
     exchange: ExchangeId,
     instrument: K,
 ) -> Result<impl Iterator<Item = Result<MarketEvent<K, PublicTrade>, DataError>>, DataError> {
-    let decoder = DynDecoder::from_file(path, VersionUpgradePolicy::AsIs)
-        .map_err(|e| DataError::Socket(format!("opening DBN file: {e}")))?;
+    let decoder =
+        DynDecoder::from_file(path, VersionUpgradePolicy::AsIs).with_context("opening DBN file")?;
 
     Ok(DbnTradeIterator {
         decoder,
@@ -229,23 +397,42 @@ pub fn load_trades_from_dbn<K: Clone>(
 
 /// Load quotes from a pre-downloaded DBN file.
 ///
+/// # Arguments
+///
+/// * `path` - Path to `.dbn` or `.dbn.zst` file
+/// * `exchange` - ExchangeId to tag events with
+/// * `instrument` - Instrument key to tag events with (use `Arc<K>` for efficiency)
+///
 /// # Errors
 ///
-/// Returns [`DataError::Socket`] if the file cannot be opened or the DBN
+/// Returns [`DataError::Databento`] if the file cannot be opened or the DBN
 /// header is invalid.
 pub fn load_quotes_from_dbn<K: Clone>(
     path: &Path,
     exchange: ExchangeId,
     instrument: K,
 ) -> Result<impl Iterator<Item = Result<MarketEvent<K, Quote>, DataError>>, DataError> {
-    let decoder = DynDecoder::from_file(path, VersionUpgradePolicy::AsIs)
-        .map_err(|e| DataError::Socket(format!("opening DBN file: {e}")))?;
+    let decoder =
+        DynDecoder::from_file(path, VersionUpgradePolicy::AsIs).with_context("opening DBN file")?;
 
     Ok(DbnQuoteIterator {
         decoder,
         exchange,
         instrument,
     })
+}
+
+// Stream state types for async streaming
+struct TradeStreamState<K, D> {
+    decoder: D,
+    exchange: ExchangeId,
+    instrument: K,
+}
+
+struct QuoteStreamState<K, D> {
+    decoder: D,
+    exchange: ExchangeId,
+    instrument: K,
 }
 
 struct DbnTradeIterator<K> {
@@ -277,7 +464,7 @@ impl<K: Clone> Iterator for DbnTradeIterator<K> {
                 },
                 Ok(None) => return None,
                 Err(e) => {
-                    return Some(Err(DataError::Socket(format!("decoding DBN record: {e}"))));
+                    return Some(Err(decode_error(e.to_string())));
                 }
             }
         }
@@ -313,7 +500,7 @@ impl<K: Clone> Iterator for DbnQuoteIterator<K> {
                 },
                 Ok(None) => return None,
                 Err(e) => {
-                    return Some(Err(DataError::Socket(format!("decoding DBN record: {e}"))));
+                    return Some(Err(decode_error(e.to_string())));
                 }
             }
         }

--- a/rustrade-data/src/exchange/databento/live.rs
+++ b/rustrade-data/src/exchange/databento/live.rs
@@ -46,7 +46,7 @@
 //! }
 //! ```
 
-use super::error::DatabentoResultExt;
+use super::error::{DatabentoErrorKind, DatabentoResultExt};
 use super::transformer::{dbn_mbp1_to_orderbook_l1, dbn_trade_to_public_trade};
 use crate::error::DataError;
 use crate::event::{DataKind, MarketEvent};
@@ -71,6 +71,19 @@ use tracing::{debug, trace, warn};
 ///
 /// Consolidate symbol subscriptions within one `DatabentoLive` instance per dataset
 /// rather than creating multiple instances for the same dataset.
+///
+/// # Performance
+///
+/// The instrument key is cloned for each record. For high-frequency data, use
+/// [`Arc<K>`](std::sync::Arc) to avoid per-record heap allocations:
+///
+/// ```ignore
+/// use std::sync::Arc;
+///
+/// let instruments: HashMap<String, Arc<String>> = [
+///     ("ESM5".to_string(), Arc::new("ES-front".to_string())),
+/// ].into_iter().collect();
+/// ```
 #[derive(Debug)]
 pub struct DatabentoLive<K> {
     client: LiveClient,
@@ -225,7 +238,11 @@ impl<K: Clone + Send + 'static> DatabentoLive<K> {
                             return None;
                         }
                         Err(e) => {
-                            let err = DataError::Socket(format!("receiving record: {e}"));
+                            let err = DataError::Databento {
+                                kind: DatabentoErrorKind::Network,
+                                context: "receiving record".to_string(),
+                                message: e.to_string(),
+                            };
                             return Some((Err(err), state));
                         }
                     };

--- a/rustrade-data/src/exchange/databento/mod.rs
+++ b/rustrade-data/src/exchange/databento/mod.rs
@@ -48,5 +48,6 @@ pub mod historical;
 pub mod live;
 pub(crate) mod transformer;
 
+pub use error::DatabentoErrorKind;
 pub use historical::{DatabentoHistorical, load_quotes_from_dbn, load_trades_from_dbn};
 pub use live::DatabentoLive;


### PR DESCRIPTION
## Summary
- Add streaming APIs (`get_range_stream`, `get_range_to_file_stream`) for memory-efficient historical data retrieval with backpressure support
- Introduce `DatabentoErrorKind` enum for programmatic error classification (authentication, rate limiting, data errors, etc.)
- Document `Arc<K>` pattern for high-frequency instrument key scenarios to reduce clone overhead

Closes #45, #46, #47

## Test plan
- [x] Verify streaming APIs handle large date ranges without memory spikes
- [x] Confirm error kinds are correctly classified from API responses
- [x] Check that existing non-streaming APIs still work as expected