### PR TITLE
docs: Update READMEs for v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,16 @@ rustrade is a collection of Rust libraries for live-trading, paper-trading, and 
 | Exchange | Market Data | Execution | Notes |
 |----------|-------------|-----------|-------|
 | **Binance** | ✅ Spot | ✅ Spot | WebSocket + REST |
-| **Alpaca** | ✅ Equities (IEX/SIP), Crypto | ✅ Equities, Options, Crypto | WebSocket + REST |
+| **Alpaca** | ✅ Equities (IEX/SIP), Crypto, Options | ✅ Equities, Options, Crypto | WebSocket + REST |
 | **Hyperliquid** | ✅ Perps, Spot | ✅ Perps, Spot | WebSocket + REST |
 | **Interactive Brokers** | ✅ All asset classes | ✅ All asset classes | TWS/Gateway API |
+
+### Data Providers
+
+| Provider | Asset Classes | Notes |
+|----------|---------------|-------|
+| **Massive** | Stocks, Crypto, Forex, Options, Futures | Historical + live streaming |
+| **Databento** | Equities, Futures, Options | Nanosecond precision, DBN format |
 
 ## Quick Start
 
@@ -59,9 +66,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustrade = "0.1"
-rustrade-data = { version = "0.1", features = ["hyperliquid"] }
-rustrade-execution = { version = "0.1", features = ["binance"] }
+rustrade = "0.2"
+rustrade-data = { version = "0.2", features = ["hyperliquid"] }
+rustrade-execution = { version = "0.2", features = ["binance"] }
 ```
 
 See the [examples](https://github.com/Niqnil/rustrade/tree/main/rustrade/examples) for complete working code.

--- a/rustrade-data/README.md
+++ b/rustrade-data/README.md
@@ -1,13 +1,13 @@
 # rustrade-data
 
-WebSocket integration library for streaming public market data from exchanges.
+Integration library for streaming public market data from exchanges and data providers.
 
 ## Supported Exchanges
 
 | Exchange | Constructor | InstrumentKinds | SubscriptionKinds |
 |:--------:|:-----------:|:---------------:|:-----------------:|
-| **BinanceSpot** | `BinanceSpot::default()` | Spot | PublicTrades, OrderBooksL1, OrderBooksL2 |
-| **BinanceFuturesUsd** | `BinanceFuturesUsd::default()` | Perpetual | PublicTrades, OrderBooksL1, OrderBooksL2, Liquidations |
+| **BinanceSpot** | `BinanceSpot::default()` | Spot | PublicTrades, Quotes, OrderBooksL1, OrderBooksL2 |
+| **BinanceFuturesUsd** | `BinanceFuturesUsd::default()` | Perpetual | PublicTrades, Quotes, OrderBooksL1, OrderBooksL2, Liquidations |
 | **Bitfinex** | `Bitfinex` | Spot | PublicTrades |
 | **Bitmex** | `Bitmex` | Perpetual | PublicTrades |
 | **BybitSpot** | `BybitSpot::default()` | Spot | PublicTrades, OrderBooksL1, OrderBooksL2 |
@@ -23,6 +23,17 @@ WebSocket integration library for streaming public market data from exchanges.
 | **Okx** | `Okx` | Spot, Future, Perpetual, Option | PublicTrades |
 | **Hyperliquid** | `Hyperliquid::default()` | Perpetual | PublicTrades, OrderBooksL2 |
 | **HyperliquidSpot** | `HyperliquidSpot::default()` | Spot | PublicTrades, OrderBooksL2 |
-| **IBKR** | `IbkrMarketStream::connect()` | Spot, Future, Option | PublicTrades, OrderBooksL1, OrderBooksL2, Candles |
+| **IBKR** | `IbkrMarketStream::connect()` | Spot, Future, Option | PublicTrades, Quotes, OrderBooksL1, OrderBooksL2, Candles, OptionGreeks |
+| **AlpacaIex** | `AlpacaIex::new(credentials)` | Spot (Equities) | PublicTrades, Quotes |
+| **AlpacaSip** | `AlpacaSip::new(credentials)` | Spot (Equities) | PublicTrades, Quotes |
+| **AlpacaCrypto** | `AlpacaCrypto::new(credentials)` | Spot (Crypto) | PublicTrades, Quotes |
+| **AlpacaOptionsClient** | `AlpacaOptionsClient::new(credentials)` | Option | Quotes, OptionGreeks (REST snapshots) |
+
+## Data Providers
+
+| Provider | Constructor | InstrumentKinds | SubscriptionKinds |
+|:--------:|:-----------:|:---------------:|:-----------------:|
+| **Massive** | `MassiveRestClient` / `MassiveLive` | Spot, Future, Option | PublicTrades, Quotes, Candles |
+| **Databento** | `DatabentoHistorical` / `DatabentoLive` | Spot, Future, Option | PublicTrades, Quotes |
 
 See the [workspace README](../README.md) for documentation, examples, and contributing guidelines.

--- a/rustrade-execution/README.md
+++ b/rustrade-execution/README.md
@@ -7,9 +7,20 @@ Execution client library for streaming private account data and executing orders
 | Exchange | Constructor | InstrumentKinds | Features |
 |:--------:|:-----------:|:---------------:|:--------:|
 | **Binance** | `BinanceClient::connect()` | Spot | Orders, Balances, Positions |
-| **Alpaca** | `AlpacaClient::connect()` | Spot (Equities, Crypto) | Orders, Balances, Positions |
+| **Alpaca** | `AlpacaClient::connect()` | Spot (Equities, Crypto), Option | Orders, Balances, Positions, BracketOrders |
 | **Hyperliquid** | `HyperliquidClient::connect()` | Perpetual | Orders, Balances, Positions |
 | **HyperliquidSpot** | `HyperliquidSpotClient::connect()` | Spot | Orders, Balances, Positions |
-| **IBKR** | `IbkrClient::connect()` | Spot, Future, Option | Orders, Balances, Positions |
+| **IBKR** | `IbkrClient::connect()` | Spot, Future, Option | Orders, Balances, Positions, BracketOrders |
+
+## Order Types
+
+All connectors support Market and Limit orders. Additional order types:
+
+| Order Type | IBKR | Alpaca | Binance | Hyperliquid |
+|:----------:|:----:|:------:|:-------:|:-----------:|
+| Stop | ✅ | ✅ | ❌ | ❌ |
+| StopLimit | ✅ | ✅ | ❌ | ❌ |
+| TrailingStop | ✅ | ✅ | ❌ | ❌ |
+| TrailingStopLimit | ✅ | ❌ | ❌ | ❌ |
 
 See the [workspace README](../README.md) for documentation, examples, and contributing guidelines.

--- a/rustrade-execution/src/fill.rs
+++ b/rustrade-execution/src/fill.rs
@@ -13,6 +13,14 @@ use serde::{Deserialize, Serialize};
 /// Live execution clients receive real fill prices from the venue — they do
 /// not use `FillModel`.
 ///
+/// # Extensibility
+///
+/// Implement this trait to model slippage, market impact, or other execution
+/// dynamics. The built-in models ([`LastPriceFillModel`], [`BidAskFillModel`],
+/// [`MidpointFillModel`]) provide baseline behavior; custom implementations
+/// can add fixed or random slippage, volume-based price impact, or other
+/// realistic execution simulation.
+///
 /// # Arguments
 ///
 /// * `side` — order side (Buy or Sell).
@@ -39,9 +47,8 @@ pub trait FillModel {
 ///
 /// Fallback chain: `order_price` → `last_price` → `best_ask` (Buy) / `best_bid` (Sell).
 ///
-/// This is the simplest fill model and is well-suited for RL training where
-/// speed matters more than realism: it eliminates spread noise and keeps
-/// episode reward signals clean.
+/// The simplest fill model — ignores spread entirely. Useful when spread
+/// modeling is handled elsewhere or when deterministic fills are preferred.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Deserialize, Serialize,
 )]


### PR DESCRIPTION
## Summary

- Bump version in Quick Start examples from 0.1 to 0.2
- Add Massive and Databento data providers to documentation
- Add Alpaca market data connectors (IEX, SIP, Crypto, Options)
- Separate exchanges from data providers in tables
- Add Order Types support table to rustrade-execution README
- Add Quotes and OptionGreeks to subscription kinds where applicable

## Test plan

- [x] README tables render correctly on GitHub