### PR TITLE
feat(binance-margin): Binance isolated margin execution support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Binance Cross Margin execution client** (`BinanceMargin`, `binance` feature)
+- **Binance Margin execution client** (`BinanceMargin`, `binance` feature) — **cross and isolated**
   - Implements the full `ExecutionClient` trait, so callers do not branch on spot-vs-margin
     transport: order submission/cancel and account snapshot / balance / open-order / trade queries
     over the margin REST API, plus a live account event stream.
   - `BinanceMarginConfig` with `MarginSideEffect` borrow/repay policy (`AutoBorrowRepay` default /
-    `NoBorrow`), set once per client (`sideEffectType`). `BinanceMarginConfig::cross_margin(api_key, secret_key)`
-    convenience constructor.
+    `NoBorrow`), set once per client (`sideEffectType`). Mode is selected by `is_isolated`, with
+    `BinanceMarginConfig::cross_margin(api_key, secret_key)` and
+    `BinanceMarginConfig::isolated(api_key, secret_key, symbols)` convenience constructors.
   - Live user-data stream is hand-rolled over the `userListenToken` model (the legacy margin
     listen-key API was retired by Binance on 2026-02-20): token acquisition, renew-before-expiry,
     auto-reconnect, exponential backoff, heartbeat monitoring, fill recovery, and dedup —
     spot-equivalent resilience.
-  - Scope: **cross** margin only (account-wide). Isolated (per-pair) margin is a planned follow-up.
   - Limitations: `TrailingStop`/`TrailingStopLimit` return `UnsupportedOrderType` (the SDK margin
     binding omits `trailingDelta`); Binance margin/SAPI has no testnet (a `testnet: true` config is
     inert and resolves to production, logged at construction).
+- **Binance Isolated Margin support** (per-pair sub-accounts; `is_isolated = true` + `isolated_symbols`)
+  - `BinanceMarginConfig::isolated_symbols: Vec<InstrumentNameExchange>` declares the per-pair
+    universe (the authoritative symbol set for the isolated tokens/stream, fixed for the stream's
+    lifetime — pairs added later require a restart). `BinanceMargin::new` **panics** if
+    `is_isolated = true` with an empty `isolated_symbols`.
+  - Per-pair balances and risk are surfaced **per-instrument** on
+    `InstrumentAccountSnapshot.isolated` — a single `Option<IsolatedInstrumentState>` field carrying
+    base/quote `AssetBalance` plus `risk` — rather than folded into the asset-keyed `AccountSnapshot.balances`
+    (which would collide on shared assets). New public types `IsolatedInstrumentState` and
+    `IsolatedMarginRisk` (`margin_level` / `margin_ratio` / `liquidation_price`, snapshot-fresh, no
+    live stream twin). Under isolated, `fetch_balances` returns an empty `Vec` (per-pair balances are
+    per-instrument, not asset-keyed); snapshot/open-order/trade queries cover one identical effective
+    set (`isolated_symbols`, or `instruments ∩ isolated_symbols` with out-of-set instruments skipped
+    with a warning).
+  - Live per-pair `free`/`locked` arrives over the isolated stream as the new
+    `AccountEventKind::InstrumentBalanceUpdate` (base + quote per pair). The engine deliberately does
+    **not** store it (mirroring the snapshot's `isolated` field): consumers read it off the raw
+    account-event stream, not via `EngineState` / a `StateReplicaManager` replica. The public
+    `Balance::apply_stream_update` utility single-sources the no-clobber merge (apply WS `free`/`locked`,
+    preserve REST-snapshot debt).
+  - Transport: per-symbol `userListenToken`s are **multiplexed onto a single WS-API socket**; all
+    tokens are acquired, connected, and subscribed before `account_stream` returns (any failure →
+    `Err`, nothing spawned), with planned-reconnect token renewal. The cross stream is a separate,
+    untouched manager.
+  - Known limitation: all events are stamped `ExchangeId::BinanceMargin`, so a single engine should
+    run at most one `BinanceMargin` client (cross + isolated concurrently need separate engines).
 - **Margin-aware universal `Balance`**
   - `MarginDetails { borrowed, interest }` and `Balance.margin: Option<MarginDetails>`; the per-asset
     debt model generalises across CEX per-asset-margin venues (cash/no-debt venues leave `margin: None`).
@@ -51,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `margin`). No behavioural change for spot (which carries no debt) beyond the event variant.
 - **Binance `GoodUntilEndOfDay` (GTD) time-in-force is now rejected as `UnsupportedOrderType`** instead of being silently coerced to `GoodTillCancelled` (GTC). Binance has no native end-of-day order, and coercing to GTC dropped the EOD auto-cancel semantics — risking an unintended resting order. This affects both the spot and margin clients.
 - **Binance margin user-data frames are parsed without a full JSON DOM.** The WS receive path now deserializes a borrowed envelope (`serde_json::value::RawValue` for the inner `event`) and reads the event discriminator from a raw slice, so only the matched event type pays for a single typed pass — no intermediate `serde_json::Value` tree is built per frame on this hot path. Internal only; no public API change (the `binance` feature now enables `serde_json/raw_value`).
+- **`InstrumentAccountSnapshot` gained a public `isolated: Option<IsolatedInstrumentState>` field**, and **`AccountEventKind` gained an `InstrumentBalanceUpdate` variant** (both for isolated margin). Both are additive on the wire (`Option` + `#[serde(default)]` / `#[non_exhaustive]` enum), but `InstrumentAccountSnapshot::new()`'s arity went 3→4 (struct-literal / `::new()` call sites must pass the new field) and the library's `indexer.rs` gained one match arm — a minor breaking change for code that directly constructs `InstrumentAccountSnapshot`. The new field sorts/hashes last (`None` before `Some`), so it acts only as a tie-breaker; the cross stream/snapshot paths are unchanged.
 
 ### Fixed
 

--- a/rustrade-execution/src/balance.rs
+++ b/rustrade-execution/src/balance.rs
@@ -129,6 +129,25 @@ impl Balance {
             None => self.total,
         }
     }
+
+    /// Merge a WS partial [`BalanceUpdate`] onto an optional prior [`Balance`], preserving debt.
+    ///
+    /// Applies the stream's live `free`/`locked` (recomputing `total = free + locked`) while
+    /// carrying forward any [`MarginDetails`] from `prior` — a partial update never carries debt, so
+    /// this is the single-sourced "debt fresh as of last snapshot, `free`/`locked` live over the
+    /// stream" merge. On a cold start (`prior = None`) the result has `margin: None`.
+    ///
+    /// This is the same no-clobber merge the engine applies internally for asset-keyed balances. It
+    /// is exposed so consumers applying per-instrument
+    /// [`InstrumentBalanceUpdate`](crate::InstrumentBalanceUpdate) frames — which the engine does
+    /// not store — can reuse it rather than re-implement the contract.
+    pub fn apply_stream_update(prior: Option<Balance>, update: &BalanceUpdate) -> Balance {
+        Balance {
+            total: update.total(),
+            free: update.free,
+            margin: prior.and_then(|b| b.margin),
+        }
+    }
 }
 
 /// Partial balance update carrying only `free`/`locked` — the shape delivered by exchange WS

--- a/rustrade-execution/src/client/alpaca/mod.rs
+++ b/rustrade-execution/src/client/alpaca/mod.rs
@@ -2771,7 +2771,7 @@ fn build_instrument_snapshots(
         by_symbol
             .into_iter()
             .map(|(sym, orders)| {
-                InstrumentAccountSnapshot::new(InstrumentNameExchange::new(sym), orders, None)
+                InstrumentAccountSnapshot::new(InstrumentNameExchange::new(sym), orders, None, None)
             })
             .collect()
     } else {
@@ -2783,7 +2783,7 @@ fn build_instrument_snapshots(
                 let orders = by_symbol
                     .swap_remove(inst.name().as_str())
                     .unwrap_or_default();
-                InstrumentAccountSnapshot::new(inst.clone(), orders, None)
+                InstrumentAccountSnapshot::new(inst.clone(), orders, None, None)
             })
             .collect()
     }

--- a/rustrade-execution/src/client/binance/margin.rs
+++ b/rustrade-execution/src/client/binance/margin.rs
@@ -32,8 +32,8 @@ use super::shared::{
     new_dedup_cache, parse_order_kind, parse_side, parse_time_in_force, rest_call_with_retry,
 };
 use crate::{
-    AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot, UnindexedAccountEvent,
-    UnindexedAccountSnapshot,
+    AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot, IsolatedInstrumentState,
+    IsolatedMarginRisk, UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::{AssetBalance, AssetBalanceUpdate, Balance, BalanceUpdate},
     client::ExecutionClient,
     error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
@@ -59,8 +59,10 @@ use binance_sdk::{
             MarginAccountNewOrderParams, MarginAccountNewOrderSideEnum,
             MarginAccountNewOrderTimeInForceEnum, QueryCrossMarginAccountDetailsParams,
             QueryCrossMarginAccountDetailsResponseUserAssetsInner,
-            QueryMarginAccountsOpenOrdersParams, QueryMarginAccountsOpenOrdersResponseInner,
-            QueryMarginAccountsTradeListParams, QueryMarginAccountsTradeListResponseInner, RestApi,
+            QueryIsolatedMarginAccountInfoParams,
+            QueryIsolatedMarginAccountInfoResponseAssetsInner, QueryMarginAccountsOpenOrdersParams,
+            QueryMarginAccountsOpenOrdersResponseInner, QueryMarginAccountsTradeListParams,
+            QueryMarginAccountsTradeListResponseInner, RestApi,
         },
         websocket_streams::{
             Executionreport, MarginLevelStatusChange, Outboundaccountposition, UserLiabilityChange,
@@ -77,7 +79,7 @@ use rustrade_instrument::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, format_smolstr};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     str::FromStr,
     sync::{
         Arc,
@@ -288,10 +290,15 @@ impl BinanceMarginConfig {
 /// borrow intent is intentionally not modelled (it would require position tracking); see
 /// [`MarginSideEffect`] for the rationale and upgrade path.
 ///
-/// # Scope: cross margin only
-/// This client is **cross** margin (`isIsolated = "FALSE"`, account-wide collateral). Isolated
-/// (per-pair) margin is a separate follow-up and is **not** honoured by this client regardless of
-/// [`BinanceMarginConfig::is_isolated`] (the constructor warns if it is set).
+/// # Cross vs. isolated margin
+/// The mode is fixed per client via [`BinanceMarginConfig::is_isolated`]:
+/// - **Cross** (`is_isolated = false`, `isIsolated = "FALSE"`, account-wide collateral): per-asset
+///   balances (incl. debt) are surfaced account-wide in the top-level `balances`.
+/// - **Isolated** (`is_isolated = true`): per-pair sub-accounts. Balances + risk are attached
+///   **per-instrument** via [`InstrumentAccountSnapshot::isolated`] (the asset-keyed top-level
+///   `balances` is left empty, since `(pair, asset)` slots would collide), and per-symbol queries
+///   are scoped to the configured [`BinanceMarginConfig::isolated_symbols`]. See
+///   [`account_snapshot`](Self::account_snapshot) for the full per-method semantics.
 ///
 /// # Trailing stops unsupported
 /// `TrailingStop` / `TrailingStopLimit` return [`OrderError::UnsupportedOrderType`]: the binance-sdk
@@ -379,6 +386,112 @@ impl BinanceMargin {
             .ws_url(SPOT_WS_API_PROD_URL)
             .build()
             .expect("failed to build Binance margin WebSocket configuration")
+    }
+
+    /// Resolve the per-call effective isolated symbol set (isolated mode only).
+    ///
+    /// Isolated margin queries are per-symbol on the venue (there is no account-wide "no symbol =
+    /// all" affordance), so every isolated snapshot/query iterates an explicit symbol set:
+    /// - empty `instruments` (the "return all" sentinel) → the full configured
+    ///   [`isolated_symbols`](BinanceMarginConfig::isolated_symbols);
+    /// - non-empty → `instruments ∩ isolated_symbols`; any requested instrument NOT in
+    ///   `isolated_symbols` is skipped with a `warn!` (there is no configured isolated
+    ///   token/stream/snapshot for it — returning it would be a silent mismatch).
+    ///
+    /// Shared by `account_snapshot`, `fetch_open_orders`, and `fetch_trades` so their instrument,
+    /// open-order, and trade sets cannot drift apart.
+    fn effective_isolated_set(
+        &self,
+        instruments: &[InstrumentNameExchange],
+    ) -> Vec<InstrumentNameExchange> {
+        if instruments.is_empty() {
+            return self.config.isolated_symbols.clone();
+        }
+        instruments
+            .iter()
+            .filter(|inst| {
+                let in_set = self.config.isolated_symbols.contains(*inst);
+                if !in_set {
+                    warn!(
+                        instrument = %inst.name(),
+                        "BinanceMargin isolated: requested instrument not in configured isolated_symbols — skipping"
+                    );
+                }
+                in_set
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Isolated-margin `account_snapshot`: per-pair balances + risk attached per-instrument, with
+    /// the asset-keyed top-level `balances` left empty (Design decision #2). Open orders and
+    /// isolated balances cover the same effective isolated set so they cannot diverge.
+    async fn isolated_account_snapshot(
+        &self,
+        instruments: &[InstrumentNameExchange],
+    ) -> Result<UnindexedAccountSnapshot, UnindexedClientError> {
+        use futures::{StreamExt as _, TryStreamExt as _};
+
+        let effective = self.effective_isolated_set(instruments);
+        if effective.is_empty() {
+            // No configured isolated pair matched: a no-symbol isolated call is invalid, so there is
+            // nothing to query — return an empty snapshot rather than an account-wide one.
+            return Ok(AccountSnapshot::new(
+                ExchangeId::BinanceMargin,
+                Vec::new(),
+                Vec::new(),
+            ));
+        }
+
+        // Per-pair isolated balances + risk (chunked ≤5 symbols/request), keyed by instrument.
+        let mut balances_by_symbol = convert_isolated_margin_assets(
+            fetch_isolated_margin_account_info(
+                self.rest.clone(),
+                self.rate_limiter.clone(),
+                effective.clone(),
+            )
+            .await?,
+        );
+
+        // Open orders per instrument over the same effective set, concurrently (bounded to avoid
+        // bursting request-weight limits).
+        let instrument_snapshots: Vec<_> =
+            futures::stream::iter(effective.into_iter().map(|instrument| {
+                fetch_margin_open_orders_for_instrument(
+                    self.rest.clone(),
+                    self.rate_limiter.clone(),
+                    instrument,
+                    true,
+                )
+            }))
+            .buffer_unordered(8)
+            .map(|result| {
+                let (inst, orders) = result?;
+                let wrapped = orders.into_iter().map(active_order_snapshot).collect();
+                let isolated = balances_by_symbol.remove(&inst);
+                if isolated.is_none() {
+                    // The same effective set drives both balances and open orders, so a miss here
+                    // means the venue's isolated-account response omitted (or mis-keyed) a requested
+                    // pair. Surface it rather than silently emitting `isolated: None`.
+                    warn!(
+                        instrument = %inst.name(),
+                        "BinanceMargin isolated: no isolated balance entry returned for instrument — snapshot will carry isolated: None"
+                    );
+                }
+                Ok::<_, UnindexedClientError>(InstrumentAccountSnapshot::new(
+                    inst, wrapped, None, isolated,
+                ))
+            })
+            .try_collect()
+            .await?;
+
+        // Isolated balances live on the instrument snapshots; the asset-keyed top-level vec stays
+        // empty so the engine's `update_from_account` never writes colliding per-asset slots.
+        Ok(AccountSnapshot::new(
+            ExchangeId::BinanceMargin,
+            Vec::new(),
+            instrument_snapshots,
+        ))
     }
 }
 
@@ -692,18 +805,28 @@ impl ExecutionClient for BinanceMargin {
         })
     }
 
-    /// Fetch a full cross-margin account snapshot: per-asset balances (incl. debt) plus open
-    /// orders for each requested instrument.
+    /// Fetch a full margin account snapshot: balances plus open orders per instrument.
     ///
-    /// Balances come from `query_cross_margin_account_details` (account-wide `userAssets`,
-    /// carrying `borrowed`/`interest` → [`Balance::new_margin`]); open orders are fetched
-    /// per-instrument, mirroring [`BinanceSpot::account_snapshot`](super::spot::BinanceSpot).
-    /// Cross only (`isIsolated = "FALSE"`).
+    /// **Cross** (`is_isolated = false`): account-wide per-asset balances from
+    /// `query_cross_margin_account_details` (carrying `borrowed`/`interest` → [`Balance::new_margin`])
+    /// in the top-level `balances`, plus open orders per requested instrument — mirroring
+    /// [`BinanceSpot::account_snapshot`](super::spot::BinanceSpot).
+    ///
+    /// **Isolated** (`is_isolated = true`): per-pair balances + risk from
+    /// `query_isolated_margin_account_info` (chunked ≤5 symbols/request), attached **per-instrument**
+    /// via [`InstrumentAccountSnapshot::isolated`] rather than folded into the asset-keyed
+    /// top-level `balances` (which is left **empty**) — isolated sub-accounts are per-`(pair, asset)`
+    /// and would collide in the asset-keyed model. The instrument set is the effective isolated set
+    /// (see [`effective_isolated_set`](Self::effective_isolated_set)); each instrument's open orders
+    /// and isolated balances are fetched over that same set.
     async fn account_snapshot(
         &self,
         assets: &[AssetNameExchange],
         instruments: &[InstrumentNameExchange],
     ) -> Result<UnindexedAccountSnapshot, UnindexedClientError> {
+        if self.config.is_isolated {
+            return self.isolated_account_snapshot(instruments).await;
+        }
         let response = rest_call_with_retry(&self.rest, &self.rate_limiter, |rest| {
             Box::pin(async move {
                 let params = QueryCrossMarginAccountDetailsParams::builder().build()?;
@@ -732,25 +855,17 @@ impl ExecutionClient for BinanceMargin {
                     self.rest.clone(),
                     self.rate_limiter.clone(),
                     instrument,
-                    self.config.is_isolated,
+                    // Cross path only: isolated returns early via `isolated_account_snapshot`.
+                    false,
                 )
             }))
             .buffer_unordered(8)
             .map(|result| {
                 let (inst, orders) = result?;
-                let wrapped = orders
-                    .into_iter()
-                    .map(|o| Order {
-                        key: o.key,
-                        side: o.side,
-                        price: o.price,
-                        quantity: o.quantity,
-                        kind: o.kind,
-                        time_in_force: o.time_in_force,
-                        state: OrderState::active(o.state),
-                    })
-                    .collect();
-                Ok::<_, UnindexedClientError>(InstrumentAccountSnapshot::new(inst, wrapped, None))
+                let wrapped = orders.into_iter().map(active_order_snapshot).collect();
+                Ok::<_, UnindexedClientError>(InstrumentAccountSnapshot::new(
+                    inst, wrapped, None, None,
+                ))
             })
             .try_collect()
             .await?;
@@ -762,12 +877,22 @@ impl ExecutionClient for BinanceMargin {
         ))
     }
 
-    /// Fetch current cross-margin balances (incl. `borrowed`/`interest` debt) for the requested
-    /// assets. An empty `assets` slice is the "return all" sentinel.
+    /// Fetch current margin balances (incl. `borrowed`/`interest` debt) for the requested assets.
+    ///
+    /// **Cross**: account-wide per-asset balances; an empty `assets` slice is the "return all"
+    /// sentinel.
+    ///
+    /// **Isolated**: returns an empty `Vec`. Isolated balances are per-`(pair, asset)` and the
+    /// asset-keyed return type cannot carry them without collision — they are surfaced per-instrument
+    /// via [`account_snapshot`](Self::account_snapshot)'s [`InstrumentAccountSnapshot::isolated`]
+    /// instead (Design decision #2).
     async fn fetch_balances(
         &self,
         assets: &[AssetNameExchange],
     ) -> Result<Vec<AssetBalance<AssetNameExchange>>, UnindexedClientError> {
+        if self.config.is_isolated {
+            return Ok(Vec::new());
+        }
         let response = rest_call_with_retry(&self.rest, &self.rate_limiter, |rest| {
             Box::pin(async move {
                 let params = QueryCrossMarginAccountDetailsParams::builder().build()?;
@@ -788,34 +913,64 @@ impl ExecutionClient for BinanceMargin {
         ))
     }
 
-    /// Fetch currently open cross-margin orders, optionally filtered by instrument.
+    /// Fetch currently open margin orders, optionally filtered by instrument.
     ///
-    /// Honours the `ExecutionClient::fetch_open_orders` contract: an empty `instruments` slice is
-    /// the "return all" sentinel, served by a single no-symbol `query_margin_accounts_open_orders`
-    /// call returning open orders across every cross-margin instrument (each order's instrument is
-    /// taken from its own `symbol` field). A non-empty slice fetches the listed instruments
-    /// concurrently, per-symbol. Cross only (`isIsolated = "FALSE"`).
+    /// **Cross**: honours the `ExecutionClient::fetch_open_orders` "return all" sentinel — an empty
+    /// `instruments` slice is served by a single no-symbol `query_margin_accounts_open_orders` call
+    /// (each order's instrument taken from its own `symbol`); a non-empty slice fetches the listed
+    /// instruments concurrently, per-symbol.
+    ///
+    /// **Isolated**: per-symbol on the venue — always iterates the effective isolated set (empty
+    /// `instruments` → configured `isolated_symbols`; out-of-set instruments skipped with a warning);
+    /// never issues a no-symbol isolated call (Design decision #4).
     async fn fetch_open_orders(
         &self,
         instruments: &[InstrumentNameExchange],
     ) -> Result<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>, UnindexedClientError> {
-        // Empty slice = "return all" sentinel: a single no-symbol query is both correct (the
-        // contract requires all instruments) and far cheaper than enumerating every symbol.
+        use futures::{StreamExt as _, TryStreamExt as _};
+
+        // Isolated: per-symbol on the venue — always iterate the effective set (never a no-symbol
+        // isolated call, which would error). The empty-`instruments` sentinel resolves to the
+        // configured isolated_symbols (Design decision #4).
+        if self.config.is_isolated {
+            let effective = self.effective_isolated_set(instruments);
+            let capacity = effective.len();
+            return futures::stream::iter(effective.into_iter().map(|instrument| {
+                fetch_margin_open_orders_for_instrument(
+                    self.rest.clone(),
+                    self.rate_limiter.clone(),
+                    instrument,
+                    true,
+                )
+            }))
+            .buffer_unordered(8)
+            .try_fold(
+                Vec::with_capacity(capacity),
+                |mut acc: Vec<Order<ExchangeId, InstrumentNameExchange, Open>>,
+                 (_, orders)| async move {
+                    acc.extend(orders);
+                    Ok(acc)
+                },
+            )
+            .await;
+        }
+
+        // Cross: empty slice = "return all" sentinel — a single no-symbol query is both correct
+        // (the contract requires all instruments) and far cheaper than enumerating every symbol.
         if instruments.is_empty() {
             return fetch_margin_all_open_orders(
                 self.rest.clone(),
                 self.rate_limiter.clone(),
-                self.config.is_isolated,
+                false,
             )
             .await;
         }
-        use futures::{StreamExt as _, TryStreamExt as _};
         futures::stream::iter(instruments.iter().cloned().map(|instrument| {
             fetch_margin_open_orders_for_instrument(
                 self.rest.clone(),
                 self.rate_limiter.clone(),
                 instrument,
-                self.config.is_isolated,
+                false,
             )
         }))
         .buffer_unordered(8)
@@ -829,16 +984,18 @@ impl ExecutionClient for BinanceMargin {
         .await
     }
 
-    /// Fetch cross-margin trades (fills) since `time_since`, optionally filtered by instrument.
+    /// Fetch margin trades (fills) since `time_since`, optionally filtered by instrument.
     ///
     /// **Documented deviation from the `ExecutionClient::fetch_trades` "return all" contract:**
     /// Binance's margin trade-list endpoint (`myTrades`) requires a symbol — there is no no-symbol
-    /// "all trades" query (unlike open orders). An empty `instruments` slice therefore has nothing
-    /// to query and returns an empty `Vec`; callers wanting all trades must enumerate instruments
-    /// explicitly. (Open orders *do* honour the sentinel — see [`fetch_open_orders`](Self::fetch_open_orders).)
-    // `.iter().cloned()` is required: Rust async closures cannot satisfy the HRTB needed by the
-    // iterator machinery, even when the clone is moved inside the closure body (mirrors spot).
-    #[allow(clippy::redundant_iter_cloned)]
+    /// "all trades" query (unlike open orders).
+    ///
+    /// **Cross**: an empty `instruments` slice has nothing to query and returns an empty `Vec`;
+    /// callers wanting all trades must enumerate instruments explicitly.
+    ///
+    /// **Isolated**: the empty sentinel resolves to the configured `isolated_symbols` (the effective
+    /// isolated set; out-of-set instruments skipped with a warning), iterated per-symbol (Design
+    /// decision #4).
     async fn fetch_trades(
         &self,
         time_since: DateTime<Utc>,
@@ -846,9 +1003,19 @@ impl ExecutionClient for BinanceMargin {
     ) -> Result<Vec<Trade<AssetNameExchange, InstrumentNameExchange>>, UnindexedClientError> {
         use futures::StreamExt as _;
 
-        if instruments.is_empty() {
+        // Resolve the effective instrument set. Isolated resolves the empty sentinel to the
+        // configured isolated_symbols; cross keeps the slice verbatim (no no-symbol "all" form).
+        let effective: Vec<InstrumentNameExchange> = if self.config.is_isolated {
+            self.effective_isolated_set(instruments)
+        } else {
+            instruments.to_vec()
+        };
+        if effective.is_empty() {
+            // Distinguish the two empty causes: cross with an empty `instruments` slice (the
+            // documented no-op sentinel) vs. isolated with no configured `isolated_symbols` matched.
             debug!(
-                "BinanceMargin fetch_trades called with empty instruments slice — returning empty result"
+                is_isolated = self.config.is_isolated,
+                "BinanceMargin fetch_trades: empty effective instrument set — returning empty result"
             );
             return Ok(Vec::new());
         }
@@ -858,7 +1025,7 @@ impl ExecutionClient for BinanceMargin {
 
         // Binance requires per-symbol queries for trade history. Limit concurrency to avoid
         // bursting Binance's request weight limits.
-        let mut stream = futures::stream::iter(instruments.iter().cloned().map(|inst| {
+        let mut stream = futures::stream::iter(effective.into_iter().map(|inst| {
             let rest = self.rest.clone();
             let rate_limiter = self.rate_limiter.clone();
             async move {
@@ -2162,6 +2329,211 @@ fn filter_and_convert_margin_balances(
         .collect()
 }
 
+/// Wrap a fetched `Open` order as an `OrderState::active` snapshot for `account_snapshot`.
+///
+/// `account_snapshot` reports open orders wrapped in `OrderState::active(..)`, whereas
+/// `fetch_open_orders` returns the bare `Open` — both share
+/// [`fetch_margin_open_orders_for_instrument`], so this is the single wrap used by the cross and
+/// isolated snapshot paths.
+fn active_order_snapshot(
+    o: Order<ExchangeId, InstrumentNameExchange, Open>,
+) -> Order<ExchangeId, InstrumentNameExchange, OrderState<AssetNameExchange, InstrumentNameExchange>>
+{
+    Order {
+        key: o.key,
+        side: o.side,
+        price: o.price,
+        quantity: o.quantity,
+        kind: o.kind,
+        time_in_force: o.time_in_force,
+        state: OrderState::active(o.state),
+    }
+}
+
+/// Convert one side (base or quote) of an isolated `assets[]` entry into a margin [`AssetBalance`].
+///
+/// Mirrors [`convert_margin_balance_entry`]'s field handling: `free`/`locked` are required (missing
+/// → `None`, drop), while `borrowed`/`interest` default to zero when absent — a real isolated
+/// sub-account row with absent debt means "no debt", not corrupt data, upholding the
+/// Design-decision-#4 invariant that a REST snapshot always populates `margin`. `total = free + locked`.
+///
+/// Takes the fields rather than the SDK side type because the base and quote sides are distinct
+/// nominal types (`...BaseAsset` / `...QuoteAsset`) with identical fields.
+fn convert_isolated_asset_balance(
+    asset: Option<&str>,
+    free: Option<&str>,
+    locked: Option<&str>,
+    borrowed: Option<&str>,
+    interest: Option<&str>,
+    now: DateTime<Utc>,
+) -> Option<AssetBalance<AssetNameExchange>> {
+    let asset_name = AssetNameExchange::new(asset?);
+    let free = match free.and_then(|s| Decimal::from_str(s).ok()) {
+        Some(v) => v,
+        None => {
+            warn!(%asset_name, "BinanceMargin isolated balance missing/unparseable 'free' field");
+            return None;
+        }
+    };
+    let locked = match locked.and_then(|s| Decimal::from_str(s).ok()) {
+        Some(v) => v,
+        None => {
+            warn!(%asset_name, "BinanceMargin isolated balance missing/unparseable 'locked' field");
+            return None;
+        }
+    };
+    let borrowed = borrowed
+        .and_then(|s| Decimal::from_str(s).ok())
+        .unwrap_or(Decimal::ZERO);
+    let interest = interest
+        .and_then(|s| Decimal::from_str(s).ok())
+        .unwrap_or(Decimal::ZERO);
+    Some(AssetBalance::new(
+        asset_name,
+        Balance::new_margin(free + locked, free, borrowed, interest),
+        now,
+    ))
+}
+
+/// Map isolated `query_isolated_margin_account_info` `assets[]` entries to per-instrument
+/// [`IsolatedInstrumentState`], keyed by instrument (pair symbol).
+///
+/// An entry must carry a `symbol` plus a `baseAsset` and `quoteAsset` with parseable `free`/`locked`;
+/// an entry missing any of these is dropped with a `warn!` (observable, never silently mis-mapped).
+/// Per-pair risk metrics (`marginLevel`/`marginRatio`/`liquidatePrice`) are best-effort `Option`s — a
+/// missing/unparseable risk field becomes `None` and does NOT drop the entry.
+fn convert_isolated_margin_assets(
+    assets: Vec<QueryIsolatedMarginAccountInfoResponseAssetsInner>,
+) -> HashMap<InstrumentNameExchange, IsolatedInstrumentState<AssetNameExchange>> {
+    // Single timestamp for the whole batch: every entry came from the same REST response, so this
+    // is the response's freshness (mirrors the cross-margin `convert_margin_balance_entry` `now`).
+    let now = Utc::now();
+    let mut map = HashMap::with_capacity(assets.len());
+    for entry in assets {
+        let Some(symbol) = entry.symbol.as_deref() else {
+            warn!("BinanceMargin isolated asset entry missing 'symbol' — skipping");
+            continue;
+        };
+        let instrument = InstrumentNameExchange::new(symbol);
+
+        let Some(base_raw) = entry.base_asset.as_deref() else {
+            warn!(%instrument, "BinanceMargin isolated entry missing baseAsset — skipping");
+            continue;
+        };
+        let Some(quote_raw) = entry.quote_asset.as_deref() else {
+            warn!(%instrument, "BinanceMargin isolated entry missing quoteAsset — skipping");
+            continue;
+        };
+
+        let Some(base) = convert_isolated_asset_balance(
+            base_raw.asset.as_deref(),
+            base_raw.free.as_deref(),
+            base_raw.locked.as_deref(),
+            base_raw.borrowed.as_deref(),
+            base_raw.interest.as_deref(),
+            now,
+        ) else {
+            warn!(%instrument, "BinanceMargin isolated baseAsset missing required field — skipping");
+            continue;
+        };
+        let Some(quote) = convert_isolated_asset_balance(
+            quote_raw.asset.as_deref(),
+            quote_raw.free.as_deref(),
+            quote_raw.locked.as_deref(),
+            quote_raw.borrowed.as_deref(),
+            quote_raw.interest.as_deref(),
+            now,
+        ) else {
+            warn!(%instrument, "BinanceMargin isolated quoteAsset missing required field — skipping");
+            continue;
+        };
+
+        let risk = IsolatedMarginRisk {
+            margin_level: entry
+                .margin_level
+                .as_deref()
+                .and_then(|s| Decimal::from_str(s).ok()),
+            margin_ratio: entry
+                .margin_ratio
+                .as_deref()
+                .and_then(|s| Decimal::from_str(s).ok()),
+            liquidation_price: entry
+                .liquidate_price
+                .as_deref()
+                .and_then(|s| Decimal::from_str(s).ok()),
+        };
+
+        map.insert(instrument, IsolatedInstrumentState { base, quote, risk });
+    }
+    map
+}
+
+/// Group symbols into comma-separated request strings, ≤5 symbols each (the venue's per-request
+/// cap on `query_isolated_margin_account_info`'s `symbols`). An empty input yields no chunks.
+fn chunk_symbols(symbols: &[InstrumentNameExchange]) -> Vec<String> {
+    symbols
+        .chunks(5)
+        .map(|chunk| {
+            chunk
+                .iter()
+                .map(|s| s.name().as_str())
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect()
+}
+
+/// Fetch isolated-margin account info for `symbols`, chunked at the venue's max-5-symbols/request
+/// cap and flattened to the `assets[]` entries across all chunks.
+///
+/// `symbols` must be non-empty (a no-symbol isolated call is invalid). Chunks are fetched
+/// concurrently (bounded to 8) through the shared rate-limit/backoff machinery.
+async fn fetch_isolated_margin_account_info(
+    rest: Arc<RestApi>,
+    rate_limiter: Arc<RateLimitTracker>,
+    symbols: Vec<InstrumentNameExchange>,
+) -> Result<Vec<QueryIsolatedMarginAccountInfoResponseAssetsInner>, UnindexedClientError> {
+    use futures::{StreamExt as _, TryStreamExt as _};
+
+    let chunks = chunk_symbols(&symbols);
+
+    // One `assets[]` entry per requested symbol, so pre-size the flat accumulator to `symbols.len()`
+    // and `try_fold` the per-chunk results straight into it — avoiding the intermediate
+    // `Vec<Vec<_>>` + re-copying `flatten().collect()` (mirrors the `try_fold` in `fetch_open_orders`).
+    futures::stream::iter(chunks.into_iter().map(|symbols_param| {
+        let rest = rest.clone();
+        let rate_limiter = rate_limiter.clone();
+        async move {
+            let response = rest_call_with_retry(&rest, &rate_limiter, |rest| {
+                let symbols_param = symbols_param.clone();
+                Box::pin(async move {
+                    let params = QueryIsolatedMarginAccountInfoParams::builder()
+                        .symbols(symbols_param)
+                        .build()?;
+                    rest.query_isolated_margin_account_info(params).await
+                })
+            })
+            .await
+            .map_err(connectivity_error)?;
+
+            let info = response
+                .data()
+                .await
+                .map_err(|e| connectivity_error(e.into()))?;
+            Ok::<_, UnindexedClientError>(info.assets.unwrap_or_default())
+        }
+    }))
+    .buffer_unordered(8)
+    .try_fold(
+        Vec::with_capacity(symbols.len()),
+        |mut acc, assets| async move {
+            acc.extend(assets);
+            Ok(acc)
+        },
+    )
+    .await
+}
+
 /// Convert a margin open-order response into rustrade's `Open` state order.
 ///
 /// Field-for-field identical to spot's `convert_open_order` but typed to the margin SDK response
@@ -3128,6 +3500,257 @@ mod tests {
         let filtered = filter_and_convert_margin_balances(assets, &requested);
         assert_eq!(filtered.len(), 2);
         assert!(filtered.iter().all(|b| b.asset.name().as_str() != "DOGE"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Isolated account snapshot converters + query scoping
+    // -----------------------------------------------------------------------
+
+    use binance_sdk::margin_trading::rest_api::{
+        QueryIsolatedMarginAccountInfoResponseAssetsInnerBaseAsset as IsoBase,
+        QueryIsolatedMarginAccountInfoResponseAssetsInnerQuoteAsset as IsoQuote,
+    };
+
+    fn d(s: &str) -> Decimal {
+        Decimal::from_str(s).unwrap()
+    }
+
+    fn iso_base(asset: &str, free: &str, locked: &str, borrowed: &str, interest: &str) -> IsoBase {
+        let mut b = IsoBase::new();
+        b.asset = Some(asset.to_string());
+        b.free = Some(free.to_string());
+        b.locked = Some(locked.to_string());
+        b.borrowed = Some(borrowed.to_string());
+        b.interest = Some(interest.to_string());
+        b
+    }
+
+    fn iso_quote(
+        asset: &str,
+        free: &str,
+        locked: &str,
+        borrowed: &str,
+        interest: &str,
+    ) -> IsoQuote {
+        let mut q = IsoQuote::new();
+        q.asset = Some(asset.to_string());
+        q.free = Some(free.to_string());
+        q.locked = Some(locked.to_string());
+        q.borrowed = Some(borrowed.to_string());
+        q.interest = Some(interest.to_string());
+        q
+    }
+
+    fn iso_entry(
+        symbol: &str,
+        base: IsoBase,
+        quote: IsoQuote,
+        margin_level: Option<&str>,
+        margin_ratio: Option<&str>,
+        liquidate_price: Option<&str>,
+    ) -> QueryIsolatedMarginAccountInfoResponseAssetsInner {
+        let mut e = QueryIsolatedMarginAccountInfoResponseAssetsInner::new();
+        e.symbol = Some(symbol.to_string());
+        e.base_asset = Some(Box::new(base));
+        e.quote_asset = Some(Box::new(quote));
+        e.margin_level = margin_level.map(str::to_string);
+        e.margin_ratio = margin_ratio.map(str::to_string);
+        e.liquidate_price = liquidate_price.map(str::to_string);
+        e
+    }
+
+    fn isolated_client(symbols: &[&str]) -> BinanceMargin {
+        let config = BinanceMarginConfig::isolated(
+            "k".to_string(),
+            "s".to_string(),
+            symbols
+                .iter()
+                .map(|s| InstrumentNameExchange::new(*s))
+                .collect(),
+        );
+        BinanceMargin::new(config)
+    }
+
+    #[test]
+    fn isolated_assets_map_base_quote_and_risk() {
+        // base: free 0.5 + locked 0.1 = total 0.6, borrowed 0.2 → net 0.4.
+        // quote: free 1000 + locked 50 = total 1050, borrowed 300 → net 750.
+        let entry = iso_entry(
+            "BTCUSDT",
+            iso_base("BTC", "0.5", "0.1", "0.2", "0.001"),
+            iso_quote("USDT", "1000", "50", "300", "1.5"),
+            Some("3.5"),
+            Some("0.12"),
+            Some("48000"),
+        );
+        let map = convert_isolated_margin_assets(vec![entry]);
+        let state = map
+            .get(&InstrumentNameExchange::new("BTCUSDT"))
+            .expect("entry present");
+
+        assert_eq!(state.base.asset.name().as_str(), "BTC");
+        assert_eq!(state.base.balance.total, d("0.6"));
+        assert_eq!(state.base.balance.free, d("0.5"));
+        assert_eq!(state.base.balance.net_asset(), d("0.4"));
+
+        assert_eq!(state.quote.asset.name().as_str(), "USDT");
+        assert_eq!(state.quote.balance.total, d("1050"));
+        assert_eq!(state.quote.balance.net_asset(), d("750"));
+
+        assert_eq!(state.risk.margin_level, Some(d("3.5")));
+        assert_eq!(state.risk.margin_ratio, Some(d("0.12")));
+        assert_eq!(state.risk.liquidation_price, Some(d("48000")));
+    }
+
+    #[test]
+    fn isolated_base_short_is_negative_net() {
+        // A short on the base side: total 0, borrowed 1.5 → net_asset = -1.5.
+        let entry = iso_entry(
+            "BTCUSDT",
+            iso_base("BTC", "0", "0", "1.5", "0.001"),
+            iso_quote("USDT", "100", "0", "0", "0"),
+            None,
+            None,
+            None,
+        );
+        let map = convert_isolated_margin_assets(vec![entry]);
+        let state = map.get(&InstrumentNameExchange::new("BTCUSDT")).unwrap();
+        assert_eq!(state.base.balance.net_asset(), d("-1.5"));
+    }
+
+    #[test]
+    fn isolated_missing_debt_defaults_zero_and_risk_optional() {
+        // No borrowed/interest = real no-debt position → margin still populated (zero debt), not
+        // dropped. Absent risk fields → None, but the snapshot is still produced.
+        let mut base = IsoBase::new();
+        base.asset = Some("BTC".to_string());
+        base.free = Some("0.5".to_string());
+        base.locked = Some("0".to_string());
+        let mut quote = IsoQuote::new();
+        quote.asset = Some("USDT".to_string());
+        quote.free = Some("100".to_string());
+        quote.locked = Some("0".to_string());
+
+        let map = convert_isolated_margin_assets(vec![iso_entry(
+            "BTCUSDT", base, quote, None, None, None,
+        )]);
+        let state = map.get(&InstrumentNameExchange::new("BTCUSDT")).unwrap();
+        assert!(state.base.balance.margin.is_some());
+        assert_eq!(state.base.balance.net_asset(), d("0.5"));
+        assert_eq!(state.risk.margin_level, None);
+        assert_eq!(state.risk.liquidation_price, None);
+    }
+
+    #[test]
+    fn isolated_unparseable_risk_is_none_but_entry_kept() {
+        let entry = iso_entry(
+            "BTCUSDT",
+            iso_base("BTC", "1", "0", "0", "0"),
+            iso_quote("USDT", "1", "0", "0", "0"),
+            Some("not_a_number"),
+            None,
+            None,
+        );
+        let map = convert_isolated_margin_assets(vec![entry]);
+        let state = map.get(&InstrumentNameExchange::new("BTCUSDT")).unwrap();
+        assert_eq!(state.risk.margin_level, None);
+    }
+
+    #[test]
+    fn isolated_missing_base_free_drops_entry() {
+        // Missing free/locked is corrupt (not no-debt) → drop the whole pair entry.
+        let mut base = IsoBase::new();
+        base.asset = Some("BTC".to_string());
+        base.locked = Some("0".to_string()); // no free
+        let entry = iso_entry(
+            "BTCUSDT",
+            base,
+            iso_quote("USDT", "100", "0", "0", "0"),
+            None,
+            None,
+            None,
+        );
+        assert!(convert_isolated_margin_assets(vec![entry]).is_empty());
+    }
+
+    #[test]
+    fn isolated_missing_symbol_drops_entry() {
+        let mut e = QueryIsolatedMarginAccountInfoResponseAssetsInner::new();
+        e.base_asset = Some(Box::new(iso_base("BTC", "1", "0", "0", "0")));
+        e.quote_asset = Some(Box::new(iso_quote("USDT", "1", "0", "0", "0")));
+        // no symbol set
+        assert!(convert_isolated_margin_assets(vec![e]).is_empty());
+    }
+
+    #[test]
+    fn chunk_symbols_batches_by_five() {
+        let syms: Vec<InstrumentNameExchange> = (0..12)
+            .map(|i| InstrumentNameExchange::new(format!("S{i:02}")))
+            .collect();
+        let chunks = chunk_symbols(&syms);
+        assert_eq!(chunks.len(), 3, "12 symbols → 5 + 5 + 2");
+        assert_eq!(chunks[0].split(',').count(), 5);
+        assert_eq!(chunks[1].split(',').count(), 5);
+        assert_eq!(chunks[2].split(',').count(), 2);
+
+        // ≤5 → a single chunk.
+        let three: Vec<_> = (0..3)
+            .map(|i| InstrumentNameExchange::new(format!("S{i}")))
+            .collect();
+        assert_eq!(chunk_symbols(&three).len(), 1);
+
+        // exactly 5 → a single chunk of 5.
+        let five: Vec<_> = (0..5)
+            .map(|i| InstrumentNameExchange::new(format!("S{i}")))
+            .collect();
+        let c = chunk_symbols(&five);
+        assert_eq!(c.len(), 1);
+        assert_eq!(c[0].split(',').count(), 5);
+
+        // empty → no chunks (never a no-symbol call).
+        assert!(chunk_symbols(&[]).is_empty());
+    }
+
+    #[test]
+    fn effective_isolated_set_empty_returns_all_configured() {
+        let client = isolated_client(&["BTCUSDT", "ETHUSDT"]);
+        assert_eq!(
+            client.effective_isolated_set(&[]),
+            vec![
+                InstrumentNameExchange::new("BTCUSDT"),
+                InstrumentNameExchange::new("ETHUSDT"),
+            ]
+        );
+    }
+
+    #[test]
+    fn effective_isolated_set_intersects_requested() {
+        let client = isolated_client(&["BTCUSDT", "ETHUSDT"]);
+        assert_eq!(
+            client.effective_isolated_set(&[InstrumentNameExchange::new("ETHUSDT")]),
+            vec![InstrumentNameExchange::new("ETHUSDT")]
+        );
+    }
+
+    #[test]
+    fn effective_isolated_set_skips_out_of_set() {
+        let client = isolated_client(&["BTCUSDT", "ETHUSDT"]);
+        // DOGEUSDT is not configured → skipped (warn), only BTCUSDT survives.
+        assert_eq!(
+            client.effective_isolated_set(&[
+                InstrumentNameExchange::new("BTCUSDT"),
+                InstrumentNameExchange::new("DOGEUSDT"),
+            ]),
+            vec![InstrumentNameExchange::new("BTCUSDT")]
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_balances_isolated_returns_empty() {
+        // Isolated balances are per-pair (on account_snapshot); the asset-keyed fetch returns empty
+        // without a network call.
+        let client = isolated_client(&["BTCUSDT"]);
+        assert!(client.fetch_balances(&[]).await.expect("ok").is_empty());
     }
 
     fn open_order(order_id: Option<i64>, side: &str) -> QueryMarginAccountsOpenOrdersResponseInner {

--- a/rustrade-execution/src/client/binance/margin.rs
+++ b/rustrade-execution/src/client/binance/margin.rs
@@ -32,8 +32,8 @@ use super::shared::{
     new_dedup_cache, parse_order_kind, parse_side, parse_time_in_force, rest_call_with_retry,
 };
 use crate::{
-    AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot, IsolatedInstrumentState,
-    IsolatedMarginRisk, UnindexedAccountEvent, UnindexedAccountSnapshot,
+    AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot, InstrumentBalanceUpdate,
+    IsolatedInstrumentState, IsolatedMarginRisk, UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::{AssetBalance, AssetBalanceUpdate, Balance, BalanceUpdate},
     client::ExecutionClient,
     error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
@@ -50,7 +50,10 @@ use binance_sdk::{
         config::{ConfigurationRestApi, ConfigurationWebsocketApi},
         constants::{MARGIN_TRADING_REST_API_PROD_URL, SPOT_WS_API_PROD_URL},
         models::WebsocketEvent,
-        websocket::{WebsocketApi as WsApiBase, WebsocketMessageSendOptions},
+        websocket::{
+            SendWebsocketMessageResult, Subscription, WebsocketApi as WsApiBase,
+            WebsocketMessageSendOptions,
+        },
     },
     margin_trading::{
         MarginTradingRestApi,
@@ -82,7 +85,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     str::FromStr,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
     time::Duration,
@@ -1089,36 +1092,99 @@ impl ExecutionClient for BinanceMargin {
         let rest_config = self.rest_config.clone();
         let ws_config = self.ws_config.clone();
         let rate_limiter = self.rate_limiter.clone();
-        let instruments = instruments.to_vec();
-        // All current Binance margin symbols are ≤22 bytes (within SmolStr's 23-byte inline limit),
-        // making clone() a stack memcpy with no heap allocation. Guard this implicit invariant so
-        // future symbols that exceed the limit are caught early.
-        debug_assert!(
-            instruments.iter().all(|i| i.name().len() <= 23),
-            "instrument name exceeds SmolStr inline capacity: {:?}",
-            instruments.iter().find(|i| i.name().len() > 23)
-        );
 
-        // Validate credentials + connectivity before returning the stream so the caller can
-        // distinguish "can't start at all" from "started then disconnected" (auto-reconnect handles
-        // the latter). The token POST is a signed REST round-trip; the WS connect proves the socket.
-        // Subscription happens inside the manager (after the event listener attaches), so early
-        // pushed events are not missed.
-        let initial_token = acquire_user_listen_token(&rest_config, &rate_limiter).await?;
-        let initial_ws = connect_margin_ws(&ws_config).await.map_err(|e| {
-            UnindexedClientError::Connectivity(ConnectivityError::Socket(e.to_string()))
-        })?;
+        let cm_handle = if self.config.is_isolated {
+            // --- Isolated: separate multiplexed manager over the configured isolated_symbols ---
+            // The stream covers exactly `isolated_symbols` (the per-symbol token universe — Design
+            // decision #1); the trait's `instruments` argument does NOT drive the isolated token set.
+            let symbols = self.config.isolated_symbols.clone();
+            // All current Binance margin symbols are ≤22 bytes (within SmolStr's 23-byte inline
+            // limit); guard the implicit invariant so an over-long symbol is caught early.
+            debug_assert!(
+                symbols.iter().all(|i| i.name().len() <= 23),
+                "instrument name exceeds SmolStr inline capacity: {:?}",
+                symbols.iter().find(|i| i.name().len() > 23)
+            );
 
-        let cm_handle = tokio::spawn(margin_connection_manager(
-            tx,
-            dedup,
-            ws_config,
-            rest_config,
-            rest,
-            rate_limiter,
-            instruments,
-            Some((initial_ws, initial_token)),
-        ));
+            // (0) Build the invariant `instrument → (base, quote)` map from the isolated account
+            // info. Authoritative base/quote split for routing the symbol-less
+            // `outboundAccountPosition` frames (Design decision #5); built once, reused across
+            // reconnects (a pair's base/quote never change). A REST failure here is a hard Err
+            // before anything spawns.
+            let assets = fetch_isolated_margin_account_info(
+                rest.clone(),
+                rate_limiter.clone(),
+                symbols.clone(),
+            )
+            .await?;
+            let base_quote = Arc::new(build_base_quote_map(&assets));
+            for sym in &symbols {
+                if !base_quote.contains_key(sym) {
+                    warn!(
+                        symbol = %sym.name(),
+                        "BinanceMargin isolated: account info returned no base/quote for configured \
+                         symbol — its live per-pair balance frames will be dropped (fills/orders \
+                         unaffected; balances available via account_snapshot)"
+                    );
+                }
+            }
+
+            // (1) Acquire all N per-symbol tokens, (2) connect one socket, (3) subscribe all N —
+            // all before returning so connect-or-any-subscribe failure → Err (nothing spawned),
+            // preserving cross's "can't-start vs started-then-dropped" distinction.
+            let tokens = acquire_all_isolated_tokens(&rest_config, &rate_limiter, &symbols).await?;
+            let live =
+                isolated_connect_and_subscribe(&ws_config, &tx, &dedup, &base_quote, &tokens)
+                    .await
+                    .map_err(|e| {
+                        UnindexedClientError::Connectivity(ConnectivityError::Socket(e.to_string()))
+                    })?;
+
+            tokio::spawn(isolated_connection_manager(
+                tx,
+                dedup,
+                ws_config,
+                rest_config,
+                rest,
+                rate_limiter,
+                symbols,
+                base_quote,
+                Some(live),
+            ))
+        } else {
+            // --- Cross: the live-validated account-wide manager (TG17, unchanged) ---
+            let instruments = instruments.to_vec();
+            // All current Binance margin symbols are ≤22 bytes (within SmolStr's 23-byte inline
+            // limit), making clone() a stack memcpy with no heap allocation. Guard this implicit
+            // invariant so future symbols that exceed the limit are caught early.
+            debug_assert!(
+                instruments.iter().all(|i| i.name().len() <= 23),
+                "instrument name exceeds SmolStr inline capacity: {:?}",
+                instruments.iter().find(|i| i.name().len() > 23)
+            );
+
+            // Validate credentials + connectivity before returning the stream so the caller can
+            // distinguish "can't start at all" from "started then disconnected" (auto-reconnect
+            // handles the latter). The token POST is a signed REST round-trip; the WS connect proves
+            // the socket. Subscription happens inside the manager (after the event listener
+            // attaches), so early pushed events are not missed.
+            let initial_token =
+                acquire_user_listen_token(&rest_config, &rate_limiter, None).await?;
+            let initial_ws = connect_margin_ws(&ws_config).await.map_err(|e| {
+                UnindexedClientError::Connectivity(ConnectivityError::Socket(e.to_string()))
+            })?;
+
+            tokio::spawn(margin_connection_manager(
+                tx,
+                dedup,
+                ws_config,
+                rest_config,
+                rest,
+                rate_limiter,
+                instruments,
+                Some((initial_ws, initial_token)),
+            ))
+        };
 
         let rx_stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
         let guarded_stream = AbortOnDropStream::new(rx_stream, cm_handle);
@@ -1141,6 +1207,26 @@ struct UserListenToken {
     expiration_time_ms: i64,
 }
 
+/// Build the query params for the `userListenToken` POST: empty for **cross**, or
+/// `isIsolated=TRUE&symbol=SYM` for **isolated** (a per-symbol token). Factored out so the
+/// cross-vs-isolated param shape is unit-testable without a network round-trip.
+fn build_listen_token_query(
+    symbol: Option<&InstrumentNameExchange>,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut query = BTreeMap::new();
+    if let Some(sym) = symbol {
+        query.insert(
+            "isIsolated".to_string(),
+            serde_json::Value::String("TRUE".to_string()),
+        );
+        query.insert(
+            "symbol".to_string(),
+            serde_json::Value::String(sym.name().to_string()),
+        );
+    }
+    query
+}
+
 /// Wire shape of the `POST /sapi/v1/userListenToken` response.
 #[derive(Deserialize)]
 struct UserListenTokenResponse {
@@ -1151,11 +1237,14 @@ struct UserListenTokenResponse {
     expiration_time: i64,
 }
 
-/// Acquire a cross-margin `userListenToken` via the SDK's generic signed sender.
+/// Acquire a `userListenToken` via the SDK's generic signed sender.
 ///
 /// The endpoint is unbound in the SDK, so this reuses `common::utils::send_request` (signing,
 /// timestamp, `X-MBX-APIKEY`, and the SDK's reqwest client) against the production REST config.
-/// Cross margin sends no params (`isIsolated`/`symbol` omitted).
+/// `symbol` selects the scope:
+/// - `None` → **cross** margin (account-wide), no `isIsolated`/`symbol` params;
+/// - `Some(sym)` → **isolated** margin, scoped to that pair (`isIsolated=TRUE&symbol=SYM`). Each
+///   isolated symbol gets its own per-symbol token (the isolated stream multiplexes N of them).
 ///
 /// Routed through [`rest_call_with_retry`] so a transient rate-limit during a *planned* token
 /// renewal retries in place rather than collapsing the stream into the full reconnect+backoff
@@ -1164,16 +1253,21 @@ struct UserListenTokenResponse {
 async fn acquire_user_listen_token(
     rest_config: &Arc<ConfigurationRestApi>,
     rate_limiter: &RateLimitTracker,
+    symbol: Option<&InstrumentNameExchange>,
 ) -> Result<UserListenToken, UnindexedClientError> {
+    // Cross sends no params; isolated scopes the token to one symbol. Built once and cloned per
+    // retry attempt (the closure runs per attempt; mirrors `fetch_isolated_margin_account_info`).
+    let query = build_listen_token_query(symbol);
     let response = rest_call_with_retry(rest_config, rate_limiter, |cfg| {
+        let query = query.clone();
         Box::pin(async move {
             binance_sdk::common::utils::send_request::<UserListenTokenResponse>(
                 &cfg,
                 "/sapi/v1/userListenToken",
                 reqwest::Method::POST,
-                // `send_request` takes owned query + body maps; cross margin sends no params, so
-                // both are empty. The allocations are SDK-signature-forced and run once per attempt.
-                BTreeMap::new(),
+                // `send_request` takes owned query + body maps; params (if any) ride the query
+                // string the signature is computed over, the body stays empty.
+                query,
                 BTreeMap::new(),
                 None,
                 true, // is_signed — token is auth-bearing; HMAC/timestamp/api-key by send_request
@@ -1265,6 +1359,75 @@ async fn subscribe_listen_token(ws: &Arc<WsApiBase>, token: &str) -> anyhow::Res
     Ok(())
 }
 
+/// Subscribe over an existing WS-API connection and return the ack's `subscriptionId` (isolated).
+///
+/// Identical wire frame to [`subscribe_listen_token`] (unsigned, token-as-auth) but deserializes the
+/// ack's `result.subscriptionId` so the isolated manager can build the `subscriptionId → symbol`
+/// routing map (the symbol-less `outboundAccountPosition` frames carry only this id — Design
+/// decision #5). Returns:
+/// - `Ok(Some(id))` — subscribed; the id correlates this symbol's pushed balance frames;
+/// - `Ok(None)` — subscribed, but the ack carried no `subscriptionId` (per-instrument balance
+///   routing for this pair is then unavailable: its `outboundAccountPosition` frames drop with a
+///   `warn!` and the consumer falls back to snapshot-polled balances — fills/orders are unaffected,
+///   they self-identify by inner `s`). This is the documented first-prod-run degradation path.
+/// - `Err(..)` — the subscribe itself failed (a startup/reconnect error, surfaced by the caller).
+async fn subscribe_listen_token_capture(
+    ws: &Arc<WsApiBase>,
+    token: &str,
+) -> anyhow::Result<Option<i64>> {
+    /// Ack `result` shape — `subscriptionId` is read defensively as an `Option` (its presence on the
+    /// `.listenToken` ack is the one assumption no offline source closes; absent → `Ok(None)`).
+    #[derive(Deserialize)]
+    struct SubscribeAck {
+        #[serde(rename = "subscriptionId", default)]
+        subscription_id: Option<i64>,
+    }
+
+    let mut payload = BTreeMap::new();
+    payload.insert(
+        "listenToken".to_string(),
+        serde_json::Value::String(token.to_string()),
+    );
+    let result = ws
+        .send_message::<SubscribeAck>(
+            "userDataStream.subscribe.listenToken",
+            payload,
+            WebsocketMessageSendOptions::new(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("userDataStream.subscribe.listenToken failed: {e}"))?;
+    let ack = match result {
+        SendWebsocketMessageResult::Single(resp) => resp.data()?,
+        // The subscribe is a single request; defensively take the first if the SDK ever batches.
+        SendWebsocketMessageResult::Multiple(responses) => responses
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("empty subscribe ack"))?
+            .data()?,
+    };
+    Ok(ack.subscription_id)
+}
+
+/// Cross-margin balance-arm handler: convert an `outboundAccountPosition` into asset-keyed
+/// `BalanceStreamUpdate`s (the `subscriptionId` is unused — cross is account-wide). This is the
+/// `handle_position` passed to [`convert_margin_user_data_events_with`] / the cross manager.
+fn cross_account_position_handler(
+    position: Outboundaccountposition,
+    _subscription_id: Option<i64>,
+    buf: &mut Vec<UnindexedAccountEvent>,
+) {
+    convert_margin_account_position(position, buf);
+}
+
+/// Cross-margin convenience wrapper over [`convert_margin_user_data_events_with`] using
+/// [`cross_account_position_handler`] (account-wide `BalanceStreamUpdate`s). Test-only: the cross
+/// manager calls the listener helper with the handler directly, but the converter unit tests exercise
+/// frame discrimination through this two-arg form (they do not route balances per-instrument).
+#[cfg(test)]
+fn convert_margin_user_data_events(frame: &str, buf: &mut Vec<UnindexedAccountEvent>) -> bool {
+    convert_margin_user_data_events_with(frame, buf, &mut cross_account_position_handler)
+}
+
 /// Frame discrimination for the WS-API user-data delivery (Phase 0 finding).
 ///
 /// Each text frame is either an RPC response (`{ "id", "status", "result", … }` — e.g. the
@@ -1272,19 +1435,36 @@ async fn subscribe_listen_token(ws: &Arc<WsApiBase>, token: &str) -> anyhow::Res
 /// Returns `true` if the exchange signalled stream termination (a reconnect trigger). Unknown frames
 /// are ignored. Deserialization of a known event type is defensive: a mismatch is logged and the
 /// event dropped (observable), never silently mis-parsed.
-fn convert_margin_user_data_events(frame: &str, buf: &mut Vec<UnindexedAccountEvent>) -> bool {
+///
+/// The `outboundAccountPosition` (balance) arm is delegated to `handle_position` — the **only** arm
+/// that differs between cross (account-wide `BalanceStreamUpdate`) and isolated (per-instrument
+/// `InstrumentBalanceUpdate`, routed via the frame's `subscriptionId`). Everything else
+/// (`executionReport` routing by inner `s`, the observable-only margin events, termination
+/// signalling) is single-sourced here.
+fn convert_margin_user_data_events_with(
+    frame: &str,
+    buf: &mut Vec<UnindexedAccountEvent>,
+    handle_position: &mut impl FnMut(
+        Outboundaccountposition,
+        Option<i64>,
+        &mut Vec<UnindexedAccountEvent>,
+    ),
+) -> bool {
     use serde_json::value::RawValue;
 
     // Borrowed envelope — avoids building a full `serde_json::Value` DOM for every inbound frame
     // (hot path). RPC responses (subscribe ack, errors) carry a top-level `id`; pushed user-data
     // events are wrapped as `{ subscriptionId, event: { e, .. } }`. The inner `event` is kept as an
-    // un-parsed raw slice so only the matched branch below pays for a single typed pass.
+    // un-parsed raw slice so only the matched branch below pays for a single typed pass. The
+    // `subscriptionId` (present on pushed frames) is recovered as a plain int for isolated routing.
     #[derive(Deserialize)]
     struct Envelope<'a> {
         #[serde(borrow, default)]
         id: Option<&'a RawValue>,
         #[serde(borrow, default)]
         event: Option<&'a RawValue>,
+        #[serde(rename = "subscriptionId", default)]
+        subscription_id: Option<i64>,
     }
     // Discriminator-only view of the inner event: reads `e` without materialising the payload.
     #[derive(Deserialize)]
@@ -1309,6 +1489,7 @@ fn convert_margin_user_data_events(frame: &str, buf: &mut Vec<UnindexedAccountEv
         trace!("BinanceMargin WS: ignoring frame without `event` or `id`");
         return false;
     };
+    let subscription_id = envelope.subscription_id;
     let event_raw = event.get();
     let event_type = serde_json::from_str::<EventTag<'_>>(event_raw)
         .ok()
@@ -1332,7 +1513,8 @@ fn convert_margin_user_data_events(frame: &str, buf: &mut Vec<UnindexedAccountEv
         }
         "outboundAccountPosition" => {
             match serde_json::from_str::<Outboundaccountposition>(event_raw) {
-                Ok(position) => convert_margin_account_position(position, buf),
+                // Balance arm is the one cross/isolated divergence — delegate to the handler.
+                Ok(position) => handle_position(position, subscription_id, buf),
                 Err(e) => {
                     warn!(error = %e, "BinanceMargin: undeserializable outboundAccountPosition, dropping")
                 }
@@ -1732,6 +1914,197 @@ fn convert_margin_account_position(
     }
 }
 
+/// Route an isolated `outboundAccountPosition` frame to an [`InstrumentBalanceUpdate`] (Tier B).
+///
+/// The frame carries no symbol inline, so the pair is recovered from `subscription_id` via
+/// `sub_map` (populated from the per-symbol subscribe acks). The flat `b[]` asset list is then
+/// split into `base`/`quote` by **asset-name equality** against the pair's known `(base, quote)`
+/// from `base_quote` (the authoritative startup map — never string-matched against the symbol).
+/// Emits one `InstrumentBalanceUpdate` carrying both sides' free/locked. Dropped with a `warn!`
+/// (observable, never mis-applied) when: the `subscriptionId` is missing/unmapped; the pair's
+/// base/quote is unknown; or either side is absent/unparseable in the frame. The engine does not
+/// store this variant (`_ => None` wildcard); the wrapper consumes it off the account-event feed.
+fn route_isolated_account_position(
+    position: Outboundaccountposition,
+    subscription_id: Option<i64>,
+    sub_map: &Mutex<HashMap<i64, InstrumentNameExchange>>,
+    base_quote: &HashMap<InstrumentNameExchange, (AssetNameExchange, AssetNameExchange)>,
+    buf: &mut Vec<UnindexedAccountEvent>,
+) {
+    let Some(sub_id) = subscription_id else {
+        warn!(
+            "BinanceMargin isolated: outboundAccountPosition without subscriptionId — dropping \
+             (per-instrument balance routing requires it)"
+        );
+        return;
+    };
+    let instrument = {
+        // Brief lock: the map is read-only after startup and only written by the subscribe loop on
+        // (re)connect. Recover from poisoning rather than killing balance routing.
+        let map = sub_map.lock().unwrap_or_else(|p| p.into_inner());
+        match map.get(&sub_id) {
+            Some(inst) => inst.clone(),
+            None => {
+                warn!(
+                    subscription_id = sub_id,
+                    "BinanceMargin isolated: outboundAccountPosition for unmapped subscriptionId — dropping"
+                );
+                return;
+            }
+        }
+    };
+    let Some((base_asset, quote_asset)) = base_quote.get(&instrument) else {
+        warn!(
+            instrument = %instrument.name(),
+            "BinanceMargin isolated: no base/quote known for instrument — dropping balance frame"
+        );
+        return;
+    };
+
+    let time_exchange = position
+        .u
+        .and_then(|ms| Utc.timestamp_millis_opt(ms).single())
+        .unwrap_or_else(Utc::now);
+
+    let mut base_update: Option<AssetBalanceUpdate<AssetNameExchange>> = None;
+    let mut quote_update: Option<AssetBalanceUpdate<AssetNameExchange>> = None;
+    for b in position.b_uppercase.unwrap_or_default() {
+        let Some(asset) = b.a.as_deref() else {
+            warn!(instrument = %instrument.name(), "BinanceMargin isolated account position entry missing asset name");
+            continue;
+        };
+        // Only the pair's own base/quote are relevant; ignore any stray asset on the frame.
+        let side = if asset == base_asset.name().as_str() {
+            &mut base_update
+        } else if asset == quote_asset.name().as_str() {
+            &mut quote_update
+        } else {
+            continue;
+        };
+        let (Some(free), Some(locked)) = (
+            b.f.as_deref().and_then(|s| Decimal::from_str(s).ok()),
+            b.l.as_deref().and_then(|s| Decimal::from_str(s).ok()),
+        ) else {
+            warn!(%asset, instrument = %instrument.name(), "BinanceMargin isolated account position missing/unparseable free/locked");
+            continue;
+        };
+        *side = Some(AssetBalanceUpdate::new(
+            AssetNameExchange::new(asset),
+            BalanceUpdate::new(free, locked),
+            time_exchange,
+        ));
+    }
+
+    // InstrumentBalanceUpdate carries BOTH sides; a frame missing either is dropped rather than
+    // fabricating a zero side (which would silently report a wrong free/locked). A trade-driven
+    // outboundAccountPosition changes both base and quote together, so both are normally present.
+    let (Some(base), Some(quote)) = (base_update, quote_update) else {
+        warn!(
+            instrument = %instrument.name(),
+            "BinanceMargin isolated: outboundAccountPosition missing base or quote side — dropping (no partial InstrumentBalanceUpdate)"
+        );
+        return;
+    };
+    buf.push(UnindexedAccountEvent::new(
+        ExchangeId::BinanceMargin,
+        AccountEventKind::InstrumentBalanceUpdate(InstrumentBalanceUpdate::new(
+            instrument, base, quote,
+        )),
+    ));
+}
+
+/// Register the WS-API event-dispatch callback shared by both margin managers.
+///
+/// Single-sources the demux/dedup/dispatch + heartbeat + terminal-signal logic the cross and
+/// isolated managers both need; only the `outboundAccountPosition` (balance) arm differs and is
+/// supplied as `handle_position` (cross → account-wide `BalanceStreamUpdate` via
+/// [`cross_account_position_handler`]; isolated → per-instrument `InstrumentBalanceUpdate` via
+/// [`route_isolated_account_position`]). Returns the [`Subscription`] handle; the caller must
+/// `unsubscribe()` it on disconnect. `heartbeat_flag` is shared with the caller's monitor loop
+/// (set on every inbound frame/ping); `signal_tx` fires once on a terminal condition
+/// (consumer-drop, socket error/close, or exchange `eventStreamTerminated`).
+fn register_user_data_listener(
+    ws: &Arc<WsApiBase>,
+    tx: mpsc::UnboundedSender<UnindexedAccountEvent>,
+    dedup: SharedDedupCache,
+    heartbeat_flag: Arc<AtomicBool>,
+    signal_tx: oneshot::Sender<()>,
+    mut handle_position: impl FnMut(
+        Outboundaccountposition,
+        Option<i64>,
+        &mut Vec<UnindexedAccountEvent>,
+    ) + Send
+    + 'static,
+) -> Subscription {
+    let mut signal_tx_opt = Some(signal_tx);
+    let mut event_tx = Some(tx);
+    // 32 comfortably covers a typical account's outboundAccountPosition (one entry per asset) plus
+    // the execution events in a single message; an account with >32 assets reallocates once, after
+    // which the buffer is reused across messages via drain(..).
+    let mut event_buf = Vec::with_capacity(32);
+
+    // Safety — non-atomic Option::take() in the callback is safe: binance-sdk drives one spawned
+    // task per subscription, invoking the FnMut sequentially (verified =50.0.0; re-verify on SDK
+    // upgrade). Same contract spot relies on.
+    ws.common.events.subscribe(move |event| {
+        let Some(ref sender) = event_tx else { return };
+        match event {
+            WebsocketEvent::Message(json_str) => {
+                heartbeat_flag.store(true, Ordering::Release);
+                // Frame parsing (including skipping non-JSON frames) happens inside the converter,
+                // which parses borrowed slices rather than a full DOM (hot path).
+                let terminated = convert_margin_user_data_events_with(
+                    &json_str,
+                    &mut event_buf,
+                    &mut handle_position,
+                );
+                for ev in event_buf.drain(..) {
+                    if let Some(key) = dedup_key_from_event(&ev)
+                        && is_duplicate(&dedup, key)
+                    {
+                        trace!("BinanceMargin dedup: skipping duplicate event");
+                        continue;
+                    }
+                    if sender.send(ev).is_err() {
+                        warn!("BinanceMargin account_stream receiver dropped, suppressing sends");
+                        event_tx.take();
+                        if let Some(s) = signal_tx_opt.take() {
+                            let _ = s.send(());
+                        }
+                        return;
+                    }
+                }
+                if terminated {
+                    event_tx.take();
+                    if let Some(s) = signal_tx_opt.take() {
+                        let _ = s.send(());
+                    }
+                }
+            }
+            WebsocketEvent::Ping | WebsocketEvent::Pong => {
+                heartbeat_flag.store(true, Ordering::Release);
+            }
+            WebsocketEvent::Error(e) => {
+                warn!(%e, "BinanceMargin WebSocket error, will attempt reconnect");
+                event_tx.take();
+                if let Some(s) = signal_tx_opt.take() {
+                    let _ = s.send(());
+                }
+            }
+            WebsocketEvent::Close(code, reason) => {
+                warn!(code, %reason, "BinanceMargin WebSocket closed");
+                event_tx.take();
+                if let Some(s) = signal_tx_opt.take() {
+                    let _ = s.send(());
+                }
+            }
+            _ => {
+                trace!("BinanceMargin ignoring unhandled WebsocketEvent variant");
+            }
+        }
+    })
+}
+
 /// Recover fills missed during a disconnect via REST `myTrades`, routed through the dedup cache.
 ///
 /// Only TRADE fills are recovered — order-lifecycle events (NEW/CANCELED) require a
@@ -1829,9 +2202,11 @@ async fn recover_margin_fills(
 /// disconnect/heartbeat-timeout/token-expiry → backoff → fill recovery → reconnect. The `tx`
 /// channel persists across reconnections so the consumer sees a seamless stream. Terminates when
 /// the consumer drops the stream or max reconnect attempts are exhausted.
-// inherent reconnect-loop complexity (token + connect + subscribe + callback + recovery + monitor
-// + cleanup + backoff); mirrors spot's `connection_manager`, not worth splitting further.
-#[allow(clippy::cognitive_complexity)]
+#[allow(
+    clippy::cognitive_complexity,
+    reason = "inherent reconnect-loop complexity (token + connect + subscribe + callback + recovery \
+              + monitor + cleanup + backoff); mirrors spot's `connection_manager`, not worth splitting further"
+)]
 async fn margin_connection_manager(
     tx: mpsc::UnboundedSender<UnindexedAccountEvent>,
     dedup: SharedDedupCache,
@@ -1860,7 +2235,7 @@ async fn margin_connection_manager(
         // --- Token: reuse the verified/previous token, else acquire a fresh one ---
         let token = match current_token.take() {
             Some(t) => t,
-            None => match acquire_user_listen_token(&rest_config, &rate_limiter).await {
+            None => match acquire_user_listen_token(&rest_config, &rate_limiter, None).await {
                 Ok(t) => t,
                 Err(e) => {
                     error!(%e, "BinanceMargin userListenToken acquisition failed");
@@ -1891,75 +2266,18 @@ async fn margin_connection_manager(
 
         // --- Register the event listener BEFORE subscribing so no pushed event is missed ---
         let (signal_tx, signal_rx) = oneshot::channel::<()>();
-        let mut signal_tx_opt = Some(signal_tx);
         // start true — grant one full heartbeat window before requiring activity.
         let heartbeat_flag = Arc::new(AtomicBool::new(true));
-        let hb_callback = heartbeat_flag.clone();
-        let dedup_callback = dedup.clone();
-        let mut event_tx = Some(tx.clone());
-        // 32 comfortably covers a typical margin account's outboundAccountPosition (one entry per
-        // asset) plus the execution events in a single message; an account with >32 assets reallocates
-        // once, after which the buffer is reused across messages via drain(..).
-        let mut event_buf = Vec::with_capacity(32);
-
-        // Safety — non-atomic Option::take() in the callback is safe: binance-sdk drives one
-        // spawned task per subscription, invoking the FnMut sequentially (verified =50.0.0;
-        // re-verify on SDK upgrade). Same contract spot relies on.
-        let subscription = ws.common.events.subscribe(move |event| {
-            let Some(ref sender) = event_tx else { return };
-            match event {
-                WebsocketEvent::Message(json_str) => {
-                    hb_callback.store(true, Ordering::Release);
-                    // Frame parsing (including skipping non-JSON frames) happens inside the
-                    // converter, which parses borrowed slices rather than a full DOM (hot path).
-                    let terminated = convert_margin_user_data_events(&json_str, &mut event_buf);
-                    for ev in event_buf.drain(..) {
-                        if let Some(key) = dedup_key_from_event(&ev)
-                            && is_duplicate(&dedup_callback, key)
-                        {
-                            trace!("BinanceMargin dedup: skipping duplicate event");
-                            continue;
-                        }
-                        if sender.send(ev).is_err() {
-                            warn!(
-                                "BinanceMargin account_stream receiver dropped, suppressing sends"
-                            );
-                            event_tx.take();
-                            if let Some(s) = signal_tx_opt.take() {
-                                let _ = s.send(());
-                            }
-                            return;
-                        }
-                    }
-                    if terminated {
-                        event_tx.take();
-                        if let Some(s) = signal_tx_opt.take() {
-                            let _ = s.send(());
-                        }
-                    }
-                }
-                WebsocketEvent::Ping | WebsocketEvent::Pong => {
-                    hb_callback.store(true, Ordering::Release);
-                }
-                WebsocketEvent::Error(e) => {
-                    warn!(%e, "BinanceMargin WebSocket error, will attempt reconnect");
-                    event_tx.take();
-                    if let Some(s) = signal_tx_opt.take() {
-                        let _ = s.send(());
-                    }
-                }
-                WebsocketEvent::Close(code, reason) => {
-                    warn!(code, %reason, "BinanceMargin WebSocket closed");
-                    event_tx.take();
-                    if let Some(s) = signal_tx_opt.take() {
-                        let _ = s.send(());
-                    }
-                }
-                _ => {
-                    trace!("BinanceMargin ignoring unhandled WebsocketEvent variant");
-                }
-            }
-        });
+        // Cross is account-wide: balance frames become asset-keyed BalanceStreamUpdates (no
+        // per-instrument routing). The shared dispatch/dedup/heartbeat logic lives in the helper.
+        let subscription = register_user_data_listener(
+            &ws,
+            tx.clone(),
+            dedup.clone(),
+            heartbeat_flag.clone(),
+            signal_tx,
+            cross_account_position_handler,
+        );
 
         // --- Subscribe (token is the sole auth) ---
         if let Err(e) = subscribe_listen_token(&ws, &token.token).await {
@@ -2073,6 +2391,362 @@ async fn margin_connection_manager(
         // `current_token` and `current_ws` are already None, forcing a fresh token + connection.
         if !matches!(reason, DisconnectReason::TokenRefresh) && !backoff.wait().await {
             error!("BinanceMargin max reconnect attempts exhausted, stream terminating");
+            break;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Isolated user-data stream (separate multiplexed manager; cross untouched)
+// ---------------------------------------------------------------------------
+
+/// Extract the invariant `instrument → (base_asset, quote_asset)` map from an isolated
+/// account-info response.
+///
+/// The authoritative base/quote split for routing symbol-less `outboundAccountPosition` frames
+/// (Design decision #5 / [`route_isolated_account_position`]) — base/quote never change for a pair,
+/// so this is built once at stream start and reused across reconnects. Entries missing a symbol or
+/// either asset name are skipped (their balance frames then drop with a `warn!` at routing time).
+fn build_base_quote_map(
+    assets: &[QueryIsolatedMarginAccountInfoResponseAssetsInner],
+) -> HashMap<InstrumentNameExchange, (AssetNameExchange, AssetNameExchange)> {
+    let mut map = HashMap::with_capacity(assets.len());
+    for entry in assets {
+        let (Some(symbol), Some(base), Some(quote)) = (
+            entry.symbol.as_deref(),
+            entry.base_asset.as_deref().and_then(|b| b.asset.as_deref()),
+            entry
+                .quote_asset
+                .as_deref()
+                .and_then(|q| q.asset.as_deref()),
+        ) else {
+            warn!(
+                "BinanceMargin isolated: account-info entry missing symbol/base/quote asset — \
+                 skipping base/quote map entry"
+            );
+            continue;
+        };
+        map.insert(
+            InstrumentNameExchange::new(symbol),
+            (AssetNameExchange::new(base), AssetNameExchange::new(quote)),
+        );
+    }
+    map
+}
+
+/// Acquire one per-symbol isolated `userListenToken` for every configured symbol, bounded-concurrent.
+///
+/// Fans out at 8-wide (mirroring `recover_margin_fills`) through the shared rate-limit/backoff
+/// machinery — ~1s at the v1 N≤100 ceiling vs ~5–10s sequential (Design decision #5). Each token is
+/// a weight-1 signed POST; the bound stays well inside SAPI weight limits. Errors if any acquisition
+/// fails (the caller treats a partial set as a startup/reconnect failure).
+///
+/// Takes `&Arc<_>` rather than the file-wide `&RateLimitTracker` convention because each per-symbol
+/// `async move` future needs an owned `Arc` clone to share the tracker without borrowing from this
+/// frame across the concurrent `buffer_unordered` fan-out. Cloning the `Arc` (a refcount bump) is
+/// correct; cloning `RateLimitTracker` itself would be semantically wrong — each clone would get its
+/// own `blocked_until`, splitting the shared rate-limit state the fan-out is meant to respect.
+async fn acquire_all_isolated_tokens(
+    rest_config: &Arc<ConfigurationRestApi>,
+    rate_limiter: &Arc<RateLimitTracker>,
+    symbols: &[InstrumentNameExchange],
+) -> Result<Vec<(InstrumentNameExchange, UserListenToken)>, UnindexedClientError> {
+    use futures::{StreamExt as _, TryStreamExt as _};
+
+    futures::stream::iter(symbols.iter().cloned().map(|sym| {
+        let rest_config = rest_config.clone();
+        let rate_limiter = rate_limiter.clone();
+        async move {
+            let token = acquire_user_listen_token(&rest_config, &rate_limiter, Some(&sym)).await?;
+            Ok::<_, UnindexedClientError>((sym, token))
+        }
+    }))
+    .buffer_unordered(8)
+    .try_collect()
+    .await
+}
+
+/// Earliest `expirationTime` (epoch ms) across the per-symbol tokens — drives the planned-renewal
+/// deadline. The N tokens are acquired in a tight startup loop so their 24h expiries cluster;
+/// renewing on the earliest refreshes the whole set in one reconnect. Empty → `i64::MAX` (no token
+/// to expire; never happens for isolated, which always has ≥1 configured symbol).
+fn earliest_token_expiry_ms(tokens: &[(InstrumentNameExchange, UserListenToken)]) -> i64 {
+    tokens
+        .iter()
+        .map(|(_, t)| t.expiration_time_ms)
+        .min()
+        .unwrap_or(i64::MAX)
+}
+
+/// A live, subscribed isolated connection: the single multiplexed socket plus the per-connection
+/// lifecycle handles the manager's monitor loop needs.
+struct IsolatedLiveConn {
+    ws: Arc<WsApiBase>,
+    subscription: Subscription,
+    signal_rx: oneshot::Receiver<()>,
+    heartbeat_flag: Arc<AtomicBool>,
+    /// Earliest `expirationTime` across the N tokens — drives the planned-renewal deadline (the
+    /// tokens cluster, so renewing on the earliest refreshes the whole set in one reconnect).
+    earliest_expiry_ms: i64,
+}
+
+/// Connect one WS-API socket and subscribe all N per-symbol `userListenToken`s on it (multiplex).
+///
+/// Registers the shared dispatch listener (with the isolated per-instrument balance handler) BEFORE
+/// the first subscribe so no pushed event between the N acks is missed, then issues all N subscribes,
+/// capturing each ack's `subscriptionId` into the shared `subscriptionId → symbol` routing map. If
+/// **any** subscribe fails, the partially-subscribed socket is cleaned up and the error returned
+/// (startup → `Err` with nothing spawned; reconnect → retry with backoff). Reused by both the
+/// initial `account_stream` startup and the manager's reconnect path so connect+subscribe is
+/// single-sourced.
+async fn isolated_connect_and_subscribe(
+    ws_config: &ConfigurationWebsocketApi,
+    tx: &mpsc::UnboundedSender<UnindexedAccountEvent>,
+    dedup: &SharedDedupCache,
+    base_quote: &Arc<HashMap<InstrumentNameExchange, (AssetNameExchange, AssetNameExchange)>>,
+    tokens: &[(InstrumentNameExchange, UserListenToken)],
+) -> anyhow::Result<IsolatedLiveConn> {
+    let ws = connect_margin_ws(ws_config).await?;
+    // subscriptionId → symbol routing map: written here as each subscribe ack resolves, read by the
+    // dispatch callback on every `outboundAccountPosition`. Shared (Mutex) because the two run on
+    // different tasks (manager vs the SDK's per-subscription callback task); contention is negligible
+    // (writes only at (re)connect, reads only on balance frames).
+    // Sized to the token count up front — exactly one entry is inserted per subscribe ack below.
+    let sub_map = Arc::new(Mutex::new(
+        HashMap::<i64, InstrumentNameExchange>::with_capacity(tokens.len()),
+    ));
+    let (signal_tx, signal_rx) = oneshot::channel::<()>();
+    // start true — grant one full heartbeat window before requiring activity.
+    let heartbeat_flag = Arc::new(AtomicBool::new(true));
+
+    let handle_position = {
+        let sub_map = sub_map.clone();
+        let base_quote = base_quote.clone();
+        move |position, subscription_id, buf: &mut Vec<UnindexedAccountEvent>| {
+            route_isolated_account_position(position, subscription_id, &sub_map, &base_quote, buf);
+        }
+    };
+    // Register BEFORE subscribing so a pushed event arriving mid-fan-out is not missed.
+    let subscription = register_user_data_listener(
+        &ws,
+        tx.clone(),
+        dedup.clone(),
+        heartbeat_flag.clone(),
+        signal_tx,
+        handle_position,
+    );
+
+    let earliest_expiry_ms = earliest_token_expiry_ms(tokens);
+    for (sym, token) in tokens {
+        match subscribe_listen_token_capture(&ws, &token.token).await {
+            Ok(Some(id)) => {
+                sub_map
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .insert(id, sym.clone());
+            }
+            Ok(None) => warn!(
+                symbol = %sym.name(),
+                "BinanceMargin isolated: subscribe ack carried no subscriptionId — live per-pair \
+                 balances unavailable for this symbol (fills/orders unaffected; balances via snapshot)"
+            ),
+            Err(e) => {
+                // Any subscribe failing voids the whole stream — clean up the partially-subscribed
+                // socket rather than leaking it, and surface the error to the caller.
+                warn!(%e, symbol = %sym.name(), "BinanceMargin isolated subscribe failed");
+                subscription.unsubscribe();
+                if let Err(de) = ws.disconnect().await {
+                    warn!(%de, "BinanceMargin isolated: disconnect after subscribe failure failed");
+                }
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(IsolatedLiveConn {
+        ws,
+        subscription,
+        signal_rx,
+        heartbeat_flag,
+        earliest_expiry_ms,
+    })
+}
+
+/// Long-running task driving the isolated `account_stream` lifecycle over one multiplexed socket.
+///
+/// Mirrors [`margin_connection_manager`] (the cross manager, left untouched) but for the N-symbol
+/// multiplex: reconnect re-acquires all N tokens + re-subscribes all N from the configured symbol
+/// set; renewal is a planned reconnect on the earliest token deadline (`DisconnectReason::TokenRefresh`,
+/// reusing cross's `token_renew_after`/`sleep_until` discipline — no make-before-break). One socket
+/// ⇒ one heartbeat, one reconnect loop, one backoff. The `base_quote` map is invariant and reused
+/// across reconnects (never rebuilt).
+#[allow(
+    clippy::cognitive_complexity,
+    reason = "inherent reconnect-loop complexity (tokens + connect + subscribe + monitor + cleanup \
+              + backoff); mirrors the cross manager, not worth splitting further"
+)]
+async fn isolated_connection_manager(
+    tx: mpsc::UnboundedSender<UnindexedAccountEvent>,
+    dedup: SharedDedupCache,
+    ws_config: ConfigurationWebsocketApi,
+    rest_config: Arc<ConfigurationRestApi>,
+    rest: Arc<RestApi>,
+    rate_limiter: Arc<RateLimitTracker>,
+    symbols: Vec<InstrumentNameExchange>,
+    base_quote: Arc<HashMap<InstrumentNameExchange, (AssetNameExchange, AssetNameExchange)>>,
+    initial: Option<IsolatedLiveConn>,
+) {
+    enum DisconnectReason {
+        Signal,
+        HeartbeatTimeout,
+        TokenRefresh,
+        ConsumerDropped,
+    }
+
+    let mut backoff = ExponentialBackoff::new();
+    let mut disconnect_time: Option<DateTime<Utc>> = None;
+    let mut current = initial;
+
+    loop {
+        // --- (Re)establish the live, subscribed connection ---
+        let IsolatedLiveConn {
+            ws,
+            subscription,
+            signal_rx,
+            heartbeat_flag,
+            earliest_expiry_ms,
+        } = match current.take() {
+            // Verified initial connection from account_stream — used as-is on the first pass.
+            Some(live) => live,
+            None => {
+                // Reconnect: re-acquire all N tokens (they cluster; a planned refresh re-acquires the
+                // whole set) then connect a fresh socket and re-subscribe all N.
+                let tokens = match acquire_all_isolated_tokens(
+                    &rest_config,
+                    &rate_limiter,
+                    &symbols,
+                )
+                .await
+                {
+                    Ok(t) => t,
+                    Err(e) => {
+                        error!(%e, "BinanceMargin isolated userListenToken acquisition failed");
+                        if !backoff.wait().await {
+                            error!("BinanceMargin isolated max reconnect attempts exhausted");
+                            break;
+                        }
+                        continue;
+                    }
+                };
+                match isolated_connect_and_subscribe(&ws_config, &tx, &dedup, &base_quote, &tokens)
+                    .await
+                {
+                    Ok(live) => live,
+                    Err(e) => {
+                        error!(%e, "BinanceMargin isolated connect/subscribe failed");
+                        if !backoff.wait().await {
+                            error!("BinanceMargin isolated max reconnect attempts exhausted");
+                            break;
+                        }
+                        continue;
+                    }
+                }
+            }
+        };
+
+        info!(
+            symbols = symbols.len(),
+            "BinanceMargin isolated account_stream connected and subscribed"
+        );
+        // Reaching a live, subscribed connection clears any prior failure count (see the cross
+        // manager) so only *consecutive* failures exhaust the reconnect budget.
+        backoff.reset();
+
+        // Absolute deadline (not a per-iteration relative sleep) so heartbeat ticks that `continue`
+        // the monitor loop don't keep restarting the renewal timer. Earliest token expiry drives it.
+        let token_deadline = tokio::time::Instant::now() + token_renew_after(earliest_expiry_ms);
+
+        // --- Fill recovery after a reconnect (isolated-scoped over the full symbol set) ---
+        if let Some(dt) = disconnect_time.take()
+            && tokio::time::timeout(
+                Duration::from_secs(FILL_RECOVERY_TIMEOUT_SECS),
+                // is_isolated = true: paginate_margin_my_trades must query isolated trades.
+                recover_margin_fills(&rest, &rate_limiter, &symbols, dt, &tx, &dedup, true),
+            )
+            .await
+            .is_err()
+        {
+            warn!(
+                timeout_secs = FILL_RECOVERY_TIMEOUT_SECS,
+                "BinanceMargin isolated fill recovery timed out — remaining instruments not queried"
+            );
+        }
+
+        // --- Monitor: disconnect signal, heartbeat timeout, token refresh, or consumer drop ---
+        // One socket regardless of N, so the conditions are identical to cross.
+        let reason = {
+            let mut signal_rx = signal_rx;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = tx.closed() => {
+                        debug!("BinanceMargin isolated consumer dropped, terminating");
+                        break DisconnectReason::ConsumerDropped;
+                    }
+                    _ = &mut signal_rx => {
+                        warn!("BinanceMargin isolated WS disconnected, will attempt reconnect");
+                        break DisconnectReason::Signal;
+                    }
+                    () = tokio::time::sleep_until(token_deadline) => {
+                        info!("BinanceMargin isolated userListenToken nearing expiry, renewing all");
+                        break DisconnectReason::TokenRefresh;
+                    }
+                    () = tokio::time::sleep(Duration::from_secs(HEARTBEAT_TIMEOUT_SECS)) => {
+                        if heartbeat_flag.swap(false, Ordering::AcqRel) {
+                            continue;
+                        }
+                        warn!("BinanceMargin isolated heartbeat timeout ({}s), will attempt reconnect", HEARTBEAT_TIMEOUT_SECS);
+                        break DisconnectReason::HeartbeatTimeout;
+                    }
+                }
+            }
+        };
+        let should_reconnect = !matches!(reason, DisconnectReason::ConsumerDropped);
+
+        if should_reconnect {
+            disconnect_time = Some(match reason {
+                DisconnectReason::HeartbeatTimeout => {
+                    Utc::now()
+                        - chrono::Duration::seconds(HEARTBEAT_TIMEOUT_SECS as i64)
+                        - chrono::Duration::milliseconds(SIGNAL_RECOVERY_LOOKBACK_MS)
+                }
+                DisconnectReason::TokenRefresh => {
+                    // A rotation fully disconnects + reconnects (re-acquire N tokens + reconnect +
+                    // re-subscribe N). Look back far enough to bound that whole window so a fill
+                    // landing during the sub-second gap isn't missed; dedup absorbs the overlap.
+                    Utc::now()
+                        - chrono::Duration::seconds(CONNECT_TIMEOUT_SECS as i64)
+                        - chrono::Duration::milliseconds(SIGNAL_RECOVERY_LOOKBACK_MS)
+                }
+                _ => Utc::now() - chrono::Duration::milliseconds(SIGNAL_RECOVERY_LOOKBACK_MS),
+            });
+        }
+
+        // --- Cleanup ---
+        subscription.unsubscribe();
+        if let Err(e) = ws.disconnect().await {
+            warn!(%e, "BinanceMargin isolated failed to disconnect WebSocket");
+        }
+
+        if !should_reconnect || tx.is_closed() {
+            debug!("BinanceMargin isolated connection manager exiting");
+            break;
+        }
+
+        // A planned token refresh is not a failure — reconnect immediately (no backoff); `current`
+        // is already None, forcing fresh tokens + a fresh connection next iteration.
+        if !matches!(reason, DisconnectReason::TokenRefresh) && !backoff.wait().await {
+            error!("BinanceMargin isolated max reconnect attempts exhausted, stream terminating");
             break;
         }
     }
@@ -4028,5 +4702,232 @@ mod tests {
             is_duplicate(&cache, second),
             "second sighting is a duplicate"
         );
+    }
+
+    // -- Isolated user-data stream: token params, base/quote map, balance routing ---------------
+
+    /// Wrap an inner `event` in the WS-API push envelope with an explicit `subscriptionId` (the
+    /// isolated routing key for symbol-less `outboundAccountPosition` frames).
+    fn push_with_sub(subscription_id: i64, event: serde_json::Value) -> String {
+        serde_json::json!({ "subscriptionId": subscription_id, "event": event }).to_string()
+    }
+
+    /// Build the isolated balance handler (closes over the routing maps) for driving
+    /// `convert_margin_user_data_events_with` in tests.
+    fn isolated_handler(
+        sub_map: Arc<Mutex<HashMap<i64, InstrumentNameExchange>>>,
+        base_quote: Arc<HashMap<InstrumentNameExchange, (AssetNameExchange, AssetNameExchange)>>,
+    ) -> impl FnMut(Outboundaccountposition, Option<i64>, &mut Vec<UnindexedAccountEvent>) {
+        move |position, subscription_id, buf| {
+            route_isolated_account_position(position, subscription_id, &sub_map, &base_quote, buf);
+        }
+    }
+
+    fn btcusdt() -> InstrumentNameExchange {
+        InstrumentNameExchange::new("BTCUSDT")
+    }
+
+    fn token(expiration_time_ms: i64) -> UserListenToken {
+        UserListenToken {
+            token: "t".to_string(),
+            expiration_time_ms,
+        }
+    }
+
+    #[test]
+    fn listen_token_query_cross_vs_isolated() {
+        // Cross → no params (the signed POST sends an empty query, exactly as TG17).
+        assert!(build_listen_token_query(None).is_empty());
+
+        // Isolated → isIsolated=TRUE & symbol=<sym> (the per-symbol scoping).
+        let q = build_listen_token_query(Some(&btcusdt()));
+        assert_eq!(q.get("isIsolated").and_then(|v| v.as_str()), Some("TRUE"));
+        assert_eq!(q.get("symbol").and_then(|v| v.as_str()), Some("BTCUSDT"));
+        assert_eq!(q.len(), 2);
+    }
+
+    #[test]
+    fn earliest_token_expiry_picks_min() {
+        let tokens = vec![
+            (btcusdt(), token(3_000)),
+            (InstrumentNameExchange::new("ETHUSDT"), token(1_000)),
+            (InstrumentNameExchange::new("BNBUSDT"), token(2_000)),
+        ];
+        assert_eq!(earliest_token_expiry_ms(&tokens), 1_000);
+        // Empty set → sentinel (never happens for isolated, which always has ≥1 symbol).
+        assert_eq!(earliest_token_expiry_ms(&[]), i64::MAX);
+    }
+
+    #[test]
+    fn base_quote_map_extracts_base_and_quote() {
+        let entries = vec![
+            iso_entry(
+                "BTCUSDT",
+                iso_base("BTC", "0", "0", "0", "0"),
+                iso_quote("USDT", "0", "0", "0", "0"),
+                None,
+                None,
+                None,
+            ),
+            iso_entry(
+                "ETHBTC",
+                iso_base("ETH", "0", "0", "0", "0"),
+                iso_quote("BTC", "0", "0", "0", "0"),
+                None,
+                None,
+                None,
+            ),
+        ];
+        let map = build_base_quote_map(&entries);
+        assert_eq!(
+            map.get(&btcusdt())
+                .map(|(b, q)| (b.name().as_str(), q.name().as_str())),
+            Some(("BTC", "USDT"))
+        );
+        // ETHBTC: prefix/suffix string-matching would be ambiguous (BTC is the quote here, base
+        // elsewhere) — the authoritative map resolves it unambiguously to base=ETH, quote=BTC.
+        assert_eq!(
+            map.get(&InstrumentNameExchange::new("ETHBTC"))
+                .map(|(b, q)| (b.name().as_str(), q.name().as_str())),
+            Some(("ETH", "BTC"))
+        );
+    }
+
+    #[test]
+    fn isolated_outbound_position_routes_to_instrument_balance_update() {
+        let sub_map = Arc::new(Mutex::new(HashMap::from([(7_i64, btcusdt())])));
+        let base_quote = Arc::new(HashMap::from([(
+            btcusdt(),
+            (
+                AssetNameExchange::new("BTC"),
+                AssetNameExchange::new("USDT"),
+            ),
+        )]));
+        let mut handler = isolated_handler(sub_map, base_quote);
+
+        // Quote listed before base in `B` → assignment is by asset-name equality, not position.
+        let frame = push_with_sub(
+            7,
+            serde_json::json!({
+                "e": "outboundAccountPosition", "u": 1_700_000_000_000_i64,
+                "B": [
+                    { "a": "USDT", "f": "1000.0", "l": "50.0" },
+                    { "a": "BTC", "f": "0.5", "l": "0.1" },
+                ],
+            }),
+        );
+        let mut buf = Vec::new();
+        assert!(!convert_margin_user_data_events_with(
+            &frame,
+            &mut buf,
+            &mut handler
+        ));
+        assert_eq!(buf.len(), 1, "one InstrumentBalanceUpdate for the pair");
+        match &buf[0].kind {
+            AccountEventKind::InstrumentBalanceUpdate(ibu) => {
+                assert_eq!(ibu.instrument.name().as_str(), "BTCUSDT");
+                assert_eq!(ibu.base.asset.name().as_str(), "BTC");
+                assert_eq!(ibu.base.update.free, Decimal::new(5, 1));
+                assert_eq!(ibu.base.update.locked, Decimal::new(1, 1));
+                assert_eq!(ibu.quote.asset.name().as_str(), "USDT");
+                assert_eq!(ibu.quote.update.free, Decimal::from(1000));
+                assert_eq!(ibu.quote.update.locked, Decimal::from(50));
+            }
+            other => panic!("expected InstrumentBalanceUpdate, got {other:?}"),
+        }
+        // Crucially NOT the asset-keyed BalanceStreamUpdate (which would corrupt AssetStates).
+        assert!(!matches!(
+            buf[0].kind,
+            AccountEventKind::BalanceStreamUpdate(_)
+        ));
+    }
+
+    #[test]
+    fn isolated_outbound_position_unknown_subscription_dropped() {
+        // subscriptionId 99 is not in the map → dropped (observable warn), nothing emitted.
+        let sub_map = Arc::new(Mutex::new(HashMap::from([(7_i64, btcusdt())])));
+        let base_quote = Arc::new(HashMap::from([(
+            btcusdt(),
+            (
+                AssetNameExchange::new("BTC"),
+                AssetNameExchange::new("USDT"),
+            ),
+        )]));
+        let mut handler = isolated_handler(sub_map, base_quote);
+
+        let frame = push_with_sub(
+            99,
+            serde_json::json!({
+                "e": "outboundAccountPosition", "u": 1_700_000_000_000_i64,
+                "B": [{ "a": "BTC", "f": "1", "l": "0" }, { "a": "USDT", "f": "1", "l": "0" }],
+            }),
+        );
+        let mut buf = Vec::new();
+        assert!(!convert_margin_user_data_events_with(
+            &frame,
+            &mut buf,
+            &mut handler
+        ));
+        assert!(buf.is_empty(), "unmapped subscriptionId frame is dropped");
+    }
+
+    #[test]
+    fn isolated_outbound_position_missing_side_dropped() {
+        // Only the base side present → no partial InstrumentBalanceUpdate (would fabricate a zero
+        // quote, silently mis-reporting free/locked). Dropped with a warn instead.
+        let sub_map = Arc::new(Mutex::new(HashMap::from([(7_i64, btcusdt())])));
+        let base_quote = Arc::new(HashMap::from([(
+            btcusdt(),
+            (
+                AssetNameExchange::new("BTC"),
+                AssetNameExchange::new("USDT"),
+            ),
+        )]));
+        let mut handler = isolated_handler(sub_map, base_quote);
+
+        let frame = push_with_sub(
+            7,
+            serde_json::json!({
+                "e": "outboundAccountPosition", "u": 1_700_000_000_000_i64,
+                "B": [{ "a": "BTC", "f": "0.5", "l": "0" }],
+            }),
+        );
+        let mut buf = Vec::new();
+        assert!(!convert_margin_user_data_events_with(
+            &frame,
+            &mut buf,
+            &mut handler
+        ));
+        assert!(buf.is_empty(), "missing quote side → frame dropped");
+    }
+
+    #[test]
+    fn isolated_execution_report_routes_by_inner_symbol_independent_of_map() {
+        // Fills self-identify via inner `s` and route regardless of the subscriptionId map (which
+        // is empty here) — only balance frames need the map. Confirms fills are unaffected if the
+        // subscriptionId→symbol routing ever fails live.
+        let sub_map = Arc::new(Mutex::new(HashMap::<i64, InstrumentNameExchange>::new()));
+        let base_quote = Arc::new(HashMap::new());
+        let mut handler = isolated_handler(sub_map, base_quote);
+
+        let frame = push_with_sub(
+            42,
+            serde_json::json!({
+                "e": "executionReport", "s": "BTCUSDT", "S": "BUY", "o": "LIMIT",
+                "x": "TRADE", "X": "FILLED", "i": 1_i64, "c": "cid", "t": 5_i64,
+                "l": "1", "L": "100", "z": "1", "n": "0", "N": "USDT", "T": 1_700_000_000_000_i64,
+            }),
+        );
+        let mut buf = Vec::new();
+        assert!(!convert_margin_user_data_events_with(
+            &frame,
+            &mut buf,
+            &mut handler
+        ));
+        assert_eq!(buf.len(), 1);
+        match &buf[0].kind {
+            AccountEventKind::Trade(t) => assert_eq!(t.instrument.name().as_str(), "BTCUSDT"),
+            other => panic!("expected Trade, got {other:?}"),
+        }
     }
 }

--- a/rustrade-execution/src/client/binance/margin.rs
+++ b/rustrade-execution/src/client/binance/margin.rs
@@ -1,17 +1,27 @@
-//! Binance Cross Margin execution client.
+//! Binance Margin execution client (cross and isolated).
 //!
 //! [`BinanceMargin`] is a margin counterpart to [`super::spot::BinanceSpot`]. It shares the
 //! exchange-agnostic infrastructure in [`super::shared`] (rate-limit tracking, reconnect/backoff,
-//! event deduplication, error parsing) and is intended to implement the same `ExecutionClient`
-//! trait so callers do not branch on spot-vs-margin transport.
+//! event deduplication, error parsing) and implements the same `ExecutionClient` trait so callers
+//! do not branch on spot-vs-margin transport.
 //!
 //! ## Scope
 //! This module provides the client's identity and configuration ([`BinanceMargin`],
 //! [`BinanceMarginConfig`], [`MarginSideEffect`]) and a full [`ExecutionClient`] implementation:
 //! order submission/cancel and account snapshot / balance / open-order / trade queries over REST,
 //! plus a live account event stream ([`ExecutionClient::account_stream`]) over the hand-rolled
-//! `userListenToken` user-data WebSocket (the SDK's retired listen-key path is not used). Cross
-//! margin only (`isIsolated = "FALSE"`); isolated margin is a separate follow-up.
+//! `userListenToken` user-data WebSocket (the SDK's retired listen-key path is not used). Both
+//! **cross** (`isIsolated = "FALSE"`, account-wide collateral) and **isolated** (`isIsolated =
+//! "TRUE"`, per-pair sub-accounts) margin are supported, selected by
+//! [`BinanceMarginConfig::is_isolated`].
+//!
+//! ## Cross vs. isolated
+//! Cross is account-wide: a single `userListenToken`, one WS-API subscription, and per-asset
+//! balances surfaced in the top-level `balances`. Isolated is per-pair: the caller declares the
+//! [`BinanceMarginConfig::isolated_symbols`] universe, each symbol gets its own `userListenToken`,
+//! and all N tokens are **multiplexed onto one WS-API socket**. Isolated per-pair balances and risk
+//! are attached per-instrument (never folded into the asset-keyed model, which cannot represent
+//! `(pair, asset)` pools). See [`BinanceMargin`] for the per-method contract.
 //!
 //! ## Borrow/repay
 //! Margin orders carry a `sideEffectType` controlling whether the venue borrows on entry and
@@ -324,6 +334,13 @@ impl BinanceMarginConfig {
 /// Consequently `net_asset` reflects debt only as fresh as the last `account_snapshot` for that
 /// asset — call it at startup and refresh on demand (see [`account_stream`](Self::account_stream)'s
 /// cold-start note).
+///
+/// # One client per engine (`ExchangeId`)
+/// All emitted events — cross and isolated alike — are stamped [`ExchangeId::BinanceMargin`], and
+/// the engine routes `AssetStates` / `ConnectivityStates` by `ExchangeId`. Running **two**
+/// `BinanceMargin` clients in a single engine (e.g. one cross, one isolated) therefore collides
+/// their exchange identity. A single engine should run **at most one** `BinanceMargin` client; a
+/// consumer needing cross and isolated concurrently runs them in separate engines.
 #[derive(Clone)]
 pub struct BinanceMargin {
     config: Arc<BinanceMarginConfig>,
@@ -820,8 +837,8 @@ impl ExecutionClient for BinanceMargin {
     /// via [`InstrumentAccountSnapshot::isolated`] rather than folded into the asset-keyed
     /// top-level `balances` (which is left **empty**) — isolated sub-accounts are per-`(pair, asset)`
     /// and would collide in the asset-keyed model. The instrument set is the effective isolated set
-    /// (see [`effective_isolated_set`](Self::effective_isolated_set)); each instrument's open orders
-    /// and isolated balances are fetched over that same set.
+    /// (`isolated_symbols`, or `instruments ∩ isolated_symbols` with out-of-set instruments skipped);
+    /// each instrument's open orders and isolated balances are fetched over that same set.
     async fn account_snapshot(
         &self,
         assets: &[AssetNameExchange],
@@ -1079,6 +1096,43 @@ impl ExecutionClient for BinanceMargin {
     /// a ~1s lookback after this returns. Callers must also call
     /// [`ExecutionClient::fetch_open_orders`] after each reconnect to reconcile order state — only
     /// TRADE fills are recovered, not order-lifecycle events.
+    ///
+    /// # Isolated mode (multiplexed `userListenToken`)
+    /// Under `is_isolated = true` a **separate** manager drives the stream (the cross path above is
+    /// left untouched). It acquires one per-symbol `userListenToken` for each
+    /// [`BinanceMarginConfig::isolated_symbols`] entry and multiplexes **all N subscriptions onto a
+    /// single WS-API socket**. Every token is acquired, the socket connected, and all subscriptions
+    /// confirmed **before this method returns** — if the connect or **any** subscribe fails, it
+    /// returns `Err` with nothing spawned (preserving the "can't-start vs started-then-dropped"
+    /// distinction). The `instruments` argument does **not** drive the isolated token set: the stream
+    /// always covers exactly `isolated_symbols`.
+    ///
+    /// ## Live per-pair balances — [`InstrumentBalanceUpdate`](crate::AccountEventKind::InstrumentBalanceUpdate)
+    /// The isolated stream delivers live fills and order updates (routed by the inner `symbol`) **and**
+    /// live per-pair `free`/`locked` balances, emitted as
+    /// [`AccountEventKind::InstrumentBalanceUpdate`](crate::AccountEventKind::InstrumentBalanceUpdate)
+    /// (base + quote per pair). Debt totals (`borrowed`/`interest`) stay REST-`BalanceSnapshot`-fresh
+    /// per the debt-freshness contract; the stream keeps only `free`/`locked` live.
+    ///
+    /// **Consumption contract (important):** the engine deliberately does **not** store
+    /// `InstrumentBalanceUpdate` — it falls through `update_from_account`'s `_ => None` wildcard,
+    /// mirroring the snapshot's
+    /// [`InstrumentAccountSnapshot::isolated`](crate::InstrumentAccountSnapshot::isolated). It is
+    /// therefore **never in `EngineState`**, and a `StateReplicaManager` replica replays the same
+    /// wildcard so it is **not** in replica state either. A consumer obtains live per-pair balances
+    /// **only** by inspecting the raw account event off the stream (`AccountStreamEvent::Item(..)` /
+    /// `audit_tick.event`) and matching the variant itself — a consumer reading solely replica
+    /// `EngineState` will see nothing and wrongly conclude the feature is broken. A wrapper wanting
+    /// engine-queryable per-instrument balances uses the `InstrumentData` extension point instead.
+    ///
+    /// ## First-prod-run check — `subscriptionId → symbol` routing
+    /// `outboundAccountPosition` frames carry no symbol inline; on the multiplexed socket their pair
+    /// is recovered via a `subscriptionId → symbol` map. This correlation is the one assumption no
+    /// offline source could validate — **verify it on the first production run**. Fills and order
+    /// updates are unaffected (they self-identify by `symbol`); if the correlation does not hold,
+    /// per-pair balance frames are dropped with a `warn!` (never mis-applied) and balances degrade to
+    /// snapshot-polling. The documented fallback is one socket per isolated symbol (symbol implied by
+    /// the connection).
     async fn account_stream(
         &self,
         // _assets is intentionally ignored — Binance pushes outboundAccountPosition for all account

--- a/rustrade-execution/src/client/binance/margin.rs
+++ b/rustrade-execution/src/client/binance/margin.rs
@@ -154,16 +154,26 @@ pub struct BinanceMarginConfig {
     /// as production. Retained to mirror the spot config shape; [`BinanceMargin::new`] warns if it
     /// is set to `true`.
     pub testnet: bool,
-    /// Isolated margin when `true`; cross margin (account-wide) when `false`.
+    /// Isolated margin (per-pair sub-accounts) when `true`; cross margin (account-wide) when
+    /// `false`.
     ///
-    /// Defaults to `false` (cross). Isolated support is a follow-up; cross is the primary mode.
-    ///
-    /// # Warning
-    /// Setting this to `true` is **not yet honoured**: the client currently operates as cross
-    /// margin regardless, logging a warning at construction (see [`BinanceMargin::new`]) rather
-    /// than failing silently. Isolated execution is a separate follow-up.
+    /// Defaults to `false` (cross). When `true`, [`isolated_symbols`](Self::isolated_symbols) must
+    /// be non-empty — it declares the pairs to snapshot/stream; [`BinanceMargin::new`] panics
+    /// otherwise.
     #[serde(default)]
     pub is_isolated: bool,
+    /// The isolated-margin pairs this client snapshots and streams when
+    /// [`is_isolated`](Self::is_isolated) is `true`.
+    ///
+    /// This is the authoritative symbol universe for the isolated per-symbol `userListenToken`
+    /// token/subscription fan-out: tokens are per-symbol and must be known at stream start, so the
+    /// set is fixed for the stream's lifetime. A pair activated *after* `account_stream` is called
+    /// is **not** auto-subscribed — reconfigure and restart the stream to pick it up.
+    ///
+    /// Ignored for cross margin (`is_isolated = false`). Empty by default; a `true` +
+    /// empty-set combination is a misconfiguration that panics in [`BinanceMargin::new`].
+    #[serde(default)]
+    pub isolated_symbols: Vec<InstrumentNameExchange>,
     /// Borrow/repay policy applied to every order placed by this client.
     ///
     /// Defaults to [`MarginSideEffect::AutoBorrowRepay`] — see its `# Warning` on silent borrowing.
@@ -179,6 +189,7 @@ impl std::fmt::Debug for BinanceMarginConfig {
             .field("secret_key", &"***")
             .field("testnet", &self.testnet)
             .field("is_isolated", &self.is_isolated)
+            .field("isolated_symbols", &self.isolated_symbols)
             .field("side_effect", &self.side_effect)
             .finish()
     }
@@ -187,15 +198,19 @@ impl std::fmt::Debug for BinanceMarginConfig {
 impl BinanceMarginConfig {
     /// Construct a [`BinanceMarginConfig`] with explicit control over every field.
     ///
-    /// Prefer [`BinanceMarginConfig::cross_margin`] for the common case, or deserialize from a
-    /// config file to keep credentials out of source. The required positional args are the
-    /// credentials plus any non-defaultable knobs; defaultable knobs (`is_isolated`, `side_effect`)
-    /// are exposed here for full control and via `#[serde(default)]` for the file path.
+    /// Prefer [`BinanceMarginConfig::cross_margin`] / [`BinanceMarginConfig::isolated`] for the
+    /// common cases, or deserialize from a config file to keep credentials out of source. The
+    /// positional args expose every field for full control; defaultable knobs (`is_isolated`,
+    /// `isolated_symbols`, `side_effect`) also default via `#[serde(default)]` on the file path.
+    ///
+    /// Note: this does not itself validate `is_isolated` against `isolated_symbols`; that gate
+    /// lives in [`BinanceMargin::new`] (it must also cover the `Deserialize`-only path).
     pub fn new(
         api_key: String,
         secret_key: String,
         testnet: bool,
         is_isolated: bool,
+        isolated_symbols: Vec<InstrumentNameExchange>,
         side_effect: MarginSideEffect,
     ) -> Self {
         Self {
@@ -203,6 +218,7 @@ impl BinanceMarginConfig {
             secret_key,
             testnet,
             is_isolated,
+            isolated_symbols,
             side_effect,
         }
     }
@@ -210,14 +226,38 @@ impl BinanceMarginConfig {
     /// Convenience constructor for the common case: cross margin, production endpoints, and the
     /// default [`MarginSideEffect::AutoBorrowRepay`] borrow/repay policy.
     ///
-    /// Equivalent to [`new`](Self::new) with `testnet = false`, `is_isolated = false`, and the
-    /// default `side_effect`. Use [`new`](Self::new) when any of those need to differ.
+    /// Equivalent to [`new`](Self::new) with `testnet = false`, `is_isolated = false`, no
+    /// `isolated_symbols`, and the default `side_effect`. Use [`new`](Self::new) when any of those
+    /// need to differ.
     pub fn cross_margin(api_key: String, secret_key: String) -> Self {
         Self::new(
             api_key,
             secret_key,
             false,
             false,
+            Vec::new(),
+            MarginSideEffect::default(),
+        )
+    }
+
+    /// Convenience constructor for isolated margin: production endpoints, the default
+    /// [`MarginSideEffect::AutoBorrowRepay`] borrow/repay policy, and the given per-pair symbol
+    /// universe (see [`isolated_symbols`](Self::isolated_symbols)).
+    ///
+    /// `symbols` should be non-empty: an isolated client with no symbols has nothing to
+    /// snapshot or stream and [`BinanceMargin::new`] panics on it. Use [`new`](Self::new) to
+    /// override `side_effect`.
+    pub fn isolated(
+        api_key: String,
+        secret_key: String,
+        symbols: Vec<InstrumentNameExchange>,
+    ) -> Self {
+        Self::new(
+            api_key,
+            secret_key,
+            false,
+            true,
+            symbols,
             MarginSideEffect::default(),
         )
     }
@@ -350,8 +390,15 @@ impl ExecutionClient for BinanceMargin {
     /// Construct a `BinanceMargin` client from its configuration.
     ///
     /// # Panics
-    /// Panics if the binance-sdk configuration builder fails (e.g. empty or malformed
-    /// API key/secret), matching [`BinanceSpot`](super::spot::BinanceSpot)'s startup contract.
+    /// Panics if:
+    /// - the binance-sdk configuration builder fails (e.g. empty or malformed API key/secret),
+    ///   matching [`BinanceSpot`](super::spot::BinanceSpot)'s startup contract; or
+    /// - `is_isolated = true` but [`isolated_symbols`](BinanceMarginConfig::isolated_symbols) is
+    ///   empty — an isolated client with no configured pairs has nothing to snapshot or stream.
+    ///   This gate lives here (not only in [`BinanceMarginConfig::isolated`]) because the config is
+    ///   `Deserialize`-only and a deserialized config bypasses the named constructor. The
+    ///   `ExecutionClient::new` signature returns `Self`, not `Result`, so an unusable config is a
+    ///   fail-fast panic (consistent with the credential `expect`s above), not a recoverable error.
     fn new(config: Self::Config) -> Self {
         if config.testnet {
             warn!(
@@ -359,12 +406,10 @@ impl ExecutionClient for BinanceMargin {
                  using production endpoints"
             );
         }
-        if config.is_isolated {
-            warn!(
-                "BinanceMarginConfig.is_isolated = true is not yet supported: isolated margin is a \
-                 follow-up; operating as cross margin"
-            );
-        }
+        assert!(
+            !(config.is_isolated && config.isolated_symbols.is_empty()),
+            "BinanceMarginConfig: is_isolated = true requires a non-empty isolated_symbols"
+        );
         // Built once and shared: one clone is consumed by the SDK `RestApi`, the original is retained
         // for the hand-rolled `userListenToken` POST via `send_request`. `ConfigurationRestApi: Clone`
         // and is cheap to copy (its `reqwest::Client` is `Arc`-backed), avoiding redundant credential
@@ -390,7 +435,7 @@ impl ExecutionClient for BinanceMargin {
     ///
     /// Margin specifics:
     /// - `sideEffectType` is the client-level [`MarginSideEffect`] (borrow/repay policy).
-    /// - `isIsolated` is always `"FALSE"` (cross) in this version — isolated margin is a follow-up.
+    /// - `isIsolated` is config-driven (`"TRUE"` for isolated, `"FALSE"` for cross).
     /// - `autoRepayAtCancel` is set only under [`MarginSideEffect::AutoBorrowRepay`]: a `NoBorrow`
     ///   client takes no loan, so requesting repay-on-cancel would be incoherent.
     /// - Trailing-stop kinds return [`OrderError::UnsupportedOrderType`] (the SDK omits
@@ -437,6 +482,7 @@ impl ExecutionClient for BinanceMargin {
             time_in_force,
             cid.0.to_string(),
             self.config.side_effect,
+            self.config.is_isolated,
         ) {
             Ok(params) => params,
             Err(BuildOrderError::Unsupported) => {
@@ -542,7 +588,7 @@ impl ExecutionClient for BinanceMargin {
     /// Cancel a resting margin order via `DELETE /sapi/v1/margin/order`.
     ///
     /// Cancels by exchange `orderId` when present and parseable, otherwise by the originating
-    /// client order id. Cross only (`isIsolated = "FALSE"`). Mirrors
+    /// client order id. `isIsolated` is config-driven. Mirrors
     /// [`BinanceSpot::cancel_order`](super::spot::BinanceSpot): every failure is folded into the
     /// returned response's `state` as an `Err`.
     ///
@@ -560,31 +606,18 @@ impl ExecutionClient for BinanceMargin {
             cid: request.key.cid.clone(),
         };
 
-        let mut builder = MarginAccountCancelOrderParams::builder(instrument.name().to_string())
-            .is_isolated("FALSE".to_string());
-
-        if let Some(ref order_id) = request.state.id {
-            if let Ok(id) = order_id.0.parse::<i64>() {
-                builder = builder.order_id(id);
-            } else {
-                // exchange order id exists but isn't a valid i64 — fall back to the cid.
-                error!(
-                    order_id = %order_id.0,
-                    "BinanceMargin cancel: exchange orderId not parseable as i64, falling back to clientOrderId"
-                );
-                builder = builder.orig_client_order_id(request.key.cid.0.to_string());
-            }
-        } else {
-            builder = builder.orig_client_order_id(request.key.cid.0.to_string());
-        }
-
-        let params = match builder.build() {
+        let params = match build_cancel_order_params(
+            instrument.name().to_string(),
+            request.state.id.as_ref(),
+            &request.key.cid,
+            self.config.is_isolated,
+        ) {
             Ok(p) => p,
             Err(e) => {
                 error!(%e, "BinanceMargin failed to build cancel order params");
                 return Some(UnindexedOrderResponseCancel {
                     key,
-                    state: Err(OrderError::Rejected(ApiError::OrderRejected(e.to_string()))),
+                    state: Err(OrderError::Rejected(ApiError::OrderRejected(e))),
                 });
             }
         };
@@ -699,6 +732,7 @@ impl ExecutionClient for BinanceMargin {
                     self.rest.clone(),
                     self.rate_limiter.clone(),
                     instrument,
+                    self.config.is_isolated,
                 )
             }))
             .buffer_unordered(8)
@@ -768,8 +802,12 @@ impl ExecutionClient for BinanceMargin {
         // Empty slice = "return all" sentinel: a single no-symbol query is both correct (the
         // contract requires all instruments) and far cheaper than enumerating every symbol.
         if instruments.is_empty() {
-            return fetch_margin_all_open_orders(self.rest.clone(), self.rate_limiter.clone())
-                .await;
+            return fetch_margin_all_open_orders(
+                self.rest.clone(),
+                self.rate_limiter.clone(),
+                self.config.is_isolated,
+            )
+            .await;
         }
         use futures::{StreamExt as _, TryStreamExt as _};
         futures::stream::iter(instruments.iter().cloned().map(|instrument| {
@@ -777,6 +815,7 @@ impl ExecutionClient for BinanceMargin {
                 self.rest.clone(),
                 self.rate_limiter.clone(),
                 instrument,
+                self.config.is_isolated,
             )
         }))
         .buffer_unordered(8)
@@ -814,6 +853,7 @@ impl ExecutionClient for BinanceMargin {
             return Ok(Vec::new());
         }
         let start_time_ms = time_since.timestamp_millis();
+        let is_isolated = self.config.is_isolated;
         let mut all_trades = Vec::new();
 
         // Binance requires per-symbol queries for trade history. Limit concurrency to avoid
@@ -822,8 +862,14 @@ impl ExecutionClient for BinanceMargin {
             let rest = self.rest.clone();
             let rate_limiter = self.rate_limiter.clone();
             async move {
-                let pages =
-                    paginate_margin_my_trades(&rest, &rate_limiter, &inst, start_time_ms).await?;
+                let pages = paginate_margin_my_trades(
+                    &rest,
+                    &rate_limiter,
+                    &inst,
+                    start_time_ms,
+                    is_isolated,
+                )
+                .await?;
                 Ok::<_, UnindexedClientError>((inst, pages))
             }
         }))
@@ -1530,6 +1576,7 @@ async fn recover_margin_fills(
     disconnect_time: DateTime<Utc>,
     tx: &mpsc::UnboundedSender<UnindexedAccountEvent>,
     dedup: &SharedDedupCache,
+    is_isolated: bool,
 ) {
     use futures::StreamExt as _;
 
@@ -1552,7 +1599,7 @@ async fn recover_margin_fills(
         let rest = rest.clone();
         let rl = rate_limiter.clone();
         async move {
-            match paginate_margin_my_trades(&rest, &rl, &inst, start_time_ms).await {
+            match paginate_margin_my_trades(&rest, &rl, &inst, start_time_ms, is_isolated).await {
                 Ok(pages) => Some(
                     pages
                         .iter()
@@ -1776,7 +1823,9 @@ async fn margin_connection_manager(
         if let Some(dt) = disconnect_time.take()
             && tokio::time::timeout(
                 Duration::from_secs(FILL_RECOVERY_TIMEOUT_SECS),
-                recover_margin_fills(&rest, &rate_limiter, &instruments, dt, &tx, &dedup),
+                // This is the cross manager (account-wide); fill recovery is always cross-scoped.
+                // The isolated manager (a separate path) passes `true`.
+                recover_margin_fills(&rest, &rate_limiter, &instruments, dt, &tx, &dedup, false),
             )
             .await
             .is_err()
@@ -1867,11 +1916,12 @@ async fn margin_connection_manager(
 // ---------------------------------------------------------------------------
 
 /// Fetch open orders for a single instrument via `query_margin_accounts_open_orders`
-/// (cross, `isIsolated = "FALSE"`). Mirrors `BinanceSpot::fetch_open_orders_for_instrument`.
+/// (`isIsolated` config-driven). Mirrors `BinanceSpot::fetch_open_orders_for_instrument`.
 async fn fetch_margin_open_orders_for_instrument(
     rest: Arc<RestApi>,
     rate_limiter: Arc<RateLimitTracker>,
     instrument: InstrumentNameExchange,
+    is_isolated: bool,
 ) -> Result<
     (
         InstrumentNameExchange,
@@ -1881,12 +1931,14 @@ async fn fetch_margin_open_orders_for_instrument(
 > {
     // Convert once before the retry closure to avoid a String allocation on every retry.
     let symbol_str = instrument.name().to_string();
+    let isolated = isolated_str(is_isolated);
     let response = rest_call_with_retry(&rest, &rate_limiter, |rest| {
         let sym = symbol_str.clone();
+        let isolated = isolated.clone();
         Box::pin(async move {
             let params = QueryMarginAccountsOpenOrdersParams::builder()
                 .symbol(sym)
-                .is_isolated("FALSE".to_string())
+                .is_isolated(isolated)
                 .build()?;
             rest.query_margin_accounts_open_orders(params).await
         })
@@ -1907,18 +1959,23 @@ async fn fetch_margin_open_orders_for_instrument(
     Ok((instrument, orders))
 }
 
-/// Fetch *all* open cross-margin orders in a single no-symbol `query_margin_accounts_open_orders`
-/// call (cross, `isIsolated = "FALSE"`). Backs the [`fetch_open_orders`](BinanceMargin::fetch_open_orders)
-/// "return all" sentinel: with no symbol the venue returns orders across every instrument, so each
-/// order's instrument is recovered from its own `symbol` field (orders missing it are dropped).
+/// Fetch *all* open margin orders in a single no-symbol `query_margin_accounts_open_orders`
+/// call. Backs the [`fetch_open_orders`](BinanceMargin::fetch_open_orders) "return all" sentinel for
+/// **cross** (the no-symbol affordance is cross-only): with no symbol the venue returns orders
+/// across every instrument, so each order's instrument is recovered from its own `symbol` field
+/// (orders missing it are dropped). `isIsolated` is config-driven, but under isolated the caller
+/// iterates the configured symbol set per-symbol rather than using this no-symbol path.
 async fn fetch_margin_all_open_orders(
     rest: Arc<RestApi>,
     rate_limiter: Arc<RateLimitTracker>,
+    is_isolated: bool,
 ) -> Result<Vec<Order<ExchangeId, InstrumentNameExchange, Open>>, UnindexedClientError> {
+    let isolated = isolated_str(is_isolated);
     let response = rest_call_with_retry(&rest, &rate_limiter, |rest| {
+        let isolated = isolated.clone();
         Box::pin(async move {
             let params = QueryMarginAccountsOpenOrdersParams::builder()
-                .is_isolated("FALSE".to_string())
+                .is_isolated(isolated)
                 .build()?;
             rest.query_margin_accounts_open_orders(params).await
         })
@@ -1940,17 +1997,23 @@ async fn fetch_margin_all_open_orders(
 }
 
 /// Paginate the margin trade list for a single instrument since `start_time_ms`
-/// (cross, `isIsolated = "FALSE"`). Mirrors `BinanceSpot::paginate_my_trades`: cursor-based,
+/// (`isIsolated` config-driven). Mirrors `BinanceSpot::paginate_my_trades`: cursor-based,
 /// first page by `start_time`, subsequent pages by `from_id = last_id + 1` (Binance ignores
 /// `start_time` once `from_id` is set), producing a gapless result.
+///
+/// **Isolated correctness:** this also backs reconnect fill-recovery (`recover_margin_fills`), so a
+/// missed `isIsolated` flip would silently query *cross* trades on an isolated client — hence the
+/// value is threaded from config rather than hardcoded.
 async fn paginate_margin_my_trades(
     rest: &Arc<RestApi>,
     rate_limiter: &Arc<RateLimitTracker>,
     instrument: &InstrumentNameExchange,
     start_time_ms: i64,
+    is_isolated: bool,
 ) -> Result<Vec<QueryMarginAccountsTradeListResponseInner>, UnindexedClientError> {
     // Convert once before the retry closure to avoid a String allocation on every retry.
     let symbol_str = instrument.name().to_string();
+    let isolated = isolated_str(is_isolated);
     // The const_assert! in shared bounds BINANCE_MAX_TRADES <= i32::MAX, which trivially fits in
     // i64, so this cast is always lossless. clippy::cast_possible_wrap fires only because usize is
     // the same width as i64 on 64-bit targets (a hypothetical >64-bit usize could wrap); the bound
@@ -1963,10 +2026,11 @@ async fn paginate_margin_my_trades(
         let fid = cursor; // Option<i64> is Copy
         let response = rest_call_with_retry(rest, rate_limiter, |rest| {
             let sym = symbol_str.clone();
+            let isolated = isolated.clone();
             let stm = start_time_ms;
             Box::pin(async move {
                 let builder = QueryMarginAccountsTradeListParams::builder(sym)
-                    .is_isolated("FALSE".to_string())
+                    .is_isolated(isolated)
                     .limit(limit);
                 let params = if let Some(id) = fid {
                     builder.from_id(id).build()?
@@ -2302,12 +2366,55 @@ enum BuildOrderError {
     Build(String),
 }
 
+/// The Binance `isIsolated` query/param wire string for the configured margin mode.
+///
+/// `true` → `"TRUE"` (isolated, per-pair sub-accounts); `false` → `"FALSE"` (cross, account-wide).
+/// Threaded through every margin order/cancel/query call so the mode is config-driven from a single
+/// source rather than hardcoded per-call.
+fn isolated_str(is_isolated: bool) -> String {
+    if is_isolated { "TRUE" } else { "FALSE" }.to_string()
+}
+
+/// Build the margin cancel-order params (pure; no I/O).
+///
+/// Cancels by exchange `orderId` when present and parseable as `i64`, otherwise falls back to the
+/// originating client order id (`origClientOrderId`). `isIsolated` is config-driven. Factored out of
+/// [`BinanceMargin::cancel_order`] so the id-vs-cid fallback branch and the `isIsolated` value are
+/// unit-testable without a live REST call. Returns the builder's error message (stringified) on the
+/// rare build failure (e.g. a malformed symbol).
+fn build_cancel_order_params(
+    symbol: String,
+    id: Option<&OrderId>,
+    cid: &ClientOrderId,
+    is_isolated: bool,
+) -> Result<MarginAccountCancelOrderParams, String> {
+    let mut builder =
+        MarginAccountCancelOrderParams::builder(symbol).is_isolated(isolated_str(is_isolated));
+
+    match id {
+        Some(order_id) => match order_id.0.parse::<i64>() {
+            Ok(id) => builder = builder.order_id(id),
+            Err(_) => {
+                // exchange order id exists but isn't a valid i64 — fall back to the cid.
+                error!(
+                    order_id = %order_id.0,
+                    "BinanceMargin cancel: exchange orderId not parseable as i64, falling back to clientOrderId"
+                );
+                builder = builder.orig_client_order_id(cid.0.to_string());
+            }
+        },
+        None => builder = builder.orig_client_order_id(cid.0.to_string()),
+    }
+
+    builder.build().map_err(|e| e.to_string())
+}
+
 /// Build the margin new-order params from a rustrade order request (pure; no I/O).
 ///
 /// Factored out of [`BinanceMargin::open_order`] so the rustrade→Binance mapping (sideEffectType,
-/// cross `isIsolated`, conditional `stopPrice`, `autoRepayAtCancel` gating, trailing rejection) is
-/// unit-testable without a live REST call. `isIsolated` is always `"FALSE"` (cross) in this
-/// version.
+/// `isIsolated`, conditional `stopPrice`, `autoRepayAtCancel` gating, trailing rejection) is
+/// unit-testable without a live REST call. `isIsolated` is config-driven via `is_isolated`
+/// (`true` = isolated, `false` = cross).
 #[allow(clippy::too_many_arguments)] // mirrors the flat request fields; grouping them into a
 // struct would just shuffle the same data and obscure the 1:1 mapping to SDK params.
 fn build_new_order_params(
@@ -2319,6 +2426,7 @@ fn build_new_order_params(
     time_in_force: TimeInForce,
     new_client_order_id: String,
     side_effect: MarginSideEffect,
+    is_isolated: bool,
 ) -> Result<MarginAccountNewOrderParams, BuildOrderError> {
     let binance_side = match side {
         Side::Buy => MarginAccountNewOrderSideEnum::Buy,
@@ -2328,14 +2436,14 @@ fn build_new_order_params(
     let (binance_type, binance_tif) =
         convert_order_kind_tif_margin(kind, time_in_force).ok_or(BuildOrderError::Unsupported)?;
 
-    // isIsolated is always "FALSE" (cross) in this version — isolated margin is a follow-up.
+    // isIsolated is config-driven: "TRUE" for isolated, "FALSE" for cross.
     let mut builder = MarginAccountNewOrderParams::builder(
         symbol,
         binance_side,
         binance_type.as_binance_str().to_string(),
     )
     .quantity(quantity)
-    .is_isolated("FALSE".to_string())
+    .is_isolated(isolated_str(is_isolated))
     .side_effect_type(side_effect.as_binance_str().to_string())
     .new_client_order_id(new_client_order_id)
     .new_order_resp_type(MarginAccountNewOrderNewOrderRespTypeEnum::Full);
@@ -2487,6 +2595,7 @@ mod tests {
             "my_secret_key".to_string(),
             false,
             false,
+            Vec::new(),
             MarginSideEffect::default(),
         );
         let debug = format!("{config:?}");
@@ -2524,13 +2633,129 @@ mod tests {
         assert_eq!(config.side_effect, MarginSideEffect::NoBorrow);
     }
 
+    #[test]
+    fn isolated_ctor_sets_symbols_and_flag() {
+        let symbols = vec![
+            InstrumentNameExchange::new("BTCUSDT"),
+            InstrumentNameExchange::new("ETHUSDT"),
+        ];
+        let config =
+            BinanceMarginConfig::isolated("k".to_string(), "s".to_string(), symbols.clone());
+        assert!(config.is_isolated);
+        assert_eq!(config.isolated_symbols, symbols);
+        assert_eq!(config.side_effect, MarginSideEffect::AutoBorrowRepay);
+    }
+
+    #[test]
+    fn isolated_config_with_symbols_constructs() {
+        // The construction gate only rejects isolated + *empty* symbols; a populated set is fine.
+        let config = BinanceMarginConfig::isolated(
+            "k".to_string(),
+            "s".to_string(),
+            vec![InstrumentNameExchange::new("BTCUSDT")],
+        );
+        let _client = BinanceMargin::new(config); // must not panic
+    }
+
+    #[test]
+    #[should_panic(expected = "non-empty isolated_symbols")]
+    fn isolated_empty_symbols_panics_at_new() {
+        // is_isolated = true with no isolated_symbols is an unusable config → fail-fast panic.
+        let config = BinanceMarginConfig::new(
+            "k".to_string(),
+            "s".to_string(),
+            false,
+            true,
+            Vec::new(),
+            MarginSideEffect::default(),
+        );
+        let _ = BinanceMargin::new(config);
+    }
+
+    #[test]
+    #[should_panic(expected = "non-empty isolated_symbols")]
+    fn isolated_empty_symbols_panics_via_deserialize_path() {
+        // The gate must also cover the Deserialize-only path (a config file with is_isolated = true
+        // and no isolated_symbols bypasses the named constructor).
+        let config: BinanceMarginConfig = serde_json::from_str(
+            r#"{"api_key":"k","secret_key":"s","testnet":false,"is_isolated":true}"#,
+        )
+        .expect("deserialize");
+        assert!(config.isolated_symbols.is_empty());
+        let _ = BinanceMargin::new(config);
+    }
+
+    #[test]
+    fn isolated_str_maps_mode() {
+        assert_eq!(isolated_str(false), "FALSE");
+        assert_eq!(isolated_str(true), "TRUE");
+    }
+
+    // -----------------------------------------------------------------------
+    // Cancel param mapping (orderId-vs-cid fallback + config-driven isIsolated)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cancel_params_cross_with_parseable_order_id() {
+        let p = build_cancel_order_params(
+            "BTCUSDT".to_string(),
+            Some(&OrderId::new("12345")),
+            &ClientOrderId::new("cid-1"),
+            false,
+        )
+        .expect("build");
+        assert_eq!(p.symbol, "BTCUSDT");
+        assert_eq!(p.is_isolated.as_deref(), Some("FALSE"));
+        assert_eq!(p.order_id, Some(12345));
+        assert_eq!(p.orig_client_order_id, None);
+    }
+
+    #[test]
+    fn cancel_params_isolated_is_config_driven() {
+        let p = build_cancel_order_params(
+            "BTCUSDT".to_string(),
+            Some(&OrderId::new("12345")),
+            &ClientOrderId::new("cid-1"),
+            true,
+        )
+        .expect("build");
+        assert_eq!(p.is_isolated.as_deref(), Some("TRUE"));
+        assert_eq!(p.order_id, Some(12345));
+    }
+
+    #[test]
+    fn cancel_params_non_i64_order_id_falls_back_to_cid() {
+        let p = build_cancel_order_params(
+            "BTCUSDT".to_string(),
+            Some(&OrderId::new("not-an-i64")),
+            &ClientOrderId::new("cid-1"),
+            false,
+        )
+        .expect("build");
+        assert_eq!(p.order_id, None);
+        assert_eq!(p.orig_client_order_id.as_deref(), Some("cid-1"));
+    }
+
+    #[test]
+    fn cancel_params_absent_order_id_uses_cid() {
+        let p = build_cancel_order_params(
+            "BTCUSDT".to_string(),
+            None,
+            &ClientOrderId::new("cid-1"),
+            false,
+        )
+        .expect("build");
+        assert_eq!(p.order_id, None);
+        assert_eq!(p.orig_client_order_id.as_deref(), Some("cid-1"));
+    }
+
     // -----------------------------------------------------------------------
     // Order param mapping (17.4.x)
     // -----------------------------------------------------------------------
 
     use crate::order::TrailingOffsetType;
 
-    /// Build params for the common case, overriding only what a test cares about.
+    /// Build params for the common case (cross), overriding only what a test cares about.
     fn params(
         side: Side,
         price: Option<Decimal>,
@@ -2547,6 +2772,7 @@ mod tests {
             tif,
             "cid-1".to_string(),
             side_effect,
+            false, // cross
         )
     }
 
@@ -2581,18 +2807,37 @@ mod tests {
     }
 
     #[test]
-    fn new_order_is_always_cross() {
-        // TG17 is cross-only: isIsolated must be "FALSE" regardless of config.is_isolated.
-        let p = params(
+    fn new_order_is_isolated_is_config_driven() {
+        // Cross (is_isolated = false) → "FALSE".
+        let cross = build_new_order_params(
+            "BTCUSDT".to_string(),
             Side::Sell,
             Some(Decimal::from(10)),
+            Decimal::from(2),
             OrderKind::Limit,
             gtc(),
+            "cid-1".to_string(),
             MarginSideEffect::AutoBorrowRepay,
+            false,
         )
         .expect("build");
-        assert_eq!(p.is_isolated.as_deref(), Some("FALSE"));
-        assert_eq!(p.side.as_str(), "SELL");
+        assert_eq!(cross.is_isolated.as_deref(), Some("FALSE"));
+        assert_eq!(cross.side.as_str(), "SELL");
+
+        // Isolated (is_isolated = true) → "TRUE".
+        let isolated = build_new_order_params(
+            "BTCUSDT".to_string(),
+            Side::Sell,
+            Some(Decimal::from(10)),
+            Decimal::from(2),
+            OrderKind::Limit,
+            gtc(),
+            "cid-1".to_string(),
+            MarginSideEffect::AutoBorrowRepay,
+            true,
+        )
+        .expect("build");
+        assert_eq!(isolated.is_isolated.as_deref(), Some("TRUE"));
     }
 
     #[test]

--- a/rustrade-execution/src/client/binance/spot.rs
+++ b/rustrade-execution/src/client/binance/spot.rs
@@ -473,7 +473,9 @@ impl ExecutionClient for BinanceSpot {
                         state: OrderState::active(o.state),
                     })
                     .collect();
-                Ok::<_, UnindexedClientError>(InstrumentAccountSnapshot::new(inst, wrapped, None))
+                Ok::<_, UnindexedClientError>(InstrumentAccountSnapshot::new(
+                    inst, wrapped, None, None,
+                ))
             })
             .try_collect()
             .await?;

--- a/rustrade-execution/src/client/hyperliquid/mod.rs
+++ b/rustrade-execution/src/client/hyperliquid/mod.rs
@@ -383,6 +383,7 @@ impl ExecutionClient for HyperliquidClient {
                 instrument,
                 orders,
                 position,
+                isolated: None,
             });
         }
 
@@ -392,6 +393,7 @@ impl ExecutionClient for HyperliquidClient {
                 instrument,
                 orders,
                 position: None,
+                isolated: None,
             });
         }
 

--- a/rustrade-execution/src/client/hyperliquid/spot.rs
+++ b/rustrade-execution/src/client/hyperliquid/spot.rs
@@ -294,6 +294,7 @@ impl ExecutionClient for HyperliquidSpotClient {
                 instrument,
                 orders,
                 position: None, // Spot has no positions
+                isolated: None,
             })
             .collect();
 

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -953,6 +953,7 @@ impl ExecutionClient for IbkrClient {
                     instrument,
                     orders: Vec::new(),
                     position: None,
+                    isolated: None,
                 });
             }
             Ok::<_, UnindexedClientError>(snapshots)

--- a/rustrade-execution/src/exchange/mock/mod.rs
+++ b/rustrade-execution/src/exchange/mock/mod.rs
@@ -200,6 +200,7 @@ impl MockExchange {
                 instrument,
                 orders: orders.into_iter().collect(),
                 position: None,
+                isolated: None,
             })
             .collect();
 

--- a/rustrade-execution/src/indexer.rs
+++ b/rustrade-execution/src/indexer.rs
@@ -1,6 +1,7 @@
 use crate::{
     AccountEvent, AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot,
-    UnindexedAccountEvent, UnindexedAccountSnapshot,
+    InstrumentBalanceUpdate, IsolatedInstrumentState, UnindexedAccountEvent,
+    UnindexedAccountSnapshot,
     balance::{AssetBalance, AssetBalanceUpdate},
     error::{
         ApiError, ClientError, KeyError, OrderError, UnindexedApiError, UnindexedClientError,
@@ -61,6 +62,9 @@ impl AccountEventIndexer {
                     self.asset_balance_update(snapshot.0).map(Snapshot)?,
                 )
             }
+            AccountEventKind::InstrumentBalanceUpdate(update) => {
+                AccountEventKind::InstrumentBalanceUpdate(self.instrument_balance_update(update)?)
+            }
             AccountEventKind::OrderSnapshot(snapshot) => {
                 AccountEventKind::OrderSnapshot(self.order_snapshot(snapshot.0).map(Snapshot)?)
             }
@@ -98,6 +102,7 @@ impl AccountEventIndexer {
                     instrument,
                     orders,
                     position,
+                    isolated,
                 } = snapshot;
 
                 let instrument = self.map.find_instrument_index(&instrument)?;
@@ -107,10 +112,18 @@ impl AccountEventIndexer {
                     .map(|order| self.order_snapshot(order))
                     .collect::<Result<Vec<_>, _>>()?;
 
+                // Per-pair isolated balances are generic over `AssetKey`, so (unlike `position`)
+                // their base/quote asset names must be mapped to indices. A pair whose asset is
+                // unregistered fails the snapshot index, matching top-level-balance behaviour.
+                let isolated = isolated
+                    .map(|state| self.isolated_instrument_state(state))
+                    .transpose()?;
+
                 Ok(InstrumentAccountSnapshot {
                     instrument,
                     orders,
                     position,
+                    isolated,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -155,6 +168,45 @@ impl AccountEventIndexer {
             asset,
             update,
             time_exchange,
+        })
+    }
+
+    /// Index the per-pair isolated state's `base`/`quote` asset names to indices.
+    ///
+    /// # Errors
+    /// Returns `IndexError` if either the base or quote asset is not registered in the map —
+    /// matching the fail-fast behaviour of top-level [`Self::asset_balance`].
+    pub fn isolated_instrument_state(
+        &self,
+        state: IsolatedInstrumentState<AssetNameExchange>,
+    ) -> Result<IsolatedInstrumentState<AssetIndex>, IndexError> {
+        let IsolatedInstrumentState { base, quote, risk } = state;
+
+        Ok(IsolatedInstrumentState {
+            base: self.asset_balance(base)?,
+            quote: self.asset_balance(quote)?,
+            risk,
+        })
+    }
+
+    /// Index an [`InstrumentBalanceUpdate`]'s instrument and `base`/`quote` asset keys.
+    ///
+    /// # Errors
+    /// Returns `IndexError` if the instrument or either asset is not registered in the map.
+    pub fn instrument_balance_update(
+        &self,
+        update: InstrumentBalanceUpdate<AssetNameExchange, InstrumentNameExchange>,
+    ) -> Result<InstrumentBalanceUpdate, IndexError> {
+        let InstrumentBalanceUpdate {
+            instrument,
+            base,
+            quote,
+        } = update;
+
+        Ok(InstrumentBalanceUpdate {
+            instrument: self.map.find_instrument_index(&instrument)?,
+            base: self.asset_balance_update(base)?,
+            quote: self.asset_balance_update(quote)?,
         })
     }
 

--- a/rustrade-execution/src/lib.rs
+++ b/rustrade-execution/src/lib.rs
@@ -45,6 +45,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use derive_more::{Constructor, From};
 use order::state::OrderState;
+use rust_decimal::Decimal;
 use rustrade_instrument::{
     asset::{AssetIndex, name::AssetNameExchange},
     exchange::{ExchangeId, ExchangeIndex},
@@ -119,6 +120,20 @@ pub enum AccountEventKind<ExchangeKey, AssetKey, InstrumentKey> {
     /// stream update. Debt totals remain as fresh as the last [`BalanceSnapshot`](Self::BalanceSnapshot).
     BalanceStreamUpdate(Snapshot<AssetBalanceUpdate<AssetKey>>),
 
+    /// Live per-instrument isolated-margin balance update (`free`/`locked` per side).
+    ///
+    /// The stream counterpart of [`InstrumentAccountSnapshot::isolated`] for venues with per-pair
+    /// isolated sub-accounts (e.g. Binance isolated margin). Carries a point-in-time `free`/`locked`
+    /// **snapshot** for the pair's `base` and `quote` assets — NOT a delta — keyed by instrument
+    /// rather than asset, because isolated balances are per-`(pair, asset)` and cannot be folded
+    /// into the asset-keyed balance state without collision (see [`InstrumentBalanceUpdate`]).
+    ///
+    /// The engine deliberately does **not** store this (the per-asset balance state is informational
+    /// only and the engine never reads it for sizing/gating); a consumer reads it off the account
+    /// event feed. Debt totals stay as fresh as the last
+    /// [`BalanceSnapshot`](Self::BalanceSnapshot) per the debt-freshness contract.
+    InstrumentBalanceUpdate(InstrumentBalanceUpdate<AssetKey, InstrumentKey>),
+
     /// Single [`Order`] snapshot - used to upsert existing order state if it's more recent.
     ///
     /// This variant covers general order updates, and open order responses.
@@ -168,6 +183,12 @@ pub struct AccountSnapshot<
     pub instruments: Vec<InstrumentAccountSnapshot<ExchangeKey, AssetKey, InstrumentKey>>,
 }
 
+/// serde `default` for an `Option` field whose inner type is generic — returns `None` without
+/// requiring the inner type to be `Default` (see the `isolated` field below).
+fn none_option<T>() -> Option<T> {
+    None
+}
+
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, Constructor,
 )]
@@ -183,6 +204,91 @@ pub struct InstrumentAccountSnapshot<
     /// `None` for spot instruments where position is implicit in balances.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub position: Option<Position>,
+    /// Per-pair isolated-margin balances and risk, for venues with isolated sub-accounts
+    /// (e.g. Binance isolated margin). `None` for cross margin, spot, and all other contexts.
+    ///
+    /// Surfaced here — attached to the instrument — rather than folded into the asset-keyed
+    /// [`AccountSnapshot::balances`] because isolated sub-accounts are per-`(pair, asset)`: the same
+    /// asset (e.g. `USDT`) in two isolated pairs is a separate pool, which the asset-keyed balance
+    /// model cannot represent without collision. The engine does not store this; a consumer reads
+    /// it off the snapshot to compose per-pair risk. See [`IsolatedInstrumentState`].
+    ///
+    // `default = "none_option"` (not a bare `#[serde(default)]`) avoids serde inferring a spurious
+    // `AssetKey: Default` bound: a bare default on a generic-typed field conservatively requires the
+    // field type to be `Default` (the `position` field escapes this only because `Position` is
+    // concrete). Naming a function makes serde *call* it instead, requiring only `AssetKey: Deserialize`.
+    #[serde(default = "none_option", skip_serializing_if = "Option::is_none")]
+    pub isolated: Option<IsolatedInstrumentState<AssetKey>>,
+}
+
+/// Per-pair isolated-margin state attached to an [`InstrumentAccountSnapshot`].
+///
+/// Binance isolated margin (and other CEX isolated/per-pair sub-accounts) hold balances
+/// per-`(pair, asset)`, not per-asset, so they are surfaced attached to the instrument rather than
+/// in the asset-keyed [`AccountSnapshot::balances`]. A consumer composes per-pair risk from `base`,
+/// `quote`, and `risk`.
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, Constructor,
+)]
+pub struct IsolatedInstrumentState<AssetKey = AssetIndex> {
+    /// Base-asset balance of the pair's isolated sub-account (carries per-asset debt).
+    pub base: AssetBalance<AssetKey>,
+    /// Quote-asset balance of the pair's isolated sub-account (carries per-asset debt).
+    pub quote: AssetBalance<AssetKey>,
+    /// Per-pair risk metrics — snapshot-fresh, not live (see [`IsolatedMarginRisk`]).
+    pub risk: IsolatedMarginRisk,
+}
+
+/// Per-pair isolated-margin risk metrics, surfaced on [`IsolatedInstrumentState`].
+///
+/// Every field is `Option` — a venue may omit any given metric, and a missing metric must not
+/// drop the surrounding balance snapshot.
+///
+/// # Freshness
+/// These are **snapshot-only**: authoritative as of the last `account_snapshot` and refreshed on
+/// snapshot. Unlike balances, there is **no live-stream twin** — the WS `outboundAccountPosition`
+/// frame carries no margin-level / liquidation data. The live signal for risk crossing a threshold
+/// is the venue's `marginLevelStatusChange` event (surfaced observably, not accumulated here).
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    Deserialize,
+    Serialize,
+    Constructor,
+)]
+pub struct IsolatedMarginRisk {
+    /// Margin level of the isolated pair (collateral-to-debt ratio); higher is safer.
+    pub margin_level: Option<Decimal>,
+    /// Margin ratio of the isolated pair.
+    pub margin_ratio: Option<Decimal>,
+    /// Estimated liquidation price for the isolated pair.
+    pub liquidation_price: Option<Decimal>,
+}
+
+/// Live per-instrument isolated-margin balance update payload (the
+/// [`AccountEventKind::InstrumentBalanceUpdate`] counterpart of [`IsolatedInstrumentState`]).
+///
+/// Carries a point-in-time `free`/`locked` **snapshot** for the pair's `base` and `quote` assets —
+/// NOT a delta — keyed by instrument. Structurally analogous to [`AssetBalanceUpdate`] but
+/// per-instrument: it carries no debt, so applying it keeps `free`/`locked` live while preserving
+/// any known per-asset debt (use [`Balance::apply_stream_update`](balance::Balance::apply_stream_update)).
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize, Constructor,
+)]
+pub struct InstrumentBalanceUpdate<AssetKey = AssetIndex, InstrumentKey = InstrumentIndex> {
+    /// Instrument (isolated pair) the update applies to.
+    pub instrument: InstrumentKey,
+    /// Base-asset `free`/`locked` update for the pair's isolated sub-account.
+    pub base: AssetBalanceUpdate<AssetKey>,
+    /// Quote-asset `free`/`locked` update for the pair's isolated sub-account.
+    pub quote: AssetBalanceUpdate<AssetKey>,
 }
 
 impl<ExchangeKey, AssetKey, InstrumentKey> AccountSnapshot<ExchangeKey, AssetKey, InstrumentKey> {

--- a/rustrade/src/engine/clock.rs
+++ b/rustrade/src/engine/clock.rs
@@ -152,6 +152,11 @@ impl<MarketEventKind: Debug> TimeExchange for EngineEvent<MarketEventKind> {
                 AccountEventKind::Snapshot(snapshot) => snapshot.time_most_recent(),
                 AccountEventKind::BalanceSnapshot(balance) => Some(balance.0.time_exchange),
                 AccountEventKind::BalanceStreamUpdate(update) => Some(update.0.time_exchange),
+                AccountEventKind::InstrumentBalanceUpdate(update) => {
+                    // Per-pair isolated balance update — advance on its event time, consistent with
+                    // its asset-keyed sibling `BalanceStreamUpdate` (base/quote share the frame's time).
+                    Some(update.base.time_exchange)
+                }
                 AccountEventKind::OrderSnapshot(order) => order.0.state.time_exchange(),
                 AccountEventKind::OrderCancelled(response) => response
                     .state

--- a/rustrade/src/engine/state/asset/mod.rs
+++ b/rustrade/src/engine/state/asset/mod.rs
@@ -190,14 +190,10 @@ impl AssetState {
             return;
         }
 
-        // Preserve existing margin debt — a WS partial never carries it.
-        let prior_margin = self.balance.as_ref().and_then(|b| b.value.margin);
-
-        let merged = Balance {
-            total: update.update.total(),
-            free: update.update.free,
-            margin: prior_margin,
-        };
+        // Preserve existing margin debt — a WS partial never carries it. Single-sourced through
+        // the public `Balance::apply_stream_update` no-clobber merge.
+        let prior = self.balance.as_ref().map(|b| b.value);
+        let merged = Balance::apply_stream_update(prior, &update.update);
         self.balance = Some(Timed::new(merged, update.time_exchange));
 
         // Drawdown statistics track `total`, which the update changes — feed it through the same

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -839,6 +839,7 @@ where
             })
             .collect(),
         position: None,
+        isolated: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds **Binance isolated (per-pair) margin** execution support to the `BinanceMargin` client, building on the existing cross-margin `ExecutionClient` infrastructure. Closes #105.

The mode is selected by `BinanceMarginConfig.is_isolated`; isolated declares its per-pair universe via `isolated_symbols`. `BinanceMargin::new` panics if `is_isolated = true` with an empty `isolated_symbols`.

## What's in scope

- **Config-driven `isIsolated`** — order submit and cancel now send `"TRUE"`/`"FALSE"` from config instead of hardcoded cross; constructor warning and "not yet honoured" rustdoc dropped. Pure `build_cancel_order_params(...)` extracted (mirroring `build_new_order_params`) with unit coverage for the `is_isolated` value and the `orderId`→`origClientOrderId` cancel fallback.
- **Per-symbol account snapshot** — isolated balances/risk are surfaced per-instrument on the new `InstrumentAccountSnapshot.isolated: Option<IsolatedInstrumentState>` (base/quote `AssetBalance` + `IsolatedMarginRisk`), not folded into the asset-keyed `AccountSnapshot.balances` (which would collide on shared assets). Under isolated, `fetch_balances` returns empty; snapshot/open-order/trade queries scope to `isolated_symbols` (or `instruments ∩ isolated_symbols`, out-of-set instruments skipped with a warning).
- **Stream fan-in** — per-symbol `userListenToken`s (`POST /sapi/v1/userListenToken?isIsolated=true&symbol=X`) are multiplexed onto a single WS-API socket: all tokens acquired, connected, and subscribed before `account_stream` returns (any failure → `Err`, nothing spawned), with planned-reconnect token renewal per symbol. The cross stream is a separate, untouched manager.
- **Live per-pair balances** arrive as the new `AccountEventKind::InstrumentBalanceUpdate` (base + quote per pair). Consistent with the snapshot's `isolated` field, the engine deliberately does **not** store it — consumers read it off the raw account-event stream. `Balance::apply_stream_update` single-sources the no-clobber merge (apply WS free/locked, preserve REST-snapshot debt).

The symbol universe is the **configured** `isolated_symbols` set, fixed for the stream's lifetime (pairs added later require a restart) — documented as a known limitation.

## Breaking / notable API changes

- `InstrumentAccountSnapshot::new()` arity 3→4 (new `isolated` field); additive on the wire.
- `AccountEventKind` gained `InstrumentBalanceUpdate` (`#[non_exhaustive]` enum).
- New public types: `IsolatedInstrumentState`, `IsolatedMarginRisk`.
- All isolated/cross events stamp `ExchangeId::BinanceMargin`, so a single engine should run at most one `BinanceMargin` client.

See `CHANGELOG.md` `[Unreleased]` for the full list.

## Testing

- `cargo clippy --workspace --all-targets --all-features` clean.
- Unit coverage for `build_new_order_params` / `build_cancel_order_params` (isolated flag + cancel id fallback).
