### PR TITLE
feat: Add conditional order support (Stop, TakeProfit)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,6 +29,18 @@ HYPERLIQUID_PRIVATE_KEY=
 HYPERLIQUID_TESTNET=true
 
 # =============================================================================
+# Binance
+# =============================================================================
+# Get keys from:
+#   Testnet: https://testnet.binance.vision/ (login with GitHub, click Generate HMAC_SHA256 Key)
+#   Production: https://www.binance.com/en/my/settings/api-management
+BINANCE_API_KEY=
+BINANCE_SECRET_KEY=
+
+# Use testnet (true) or production (false)
+BINANCE_TESTNET=true
+
+# =============================================================================
 # Alpaca
 # =============================================================================
 # Get keys from: https://app.alpaca.markets → Paper Trading → API Keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Note: `TrailingStop` with `Absolute` offset returns `UnsupportedOrderType` (manual conversion required: `(absolute / price) * 10000`)
   - Note: `TrailingStopLimit` returns `UnsupportedOrderType` (Binance doesn't support)
 
+- **Hyperliquid conditional order support** ([#94](https://github.com/Niqnil/rustrade/issues/94))
+  - `Stop` → Hyperliquid trigger order (`tpsl: "sl"`, `is_market: true`)
+  - `StopLimit` → Hyperliquid trigger order (`tpsl: "sl"`, `is_market: false`)
+  - `TakeProfit` → Hyperliquid trigger order (`tpsl: "tp"`, `is_market: true`)
+  - `TakeProfitLimit` → Hyperliquid trigger order (`tpsl: "tp"`, `is_market: false`)
+  - Trigger orders require UUID-format client order ID (`ClientOrderId::uuid()`) for cancellation support
+  - Cancellation via `cancel_by_cloid()` for trigger orders (uses UUID), `cancel()` for regular orders (uses OID)
+  - Note: `TrailingStop`, `TrailingStopLimit`, and `Market` return `UnsupportedOrderType`
+  - Note: SDK limitation — `fetch_open_orders` and `account_stream` cannot distinguish trigger orders from limit orders (SDK structs lack trigger fields). Track `OrderKind` from placement response.
+
 ## [0.2.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Binance conditional order support** ([#93](https://github.com/Niqnil/rustrade/issues/93))
+  - `Stop` → Binance `STOP_LOSS` (market order triggered at stop price)
+  - `StopLimit` → Binance `STOP_LOSS_LIMIT` (limit order triggered at stop price)
+  - `TakeProfit` → Binance `TAKE_PROFIT` (market order triggered at take-profit price)
+  - `TakeProfitLimit` → Binance `TAKE_PROFIT_LIMIT` (limit order triggered at take-profit price)
+  - `TrailingStop` with `BasisPoints` or `Percentage` offset → Binance `STOP_LOSS` with `trailingDelta`
+    - `BasisPoints`: value passed directly as `trailingDelta` (1 bp = 0.01%)
+    - `Percentage`: value multiplied by 100 before sending (e.g., 2% → 200 trailingDelta)
+  - Note: `TrailingStop` with `Absolute` offset returns `UnsupportedOrderType` (manual conversion required: `(absolute / price) * 10000`)
+  - Note: `TrailingStopLimit` returns `UnsupportedOrderType` (Binance doesn't support)
+
 ## [0.2.0]
 
 ### Added

--- a/rustrade-execution/src/client/alpaca/mod.rs
+++ b/rustrade-execution/src/client/alpaca/mod.rs
@@ -1723,9 +1723,12 @@ impl AlpacaClient {
                 TrailingOffsetType::Absolute => (None, None, Some(offset.to_string())),
                 TrailingOffsetType::BasisPoints => unreachable!("validated above"),
             },
-            OrderKind::Market | OrderKind::Limit | OrderKind::TrailingStopLimit { .. } => {
-                (None, None, None)
-            }
+            // TakeProfit/TakeProfitLimit rejected by map_order_kind → unreachable here
+            OrderKind::Market
+            | OrderKind::Limit
+            | OrderKind::TakeProfit { .. }
+            | OrderKind::TakeProfitLimit { .. }
+            | OrderKind::TrailingStopLimit { .. } => (None, None, None),
         };
 
         let body = AlpacaOrderRequest {
@@ -3152,8 +3155,10 @@ fn map_order_kind(kind: OrderKind) -> Option<&'static str> {
         OrderKind::Stop { .. } => Some("stop"),
         OrderKind::StopLimit { .. } => Some("stop_limit"),
         OrderKind::TrailingStop { .. } => Some("trailing_stop"),
-        // Alpaca does not support trailing stop-limit orders.
-        OrderKind::TrailingStopLimit { .. } => None,
+        // Alpaca does not support take-profit or trailing stop-limit orders.
+        OrderKind::TakeProfit { .. }
+        | OrderKind::TakeProfitLimit { .. }
+        | OrderKind::TrailingStopLimit { .. } => None,
     }
 }
 
@@ -3417,6 +3422,19 @@ mod tests {
                 offset: Decimal::from_str("5.0").unwrap(),
                 offset_type: TrailingOffsetType::Percentage,
                 limit_offset: Decimal::from_str("1.0").unwrap(),
+            }),
+            None
+        );
+        // TakeProfit/TakeProfitLimit are not supported by Alpaca
+        assert_eq!(
+            map_order_kind(OrderKind::TakeProfit {
+                trigger_price: Decimal::from_str("160.00").unwrap()
+            }),
+            None
+        );
+        assert_eq!(
+            map_order_kind(OrderKind::TakeProfitLimit {
+                trigger_price: Decimal::from_str("160.00").unwrap()
             }),
             None
         );

--- a/rustrade-execution/src/client/binance/mod.rs
+++ b/rustrade-execution/src/client/binance/mod.rs
@@ -2374,6 +2374,7 @@ fn convert_new_order(
                     kind,
                     OrderKind::Limit
                         | OrderKind::StopLimit { .. }
+                        | OrderKind::TakeProfitLimit { .. }
                         | OrderKind::TrailingStopLimit { .. }
                 ) {
                     trace!(%symbol, %kind, "BinanceSpot NEW event has zero price (p) on limit-type order, treating as no limit price");
@@ -2385,13 +2386,22 @@ fn convert_new_order(
                 return None;
             }
         },
-        (None, OrderKind::Market | OrderKind::Stop { .. } | OrderKind::TrailingStop { .. }) => {
-            // Market and Stop orders don't have a limit price
+        (
+            None,
+            OrderKind::Market
+            | OrderKind::Stop { .. }
+            | OrderKind::TakeProfit { .. }
+            | OrderKind::TrailingStop { .. },
+        ) => {
+            // Market, Stop, and TakeProfit orders don't have a limit price
             None
         }
         (
             None,
-            OrderKind::Limit | OrderKind::StopLimit { .. } | OrderKind::TrailingStopLimit { .. },
+            OrderKind::Limit
+            | OrderKind::StopLimit { .. }
+            | OrderKind::TakeProfitLimit { .. }
+            | OrderKind::TrailingStopLimit { .. },
         ) => {
             warn!(%symbol, "BinanceSpot NEW limit-type order missing price (p), dropping");
             return None;
@@ -2591,10 +2601,12 @@ fn convert_order_kind_tif(
                 None
             }
         },
-        // TODO(TG13): Binance supports STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT,
-        // TAKE_PROFIT_LIMIT, and TRAILING_STOP_MARKET. Add mapping in a future PR.
+        // TODO(TG16): Binance supports STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT,
+        // TAKE_PROFIT_LIMIT, and TRAILING_STOP_MARKET. Implement in Phase 2.
         OrderKind::Stop { .. }
         | OrderKind::StopLimit { .. }
+        | OrderKind::TakeProfit { .. }
+        | OrderKind::TakeProfitLimit { .. }
         | OrderKind::TrailingStop { .. }
         | OrderKind::TrailingStopLimit { .. } => {
             warn!(

--- a/rustrade-execution/src/client/binance/mod.rs
+++ b/rustrade-execution/src/client/binance/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     client::ExecutionClient,
     error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
     order::{
-        Order, OrderKey, OrderKind, TimeInForce,
+        Order, OrderKey, OrderKind, TimeInForce, TrailingOffsetType,
         id::{ClientOrderId, OrderId, StrategyId},
         request::{OrderRequestCancel, OrderRequestOpen, UnindexedOrderResponseCancel},
         state::{Cancelled, Filled, Open, OrderState, UnindexedOrderState},
@@ -1182,9 +1182,88 @@ impl ExecutionClient for BinanceSpot {
                 .quantity(quantity)
                 .new_client_order_id(cid.0.to_string());
 
-        // Set price for limit orders
-        if matches!(kind, OrderKind::Limit) {
-            params_builder = params_builder.price(price);
+        // Set price, stop_price, and trailing_delta in a single exhaustive match
+        // so that adding a new OrderKind variant fails to compile until handled here.
+        match kind {
+            OrderKind::Limit => {
+                params_builder = params_builder.price(price);
+            }
+            OrderKind::Stop { trigger_price } | OrderKind::TakeProfit { trigger_price } => {
+                params_builder = params_builder.stop_price(trigger_price);
+            }
+            OrderKind::StopLimit { trigger_price }
+            | OrderKind::TakeProfitLimit { trigger_price } => {
+                params_builder = params_builder.price(price).stop_price(trigger_price);
+            }
+            OrderKind::TrailingStop {
+                offset,
+                offset_type,
+            } => {
+                // Convert to basis points (i32). Binance trailingDelta is in basis points.
+                let basis_points: i32 = match offset_type {
+                    TrailingOffsetType::BasisPoints => {
+                        let Ok(bp) = i32::try_from(offset) else {
+                            return Some(Order {
+                                key: order_key,
+                                side,
+                                price,
+                                quantity,
+                                kind,
+                                time_in_force,
+                                state: OrderState::inactive(OrderError::UnsupportedOrderType(
+                                    format!(
+                                        "TrailingStop basis-point offset {offset} overflows i32 \
+                                         (Binance trailingDelta filter typically caps at 2000)"
+                                    ),
+                                )),
+                            });
+                        };
+                        bp
+                    }
+                    TrailingOffsetType::Percentage => {
+                        let Ok(bp) = i32::try_from(offset * Decimal::from(100)) else {
+                            return Some(Order {
+                                key: order_key,
+                                side,
+                                price,
+                                quantity,
+                                kind,
+                                time_in_force,
+                                state: OrderState::inactive(OrderError::UnsupportedOrderType(
+                                    format!(
+                                        "TrailingStop percentage offset {offset} overflows i32 \
+                                         after scaling to basis points"
+                                    ),
+                                )),
+                            });
+                        };
+                        bp
+                    }
+                    TrailingOffsetType::Absolute => {
+                        // convert_order_kind_tif already rejects Absolute; surface a clean
+                        // error here too rather than panic, so a future refactor that
+                        // changes that contract still fails observably.
+                        return Some(Order {
+                            key: order_key,
+                            side,
+                            price,
+                            quantity,
+                            kind,
+                            time_in_force,
+                            state: OrderState::inactive(OrderError::UnsupportedOrderType(
+                                "TrailingStop with Absolute offset is not supported by Binance; \
+                                 convert to basis points: (absolute / price) * 10000"
+                                    .into(),
+                            )),
+                        });
+                    }
+                };
+                params_builder = params_builder.trailing_delta(basis_points);
+            }
+            // Market and TrailingStopLimit need no price/stop_price/trailing_delta here.
+            // (TrailingStopLimit is already rejected by convert_order_kind_tif above.)
+            // Wildcard catches them and any future variants added before this match is updated.
+            _ => {}
         }
 
         if let Some(tif) = binance_tif {
@@ -2559,6 +2638,32 @@ fn parse_time_in_force(tif: &str) -> TimeInForce {
     }
 }
 
+/// Convert rustrade OrderKind + TimeInForce to Binance SDK order type and TIF.
+///
+/// Returns `None` for unsupported combinations, which `open_order` converts to
+/// `UnsupportedOrderType` rejection.
+///
+/// # Conditional Orders
+///
+/// - `Stop` → `STOP_LOSS` (market order triggered at stop price)
+/// - `StopLimit` → `STOP_LOSS_LIMIT` (limit order triggered at stop price)
+/// - `TakeProfit` → `TAKE_PROFIT` (market order triggered at take-profit price)
+/// - `TakeProfitLimit` → `TAKE_PROFIT_LIMIT` (limit order triggered at take-profit price)
+///
+/// # Trailing Stop Orders
+///
+/// Binance implements trailing stops via `STOP_LOSS` with `trailingDelta` parameter.
+///
+/// **Supported offset types:**
+/// - `BasisPoints`: used directly (1 basis point = 0.01%)
+/// - `Percentage`: converted to basis points (multiplied by 100)
+///
+/// **Unsupported:**
+/// - `Absolute`: returns `None` → `UnsupportedOrderType`. The caller (`open_order`)
+///   must surface this so end users can convert absolute offsets to basis points
+///   themselves: `basis_points = (absolute / price) * 10000`
+/// - `TrailingStopLimit`: Binance does not support limit orders with trailing stops
+///
 fn convert_order_kind_tif(
     kind: OrderKind,
     tif: TimeInForce,
@@ -2601,18 +2706,75 @@ fn convert_order_kind_tif(
                 None
             }
         },
-        // TODO(TG16): Binance supports STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT,
-        // TAKE_PROFIT_LIMIT, and TRAILING_STOP_MARKET. Implement in Phase 2.
-        OrderKind::Stop { .. }
-        | OrderKind::StopLimit { .. }
-        | OrderKind::TakeProfit { .. }
-        | OrderKind::TakeProfitLimit { .. }
-        | OrderKind::TrailingStop { .. }
-        | OrderKind::TrailingStopLimit { .. } => {
-            warn!(
-                "Binance connector does not yet support OrderKind::{:?}",
-                kind
-            );
+        // Conditional orders: stop_price/trailing_delta set separately in open_order
+        OrderKind::Stop { .. } => Some((OrderPlaceTypeEnum::StopLoss, None)),
+        OrderKind::StopLimit { .. } => {
+            // StopLimit requires TIF like regular Limit orders
+            match tif {
+                TimeInForce::GoodUntilCancelled { post_only: false } => Some((
+                    OrderPlaceTypeEnum::StopLossLimit,
+                    Some(OrderPlaceTimeInForceEnum::Gtc),
+                )),
+                TimeInForce::FillOrKill => Some((
+                    OrderPlaceTypeEnum::StopLossLimit,
+                    Some(OrderPlaceTimeInForceEnum::Fok),
+                )),
+                TimeInForce::ImmediateOrCancel => Some((
+                    OrderPlaceTypeEnum::StopLossLimit,
+                    Some(OrderPlaceTimeInForceEnum::Ioc),
+                )),
+                _ => {
+                    warn!(
+                        time_in_force = ?tif,
+                        "Binance StopLimit does not support this TimeInForce"
+                    );
+                    None
+                }
+            }
+        }
+        OrderKind::TakeProfit { .. } => Some((OrderPlaceTypeEnum::TakeProfit, None)),
+        OrderKind::TakeProfitLimit { .. } => {
+            // TakeProfitLimit requires TIF like regular Limit orders
+            match tif {
+                TimeInForce::GoodUntilCancelled { post_only: false } => Some((
+                    OrderPlaceTypeEnum::TakeProfitLimit,
+                    Some(OrderPlaceTimeInForceEnum::Gtc),
+                )),
+                TimeInForce::FillOrKill => Some((
+                    OrderPlaceTypeEnum::TakeProfitLimit,
+                    Some(OrderPlaceTimeInForceEnum::Fok),
+                )),
+                TimeInForce::ImmediateOrCancel => Some((
+                    OrderPlaceTypeEnum::TakeProfitLimit,
+                    Some(OrderPlaceTimeInForceEnum::Ioc),
+                )),
+                _ => {
+                    warn!(
+                        time_in_force = ?tif,
+                        "Binance TakeProfitLimit does not support this TimeInForce"
+                    );
+                    None
+                }
+            }
+        }
+        // TrailingStop: Binance uses STOP_LOSS with trailingDelta parameter.
+        // Only BasisPoints and Percentage are supported; Absolute requires manual
+        // conversion by the caller: basis_points = (absolute / price) * 10000
+        OrderKind::TrailingStop { offset_type, .. } => match offset_type {
+            TrailingOffsetType::BasisPoints | TrailingOffsetType::Percentage => {
+                Some((OrderPlaceTypeEnum::StopLoss, None))
+            }
+            TrailingOffsetType::Absolute => {
+                warn!(
+                    "Binance TrailingStop does not support Absolute offset; \
+                     convert to basis points: (absolute / price) * 10000"
+                );
+                None
+            }
+        },
+        // Binance does not support TrailingStopLimit
+        OrderKind::TrailingStopLimit { .. } => {
+            warn!("Binance does not support TrailingStopLimit orders");
             None
         }
     }
@@ -2834,22 +2996,91 @@ mod tests {
             ))
         ));
 
-        // Stop/Trailing order types return None (not yet supported)
-        assert!(
+        // Conditional orders
+        assert!(matches!(
             convert_order_kind_tif(
                 OrderKind::Stop {
                     trigger_price: Decimal::from(100)
+                },
+                TimeInForce::GoodUntilCancelled { post_only: false }
+            ),
+            Some((OrderPlaceTypeEnum::StopLoss, None))
+        ));
+        assert!(matches!(
+            convert_order_kind_tif(
+                OrderKind::StopLimit {
+                    trigger_price: Decimal::from(100)
+                },
+                TimeInForce::GoodUntilCancelled { post_only: false }
+            ),
+            Some((
+                OrderPlaceTypeEnum::StopLossLimit,
+                Some(OrderPlaceTimeInForceEnum::Gtc)
+            ))
+        ));
+        assert!(matches!(
+            convert_order_kind_tif(
+                OrderKind::TakeProfit {
+                    trigger_price: Decimal::from(150)
+                },
+                TimeInForce::ImmediateOrCancel
+            ),
+            Some((OrderPlaceTypeEnum::TakeProfit, None))
+        ));
+        assert!(matches!(
+            convert_order_kind_tif(
+                OrderKind::TakeProfitLimit {
+                    trigger_price: Decimal::from(150)
+                },
+                TimeInForce::FillOrKill
+            ),
+            Some((
+                OrderPlaceTypeEnum::TakeProfitLimit,
+                Some(OrderPlaceTimeInForceEnum::Fok)
+            ))
+        ));
+
+        // TrailingStop with BasisPoints/Percentage → StopLoss (trailingDelta set separately)
+        assert!(matches!(
+            convert_order_kind_tif(
+                OrderKind::TrailingStop {
+                    offset: Decimal::from(100),
+                    offset_type: TrailingOffsetType::BasisPoints,
+                },
+                TimeInForce::GoodUntilCancelled { post_only: false }
+            ),
+            Some((OrderPlaceTypeEnum::StopLoss, None))
+        ));
+        assert!(matches!(
+            convert_order_kind_tif(
+                OrderKind::TrailingStop {
+                    offset: Decimal::from(5),
+                    offset_type: TrailingOffsetType::Percentage,
+                },
+                TimeInForce::GoodUntilCancelled { post_only: false }
+            ),
+            Some((OrderPlaceTypeEnum::StopLoss, None))
+        ));
+
+        // TrailingStop with Absolute → unsupported (returns None)
+        assert!(
+            convert_order_kind_tif(
+                OrderKind::TrailingStop {
+                    offset: Decimal::from(10),
+                    offset_type: TrailingOffsetType::Absolute,
                 },
                 TimeInForce::GoodUntilCancelled { post_only: false }
             )
             .is_none()
         );
 
+        // TrailingStopLimit → unsupported (Binance doesn't support)
         assert!(
             convert_order_kind_tif(
-                OrderKind::TrailingStop {
-                    offset: Decimal::from(5),
-                    offset_type: TrailingOffsetType::Percentage,
+                OrderKind::TrailingStopLimit {
+                    offset: Decimal::from(100),
+                    offset_type: TrailingOffsetType::BasisPoints,
+                    limit_offset: Decimal::from(10),
                 },
                 TimeInForce::GoodUntilCancelled { post_only: false }
             )

--- a/rustrade-execution/src/client/hyperliquid/mod.rs
+++ b/rustrade-execution/src/client/hyperliquid/mod.rs
@@ -35,6 +35,29 @@
 //! - REST clients (`InfoClient::new()`, `ExchangeClient::new()`) do NOT auto-reconnect;
 //!   only WebSocket streams via `with_reconnect()` do
 //!
+//! # Conditional Orders (Stop, TakeProfit)
+//!
+//! Hyperliquid supports conditional (trigger) orders via the `ClientOrder::Trigger` variant.
+//!
+//! **Supported order kinds**:
+//! - `Stop` → market order triggered at stop price (`tpsl: "sl"`, `is_market: true`)
+//! - `StopLimit` → limit order triggered at stop price (`tpsl: "sl"`, `is_market: false`)
+//! - `TakeProfit` → market order triggered at take-profit price (`tpsl: "tp"`, `is_market: true`)
+//! - `TakeProfitLimit` → limit order triggered at take-profit price (`tpsl: "tp"`, `is_market: false`)
+//!
+//! **Unsupported**: `TrailingStop`, `TrailingStopLimit` (Hyperliquid does not support trailing stops)
+//!
+//! **UUID requirement**: Trigger orders MUST use [`ClientOrderId::uuid()`] for the client order ID.
+//! The SDK's `cancel_by_cloid()` requires a valid UUID. Non-UUID client IDs will be rejected
+//! at order placement with a clear error message.
+//!
+//! **SDK limitations** (hyperliquid_rust_sdk 0.6.x):
+//! - `fetch_open_orders`: Returns `OpenOrdersResponse` which lacks trigger fields (`is_trigger`,
+//!   `trigger_px`). All orders appear as `OrderKind::Limit`.
+//! - `account_stream` (WebSocket): `OrderUpdate` uses `BasicOrder` which also lacks trigger fields.
+//!   Downstream consumers should correlate orders by `cloid` and track `OrderKind` from the
+//!   placement response.
+//!
 //! # Limitations
 //!
 //! - **Price precision**: Hyperliquid requires 5 significant figures for prices
@@ -535,7 +558,10 @@ impl ExecutionClient for HyperliquidClient {
         request: OrderRequestCancel<ExchangeId, &InstrumentNameExchange>,
     ) -> Option<UnindexedOrderResponseCancel> {
         use crate::order::{request::OrderResponseCancel, state::Cancelled};
-        use hyperliquid_rust_sdk::ClientCancelRequest;
+        use hyperliquid_rust_sdk::{
+            ClientCancelRequest, ClientCancelRequestCloid, ExchangeResponseStatus,
+        };
+        use uuid::Uuid;
 
         let coin = instrument_to_perp_coin(request.key.instrument);
 
@@ -558,30 +584,53 @@ impl ExecutionClient for HyperliquidClient {
             }
         };
 
-        // Parse order ID to u64
-        let oid: u64 = match order_id.0.parse() {
-            Ok(id) => id,
-            Err(e) => {
-                warn!(?order_id, %e, "Failed to parse order ID as u64");
-                return Some(OrderResponseCancel {
-                    key: OrderKey {
-                        exchange: ExchangeId::HyperliquidPerp,
-                        instrument: request.key.instrument.clone(),
-                        strategy: request.key.strategy.clone(),
-                        cid: request.key.cid.clone(),
-                    },
-                    state: Err(UnindexedOrderError::Rejected(
-                        crate::error::ApiError::OrderRejected(format!("Invalid order ID: {e}")),
-                    )),
-                });
+        // Try to determine cancel method:
+        // 1. If order_id parses as u64, use cancel() with OID (regular limit orders)
+        // 2. If order_id parses as UUID, use cancel_by_cloid() (trigger orders)
+        // 3. Otherwise, reject with clear error
+        enum CancelMethod {
+            ByOid(u64),
+            ByCloid(Uuid),
+        }
+
+        let cancel_method = if let Ok(oid) = order_id.0.parse::<u64>() {
+            CancelMethod::ByOid(oid)
+        } else if let Ok(uuid) = Uuid::parse_str(&order_id.0) {
+            CancelMethod::ByCloid(uuid)
+        } else {
+            warn!(?order_id, "Order ID is neither u64 (OID) nor UUID (cloid)");
+            return Some(OrderResponseCancel {
+                key: OrderKey {
+                    exchange: ExchangeId::HyperliquidPerp,
+                    instrument: request.key.instrument.clone(),
+                    strategy: request.key.strategy.clone(),
+                    cid: request.key.cid.clone(),
+                },
+                state: Err(UnindexedOrderError::Rejected(
+                    crate::error::ApiError::OrderRejected(
+                        "Invalid order ID: must be numeric OID or UUID (for trigger orders)"
+                            .to_string(),
+                    ),
+                )),
+            });
+        };
+
+        let response = match cancel_method {
+            CancelMethod::ByOid(oid) => {
+                debug!(oid, "Cancelling by OID");
+                let cancel_request = ClientCancelRequest { asset: coin, oid };
+                self.exchange_client.cancel(cancel_request, None).await
+            }
+            CancelMethod::ByCloid(cloid) => {
+                debug!(%cloid, "Cancelling by cloid (trigger order)");
+                let cancel_request = ClientCancelRequestCloid { asset: coin, cloid };
+                self.exchange_client
+                    .cancel_by_cloid(cancel_request, None)
+                    .await
             }
         };
 
-        let cancel_request = ClientCancelRequest { asset: coin, oid };
-
-        use hyperliquid_rust_sdk::ExchangeResponseStatus;
-
-        let response = match self.exchange_client.cancel(cancel_request, None).await {
+        let response = match response {
             Ok(r) => r,
             Err(e) => {
                 warn!(%e, "Cancel order failed (transport)");
@@ -637,18 +686,13 @@ impl ExecutionClient for HyperliquidClient {
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
     ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         use hyperliquid_rust_sdk::{
-            ClientLimit, ClientOrder, ClientOrderRequest, ExchangeDataStatus,
+            ClientLimit, ClientOrder, ClientOrderRequest, ClientTrigger, ExchangeDataStatus,
             ExchangeResponseStatus,
         };
 
-        let coin = instrument_to_perp_coin(request.key.instrument);
-        let is_buy = request.state.side == Side::Buy;
-
-        // Hyperliquid only supports Limit orders, so price is required
-        let price = match request.state.price {
-            Some(p) => p,
-            None => {
-                return Some(Order {
+        let make_rejected =
+            |msg: String| -> Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState> {
+                Order {
                     key: OrderKey {
                         exchange: ExchangeId::HyperliquidPerp,
                         instrument: request.key.instrument.clone(),
@@ -656,21 +700,89 @@ impl ExecutionClient for HyperliquidClient {
                         cid: request.key.cid.clone(),
                     },
                     side: request.state.side,
-                    price: None,
+                    price: request.state.price,
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
                     state: OrderState::inactive(OrderError::Rejected(
-                        crate::error::ApiError::OrderRejected(
-                            "Hyperliquid requires limit price for all orders".to_owned(),
-                        ),
+                        crate::error::ApiError::OrderRejected(msg),
                     )),
-                });
+                }
+            };
+
+        let make_unsupported =
+            |msg: String| -> Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState> {
+                Order {
+                    key: OrderKey {
+                        exchange: ExchangeId::HyperliquidPerp,
+                        instrument: request.key.instrument.clone(),
+                        strategy: request.key.strategy.clone(),
+                        cid: request.key.cid.clone(),
+                    },
+                    side: request.state.side,
+                    price: request.state.price,
+                    quantity: request.state.quantity,
+                    kind: request.state.kind,
+                    time_in_force: request.state.time_in_force,
+                    state: OrderState::inactive(OrderError::UnsupportedOrderType(msg)),
+                }
+            };
+
+        let coin = instrument_to_perp_coin(request.key.instrument);
+        let is_buy = request.state.side == Side::Buy;
+
+        match request.state.kind {
+            OrderKind::Market => {
+                return Some(make_unsupported(
+                    "Hyperliquid does not support market orders; use Limit with IOC time-in-force"
+                        .to_string(),
+                ));
             }
+            OrderKind::TrailingStop { .. } | OrderKind::TrailingStopLimit { .. } => {
+                return Some(make_unsupported(
+                    "Hyperliquid does not support trailing stop orders".to_string(),
+                ));
+            }
+            OrderKind::Limit
+            | OrderKind::Stop { .. }
+            | OrderKind::StopLimit { .. }
+            | OrderKind::TakeProfit { .. }
+            | OrderKind::TakeProfitLimit { .. } => {}
+        }
+
+        let cloid = cid_to_cloid(&request.key.cid);
+        let cloid_is_some = cloid.is_some();
+        let is_trigger_order = matches!(
+            request.state.kind,
+            OrderKind::Stop { .. }
+                | OrderKind::StopLimit { .. }
+                | OrderKind::TakeProfit { .. }
+                | OrderKind::TakeProfitLimit { .. }
+        );
+        if is_trigger_order && cloid.is_none() {
+            return Some(make_rejected(
+                "Trigger orders require UUID-format client order ID (use ClientOrderId::uuid()). \
+                 Non-UUID IDs cannot be cancelled via cancel_by_cloid()."
+                    .to_string(),
+            ));
+        }
+
+        let limit_px = match request.state.kind {
+            // Market triggers: SDK uses trigger_px as limit_px
+            OrderKind::Stop { trigger_price } | OrderKind::TakeProfit { trigger_price } => {
+                round_to_5_sig_figs(trigger_price)
+            }
+            _ => match request.state.price {
+                Some(p) => round_to_5_sig_figs(p),
+                None => {
+                    return Some(make_rejected(
+                        "Hyperliquid requires limit price for Limit/StopLimit/TakeProfitLimit orders"
+                            .to_string(),
+                    ));
+                }
+            },
         };
 
-        // Round price and quantity to 5 significant figures
-        let limit_px = round_to_5_sig_figs(price);
         let sz = round_to_5_sig_figs(request.state.quantity);
 
         // Map time-in-force (warn if FOK is substituted with IOC)
@@ -682,9 +794,37 @@ impl ExecutionClient for HyperliquidClient {
         }
         let tif = map_tif(&request.state.time_in_force).to_string();
 
-        // Build order request
-        // Pass cloid if cid is a valid UUID (enables order correlation via client ID)
-        let cloid = cid_to_cloid(&request.key.cid);
+        // Build order_type based on OrderKind
+        let order_type = match request.state.kind {
+            OrderKind::Limit => ClientOrder::Limit(ClientLimit { tif }),
+            OrderKind::Stop { trigger_price } => ClientOrder::Trigger(ClientTrigger {
+                is_market: true,
+                trigger_px: round_to_5_sig_figs(trigger_price),
+                tpsl: "sl".to_string(),
+            }),
+            OrderKind::StopLimit { trigger_price } => ClientOrder::Trigger(ClientTrigger {
+                is_market: false,
+                trigger_px: round_to_5_sig_figs(trigger_price),
+                tpsl: "sl".to_string(),
+            }),
+            OrderKind::TakeProfit { trigger_price } => ClientOrder::Trigger(ClientTrigger {
+                is_market: true,
+                trigger_px: round_to_5_sig_figs(trigger_price),
+                tpsl: "tp".to_string(),
+            }),
+            OrderKind::TakeProfitLimit { trigger_price } => ClientOrder::Trigger(ClientTrigger {
+                is_market: false,
+                trigger_px: round_to_5_sig_figs(trigger_price),
+                tpsl: "tp".to_string(),
+            }),
+            // Already rejected above
+            OrderKind::Market
+            | OrderKind::TrailingStop { .. }
+            | OrderKind::TrailingStopLimit { .. } => {
+                unreachable!("unsupported order kinds rejected earlier")
+            }
+        };
+
         let order_request = ClientOrderRequest {
             asset: coin,
             is_buy,
@@ -692,7 +832,7 @@ impl ExecutionClient for HyperliquidClient {
             limit_px,
             sz,
             cloid,
-            order_type: ClientOrder::Limit(ClientLimit { tif }),
+            order_type,
         };
 
         let response = match self.exchange_client.order(order_request, None).await {
@@ -751,16 +891,30 @@ impl ExecutionClient for HyperliquidClient {
                             crate::error::ApiError::OrderRejected(msg),
                         ))
                     }
-                    Some(ExchangeDataStatus::WaitingForFill)
-                    | Some(ExchangeDataStatus::WaitingForTrigger) => {
-                        // Trigger/conditional orders return no usable order ID.
-                        // Reject since we can't track or cancel these orders.
-                        warn!("Trigger/conditional orders not supported");
-                        OrderState::inactive(OrderError::Rejected(
-                            crate::error::ApiError::OrderRejected(
-                                "trigger/conditional orders not supported".to_string(),
-                            ),
-                        ))
+                    Some(
+                        ExchangeDataStatus::WaitingForFill | ExchangeDataStatus::WaitingForTrigger,
+                    ) => {
+                        // Use cid as OrderId only if it's a valid UUID (required for
+                        // cancel_by_cloid). Trigger orders pass the UUID guard above;
+                        // limit IOC/FOK orders may have non-UUID cids — those become
+                        // untrackable, so reject with an observable failure rather than
+                        // returning an OrderId that cancel cannot parse.
+                        if cloid_is_some {
+                            debug!(cloid = %request.key.cid.0, "Order waiting (cloid trackable)");
+                            OrderState::active(Open {
+                                id: OrderId(request.key.cid.0.clone()),
+                                time_exchange: Utc::now(),
+                                filled_quantity: Decimal::ZERO,
+                            })
+                        } else {
+                            warn!("Order accepted but cid is not UUID — untrackable");
+                            OrderState::inactive(OrderError::Rejected(
+                                crate::error::ApiError::OrderRejected(
+                                    "order accepted but cid is not UUID; cannot track for cancel"
+                                        .to_string(),
+                                ),
+                            ))
+                        }
                     }
                     Some(ExchangeDataStatus::Success) | None => {
                         // Generic success without order ID — SDK didn't return structured data.

--- a/rustrade-execution/src/client/hyperliquid/spot.rs
+++ b/rustrade-execution/src/client/hyperliquid/spot.rs
@@ -27,6 +27,14 @@
 //!
 //! If a user has both perp and spot clients for the same wallet, events will be
 //! duplicated. Consumers should use one client type per account, or deduplicate externally.
+//!
+//! # Conditional Orders (Stop, TakeProfit)
+//!
+//! See [`super`] module documentation for conditional order support details.
+//! The same constraints apply to spot:
+//! - Supported: `Stop`, `StopLimit`, `TakeProfit`, `TakeProfitLimit`
+//! - Unsupported: `TrailingStop`, `TrailingStopLimit`, `Market`
+//! - UUID requirement: Trigger orders MUST use [`crate::order::id::ClientOrderId::uuid()`]
 
 use super::common::{
     CancelOnDropStream, cid_to_cloid, instrument_to_spot_coin, is_spot_coin, map_tif,
@@ -449,7 +457,10 @@ impl ExecutionClient for HyperliquidSpotClient {
         request: OrderRequestCancel<ExchangeId, &InstrumentNameExchange>,
     ) -> Option<UnindexedOrderResponseCancel> {
         use crate::order::{request::OrderResponseCancel, state::Cancelled};
-        use hyperliquid_rust_sdk::ClientCancelRequest;
+        use hyperliquid_rust_sdk::{
+            ClientCancelRequest, ClientCancelRequestCloid, ExchangeResponseStatus,
+        };
+        use uuid::Uuid;
 
         let coin = match instrument_to_spot_coin(request.key.instrument) {
             Some(c) => c,
@@ -493,29 +504,53 @@ impl ExecutionClient for HyperliquidSpotClient {
             }
         };
 
-        let oid: u64 = match order_id.0.parse() {
-            Ok(id) => id,
-            Err(e) => {
-                warn!(?order_id, %e, "Failed to parse order ID as u64");
-                return Some(OrderResponseCancel {
-                    key: OrderKey {
-                        exchange: ExchangeId::HyperliquidSpot,
-                        instrument: request.key.instrument.clone(),
-                        strategy: request.key.strategy.clone(),
-                        cid: request.key.cid.clone(),
-                    },
-                    state: Err(UnindexedOrderError::Rejected(
-                        crate::error::ApiError::OrderRejected(format!("Invalid order ID: {e}")),
-                    )),
-                });
+        // Try to determine cancel method:
+        // 1. If order_id parses as u64, use cancel() with OID (regular limit orders)
+        // 2. If order_id parses as UUID, use cancel_by_cloid() (trigger orders)
+        // 3. Otherwise, reject with clear error
+        enum CancelMethod {
+            ByOid(u64),
+            ByCloid(Uuid),
+        }
+
+        let cancel_method = if let Ok(oid) = order_id.0.parse::<u64>() {
+            CancelMethod::ByOid(oid)
+        } else if let Ok(uuid) = Uuid::parse_str(&order_id.0) {
+            CancelMethod::ByCloid(uuid)
+        } else {
+            warn!(?order_id, "Order ID is neither u64 (OID) nor UUID (cloid)");
+            return Some(OrderResponseCancel {
+                key: OrderKey {
+                    exchange: ExchangeId::HyperliquidSpot,
+                    instrument: request.key.instrument.clone(),
+                    strategy: request.key.strategy.clone(),
+                    cid: request.key.cid.clone(),
+                },
+                state: Err(UnindexedOrderError::Rejected(
+                    crate::error::ApiError::OrderRejected(
+                        "Invalid order ID: must be numeric OID or UUID (for trigger orders)"
+                            .to_string(),
+                    ),
+                )),
+            });
+        };
+
+        let response = match cancel_method {
+            CancelMethod::ByOid(oid) => {
+                debug!(oid, "Cancelling spot order by OID");
+                let cancel_request = ClientCancelRequest { asset: coin, oid };
+                self.exchange_client.cancel(cancel_request, None).await
+            }
+            CancelMethod::ByCloid(cloid) => {
+                debug!(%cloid, "Cancelling spot order by cloid (trigger order)");
+                let cancel_request = ClientCancelRequestCloid { asset: coin, cloid };
+                self.exchange_client
+                    .cancel_by_cloid(cancel_request, None)
+                    .await
             }
         };
 
-        let cancel_request = ClientCancelRequest { asset: coin, oid };
-
-        use hyperliquid_rust_sdk::ExchangeResponseStatus;
-
-        let response = match self.exchange_client.cancel(cancel_request, None).await {
+        let response = match response {
             Ok(r) => r,
             Err(e) => {
                 warn!(%e, "Spot cancel order failed (transport)");
@@ -571,18 +606,13 @@ impl ExecutionClient for HyperliquidSpotClient {
         request: OrderRequestOpen<ExchangeId, &InstrumentNameExchange>,
     ) -> Option<Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState>> {
         use hyperliquid_rust_sdk::{
-            ClientLimit, ClientOrder, ClientOrderRequest, ExchangeDataStatus,
+            ClientLimit, ClientOrder, ClientOrderRequest, ClientTrigger, ExchangeDataStatus,
             ExchangeResponseStatus,
         };
 
-        let coin = match instrument_to_spot_coin(request.key.instrument) {
-            Some(c) => c,
-            None => {
-                warn!(
-                    instrument = %request.key.instrument,
-                    "Invalid spot instrument format (expected BASE-QUOTE-SPOT)"
-                );
-                return Some(Order {
+        let make_rejected =
+            |msg: String| -> Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState> {
+                Order {
                     key: OrderKey {
                         exchange: ExchangeId::HyperliquidSpot,
                         instrument: request.key.instrument.clone(),
@@ -595,21 +625,14 @@ impl ExecutionClient for HyperliquidSpotClient {
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
                     state: OrderState::inactive(OrderError::Rejected(
-                        crate::error::ApiError::OrderRejected(format!(
-                            "Invalid instrument format: {}",
-                            request.key.instrument
-                        )),
+                        crate::error::ApiError::OrderRejected(msg),
                     )),
-                });
-            }
-        };
-        let is_buy = request.state.side == Side::Buy;
+                }
+            };
 
-        // Hyperliquid only supports Limit orders, so price is required
-        let price = match request.state.price {
-            Some(p) => p,
-            None => {
-                return Some(Order {
+        let make_unsupported =
+            |msg: String| -> Order<ExchangeId, InstrumentNameExchange, UnindexedOrderState> {
+                Order {
                     key: OrderKey {
                         exchange: ExchangeId::HyperliquidSpot,
                         instrument: request.key.instrument.clone(),
@@ -617,48 +640,101 @@ impl ExecutionClient for HyperliquidSpotClient {
                         cid: request.key.cid.clone(),
                     },
                     side: request.state.side,
-                    price: None,
+                    price: request.state.price,
                     quantity: request.state.quantity,
                     kind: request.state.kind,
                     time_in_force: request.state.time_in_force,
-                    state: OrderState::inactive(OrderError::Rejected(
-                        crate::error::ApiError::OrderRejected(
-                            "Hyperliquid requires limit price for all orders".to_owned(),
-                        ),
-                    )),
-                });
+                    state: OrderState::inactive(OrderError::UnsupportedOrderType(msg)),
+                }
+            };
+
+        let coin = match instrument_to_spot_coin(request.key.instrument) {
+            Some(c) => c,
+            None => {
+                warn!(
+                    instrument = %request.key.instrument,
+                    "Invalid spot instrument format (expected BASE-QUOTE-SPOT)"
+                );
+                return Some(make_rejected(format!(
+                    "Invalid instrument format: {}",
+                    request.key.instrument
+                )));
             }
         };
+        let is_buy = request.state.side == Side::Buy;
 
-        let limit_px = round_to_5_sig_figs(price);
+        match request.state.kind {
+            OrderKind::Market => {
+                return Some(make_unsupported(
+                    "Hyperliquid does not support market orders; use Limit with IOC time-in-force"
+                        .to_string(),
+                ));
+            }
+            OrderKind::TrailingStop { .. } | OrderKind::TrailingStopLimit { .. } => {
+                return Some(make_unsupported(
+                    "Hyperliquid does not support trailing stop orders".to_string(),
+                ));
+            }
+            OrderKind::Limit
+            | OrderKind::Stop { .. }
+            | OrderKind::StopLimit { .. }
+            | OrderKind::TakeProfit { .. }
+            | OrderKind::TakeProfitLimit { .. } => {}
+        }
+
+        let cloid = cid_to_cloid(&request.key.cid);
+        let cloid_is_some = cloid.is_some();
+        let is_trigger_order = matches!(
+            request.state.kind,
+            OrderKind::Stop { .. }
+                | OrderKind::StopLimit { .. }
+                | OrderKind::TakeProfit { .. }
+                | OrderKind::TakeProfitLimit { .. }
+        );
+        if is_trigger_order && cloid.is_none() {
+            return Some(make_rejected(
+                "Trigger orders require UUID-format client order ID (use ClientOrderId::uuid()). \
+                 Non-UUID IDs cannot be cancelled via cancel_by_cloid()."
+                    .to_string(),
+            ));
+        }
+
+        let limit_px = match request.state.kind {
+            // Market triggers: SDK uses trigger_px as limit_px
+            OrderKind::Stop { trigger_price } | OrderKind::TakeProfit { trigger_price } => {
+                round_to_5_sig_figs(trigger_price)
+            }
+            _ => match request.state.price {
+                Some(p) => round_to_5_sig_figs(p),
+                None => {
+                    return Some(make_rejected(
+                        "Hyperliquid requires limit price for Limit/StopLimit/TakeProfitLimit orders"
+                            .to_string(),
+                    ));
+                }
+            },
+        };
+
         let sz = round_to_5_sig_figs(request.state.quantity);
 
         // Hyperliquid spot requires minimum $10 notional value
-        let notional = price * request.state.quantity;
+        // For market triggers, use trigger_price for notional calculation
+        let notional_price = match request.state.kind {
+            OrderKind::Stop { trigger_price } | OrderKind::TakeProfit { trigger_price } => {
+                trigger_price
+            }
+            _ => request.state.price.unwrap_or(Decimal::ZERO),
+        };
+        let notional = notional_price * request.state.quantity;
         if notional < Decimal::TEN {
             warn!(
                 instrument = %request.key.instrument,
                 %notional,
                 "Spot order below $10 minimum notional value"
             );
-            return Some(Order {
-                key: OrderKey {
-                    exchange: ExchangeId::HyperliquidSpot,
-                    instrument: request.key.instrument.clone(),
-                    strategy: request.key.strategy.clone(),
-                    cid: request.key.cid.clone(),
-                },
-                side: request.state.side,
-                price: request.state.price,
-                quantity: request.state.quantity,
-                kind: request.state.kind,
-                time_in_force: request.state.time_in_force,
-                state: OrderState::inactive(OrderError::Rejected(
-                    crate::error::ApiError::OrderRejected(format!(
-                        "Spot order notional ${notional} below $10 minimum"
-                    )),
-                )),
-            });
+            return Some(make_rejected(format!(
+                "Spot order notional ${notional} below $10 minimum"
+            )));
         }
 
         if matches!(request.state.time_in_force, TimeInForce::FillOrKill) {
@@ -669,7 +745,37 @@ impl ExecutionClient for HyperliquidSpotClient {
         }
         let tif = map_tif(&request.state.time_in_force).to_string();
 
-        let cloid = cid_to_cloid(&request.key.cid);
+        // Build order_type based on OrderKind
+        let order_type = match request.state.kind {
+            OrderKind::Limit => ClientOrder::Limit(ClientLimit { tif }),
+            OrderKind::Stop { trigger_price } => ClientOrder::Trigger(ClientTrigger {
+                is_market: true,
+                trigger_px: round_to_5_sig_figs(trigger_price),
+                tpsl: "sl".to_string(),
+            }),
+            OrderKind::StopLimit { trigger_price } => ClientOrder::Trigger(ClientTrigger {
+                is_market: false,
+                trigger_px: round_to_5_sig_figs(trigger_price),
+                tpsl: "sl".to_string(),
+            }),
+            OrderKind::TakeProfit { trigger_price } => ClientOrder::Trigger(ClientTrigger {
+                is_market: true,
+                trigger_px: round_to_5_sig_figs(trigger_price),
+                tpsl: "tp".to_string(),
+            }),
+            OrderKind::TakeProfitLimit { trigger_price } => ClientOrder::Trigger(ClientTrigger {
+                is_market: false,
+                trigger_px: round_to_5_sig_figs(trigger_price),
+                tpsl: "tp".to_string(),
+            }),
+            // Already rejected above
+            OrderKind::Market
+            | OrderKind::TrailingStop { .. }
+            | OrderKind::TrailingStopLimit { .. } => {
+                unreachable!("unsupported order kinds rejected earlier")
+            }
+        };
+
         let order_request = ClientOrderRequest {
             asset: coin,
             is_buy,
@@ -677,7 +783,7 @@ impl ExecutionClient for HyperliquidSpotClient {
             limit_px,
             sz,
             cloid,
-            order_type: ClientOrder::Limit(ClientLimit { tif }),
+            order_type,
         };
 
         let response = match self.exchange_client.order(order_request, None).await {
@@ -735,14 +841,30 @@ impl ExecutionClient for HyperliquidSpotClient {
                             crate::error::ApiError::OrderRejected(msg),
                         ))
                     }
-                    Some(ExchangeDataStatus::WaitingForFill)
-                    | Some(ExchangeDataStatus::WaitingForTrigger) => {
-                        warn!("Trigger/conditional orders not supported");
-                        OrderState::inactive(OrderError::Rejected(
-                            crate::error::ApiError::OrderRejected(
-                                "trigger/conditional orders not supported".to_string(),
-                            ),
-                        ))
+                    Some(
+                        ExchangeDataStatus::WaitingForFill | ExchangeDataStatus::WaitingForTrigger,
+                    ) => {
+                        // Use cid as OrderId only if it's a valid UUID (required for
+                        // cancel_by_cloid). Trigger orders pass the UUID guard above;
+                        // limit IOC/FOK orders may have non-UUID cids — those become
+                        // untrackable, so reject with an observable failure rather than
+                        // returning an OrderId that cancel cannot parse.
+                        if cloid_is_some {
+                            debug!(cloid = %request.key.cid.0, "Spot order waiting (cloid trackable)");
+                            OrderState::active(Open {
+                                id: OrderId(request.key.cid.0.clone()),
+                                time_exchange: Utc::now(),
+                                filled_quantity: Decimal::ZERO,
+                            })
+                        } else {
+                            warn!("Spot order accepted but cid is not UUID — untrackable");
+                            OrderState::inactive(OrderError::Rejected(
+                                crate::error::ApiError::OrderRejected(
+                                    "order accepted but cid is not UUID; cannot track for cancel"
+                                        .to_string(),
+                                ),
+                            ))
+                        }
                     }
                     Some(ExchangeDataStatus::Success) | None => {
                         warn!("Spot order accepted but no order ID returned");

--- a/rustrade-execution/src/client/ibkr/order.rs
+++ b/rustrade-execution/src/client/ibkr/order.rs
@@ -310,6 +310,8 @@ pub enum OrderMappingError {
     MissingLimitPrice(OrderKind),
     /// Trailing offset type not supported by IBKR.
     UnsupportedOffsetType(TrailingOffsetType),
+    /// Order kind not supported by IBKR (e.g., TakeProfit).
+    UnsupportedOrderKind(OrderKind),
     /// AtClose TIF only valid with Market or Limit orders (becomes MOC/LOC).
     /// Stop orders cannot be combined with at-close execution.
     UnsupportedOrderKindForAtClose(OrderKind),
@@ -329,6 +331,9 @@ impl std::fmt::Display for OrderMappingError {
             }
             Self::UnsupportedOffsetType(t) => {
                 write!(f, "trailing offset type {t:?} not supported by IBKR")
+            }
+            Self::UnsupportedOrderKind(k) => {
+                write!(f, "order kind {k} not supported by IBKR")
             }
             Self::UnsupportedOrderKindForAtClose(k) => {
                 write!(
@@ -408,6 +413,8 @@ fn require_limit_price(
 /// - `TrailingStop` (Absolute) → IB "TRAIL" with `aux_price`
 /// - `TrailingStopLimit` (Absolute) → IB "TRAIL LIMIT" with `aux_price`, `limit_price_offset`
 /// - `TrailingStopLimit` (Percentage) → IB "TRAIL LIMIT" with `trailing_percent`, `limit_price_offset`
+/// - `TakeProfit` → `Err(UnsupportedOrderKind)` (IBKR has no native TP; use bracket orders)
+/// - `TakeProfitLimit` → `Err(UnsupportedOrderKind)` (IBKR has no native TP; use bracket orders)
 /// - `BasisPoints` offset type → Error (not supported by IBKR)
 ///
 /// # Price Requirements
@@ -531,6 +538,12 @@ pub fn build_ib_order(
                     ));
                 }
             }
+        }
+
+        // IBKR does not have native take-profit order types. Callers should use
+        // bracket orders or manage TP logic at the strategy level.
+        OrderKind::TakeProfit { .. } | OrderKind::TakeProfitLimit { .. } => {
+            return Err(OrderMappingError::UnsupportedOrderKind(*kind));
         }
     };
 
@@ -1088,6 +1101,46 @@ mod tests {
             result,
             Err(OrderMappingError::UnsupportedOffsetType(
                 TrailingOffsetType::BasisPoints
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_build_take_profit_unsupported() {
+        let result = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TakeProfit {
+                trigger_price: Decimal::from(150),
+            },
+            None,
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        );
+
+        assert!(matches!(
+            result,
+            Err(OrderMappingError::UnsupportedOrderKind(
+                OrderKind::TakeProfit { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_build_take_profit_limit_unsupported() {
+        let result = build_ib_order(
+            rustrade_instrument::Side::Sell,
+            100.0,
+            &OrderKind::TakeProfitLimit {
+                trigger_price: Decimal::from(150),
+            },
+            None,
+            &TimeInForce::GoodUntilCancelled { post_only: false },
+        );
+
+        assert!(matches!(
+            result,
+            Err(OrderMappingError::UnsupportedOrderKind(
+                OrderKind::TakeProfitLimit { .. }
             ))
         ));
     }

--- a/rustrade-execution/src/exchange/mock/mod.rs
+++ b/rustrade-execution/src/exchange/mock/mod.rs
@@ -332,8 +332,10 @@ impl MockExchange {
                     OrderKind::Market => None,
                     OrderKind::Limit
                     | OrderKind::StopLimit { .. }
+                    | OrderKind::TakeProfitLimit { .. }
                     | OrderKind::TrailingStopLimit { .. } => request.state.price,
                     OrderKind::Stop { trigger_price }
+                    | OrderKind::TakeProfit { trigger_price }
                     | OrderKind::TrailingStop {
                         offset: trigger_price,
                         ..

--- a/rustrade-execution/src/order/id.rs
+++ b/rustrade-execution/src/order/id.rs
@@ -16,6 +16,19 @@ impl ClientOrderId<SmolStr> {
         Self(id.into())
     }
 
+    /// Construct a `ClientOrderId` containing a UUID v4 string.
+    ///
+    /// Produces lowercase hyphenated format (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`, 36 chars),
+    /// the format required by Hyperliquid's `cancel_by_cloid()` endpoint.
+    ///
+    /// Required for Hyperliquid trigger orders (Stop, TakeProfit, etc.), which must use
+    /// UUID-format client order IDs for `cancel_by_cloid()` to work. Regular orders can
+    /// use [`Self::random`] for better performance (stack-allocated, no heap).
+    #[cfg(feature = "hyperliquid")]
+    pub fn uuid() -> Self {
+        Self(SmolStr::new(uuid::Uuid::new_v4().to_string()))
+    }
+
     /// Construct a stack-allocated `ClientOrderId` backed by a 23 byte [`SmolStr`].
     pub fn random() -> Self {
         const LEN_URL_SAFE_SYMBOLS: usize = 64;
@@ -116,5 +129,27 @@ impl Default for PositionId {
 impl std::fmt::Display for PositionId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_order_id_random_is_23_bytes() {
+        let cid = ClientOrderId::random();
+        assert_eq!(cid.0.len(), 23);
+    }
+
+    #[test]
+    #[cfg(feature = "hyperliquid")]
+    fn client_order_id_uuid_is_valid_uuid() {
+        let cid = ClientOrderId::uuid();
+        // UUID v4 string is 36 chars (8-4-4-4-12 with hyphens)
+        assert_eq!(cid.0.len(), 36);
+        // Verify it parses as a valid UUID
+        uuid::Uuid::parse_str(&cid.0).expect("should be valid UUID");
     }
 }

--- a/rustrade-execution/src/order/mod.rs
+++ b/rustrade-execution/src/order/mod.rs
@@ -178,6 +178,7 @@ pub enum TrailingOffsetType {
 #[derive(
     Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Display,
 )]
+#[non_exhaustive]
 pub enum OrderKind {
     Market,
     Limit,
@@ -189,6 +190,17 @@ pub enum OrderKind {
     /// Stop-limit order - triggers a limit order at Order.price when trigger_price is reached.
     #[display("StopLimit({trigger_price})")]
     StopLimit {
+        trigger_price: Decimal,
+    },
+    /// Take-profit (market) order - triggers a market order when trigger_price is reached.
+    /// Opposite of Stop: triggers when price moves favorably (above for longs, below for shorts).
+    #[display("TakeProfit({trigger_price})")]
+    TakeProfit {
+        trigger_price: Decimal,
+    },
+    /// Take-profit limit order - triggers a limit order at Order.price when trigger_price is reached.
+    #[display("TakeProfitLimit({trigger_price})")]
+    TakeProfitLimit {
         trigger_price: Decimal,
     },
     /// Trailing stop order - stop price trails the market by a specified offset.
@@ -336,5 +348,48 @@ impl<ExchangeKey, AssetKey, InstrumentKey> From<Order<ExchangeKey, InstrumentKey
             time_in_force,
             state: OrderState::Inactive(InactiveOrderState::Cancelled(state)),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn order_kind_display_take_profit() {
+        let tp = OrderKind::TakeProfit {
+            trigger_price: dec!(100.50),
+        };
+        assert_eq!(tp.to_string(), "TakeProfit(100.50)");
+    }
+
+    #[test]
+    fn order_kind_display_take_profit_limit() {
+        let tpl = OrderKind::TakeProfitLimit {
+            trigger_price: dec!(200.25),
+        };
+        assert_eq!(tpl.to_string(), "TakeProfitLimit(200.25)");
+    }
+
+    #[test]
+    fn order_kind_serde_roundtrip_take_profit() {
+        let original = OrderKind::TakeProfit {
+            trigger_price: dec!(150.00),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: OrderKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn order_kind_serde_roundtrip_take_profit_limit() {
+        let original = OrderKind::TakeProfitLimit {
+            trigger_price: dec!(250.75),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: OrderKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
     }
 }

--- a/rustrade-execution/tests/binance_conditional_orders.rs
+++ b/rustrade-execution/tests/binance_conditional_orders.rs
@@ -1,0 +1,715 @@
+//! Binance Conditional Orders Integration Tests
+//!
+//! Tests for Stop, StopLimit, TakeProfit, TakeProfitLimit, and TrailingStop orders.
+//!
+//! # Prerequisites
+//!
+//! 1. Binance testnet account (https://testnet.binance.vision/, login with GitHub)
+//! 2. Environment variables set (see .env.template):
+//!    - BINANCE_API_KEY
+//!    - BINANCE_SECRET_KEY
+//!    - BINANCE_TESTNET=true
+//!
+//! # Running
+//!
+//! ```bash
+//! # Load env vars from .env
+//! source .env
+//!
+//! # Run all Binance conditional order tests
+//! cargo test --test binance_conditional_orders --features binance -- --ignored --nocapture
+//!
+//! # Run specific test
+//! cargo test --test binance_conditional_orders --features binance test_stop_order -- --ignored --nocapture
+//! ```
+//!
+//! Tests are marked `#[ignore]` to avoid CI failures without testnet connectivity.
+
+#![cfg(feature = "binance")]
+// Integration tests: unwrap/expect produce clear panic messages identifying the
+// failed assertion, which is the desired behavior in test code.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use rustrade_execution::{
+    client::{
+        ExecutionClient,
+        binance::{BinanceSpot, BinanceSpotConfig},
+    },
+    order::{
+        OrderKey, OrderKind, TimeInForce, TrailingOffsetType,
+        id::{ClientOrderId, StrategyId},
+        request::RequestOpen,
+        state::{ActiveOrderState, OrderState},
+    },
+};
+use rustrade_instrument::{Side, exchange::ExchangeId, instrument::name::InstrumentNameExchange};
+use std::time::Duration;
+use tracing_subscriber::{EnvFilter, fmt};
+
+fn init_logging() {
+    let _ = fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(tracing::Level::DEBUG.into())
+                .from_env_lossy(),
+        )
+        .try_init();
+}
+
+fn test_config() -> BinanceSpotConfig {
+    let api_key = std::env::var("BINANCE_API_KEY").expect("BINANCE_API_KEY env var required");
+    let secret_key =
+        std::env::var("BINANCE_SECRET_KEY").expect("BINANCE_SECRET_KEY env var required");
+    let testnet = std::env::var("BINANCE_TESTNET")
+        .map(|v| v == "true")
+        .unwrap_or(true);
+
+    BinanceSpotConfig::new(api_key, secret_key, testnet)
+}
+
+fn test_instrument() -> InstrumentNameExchange {
+    // BTCUSDT is available on testnet
+    "BTCUSDT".into()
+}
+
+// ============================================================================
+// Connection Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_connection() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "Integration tests must run on testnet");
+
+    let client = BinanceSpot::new(config);
+
+    // Verify connection by fetching balances
+    let balances = client.fetch_balances(&[]).await;
+    assert!(
+        balances.is_ok(),
+        "fetch_balances failed: {:?}",
+        balances.err()
+    );
+
+    let balances = balances.unwrap();
+    println!("Connected to Binance testnet. Balances: {}", balances.len());
+    for b in balances.iter().filter(|b| b.balance.total > Decimal::ZERO) {
+        println!("  {}: {}", b.asset, b.balance.total);
+    }
+}
+
+// ============================================================================
+// Stop Order Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_stop_order() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = BinanceSpot::new(config);
+    let instrument = test_instrument();
+    let strategy = StrategyId::new("test-stop");
+    let cid = ClientOrderId::new(format!("stop-{}", chrono::Utc::now().timestamp_millis()));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::BinanceSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: cid.clone(),
+    };
+
+    // Place STOP_LOSS order: sell BTC when price drops to $50,000
+    // This won't trigger since testnet BTC is around $100k
+    let request = RequestOpen {
+        side: Side::Sell,
+        price: None, // Market order when triggered
+        quantity: dec!(0.001),
+        kind: OrderKind::Stop {
+            trigger_price: dec!(50000),
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request,
+    };
+
+    println!("Placing Stop order: SELL 0.001 BTC @ market when price <= $50,000");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Stop order placed successfully!");
+            println!("  Client Order ID: {}", response.key.cid);
+            println!("  Exchange Order ID: {}", open_state.id);
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Cancel the order
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::BinanceSpot,
+                instrument: &instrument,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+            assert!(cancel_response.is_some(), "Expected cancel response");
+
+            match &cancel_response.unwrap().state {
+                Ok(cancelled) => println!("Order canceled at: {}", cancelled.time_exchange),
+                Err(e) => panic!("Cancel rejected: {:?}", e),
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("Stop order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}
+
+// ============================================================================
+// StopLimit Order Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_stop_limit_order() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = BinanceSpot::new(config);
+    let instrument = test_instrument();
+    let strategy = StrategyId::new("test-stop-limit");
+    let cid = ClientOrderId::new(format!(
+        "stoplimit-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::BinanceSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: cid.clone(),
+    };
+
+    // Place STOP_LOSS_LIMIT order: sell BTC at limit $49,900 when price drops to $50,000
+    let request = RequestOpen {
+        side: Side::Sell,
+        price: Some(dec!(49900)), // Limit price after trigger
+        quantity: dec!(0.001),
+        kind: OrderKind::StopLimit {
+            trigger_price: dec!(50000),
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request,
+    };
+
+    println!("Placing StopLimit order: SELL 0.001 BTC @ $49,900 when price <= $50,000");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("StopLimit order placed successfully!");
+            println!("  Exchange Order ID: {}", open_state.id);
+
+            // Cancel
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: OrderKey {
+                    exchange: ExchangeId::BinanceSpot,
+                    instrument: &instrument,
+                    strategy: response.key.strategy.clone(),
+                    cid: response.key.cid.clone(),
+                },
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            let cancel_response = client.cancel_order(cancel_request).await;
+            assert!(matches!(
+                cancel_response.as_ref().map(|r| &r.state),
+                Some(Ok(_))
+            ));
+            println!("Order canceled");
+        }
+        OrderState::Inactive(e) => panic!("StopLimit order rejected: {:?}", e),
+        other => panic!("Unexpected state: {:?}", other),
+    }
+}
+
+// ============================================================================
+// TakeProfit Order Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_take_profit_order() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = BinanceSpot::new(config);
+    let instrument = test_instrument();
+    let strategy = StrategyId::new("test-tp");
+    let cid = ClientOrderId::new(format!("tp-{}", chrono::Utc::now().timestamp_millis()));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::BinanceSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: cid.clone(),
+    };
+
+    // Place TAKE_PROFIT order: sell BTC when price rises to $110,000
+    // Must be within PERCENT_PRICE_BY_SIDE filter (typically ~10% from current price)
+    let request = RequestOpen {
+        side: Side::Sell,
+        price: None,
+        quantity: dec!(0.001),
+        kind: OrderKind::TakeProfit {
+            trigger_price: dec!(110000),
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request,
+    };
+
+    println!("Placing TakeProfit order: SELL 0.001 BTC @ market when price >= $110,000");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("TakeProfit order placed successfully!");
+            println!("  Exchange Order ID: {}", open_state.id);
+
+            // Cancel
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: OrderKey {
+                    exchange: ExchangeId::BinanceSpot,
+                    instrument: &instrument,
+                    strategy: response.key.strategy.clone(),
+                    cid: response.key.cid.clone(),
+                },
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            let cancel_response = client.cancel_order(cancel_request).await;
+            assert!(matches!(
+                cancel_response.as_ref().map(|r| &r.state),
+                Some(Ok(_))
+            ));
+            println!("Order canceled");
+        }
+        OrderState::Inactive(e) => panic!("TakeProfit order rejected: {:?}", e),
+        other => panic!("Unexpected state: {:?}", other),
+    }
+}
+
+// ============================================================================
+// TakeProfitLimit Order Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_take_profit_limit_order() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = BinanceSpot::new(config);
+    let instrument = test_instrument();
+    let strategy = StrategyId::new("test-tpl");
+    let cid = ClientOrderId::new(format!("tpl-{}", chrono::Utc::now().timestamp_millis()));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::BinanceSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: cid.clone(),
+    };
+
+    // Place TAKE_PROFIT_LIMIT order
+    // Must be within PERCENT_PRICE_BY_SIDE filter (typically ~10% from current price)
+    let request = RequestOpen {
+        side: Side::Sell,
+        price: Some(dec!(109000)), // Limit price
+        quantity: dec!(0.001),
+        kind: OrderKind::TakeProfitLimit {
+            trigger_price: dec!(110000),
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request,
+    };
+
+    println!("Placing TakeProfitLimit order: SELL 0.001 BTC @ $109,000 when price >= $110,000");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("TakeProfitLimit order placed successfully!");
+            println!("  Exchange Order ID: {}", open_state.id);
+
+            // Cancel
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: OrderKey {
+                    exchange: ExchangeId::BinanceSpot,
+                    instrument: &instrument,
+                    strategy: response.key.strategy.clone(),
+                    cid: response.key.cid.clone(),
+                },
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            let cancel_response = client.cancel_order(cancel_request).await;
+            assert!(matches!(
+                cancel_response.as_ref().map(|r| &r.state),
+                Some(Ok(_))
+            ));
+            println!("Order canceled");
+        }
+        OrderState::Inactive(e) => panic!("TakeProfitLimit order rejected: {:?}", e),
+        other => panic!("Unexpected state: {:?}", other),
+    }
+}
+
+// ============================================================================
+// TrailingStop Order Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_trailing_stop_basis_points() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = BinanceSpot::new(config);
+    let instrument = test_instrument();
+    let strategy = StrategyId::new("test-trailing");
+    let cid = ClientOrderId::new(format!("trail-{}", chrono::Utc::now().timestamp_millis()));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::BinanceSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: cid.clone(),
+    };
+
+    // Place trailing stop with 100 basis points (1%) callback
+    let request = RequestOpen {
+        side: Side::Sell,
+        price: None,
+        quantity: dec!(0.001),
+        kind: OrderKind::TrailingStop {
+            offset: dec!(100), // 100 basis points = 1%
+            offset_type: TrailingOffsetType::BasisPoints,
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request,
+    };
+
+    println!("Placing TrailingStop order: SELL 0.001 BTC with 1% (100 bps) trailing delta");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("TrailingStop order placed successfully!");
+            println!("  Exchange Order ID: {}", open_state.id);
+
+            // Cancel
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: OrderKey {
+                    exchange: ExchangeId::BinanceSpot,
+                    instrument: &instrument,
+                    strategy: response.key.strategy.clone(),
+                    cid: response.key.cid.clone(),
+                },
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            let cancel_response = client.cancel_order(cancel_request).await;
+            assert!(matches!(
+                cancel_response.as_ref().map(|r| &r.state),
+                Some(Ok(_))
+            ));
+            println!("Order canceled");
+        }
+        OrderState::Inactive(e) => panic!("TrailingStop order rejected: {:?}", e),
+        other => panic!("Unexpected state: {:?}", other),
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_trailing_stop_percentage() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = BinanceSpot::new(config);
+    let instrument = test_instrument();
+    let strategy = StrategyId::new("test-trailing-pct");
+    let cid = ClientOrderId::new(format!(
+        "trail-pct-{}",
+        chrono::Utc::now().timestamp_millis()
+    ));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::BinanceSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: cid.clone(),
+    };
+
+    // Place trailing stop with 2% callback (specified as percentage)
+    let request = RequestOpen {
+        side: Side::Sell,
+        price: None,
+        quantity: dec!(0.001),
+        kind: OrderKind::TrailingStop {
+            offset: dec!(2), // 2% → converts to 200 basis points
+            offset_type: TrailingOffsetType::Percentage,
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request,
+    };
+
+    println!("Placing TrailingStop order: SELL 0.001 BTC with 2% trailing delta");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("TrailingStop (percentage) order placed successfully!");
+            println!("  Exchange Order ID: {}", open_state.id);
+
+            // Cancel
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: OrderKey {
+                    exchange: ExchangeId::BinanceSpot,
+                    instrument: &instrument,
+                    strategy: response.key.strategy.clone(),
+                    cid: response.key.cid.clone(),
+                },
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            let cancel_response = client.cancel_order(cancel_request).await;
+            assert!(matches!(
+                cancel_response.as_ref().map(|r| &r.state),
+                Some(Ok(_))
+            ));
+            println!("Order canceled");
+        }
+        OrderState::Inactive(e) => panic!("TrailingStop order rejected: {:?}", e),
+        other => panic!("Unexpected state: {:?}", other),
+    }
+}
+
+// ============================================================================
+// Unsupported Order Type Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_trailing_stop_absolute_rejected() {
+    init_logging();
+
+    let config = test_config();
+    assert!(
+        config.testnet,
+        "Integration tests must run on testnet only!"
+    );
+    let client = BinanceSpot::new(config);
+    let instrument = test_instrument();
+    let strategy = StrategyId::new("test-trail-abs-rejected");
+    let cid = ClientOrderId::new(format!("abs-{}", chrono::Utc::now().timestamp_millis()));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::BinanceSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: cid.clone(),
+    };
+
+    // TrailingStop with Absolute offset should be rejected
+    let request = RequestOpen {
+        side: Side::Sell,
+        price: None,
+        quantity: dec!(0.001),
+        kind: OrderKind::TrailingStop {
+            offset: dec!(1000), // $1000 absolute offset - NOT SUPPORTED
+            offset_type: TrailingOffsetType::Absolute,
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key,
+        state: request,
+    };
+
+    println!("Placing TrailingStop with Absolute offset (should be rejected)");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Inactive(e) => {
+            println!("Correctly rejected: {:?}", e);
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("Unsupported") || msg.contains("Absolute"),
+                "Error should mention unsupported type: {msg}"
+            );
+        }
+        other => panic!("Expected rejection, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_trailing_stop_limit_rejected() {
+    init_logging();
+
+    let config = test_config();
+    assert!(
+        config.testnet,
+        "Integration tests must run on testnet only!"
+    );
+    let client = BinanceSpot::new(config);
+    let instrument = test_instrument();
+    let strategy = StrategyId::new("test-tsl-rejected");
+    let cid = ClientOrderId::new(format!("tsl-{}", chrono::Utc::now().timestamp_millis()));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::BinanceSpot,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: cid.clone(),
+    };
+
+    // TrailingStopLimit should be rejected (Binance doesn't support it)
+    let request = RequestOpen {
+        side: Side::Sell,
+        price: Some(dec!(99000)),
+        quantity: dec!(0.001),
+        kind: OrderKind::TrailingStopLimit {
+            offset: dec!(100),
+            offset_type: TrailingOffsetType::BasisPoints,
+            limit_offset: dec!(50),
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key,
+        state: request,
+    };
+
+    println!("Placing TrailingStopLimit order (should be rejected)");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Inactive(e) => {
+            println!("Correctly rejected: {:?}", e);
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("Unsupported") || msg.contains("TrailingStopLimit"),
+                "Error should mention unsupported type: {msg}"
+            );
+        }
+        other => panic!("Expected rejection, got: {:?}", other),
+    }
+}

--- a/rustrade-execution/tests/hyperliquid_execution.rs
+++ b/rustrade-execution/tests/hyperliquid_execution.rs
@@ -414,6 +414,335 @@ async fn test_place_and_cancel_limit_order() {
 }
 
 // ============================================================================
+// Conditional Order Tests
+// ============================================================================
+
+/// Test that Stop orders require UUID-format client order ID.
+#[tokio::test]
+#[ignore]
+async fn test_stop_order_requires_uuid_cid() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = HyperliquidClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let instrument = btc_instrument();
+    let strategy = StrategyId::new("test-strategy");
+
+    // Use a non-UUID cid - should be rejected
+    let non_uuid_cid =
+        ClientOrderId::new(format!("test-{}", chrono::Utc::now().timestamp_millis()));
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::HyperliquidPerp,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: non_uuid_cid.clone(),
+    };
+
+    // Place a Stop order with non-UUID cid
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: None, // Market trigger - no limit price
+        quantity: dec!(0.001),
+        kind: OrderKind::Stop {
+            trigger_price: dec!(80000.0), // Stop below current price
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key,
+        state: request_open,
+    };
+
+    println!("Placing Stop order with non-UUID cid (should be rejected)...");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Inactive(rustrade_execution::order::state::InactiveOrderState::OpenFailed(
+            rustrade_execution::error::OrderError::Rejected(err),
+        )) => {
+            println!("Stop order correctly rejected: {:?}", err);
+            assert!(
+                err.to_string().contains("UUID"),
+                "Error message should mention UUID requirement"
+            );
+        }
+        other => {
+            panic!("Expected rejection for non-UUID cid, got: {:?}", other);
+        }
+    }
+}
+
+/// Test placing and canceling a Stop order with proper UUID cid.
+#[tokio::test]
+#[ignore]
+async fn test_place_and_cancel_stop_order() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = HyperliquidClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let instrument = btc_instrument();
+    let strategy = StrategyId::new("test-strategy");
+
+    // Use UUID cid as required for trigger orders
+    let uuid_cid = ClientOrderId::uuid();
+    println!("Using UUID cid: {}", uuid_cid);
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::HyperliquidPerp,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: uuid_cid.clone(),
+    };
+
+    // Place a Stop order (sell stop below market to avoid triggering)
+    // BTC ~$95k, so $50k stop is well below market
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: None, // Market trigger
+        quantity: dec!(0.001),
+        kind: OrderKind::Stop {
+            trigger_price: dec!(50000.0),
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key.clone(),
+        state: request_open,
+    };
+
+    println!("Placing Stop order: SELL 0.001 BTC-USD-PERP @ stop $50,000");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("Stop order placed successfully!");
+            println!("  Client Order ID (UUID): {}", response.key.cid);
+            println!("  Order ID: {}", open_state.id);
+
+            // Note: Exchange may return numeric OID (Resting) or UUID (WaitingForTrigger)
+            // depending on the trigger order type. Both should work for cancellation.
+            let is_uuid_format = open_state.id.0.contains('-');
+            println!(
+                "  Order ID format: {}",
+                if is_uuid_format {
+                    "UUID (cloid)"
+                } else {
+                    "numeric (OID)"
+                }
+            );
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Cancel using the order ID (works for both OID and cloid)
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::HyperliquidPerp,
+                instrument: &instrument,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling Stop order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+
+            assert!(cancel_response.is_some(), "Expected cancel response");
+            let cancel_response = cancel_response.unwrap();
+
+            match &cancel_response.state {
+                Ok(cancelled) => {
+                    println!("Stop order canceled successfully!");
+                    println!("  Cancelled at: {}", cancelled.time_exchange);
+                }
+                Err(e) => {
+                    panic!("Cancel rejected: {:?}", e);
+                }
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("Stop order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}
+
+/// Test placing and canceling a TakeProfit order.
+#[tokio::test]
+#[ignore]
+async fn test_place_and_cancel_take_profit_order() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = HyperliquidClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let instrument = btc_instrument();
+    let strategy = StrategyId::new("test-strategy");
+    let uuid_cid = ClientOrderId::uuid();
+
+    let order_key = OrderKey {
+        exchange: ExchangeId::HyperliquidPerp,
+        instrument: &instrument,
+        strategy: strategy.clone(),
+        cid: uuid_cid.clone(),
+    };
+
+    // Place a TakeProfit order (sell TP above market to avoid triggering)
+    // BTC ~$95k, so $150k TP is well above market
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: None, // Market trigger
+        quantity: dec!(0.001),
+        kind: OrderKind::TakeProfit {
+            trigger_price: dec!(150000.0),
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key,
+        state: request_open,
+    };
+
+    println!("Placing TakeProfit order: SELL 0.001 BTC-USD-PERP @ TP $150,000");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some(), "Expected order response");
+    let response = response.unwrap();
+
+    match &response.state {
+        OrderState::Active(ActiveOrderState::Open(open_state)) => {
+            println!("TakeProfit order placed successfully!");
+            println!("  Order ID (cloid): {}", open_state.id);
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Cancel
+            let cancel_key = OrderKey {
+                exchange: ExchangeId::HyperliquidPerp,
+                instrument: &response.key.instrument,
+                strategy: response.key.strategy.clone(),
+                cid: response.key.cid.clone(),
+            };
+
+            let cancel_request = rustrade_execution::order::OrderEvent {
+                key: cancel_key,
+                state: rustrade_execution::order::request::RequestCancel {
+                    id: Some(open_state.id.clone()),
+                },
+            };
+
+            println!("Canceling TakeProfit order...");
+            let cancel_response = client.cancel_order(cancel_request).await;
+            assert!(cancel_response.is_some());
+
+            match &cancel_response.unwrap().state {
+                Ok(_) => println!("TakeProfit order canceled successfully!"),
+                Err(e) => panic!("Cancel rejected: {:?}", e),
+            }
+        }
+        OrderState::Inactive(e) => {
+            panic!("TakeProfit order rejected: {:?}", e);
+        }
+        other => {
+            panic!("Unexpected order state: {:?}", other);
+        }
+    }
+}
+
+/// Test that TrailingStop orders are rejected (unsupported).
+#[tokio::test]
+#[ignore]
+async fn test_trailing_stop_unsupported() {
+    init_logging();
+
+    let config = test_config();
+    assert!(config.testnet, "This test MUST run on testnet only!");
+
+    let client = HyperliquidClient::connect(config)
+        .await
+        .expect("Failed to connect");
+
+    let instrument = btc_instrument();
+    let order_key = OrderKey {
+        exchange: ExchangeId::HyperliquidPerp,
+        instrument: &instrument,
+        strategy: StrategyId::new("test"),
+        cid: ClientOrderId::uuid(),
+    };
+
+    let request_open = RequestOpen {
+        side: Side::Sell,
+        price: None,
+        quantity: dec!(0.001),
+        kind: OrderKind::TrailingStop {
+            offset: dec!(100.0),
+            offset_type: rustrade_execution::order::TrailingOffsetType::Absolute,
+        },
+        time_in_force: TimeInForce::GoodUntilCancelled { post_only: false },
+        position_id: None,
+        reduce_only: false,
+    };
+
+    let open_request = rustrade_execution::order::OrderEvent {
+        key: order_key,
+        state: request_open,
+    };
+
+    println!("Placing TrailingStop order (should be rejected as unsupported)...");
+
+    let response = client.open_order(open_request).await;
+    assert!(response.is_some());
+
+    match &response.unwrap().state {
+        OrderState::Inactive(rustrade_execution::order::state::InactiveOrderState::OpenFailed(
+            rustrade_execution::error::OrderError::UnsupportedOrderType(msg),
+        )) => {
+            println!("TrailingStop correctly rejected: {}", msg);
+            assert!(msg.to_lowercase().contains("trailing"));
+        }
+        other => {
+            panic!("Expected UnsupportedOrderType, got: {:?}", other);
+        }
+    }
+}
+
+// ============================================================================
 // Account Stream Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Add `TakeProfit` and `TakeProfitLimit` order kinds to complete conditional order types
- Implement conditional order support for Binance Spot (Stop, StopLimit, TakeProfit, TakeProfitLimit)
- Implement conditional order support for Hyperliquid Spot and Perp with UUID-based trigger orders

## Changes

### Order Types
- New `OrderKind::TakeProfit` and `OrderKind::TakeProfitLimit` variants
- `ClientOrderId::uuid()` constructor for exchanges requiring UUID format

### Binance Spot
- Maps conditional orders to native order types (STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, TAKE_PROFIT_LIMIT)
- Full lifecycle support: placement, cancellation, fill detection

### Hyperliquid (Spot + Perp)
- Maps conditional orders to trigger orders with `tpsl` flag
- Enforces UUID requirement for trigger orders (enables cancellation via SDK)
- Dual-path cancellation: numeric OID for limit orders, UUID for trigger orders

## Test Plan

- [x] `cargo test --test binance_conditional_orders` - Binance integration tests
- [x] `cargo test --test hyperliquid_execution` - Hyperliquid integration tests
- [x] `cargo clippy --workspace --all-targets --all-features`

Closes #96 #93 #94