### PR TITLE
docs(execution): correct order-type support matrix in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the order-type support matrix in `rustrade-execution/README.md` to reflect Binance and Hyperliquid conditional order support (Stop, StopLimit, TakeProfit, TakeProfitLimit), Binance trailing-stop offset limitations, and Hyperliquid's lack of native market orders.
+
 ## [0.2.1] - 2026-05-28
 
 ### Added

--- a/rustrade-execution/README.md
+++ b/rustrade-execution/README.md
@@ -14,13 +14,22 @@ Execution client library for streaming private account data and executing orders
 
 ## Order Types
 
-All connectors support Market and Limit orders. Additional order types:
+All connectors support Limit orders. Market orders are supported everywhere except
+Hyperliquid (use a Limit order with `ImmediateOrCancel` time-in-force instead).
+Additional order types:
 
 | Order Type | IBKR | Alpaca | Binance | Hyperliquid |
 |:----------:|:----:|:------:|:-------:|:-----------:|
-| Stop | ✅ | ✅ | ❌ | ❌ |
-| StopLimit | ✅ | ✅ | ❌ | ❌ |
-| TrailingStop | ✅ | ✅ | ❌ | ❌ |
+| Stop | ✅ | ✅ | ✅ | ✅ |
+| StopLimit | ✅ | ✅ | ✅ | ✅ |
+| TakeProfit | ❌ | ❌ | ✅ | ✅ |
+| TakeProfitLimit | ❌ | ❌ | ✅ | ✅ |
+| TrailingStop | ✅ | ✅ | ⚠️ | ❌ |
 | TrailingStopLimit | ✅ | ❌ | ❌ | ❌ |
+
+⚠️ Binance `TrailingStop` supports `BasisPoints` and `Percentage` offsets only;
+`Absolute` offsets are rejected as unsupported. Hyperliquid trigger orders (Stop,
+StopLimit, TakeProfit, TakeProfitLimit) require a UUID-format client order ID
+(`ClientOrderId::uuid()`).
 
 See the [workspace README](../README.md) for documentation, examples, and contributing guidelines.


### PR DESCRIPTION
## Summary

The **Order Types** table in `rustrade-execution/README.md` was stale — it listed Binance and Hyperliquid as having no conditional order support and omitted the `TakeProfit` / `TakeProfitLimit` order kinds entirely. This corrects the matrix to match the actual client implementations.

## Changes

- Binance and Hyperliquid now show `Stop`, `StopLimit`, `TakeProfit`, and `TakeProfitLimit` as supported.
- Added `TakeProfit` / `TakeProfitLimit` rows (supported on Binance and Hyperliquid; unsupported on IBKR and Alpaca).
- Marked Binance `TrailingStop` as partial (⚠️): `BasisPoints` and `Percentage` offsets only; `Absolute` offsets are rejected.
- Corrected the prose claim that all connectors support Market orders — Hyperliquid does not (use a Limit order with `ImmediateOrCancel` instead).
- Documented that Hyperliquid trigger orders require a UUID-format client order ID.
- Added an `[Unreleased]` → `Fixed` entry to `CHANGELOG.md`.

Docs-only; no code changes.