### PR TITLE
feat(async-trait): Migrate from async_trait to native AFIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: Migrate from `async_trait` to native AFIT** ([#85](https://github.com/Niqnil/rustrade/issues/85))
+  - `Subscriber`, `SubscriptionValidator`, `ExchangeTransformer`, and `MarketStream` traits now use native async fn in trait (Rust 1.75+)
+  - Removed `async-trait` crate dependency
+  - Additional `Sync` bounds added to some generic parameters where required
+  - Return type changed from `Pin<Box<dyn Future + Send>>` to opaque `impl Future + Send`
+  - No code changes required for most downstream users unless explicitly naming future types
+
 - **Databento structured error types** ([#47](https://github.com/Niqnil/rustrade/issues/47))
   - New `DatabentoErrorKind` enum: `Authentication`, `RateLimit`, `Network`, `Decode`, `Api`
   - New `DataError::Databento { kind, context, message }` variant for programmatic error handling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ tokio-test = { version = "0.4.4" }
 futures = { version = "0.3.31" }
 futures-util = { version = "0.3.31" }
 async-stream = { version = "0.3" }
-async-trait = { version = "0.1.83" }
 pin-project = { version = "1.1.7" }
 
 # Error

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -41,7 +41,6 @@ tokio-stream = { workspace = true, features = ["sync"] }
 futures = { workspace = true }
 futures-util = { workspace = true }
 async-stream = { workspace = true, optional = true }
-async-trait = { workspace = true }
 
 # Protocol
 url = { workspace = true }

--- a/rustrade-data/src/exchange/alpaca/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/mod.rs
@@ -63,7 +63,6 @@ use crate::{
     },
     subscription::{quote::Quotes, trade::PublicTrades},
 };
-use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
 use rustrade_instrument::exchange::ExchangeId;
 use rustrade_integration::{
@@ -324,7 +323,6 @@ impl AlpacaSubscriber {
     }
 }
 
-#[async_trait]
 impl crate::subscriber::Subscriber for AlpacaSubscriber {
     type SubMapper = crate::subscriber::mapper::WebSocketSubMapper;
 

--- a/rustrade-data/src/exchange/alpaca/quote.rs
+++ b/rustrade-data/src/exchange/alpaca/quote.rs
@@ -7,7 +7,6 @@ use crate::{
     subscription::{Map, quote::Quote},
     transformer::ExchangeTransformer,
 };
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use rustrade_instrument::exchange::ExchangeId;
@@ -111,13 +110,12 @@ pub struct AlpacaQuoteTransformer<Exchange, InstrumentKey> {
     phantom: PhantomData<Exchange>,
 }
 
-#[async_trait]
 impl<Exchange, InstrumentKey>
     ExchangeTransformer<Exchange, InstrumentKey, crate::subscription::quote::Quotes>
     for AlpacaQuoteTransformer<Exchange, InstrumentKey>
 where
     Exchange: crate::exchange::Connector + Send,
-    InstrumentKey: Clone + Send,
+    InstrumentKey: Clone + Send + Sync,
 {
     async fn init(
         instrument_map: Map<InstrumentKey>,

--- a/rustrade-data/src/exchange/alpaca/trade.rs
+++ b/rustrade-data/src/exchange/alpaca/trade.rs
@@ -7,7 +7,6 @@ use crate::{
     subscription::{Map, trade::PublicTrade},
     transformer::ExchangeTransformer,
 };
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use rustrade_instrument::{Side, exchange::ExchangeId};
@@ -127,13 +126,12 @@ pub struct AlpacaTradeTransformer<Exchange, InstrumentKey> {
     phantom: PhantomData<Exchange>,
 }
 
-#[async_trait]
 impl<Exchange, InstrumentKey>
     ExchangeTransformer<Exchange, InstrumentKey, crate::subscription::trade::PublicTrades>
     for AlpacaTradeTransformer<Exchange, InstrumentKey>
 where
     Exchange: crate::exchange::Connector + Send,
-    InstrumentKey: Clone + Send,
+    InstrumentKey: Clone + Send + Sync,
 {
     async fn init(
         instrument_map: Map<InstrumentKey>,

--- a/rustrade-data/src/exchange/binance/futures/l2.rs
+++ b/rustrade-data/src/exchange/binance/futures/l2.rs
@@ -19,7 +19,6 @@ use crate::{
     },
     transformer::ExchangeTransformer,
 };
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures_util::future::try_join_all;
 use rustrade_instrument::exchange::ExchangeId;
@@ -86,7 +85,6 @@ pub struct BinanceFuturesUsdOrderBooksL2Transformer<InstrumentKey> {
         Map<BinanceOrderBookL2Meta<InstrumentKey, BinanceFuturesUsdOrderBookL2Sequencer>>,
 }
 
-#[async_trait]
 impl<InstrumentKey> ExchangeTransformer<BinanceFuturesUsd, InstrumentKey, OrderBooksL2>
     for BinanceFuturesUsdOrderBooksL2Transformer<InstrumentKey>
 where

--- a/rustrade-data/src/exchange/binance/spot/l2.rs
+++ b/rustrade-data/src/exchange/binance/spot/l2.rs
@@ -19,7 +19,6 @@ use crate::{
     },
     transformer::ExchangeTransformer,
 };
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures_util::future::try_join_all;
 use rustrade_instrument::exchange::ExchangeId;
@@ -81,7 +80,6 @@ pub struct BinanceSpotOrderBooksL2Transformer<InstrumentKey> {
     instrument_map: Map<BinanceOrderBookL2Meta<InstrumentKey, BinanceSpotOrderBookL2Sequencer>>,
 }
 
-#[async_trait]
 impl<InstrumentKey> ExchangeTransformer<BinanceSpot, InstrumentKey, OrderBooksL2>
     for BinanceSpotOrderBooksL2Transformer<InstrumentKey>
 where

--- a/rustrade-data/src/exchange/bitfinex/validator.rs
+++ b/rustrade-data/src/exchange/bitfinex/validator.rs
@@ -5,7 +5,6 @@ use crate::{
     subscriber::validator::SubscriptionValidator,
     subscription::{Map, SubscriptionKind},
 };
-use async_trait::async_trait;
 use futures::StreamExt;
 use rustrade_integration::{
     Validator,
@@ -34,7 +33,6 @@ use tracing::debug;
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct BitfinexWebSocketSubValidator;
 
-#[async_trait]
 impl SubscriptionValidator for BitfinexWebSocketSubValidator {
     type Parser = WebSocketSerdeParser;
 

--- a/rustrade-data/src/exchange/bybit/book/l2.rs
+++ b/rustrade-data/src/exchange/bybit/book/l2.rs
@@ -14,7 +14,6 @@ use crate::{
     },
     transformer::ExchangeTransformer,
 };
-use async_trait::async_trait;
 use derive_more::Constructor;
 use rustrade_integration::{Transformer, protocol::websocket::WsMessage};
 use tokio::sync::mpsc::UnboundedSender;
@@ -33,11 +32,11 @@ pub struct BybitOrderBooksL2Transformer<InstrumentKey> {
     instrument_map: Map<BybitOrderBookL2Meta<InstrumentKey, BybitOrderBookL2Sequencer>>,
 }
 
-#[async_trait]
 impl<InstrumentKey, Server> ExchangeTransformer<Bybit<Server>, InstrumentKey, OrderBooksL2>
     for BybitOrderBooksL2Transformer<InstrumentKey>
 where
     InstrumentKey: Clone + PartialEq + Send + Sync,
+    Server: Send,
 {
     async fn init(
         instrument_map: Map<InstrumentKey>,

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -115,7 +115,6 @@ use crate::{
     subscription::{Subscription, SubscriptionKind},
     transformer::ExchangeTransformer,
 };
-use async_trait::async_trait;
 use futures::{SinkExt, Stream, StreamExt};
 use rustrade_instrument::exchange::ExchangeId;
 use rustrade_integration::{
@@ -189,7 +188,6 @@ pub trait Identifier<T> {
 
 /// [`Stream`] that yields [`Market<Kind>`](MarketEvent) events. The type of [`Market<Kind>`](MarketEvent)
 /// depends on the provided [`SubscriptionKind`] of the passed [`Subscription`]s.
-#[async_trait]
 pub trait MarketStream<Exchange, Instrument, Kind>
 where
     Self: Stream<Item = Result<MarketEvent<Instrument::Key, Kind::Event>, DataError>>
@@ -200,10 +198,10 @@ where
     Instrument: InstrumentData,
     Kind: SubscriptionKind,
 {
-    async fn init<SnapFetcher>(
+    fn init<SnapFetcher>(
         subscriber: &Exchange::Subscriber,
         subscriptions: &[Subscription<Exchange, Instrument, Kind>],
-    ) -> Result<Self, DataError>
+    ) -> impl Future<Output = Result<Self, DataError>> + Send
     where
         SnapFetcher: SnapshotFetcher<Exchange, Kind>,
         Subscription<Exchange, Instrument, Kind>:
@@ -229,7 +227,6 @@ pub trait SnapshotFetcher<Exchange, Kind> {
         Subscription<Exchange, Instrument, Kind>: Identifier<Exchange::Market>;
 }
 
-#[async_trait]
 impl<Exchange, Instrument, Kind, Transformer, Parser> MarketStream<Exchange, Instrument, Kind>
     for ExchangeWsStream<Parser, Transformer>
 where
@@ -237,7 +234,7 @@ where
     Instrument: InstrumentData,
     Kind: SubscriptionKind + Send + Sync,
     Transformer: ExchangeTransformer<Exchange, Instrument::Key, Kind> + Send,
-    Kind::Event: Send,
+    Kind::Event: Send + Sync,
     Parser: StreamParser<Transformer::Input, Message = WsMessage, Error = WsError> + Send,
 {
     async fn init<SnapFetcher>(
@@ -344,8 +341,8 @@ where
 /// the [`WsSink`].
 ///
 /// **Note:**
-/// ExchangeTransformer is operating in a synchronous trait context so we use this separate task
-/// to avoid adding `#[\async_trait\]` to the transformer - this avoids allocations.
+/// [`Transformer`] is a synchronous trait, so we use this separate task to handle
+/// async WebSocket writes without requiring the transformer to be async.
 pub async fn distribute_messages_to_exchange(
     exchange: ExchangeId,
     mut ws_sink: WsSink,

--- a/rustrade-data/src/streams/builder/dynamic/mod.rs
+++ b/rustrade-data/src/streams/builder/dynamic/mod.rs
@@ -82,7 +82,7 @@ impl<InstrumentKey> DynamicStreams<InstrumentKey> {
         SubIter: IntoIterator<Item = Sub>,
         Sub: Into<Subscription<ExchangeId, Instrument, SubKind>>,
         Instrument: InstrumentData<Key = InstrumentKey> + Ord + Display + 'static,
-        InstrumentKey: Debug + Clone + Send + 'static,
+        InstrumentKey: Debug + Clone + PartialEq + Send + Sync + 'static,
         Subscription<BinanceSpot, Instrument, PublicTrades>: Identifier<BinanceMarket>,
         Subscription<BinanceSpot, Instrument, OrderBooksL1>: Identifier<BinanceMarket>,
         Subscription<BinanceSpot, Instrument, OrderBooksL2>: Identifier<BinanceMarket>,

--- a/rustrade-data/src/subscriber/mod.rs
+++ b/rustrade-data/src/subscriber/mod.rs
@@ -8,14 +8,13 @@ use crate::{
     instrument::InstrumentData,
     subscription::{Map, Subscription, SubscriptionKind, SubscriptionMeta},
 };
-use async_trait::async_trait;
 use futures::SinkExt;
 use rustrade_integration::{
     error::SocketError,
     protocol::websocket::{WebSocket, WsMessage, connect},
 };
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use std::{fmt::Debug, future::Future};
 use tracing::debug;
 
 /// [`SubscriptionMapper`] implementations defining how to map a
@@ -31,14 +30,13 @@ pub mod validator;
 /// Subscribers may carry state such as authentication credentials.
 /// The trait requires `Clone` to support reconnection (subscribers are cloned
 /// into the reconnect closure).
-#[async_trait]
 pub trait Subscriber: Clone + Send + Sync {
     type SubMapper: SubscriptionMapper;
 
-    async fn subscribe<Exchange, Instrument, Kind>(
+    fn subscribe<Exchange, Instrument, Kind>(
         &self,
         subscriptions: &[Subscription<Exchange, Instrument, Kind>],
-    ) -> Result<Subscribed<Instrument::Key>, SocketError>
+    ) -> impl Future<Output = Result<Subscribed<Instrument::Key>, SocketError>> + Send
     where
         Exchange: Connector + Send + Sync,
         Kind: SubscriptionKind + Send + Sync,
@@ -62,7 +60,6 @@ pub struct Subscribed<InstrumentKey> {
 )]
 pub struct WebSocketSubscriber;
 
-#[async_trait]
 impl Subscriber for WebSocketSubscriber {
     type SubMapper = WebSocketSubMapper;
 

--- a/rustrade-data/src/subscriber/validator.rs
+++ b/rustrade-data/src/subscriber/validator.rs
@@ -2,7 +2,6 @@ use crate::{
     exchange::Connector,
     subscription::{Map, SubscriptionKind},
 };
-use async_trait::async_trait;
 use futures::StreamExt;
 use rustrade_integration::{
     Validator,
@@ -13,18 +12,18 @@ use rustrade_integration::{
     },
 };
 use serde::{Deserialize, Serialize};
+use std::future::Future;
 use tracing::debug;
 
 /// Defines how to validate that actioned market data
 /// [`Subscription`](crate::subscription::Subscription)s were accepted by the exchange.
-#[async_trait]
 pub trait SubscriptionValidator {
     type Parser;
 
-    async fn validate<Exchange, InstrumentKey, Kind>(
+    fn validate<Exchange, InstrumentKey, Kind>(
         instrument_map: Map<InstrumentKey>,
         websocket: &mut WebSocket,
-    ) -> Result<(Map<InstrumentKey>, Vec<WsMessage>), SocketError>
+    ) -> impl Future<Output = Result<(Map<InstrumentKey>, Vec<WsMessage>), SocketError>> + Send
     where
         Exchange: Connector + Send,
         InstrumentKey: Send,
@@ -35,7 +34,6 @@ pub trait SubscriptionValidator {
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct WebSocketSubValidator;
 
-#[async_trait]
 impl SubscriptionValidator for WebSocketSubValidator {
     type Parser = WebSocketSerdeParser;
 

--- a/rustrade-data/src/transformer/mod.rs
+++ b/rustrade-data/src/transformer/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     event::MarketEvent,
     subscription::{Map, SubscriptionKind},
 };
-use async_trait::async_trait;
 use rustrade_integration::{Transformer, protocol::websocket::WsMessage};
+use std::future::Future;
 use tokio::sync::mpsc;
 
 /// Generic stateless [`ExchangeTransformer`] often used for transforming
@@ -13,7 +13,6 @@ pub mod stateless;
 
 /// Defines how to construct a [`Transformer`] used by [`MarketStream`](super::MarketStream)s to
 /// translate exchange specific types to normalised Barter types.
-#[async_trait]
 pub trait ExchangeTransformer<Exchange, InstrumentKey, Kind>
 where
     Self: Transformer<Output = MarketEvent<InstrumentKey, Kind::Event>, Error = DataError> + Sized,
@@ -23,9 +22,12 @@ where
     /// associated Exchange and SubscriptionKind market stream to function.
     ///
     /// The [`mpsc::UnboundedSender`] can be used by [`Self`] to send messages back to the exchange.
-    async fn init(
+    fn init(
         instrument_map: Map<InstrumentKey>,
         initial_snapshots: &[MarketEvent<InstrumentKey, Kind::Event>],
         ws_sink_tx: mpsc::UnboundedSender<WsMessage>,
-    ) -> Result<Self, DataError>;
+    ) -> impl Future<Output = Result<Self, DataError>> + Send
+    where
+        InstrumentKey: Sync,
+        Kind::Event: Sync;
 }

--- a/rustrade-data/src/transformer/stateless.rs
+++ b/rustrade-data/src/transformer/stateless.rs
@@ -6,7 +6,6 @@ use crate::{
     exchange::Connector,
     subscription::{Map, SubscriptionKind},
 };
-use async_trait::async_trait;
 use rustrade_instrument::exchange::ExchangeId;
 use rustrade_integration::{
     Transformer, protocol::websocket::WsMessage, subscription::SubscriptionId,
@@ -25,13 +24,13 @@ pub struct StatelessTransformer<Exchange, InstrumentKey, Kind, Input> {
     phantom: PhantomData<(Exchange, Kind, Input)>,
 }
 
-#[async_trait]
 impl<Exchange, InstrumentKey, Kind, Input> ExchangeTransformer<Exchange, InstrumentKey, Kind>
     for StatelessTransformer<Exchange, InstrumentKey, Kind, Input>
 where
     Exchange: Connector + Send,
-    InstrumentKey: Clone + Send,
+    InstrumentKey: Clone + Send + Sync,
     Kind: SubscriptionKind + Send,
+    Kind::Event: Sync,
     Input: Identifier<Option<SubscriptionId>> + for<'de> Deserialize<'de>,
     MarketIter<InstrumentKey, Kind::Event>: From<(ExchangeId, InstrumentKey, Input)>,
 {


### PR DESCRIPTION
## Summary

Closes #85

- Remove `async-trait` crate from workspace and rustrade-data dependencies
- Migrate 4 traits to native async fn in trait (AFIT, Rust 1.75+): `Subscriber`, `SubscriptionValidator`, `ExchangeTransformer`, `MarketStream`
- Add required `Sync` bounds to generic parameters where needed by AFIT's stricter opaque future semantics
- Update CHANGELOG with breaking change notice

## Breaking Changes

- Return type changes from `Pin<Box<dyn Future + Send>>` to opaque `impl Future + Send`
- Additional `Sync` bounds on some generic parameters (`InstrumentKey`, `Kind::Event`)
- No code changes required for most downstream users unless explicitly naming future types

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes (correctness/suspicious/style/perf)
- [x] Unit tests: 267 passed
- [x] Alpaca integration: 6 passed (failures are connection/subscription limits)
- [x] Massive integration: 17 passed, including live WebSocket crypto test with BTC-USD trades