### PR TITLE
chore: Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0]
+
 ### Added
 
 - **Databento streaming variants** ([#46](https://github.com/Niqnil/rustrade/issues/46))
@@ -180,7 +182,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously, repeated test runs would fail with "client id already in use" until IB Gateway
     was restarted
 
-## [0.1.0] - 2026-05-01
+## [0.1.0]
 
 Initial release of rustrade, a fork of [barter-rs](https://github.com/barter-rs/barter-rs).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ categories = ["finance", "simulation"]
 
 [workspace.dependencies]
 # Rustrade Ecosystem
-rustrade-integration = { path = "./rustrade-integration", version = "0.1" }
-rustrade-instrument = { path = "./rustrade-instrument", version = "0.1" }
-rustrade-data = { path = "./rustrade-data", version = "0.1" }
-rustrade-execution = { path = "./rustrade-execution", version = "0.1" }
-rustrade-macro = { path = "./rustrade-macro", version = "0.1" }
+rustrade-integration = { path = "./rustrade-integration", version = "0.2" }
+rustrade-instrument = { path = "./rustrade-instrument", version = "0.2" }
+rustrade-data = { path = "./rustrade-data", version = "0.2" }
+rustrade-execution = { path = "./rustrade-execution", version = "0.2" }
+rustrade-macro = { path = "./rustrade-macro", version = "0.2" }
 
 # Logging
 tracing = { version = "0.1.41" }

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-data"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-execution/Cargo.toml
+++ b/rustrade-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-execution"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-instrument/Cargo.toml
+++ b/rustrade-instrument/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-instrument"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-integration/Cargo.toml
+++ b/rustrade-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-integration"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-macro/Cargo.toml
+++ b/rustrade-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-macro"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade/Cargo.toml
+++ b/rustrade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Version bump for v0.2.0 release.

- Bump all crate versions from 0.1.0 to 0.2.0
- Bump workspace dependency versions from 0.1 to 0.2
- Add `## [0.2.0]` header in CHANGELOG.md

## Next Steps

After merging, create PR from `develop` → `main` to release.