### PR TITLE
deps(ibapi): Migrate from 2.12.0 to 3.0.1 with improved error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Bumped `ibapi` from `2.12.0` to `3.0.1`** (`ibkr` feature). ibapi 3.0 is a major release with
+  breaking API changes; the IBKR market-data (`rustrade-data`) and execution (`rustrade-execution`)
+  connectors were migrated to the new surface. Notable upstream changes absorbed: `Subscription<T>`
+  iteration now yields `Result<SubscriptionItem<T>, Error>` (most data loops use `iter_data()`,
+  surfacing subscription errors instead of silently ending — the exception is `TickSubscription`,
+  which yields `T` directly and has no error accessor; see the `fetch_historical_ticks` /
+  `fetch_historical_bid_ask` doc comments for that silent-truncation caveat); builder-style
+  market-data requests
+  (`historical_data`/`historical_ticks`/`market_depth`/`tick_by_tick`); `Contract.right` is now
+  `Option<OptionRight>`; `OrderStatus.status` is now the `OrderStatusKind` enum; and `Execution.side`
+  is now the `ExecutionSide` enum. Two small `ibkr`-feature public API changes accompany this
+  migration (see the BREAKING sub-entries below). (Downstream code that constructs the re-exported
+  `ibapi::contracts::Contract` via struct literals directly must also update `right` from `String`
+  to `Option<OptionRight>`; callers using the `rustrade-execution` contract builders are unaffected.)
+  - **Operational requirement:** ibapi 3.x speaks only the protobuf transport and refuses to
+    connect to a TWS/IB Gateway older than **server version 213** (it errors with
+    *"server version 213 required … please upgrade"*). Operators of the `ibkr` connector must
+    run a recent ("latest"-channel) TWS/Gateway build; older Gateways that worked with ibapi 2.x
+    will no longer connect.
+  - **Order placement no longer misreports IB informational order messages as rejections.**
+    Under ibapi 3.x, any TWS message outside the warning range (`2100..=2169`) — including IB's
+    informational "Order Message" code 399 (e.g. *"your order will not be placed at the exchange
+    until 09:30 US/Eastern"* for an order accepted and **held** until regular trading hours) — is
+    delivered as a stream-terminating `Err` on the placement subscription. The order-placement
+    paths now classify these: known informational codes are reported as live-but-pending (the
+    order's authoritative status is resolved via the order-update/account stream) rather than as a
+    hard rejection, while genuine rejections and transport errors still fail observably. Placement
+    loops also gained a bounded wait so a silent Gateway cannot hang them indefinitely.
+  - **Immediately-filled orders are no longer misreported as rejections.** A marketable order can
+    fill before any working status is delivered, in which case ibapi 3.x sends `OrderStatus(Filled)`
+    directly on the placement subscription. Placement now classifies `Filled` as accepted (the order
+    is live; its authoritative fill is resolved via the order-update/account stream) and retains the
+    order-id mapping, rather than returning a hard rejection and dropping the order's later
+    execution/commission events.
+  - **BREAKING (`ibkr`): `client::ibkr::contract::option_contract` now returns
+    `Result<Contract, InvalidOptionRight>`** instead of `Contract`. An unrecognized or empty option
+    `right` is now an observable error at construction (new public error type
+    `client::ibkr::contract::InvalidOptionRight`) rather than a silently right-less `Contract` that
+    IBKR only rejects later at submission. Migration: handle the `Result` (e.g. `?` or `match`) at
+    call sites; the other builders (`stock_contract`/`futures_contract`/`forex_contract`) are
+    unchanged.
+  - **BREAKING (`ibkr`): removed `client::ibkr::execution::parse_ib_side`.** `Execution.side` is now
+    the typed `ExecutionSide` enum upstream, so the string parser is obsolete — map the enum directly
+    (`ExecutionSide::Bought` → `Side::Buy`, `ExecutionSide::Sold` → `Side::Sell`).
 - **BREAKING: `Balance` gained a public `margin: Option<MarginDetails>` field.** Direct struct-literal
   construction (`Balance { total, free }`) no longer compiles. Migration: use `Balance::new(total, free)`
   for cash balances or `Balance::new_margin(..)` for margin balances. `const` sites that cannot use

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -66,7 +66,7 @@ vecmap-rs = { workspace = true }
 fnv = { workspace = true }
 
 # IBKR (optional, behind "ibkr" feature)
-ibapi = { version = "=2.12.0", optional = true, default-features = false, features = ["sync"] }
+ibapi = { version = "=3.0.1", optional = true, default-features = false, features = ["sync"] }
 time = { version = "0.3", optional = true, features = ["macros"] }
 
 # Hyperliquid (optional, behind "hyperliquid" feature)

--- a/rustrade-data/src/exchange/ibkr/depth.rs
+++ b/rustrade-data/src/exchange/ibkr/depth.rs
@@ -36,8 +36,12 @@ impl DepthAggregator {
     /// Process a depth update and emit an OrderBookEvent.
     ///
     /// Returns `Some(OrderBookEvent)` for actual depth updates, `None` for
-    /// notices or MarketDepthL2 updates (which include market maker attribution
-    /// that we don't track — we aggregate into a simple anonymous book).
+    /// MarketDepthL2 updates (which include market maker attribution that we
+    /// don't track — we aggregate into a simple anonymous book).
+    ///
+    /// Note: as of ibapi 3.x, server notices are delivered through the
+    /// subscription's `SubscriptionItem::Notice` arm rather than as a variant of
+    /// [`MarketDepths`], so they never reach this method.
     pub fn update(&mut self, depth: &MarketDepths) -> Option<OrderBookEvent> {
         match depth {
             MarketDepths::MarketDepth(d) => self.process_depth(d),
@@ -47,7 +51,6 @@ impl DepthAggregator {
                 tracing::trace!("Discarding MarketDepthL2 event (market maker data not tracked)");
                 None
             }
-            MarketDepths::Notice(_) => None,
         }
     }
 
@@ -234,19 +237,6 @@ mod tests {
             }
             _ => panic!("Expected Snapshot"),
         }
-    }
-
-    #[test]
-    fn notice_ignored() {
-        let mut agg = DepthAggregator::new();
-
-        let notice = MarketDepths::Notice(ibapi::messages::Notice {
-            code: 2100,
-            message: "test notice".to_string(),
-            error_time: None,
-        });
-        let result = agg.update(&notice);
-        assert!(result.is_none());
     }
 
     #[test]

--- a/rustrade-data/src/exchange/ibkr/historical.rs
+++ b/rustrade-data/src/exchange/ibkr/historical.rs
@@ -66,7 +66,7 @@ use ibapi::{
     client::blocking::Client,
     contracts::{Contract, SecurityType},
     market_data::{
-        TradingHours,
+        IgnoreSize, TradingHours,
         historical::{BarSize, Duration, TickBidAsk, TickLast, WhatToShow},
     },
 };
@@ -180,6 +180,10 @@ impl IbkrHistoricalData {
     /// - IB rate-limits historical data requests (pacing violations)
     /// - Some data requires paid market data subscriptions
     /// - Volume and trade count are only available for `WhatToShow::Trades`
+    /// - For daily/weekly/monthly bar sizes, IB returns a calendar date with no
+    ///   time component, so each candle's `close_time` is anchored to `00:00:00`
+    ///   UTC of that date — it does **not** represent the exchange session close.
+    ///   Intraday bar sizes carry a full timestamp and are unaffected.
     pub async fn fetch_candles(
         &self,
         request: HistoricalRequest,
@@ -201,15 +205,19 @@ impl IbkrHistoricalData {
                 TradingHours::Extended
             };
 
-            let historical_data = client
-                .historical_data(
-                    &request.contract,
-                    request.end_date,
-                    request.duration,
-                    request.bar_size,
-                    request.what_to_show,
-                    trading_hours,
-                )
+            // ibapi 3.x: historical bars are requested via a builder. `ending` is
+            // optional — omitting it anchors the window at the current time, matching
+            // the previous `end_date: None` behavior.
+            let mut builder = client
+                .historical_data(&request.contract, request.bar_size)
+                .what_to_show(request.what_to_show)
+                .duration(request.duration)
+                .trading_hours(trading_hours);
+            if let Some(end_date) = request.end_date {
+                builder = builder.ending(end_date);
+            }
+            let historical_data = builder
+                .fetch()
                 .map_err(|e| DataError::Socket(format!("historical data: {e}")))?;
 
             let mut candles = Vec::with_capacity(historical_data.bars.len());
@@ -260,6 +268,11 @@ impl IbkrHistoricalData {
     ///   identical `(timestamp, price, size)` may collide across batches.
     ///   IB timestamps have only 1-second resolution and IB provides no
     ///   native unique identifier.
+    /// - A mid-stream IB API error ends iteration silently: ibapi 3.0.1's
+    ///   `TickSubscription` stores the error internally but exposes no public
+    ///   accessor, so a shorter-than-requested result may indicate truncation
+    ///   rather than genuine end-of-data. Callers needing completeness
+    ///   guarantees should validate the returned count against expectations.
     pub async fn fetch_historical_ticks(
         &self,
         request: HistoricalTickRequest,
@@ -286,18 +299,27 @@ impl IbkrHistoricalData {
                 TradingHours::Extended
             };
 
-            let subscription = client
-                .historical_ticks_trade(
-                    &request.contract,
-                    request.start,
-                    request.end,
-                    request.number_of_ticks,
-                    trading_hours,
-                )
+            // ibapi 3.x: historical ticks use a builder; the tick type is selected
+            // by the terminal method (`.trade()` here). At least one of
+            // `starting`/`ending` is required (validated above).
+            let mut builder = client
+                .historical_ticks(&request.contract, request.number_of_ticks)
+                .trading_hours(trading_hours);
+            if let Some(start) = request.start {
+                builder = builder.starting(start);
+            }
+            if let Some(end) = request.end {
+                builder = builder.ending(end);
+            }
+            let subscription = builder
+                .trade()
                 .map_err(|e| DataError::Socket(format!("historical_ticks_trade: {e}")))?;
 
             let mut trades =
                 Vec::with_capacity(usize::try_from(request.number_of_ticks).unwrap_or(0));
+            // `TickSubscription` yields `T` directly and stops silently on a
+            // mid-stream error (no public error accessor in ibapi 3.0.1), so a
+            // short result may be truncation rather than end-of-data.
             for (seq, tick) in subscription.into_iter().enumerate() {
                 if let Some(trade) = tick_last_to_public_trade(&tick, seq) {
                     trades.push(trade);
@@ -342,6 +364,11 @@ impl IbkrHistoricalData {
     ///
     /// - Maximum 1000 ticks per request (IB limit)
     /// - For larger ranges, paginate using last tick's timestamp as new `start`
+    /// - A mid-stream IB API error ends iteration silently: ibapi 3.0.1's
+    ///   `TickSubscription` stores the error internally but exposes no public
+    ///   accessor, so a shorter-than-requested result may indicate truncation
+    ///   rather than genuine end-of-data. Callers needing completeness
+    ///   guarantees should validate the returned count against expectations.
     pub async fn fetch_historical_bid_ask(
         &self,
         request: HistoricalTickRequest,
@@ -370,19 +397,31 @@ impl IbkrHistoricalData {
                 TradingHours::Extended
             };
 
-            let subscription = client
-                .historical_ticks_bid_ask(
-                    &request.contract,
-                    request.start,
-                    request.end,
-                    request.number_of_ticks,
-                    trading_hours,
-                    ignore_size,
-                )
+            // ibapi 3.x: same builder as trades, with `.bid_ask(IgnoreSize)` as the
+            // terminal. At least one of `starting`/`ending` is required (validated above).
+            let mut builder = client
+                .historical_ticks(&request.contract, request.number_of_ticks)
+                .trading_hours(trading_hours);
+            if let Some(start) = request.start {
+                builder = builder.starting(start);
+            }
+            if let Some(end) = request.end {
+                builder = builder.ending(end);
+            }
+            let ignore_size = if ignore_size {
+                IgnoreSize::Yes
+            } else {
+                IgnoreSize::No
+            };
+            let subscription = builder
+                .bid_ask(ignore_size)
                 .map_err(|e| DataError::Socket(format!("historical_ticks_bid_ask: {e}")))?;
 
             let mut quotes =
                 Vec::with_capacity(usize::try_from(request.number_of_ticks).unwrap_or(0));
+            // `TickSubscription` yields `T` directly and stops silently on a
+            // mid-stream error (no public error accessor in ibapi 3.0.1), so a
+            // short result may be truncation rather than end-of-data.
             for tick in subscription {
                 if let Some(l1) = tick_bid_ask_to_order_book_l1(&tick) {
                     quotes.push(l1);
@@ -570,9 +609,13 @@ impl IbkrHistoricalData {
     /// # Arguments
     ///
     /// * `symbol` - Underlying symbol (e.g., "AAPL")
-    /// * `exchange` - Exchange to query (e.g., "SMART", "CBOE")
+    /// * `exchange` - `fut_fop_exchange` filter. Pass `""` for all exchanges
+    ///   (recommended); a routing exchange like "SMART" filters the result to
+    ///   zero rows.
     /// * `security_type` - Type of underlying (typically `SecurityType::Stock`)
-    /// * `contract_id` - IB contract ID of the underlying (0 to search by symbol)
+    /// * `contract_id` - IB contract ID of the underlying. Must be a valid
+    ///   conId; IBKR's `reqSecDefOptParams` rejects `0` with
+    ///   `[321] Invalid contract id`. Resolve it first via contract details.
     ///
     /// # Returns
     ///
@@ -587,7 +630,9 @@ impl IbkrHistoricalData {
     /// ```ignore
     /// let client = IbkrHistoricalData::connect("127.0.0.1:4002", 102)?;
     ///
-    /// let chains = client.fetch_option_chain("AAPL", "SMART", SecurityType::Stock, 0).await?;
+    /// // 265598 is AAPL's underlying conId; resolve via contract details for other symbols.
+    /// // Empty exchange returns every exchange's option parameters.
+    /// let chains = client.fetch_option_chain("AAPL", "", SecurityType::Stock, 265598).await?;
     /// for chain in chains {
     ///     println!("Exchange: {}, Expirations: {:?}", chain.exchange, chain.expirations);
     /// }
@@ -614,8 +659,11 @@ impl IbkrHistoricalData {
                 .option_chain(&symbol, &exchange, security_type, contract_id)
                 .map_err(|e| DataError::Socket(format!("option_chain: {e}")))?;
 
+            // ibapi 3.x: `iter_data()` yields `Result<OptionChain, Error>`, filtering
+            // subscription-level notices. Surface the first error to the caller.
             let mut entries = Vec::with_capacity(16);
-            for chain in subscription {
+            for chain in subscription.iter_data() {
+                let chain = chain.map_err(|e| DataError::Socket(format!("option_chain: {e}")))?;
                 entries.push(OptionChainEntry::from_ib(&chain));
             }
 
@@ -863,13 +911,21 @@ fn tick_bid_ask_to_order_book_l1(tick: &TickBidAsk) -> Option<OrderBookL1> {
 /// Returns `Err(DataError::Socket(...))` if any price/volume value cannot be
 /// converted to Decimal (e.g., NaN, Infinity from the IB API).
 fn bar_to_candle(bar: &ibapi::market_data::historical::Bar) -> Result<Candle, DataError> {
-    let close_time = DateTime::from_timestamp(bar.date.unix_timestamp(), bar.date.nanosecond())
-        .ok_or_else(|| {
-            DataError::Socket(format!(
-                "IB timestamp {} out of DateTime<Utc> range",
-                bar.date.unix_timestamp()
-            ))
-        })?;
+    use ibapi::market_data::historical::BarTimestamp;
+
+    // ibapi 3.0 models `Bar.date` as a `BarTimestamp` enum: daily/weekly/monthly
+    // bars carry a calendar `Date` (anchored here to midnight UTC), intraday bars
+    // a full `OffsetDateTime`. NOTE: for date-only bars `close_time` is therefore
+    // 00:00:00 UTC of the bar's date, NOT the exchange session close — consumers
+    // must not treat it as a session-close timestamp and should compare daily
+    // bars by date, not by the full timestamp.
+    let (secs, nanos) = match bar.date {
+        BarTimestamp::DateTime(dt) => (dt.unix_timestamp(), dt.nanosecond()),
+        BarTimestamp::Date(d) => (d.midnight().assume_utc().unix_timestamp(), 0),
+    };
+    let close_time = DateTime::from_timestamp(secs, nanos).ok_or_else(|| {
+        DataError::Socket(format!("IB timestamp {secs} out of DateTime<Utc> range"))
+    })?;
 
     let open =
         Decimal::try_from(bar.open).map_err(|e| DataError::Socket(format!("parse open: {e}")))?;
@@ -906,8 +962,9 @@ mod tests {
     fn bar_to_candle_converts_all_fields() {
         use rust_decimal_macros::dec;
 
+        let date = datetime!(2024-01-15 16:00 UTC);
         let bar = ibapi::market_data::historical::Bar {
-            date: datetime!(2024-01-15 16:00 UTC),
+            date: date.into(),
             open: 150.0,
             high: 155.0,
             low: 149.0,
@@ -930,13 +987,13 @@ mod tests {
         assert_eq!(candle.close_time.year(), 2024);
         assert_eq!(candle.close_time.month(), 1); // January = 1
         assert_eq!(candle.close_time.day(), 15);
-        assert_eq!(candle.close_time.timestamp(), bar.date.unix_timestamp());
+        assert_eq!(candle.close_time.timestamp(), date.unix_timestamp());
     }
 
     #[test]
     fn bar_to_candle_handles_negative_count() {
         let bar = ibapi::market_data::historical::Bar {
-            date: datetime!(2024-01-15 16:00 UTC),
+            date: datetime!(2024-01-15 16:00 UTC).into(),
             open: 100.0,
             high: 100.0,
             low: 100.0,

--- a/rustrade-data/src/exchange/ibkr/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/mod.rs
@@ -291,7 +291,20 @@ where
 
                     let mut aggregator = QuoteAggregator::new();
 
-                    for tick in sub {
+                    // ibapi 3.x: `iter_data()` yields `Result<TickTypes, Error>`,
+                    // filtering subscription-level notices. Surface errors as a
+                    // terminal event (observable failures over silent ones).
+                    for tick in sub.iter_data() {
+                        let tick = match tick {
+                            Ok(t) => t,
+                            Err(e) => {
+                                error!(symbol = %symbol, error = %e, "Quotes subscription error");
+                                let _ = tx.send(Err(DataError::Socket(format!(
+                                    "quotes subscription {symbol}: {e}"
+                                ))));
+                                break;
+                            }
+                        };
                         let now = Utc::now();
                         if let Some(l1) = aggregator.update(&tick, now) {
                             let event = MarketEvent {
@@ -347,9 +360,9 @@ where
                 let result = catch_unwind(AssertUnwindSafe(|| {
                     debug!(symbol = %symbol, rows, "Starting depth subscription");
 
-                    // smart_depth=false: We aggregate into a simple anonymous book without
-                    // tracking market maker attribution from MarketDepthL2 events.
-                    let sub = match client.market_depth(&contract, rows, false) {
+                    // Default SmartDepth::No: we aggregate into a simple anonymous book
+                    // without tracking market maker attribution from MarketDepthL2 events.
+                    let sub = match client.market_depth(&contract, rows).subscribe() {
                         Ok(s) => s,
                         Err(e) => {
                             error!(symbol = %symbol, error = %e, "Failed to subscribe to depth");
@@ -362,7 +375,17 @@ where
 
                     let mut aggregator = DepthAggregator::new();
 
-                    for depth in sub {
+                    for depth in sub.iter_data() {
+                        let depth = match depth {
+                            Ok(d) => d,
+                            Err(e) => {
+                                error!(symbol = %symbol, error = %e, "Depth subscription error");
+                                let _ = tx.send(Err(DataError::Socket(format!(
+                                    "depth subscription {symbol}: {e}"
+                                ))));
+                                break;
+                            }
+                        };
                         if let Some(book_event) = aggregator.update(&depth) {
                             // IB's MarketDepth events have no timestamp. We use time_received
                             // for both fields. Consumers should NOT interpret time_exchange
@@ -420,7 +443,7 @@ where
                 let result = catch_unwind(AssertUnwindSafe(|| {
                     debug!(symbol = %symbol, "Starting trades subscription");
 
-                    let sub = match client.tick_by_tick_all_last(&contract, 0, false) {
+                    let sub = match client.tick_by_tick(&contract, 0).all_last() {
                         Ok(s) => s,
                         Err(e) => {
                             error!(symbol = %symbol, error = %e, "Failed to subscribe to trades");
@@ -431,7 +454,17 @@ where
                         }
                     };
 
-                    for trade in sub {
+                    for trade in sub.iter_data() {
+                        let trade = match trade {
+                            Ok(t) => t,
+                            Err(e) => {
+                                error!(symbol = %symbol, error = %e, "Trades subscription error");
+                                let _ = tx.send(Err(DataError::Socket(format!(
+                                    "trades subscription {symbol}: {e}"
+                                ))));
+                                break;
+                            }
+                        };
                         let now = Utc::now();
                         let public_trade = match trades::from_ib_trade(&trade) {
                             Some(t) => t,
@@ -510,7 +543,17 @@ where
 
                     let aggregator = GreeksAggregator::new();
 
-                    for tick in sub {
+                    for tick in sub.iter_data() {
+                        let tick = match tick {
+                            Ok(t) => t,
+                            Err(e) => {
+                                error!(symbol = %symbol, error = %e, "Option Greeks subscription error");
+                                let _ = tx.send(Err(DataError::Socket(format!(
+                                    "option Greeks subscription {symbol}: {e}"
+                                ))));
+                                break;
+                            }
+                        };
                         if let Some(greeks) = aggregator.update(&tick) {
                             let now = Utc::now();
                             let event = MarketEvent {

--- a/rustrade-data/src/exchange/ibkr/quotes.rs
+++ b/rustrade-data/src/exchange/ibkr/quotes.rs
@@ -6,7 +6,8 @@
 
 use crate::{books::Level, subscription::book::OrderBookL1};
 use chrono::{DateTime, Utc};
-use ibapi::market_data::realtime::{TickPrice, TickSize, TickType, TickTypes};
+use ibapi::contracts::tick_types::TickType;
+use ibapi::market_data::realtime::{TickPrice, TickSize, TickTypes};
 use rust_decimal::Decimal;
 
 use super::decimal_from_f64;

--- a/rustrade-data/tests/ibkr_integration.rs
+++ b/rustrade-data/tests/ibkr_integration.rs
@@ -905,15 +905,67 @@ async fn test_contract_resolution() {
 // Note: These are calculator functions, not data fetches. They don't require
 // OPRA subscription — they compute Greeks from user-provided inputs.
 
-/// Create an AAPL call option contract for testing.
+/// AAPL underlying contract ID on IBKR.
 ///
-/// Uses a near-the-money strike with an expiration ~30 days out.
-/// Adjust expiration date to a valid future date when running tests.
-fn aapl_call_option() -> Contract {
-    // Note: Update expiration date to a valid future date before running
+/// This is a stable identifier — the same value is used as the canonical AAPL
+/// conId throughout `exchange::ibkr::options`. `reqSecDefOptParams` (option
+/// chain) and contract qualification require a real underlying conId; passing
+/// `0` is rejected by IBKR with `[321] Invalid contract id`.
+const AAPL_UNDERLYING_CONID: i32 = 265598;
+
+/// Resolve a currently-listed, near-the-money AAPL call option from the live
+/// option chain.
+///
+/// The previous helper hardcoded an expiration date that had to be hand-edited
+/// before every run; once it lapsed, IBKR rejected the contract with
+/// `[200] No security definition has been found`. Deriving the expiration and
+/// strike from the live chain keeps the option-calculator tests valid over time
+/// with no manual upkeep, and only uses values IBKR itself reports as listed.
+async fn resolve_aapl_call_option(client: &IbkrHistoricalData) -> Contract {
+    use chrono::{Datelike, Duration as ChronoDuration, Utc};
+    use rust_decimal::prelude::ToPrimitive;
+
+    // `fut_fop_exchange` must be empty to get every exchange's parameters; a
+    // routing exchange like "SMART" filters the result to zero rows.
+    let chains = client
+        .fetch_option_chain("AAPL", "", SecurityType::Stock, AAPL_UNDERLYING_CONID)
+        .await
+        .expect("fetch AAPL option chain to resolve a valid option contract");
+
+    // Prefer the standard SMART "AAPL" trading class (densest, most reliable
+    // strike/expiration coverage); fall back to any returned chain.
+    let chain = chains
+        .iter()
+        .find(|c| c.exchange == "SMART" && c.trading_class == "AAPL")
+        .or_else(|| chains.first())
+        .expect("at least one AAPL option chain entry");
+
+    // Earliest expiration at least ~2 weeks out: avoids about-to-expire
+    // contracts while staying on a standard, well-populated series.
+    let cutoff = Utc::now().date_naive() + ChronoDuration::days(14);
+    let expiration = chain
+        .expirations
+        .iter()
+        .filter(|d| **d > cutoff)
+        .min()
+        .copied()
+        .expect("a future AAPL option expiration in the chain");
+
+    // Median strike ≈ at-the-money and is guaranteed to be a listed strike for
+    // this series, so the (expiration, strike) pair resolves to a real contract.
+    let mut strikes = chain.strikes.clone();
+    strikes.sort();
+    let strike = strikes[strikes.len() / 2]
+        .to_f64()
+        .expect("strike Decimal converts to f64");
+
     Contract::call("AAPL")
-        .strike(200.0)
-        .expires_on(2027, 6, 18) // Third Friday of June 2027
+        .strike(strike)
+        .expires_on(
+            expiration.year() as u16,
+            expiration.month() as u8,
+            expiration.day() as u8,
+        )
         .build()
 }
 
@@ -928,15 +980,18 @@ async fn test_calculate_theoretical_greeks() {
 
     let client = IbkrHistoricalData::connect(&url, client_id).expect("connection failed");
 
-    let option = aapl_call_option();
+    let option = resolve_aapl_call_option(&client).await;
+    // Price the option at-the-money (underlying == strike) so the inputs are
+    // internally consistent regardless of where AAPL is trading at run time.
+    let underlying_price = option.strike;
 
     println!("Calculating theoretical Greeks for AAPL call option...");
     println!("  Strike: {}", option.strike);
     println!("  Using volatility: 25% (0.25)");
-    println!("  Using underlying price: $200.00");
+    println!("  Using underlying price: ${underlying_price:.2}");
 
     let greeks = client
-        .calculate_theoretical_greeks(&option, 0.25, 200.0)
+        .calculate_theoretical_greeks(&option, 0.25, underlying_price)
         .await;
 
     match greeks {
@@ -979,15 +1034,20 @@ async fn test_calculate_implied_volatility() {
 
     let client = IbkrHistoricalData::connect(&url, client_id).expect("connection failed");
 
-    let option = aapl_call_option();
+    let option = resolve_aapl_call_option(&client).await;
+    // At-the-money (underlying == strike): intrinsic value is zero, so any
+    // positive option price yields a well-defined implied volatility. ~5% of
+    // the strike is a realistic ATM premium for a near-term option.
+    let underlying_price = option.strike;
+    let option_price = option.strike * 0.05;
 
     println!("Calculating implied volatility for AAPL call option...");
     println!("  Strike: {}", option.strike);
-    println!("  Using option price: $10.00");
-    println!("  Using underlying price: $200.00");
+    println!("  Using option price: ${option_price:.2}");
+    println!("  Using underlying price: ${underlying_price:.2}");
 
     let greeks = client
-        .calculate_implied_volatility(&option, 10.0, 200.0)
+        .calculate_implied_volatility(&option, option_price, underlying_price)
         .await;
 
     match greeks {
@@ -1019,8 +1079,12 @@ async fn test_fetch_option_chain() {
 
     println!("Fetching option chain for AAPL...");
 
+    // IBKR's `reqSecDefOptParams` requires a real underlying conId (`0` is
+    // rejected with `[321] Invalid contract id`) and an empty `fut_fop_exchange`
+    // to return every exchange's parameters (a routing exchange like "SMART"
+    // filters the result to zero rows).
     let chains = client
-        .fetch_option_chain("AAPL", "SMART", SecurityType::Stock, 0)
+        .fetch_option_chain("AAPL", "", SecurityType::Stock, AAPL_UNDERLYING_CONID)
         .await;
 
     match chains {
@@ -1076,7 +1140,13 @@ async fn test_option_greeks_stream() {
         client_id: test_client_id_base() + 33,
     };
 
-    let option = aapl_call_option();
+    // Resolve a currently-listed option via a short-lived historical client
+    // (distinct client_id) before opening the streaming connection.
+    let url = format!("127.0.0.1:{}", test_port());
+    let resolver =
+        IbkrHistoricalData::connect(&url, test_client_id_base() + 34).expect("connection failed");
+    let option = resolve_aapl_call_option(&resolver).await;
+    resolver.disconnect();
 
     let registry = ContractRegistry::new();
     registry.register("AAPL_CALL".into(), option);

--- a/rustrade-execution/Cargo.toml
+++ b/rustrade-execution/Cargo.toml
@@ -103,7 +103,7 @@ lru = { workspace = true, optional = true }         # Event deduplication cache 
 parking_lot = { workspace = true, optional = true } # Lighter mutex for dedup cache (no poisoning, no OS thread park)
 
 # IBKR (optional, behind "ibkr" feature)
-ibapi = { version = "=2.12.0", optional = true, default-features = false, features = [
+ibapi = { version = "=3.0.1", optional = true, default-features = false, features = [
     "sync",
 ] }
 chrono-tz = { workspace = true, optional = true }

--- a/rustrade-execution/src/client/ibkr/contract.rs
+++ b/rustrade-execution/src/client/ibkr/contract.rs
@@ -1,6 +1,53 @@
 //! Contract builders for IB integration.
 
-use ibapi::contracts::{Contract, Currency, Exchange, SecurityType, Symbol};
+use ibapi::contracts::{Contract, Currency, Exchange, OptionRight, SecurityType, Symbol};
+
+/// Error returned by [`option_contract`] when the `right` string cannot be
+/// mapped to an [`OptionRight`].
+///
+/// Carries the offending input so callers can surface it (via [`Display`] or
+/// [`InvalidOptionRight::right`]). Building an option contract without a valid
+/// right is rejected at construction rather than deferred to an opaque IBKR
+/// submission failure.
+///
+/// [`Display`]: std::fmt::Display
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidOptionRight(String);
+
+impl InvalidOptionRight {
+    /// The unrecognized `right` input that triggered this error.
+    #[must_use]
+    pub fn right(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for InvalidOptionRight {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unrecognized option right {:?} (expected one of C/CALL/P/PUT)",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidOptionRight {}
+
+/// Map a human/wire option-right string to `OptionRight`.
+///
+/// Accepts IBKR wire values (`"C"`/`"P"`) and common long forms
+/// (`"CALL"`/`"PUT"`), case-insensitively. Returns `None` for anything else.
+fn parse_option_right(right: &str) -> Option<OptionRight> {
+    let right = right.trim();
+    if right.eq_ignore_ascii_case("C") || right.eq_ignore_ascii_case("CALL") {
+        Some(OptionRight::Call)
+    } else if right.eq_ignore_ascii_case("P") || right.eq_ignore_ascii_case("PUT") {
+        Some(OptionRight::Put)
+    } else {
+        None
+    }
+}
 
 /// Build a stock contract for the given symbol.
 pub fn stock_contract(symbol: &str, exchange: &str, currency: &str) -> Contract {
@@ -28,6 +75,13 @@ pub fn futures_contract(
 }
 
 /// Build an options contract.
+///
+/// # Errors
+///
+/// Returns [`InvalidOptionRight`] if `right` is not one of `C`/`CALL`/`P`/`PUT`
+/// (case-insensitive; leading and trailing whitespace is ignored). An option
+/// contract is invalid without a right, so this is surfaced at construction
+/// rather than as a later IBKR submission rejection.
 pub fn option_contract(
     symbol: &str,
     last_trade_date: &str,
@@ -35,17 +89,18 @@ pub fn option_contract(
     right: &str,
     exchange: &str,
     currency: &str,
-) -> Contract {
-    Contract {
+) -> Result<Contract, InvalidOptionRight> {
+    let right = parse_option_right(right).ok_or_else(|| InvalidOptionRight(right.to_string()))?;
+    Ok(Contract {
         symbol: Symbol::new(symbol),
         security_type: SecurityType::Option,
         last_trade_date_or_contract_month: last_trade_date.to_string(),
         strike,
-        right: right.to_string(),
+        right: Some(right),
         exchange: Exchange::new(exchange),
         currency: Currency::new(currency),
         ..Default::default()
-    }
+    })
 }
 
 /// Build a forex contract.

--- a/rustrade-execution/src/client/ibkr/execution.rs
+++ b/rustrade-execution/src/client/ibkr/execution.rs
@@ -5,7 +5,7 @@ use crate::{
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Tz;
 use fnv::FnvHashMap;
-use ibapi::orders::{CommissionReport, ExecutionData};
+use ibapi::orders::{CommissionReport, ExecutionData, ExecutionSide};
 use parking_lot::Mutex;
 use rust_decimal::Decimal;
 use rustrade_instrument::{
@@ -95,7 +95,7 @@ impl ExecutionBuffer {
             inner.pending.remove(&report.execution_id)?
         };
 
-        build_trade(pending, report)
+        Some(build_trade(pending, report))
     }
 
     /// Get number of pending executions (for diagnostics).
@@ -139,24 +139,17 @@ impl Default for ExecutionBuffer {
 }
 
 /// Build a rustrade Trade from IB execution + commission data.
-///
-/// Returns `None` if the side string is unrecognized (logged as warning).
 fn build_trade(
     pending: PendingExecution,
     commission: &CommissionReport,
-) -> Option<Trade<AssetNameExchange, InstrumentNameExchange>> {
+) -> Trade<AssetNameExchange, InstrumentNameExchange> {
     let exec = &pending.execution.execution;
 
-    let side = match parse_ib_side(&exec.side) {
-        Some(s) => s,
-        None => {
-            warn!(
-                side = %exec.side,
-                exec_id = %exec.execution_id,
-                "Unknown IB side string, dropping trade"
-            );
-            return None;
-        }
+    // `ExecutionSide` is a closed two-variant enum in ibapi 3.x (the decoder
+    // rejects unknown wire values upstream), so the mapping is total.
+    let side = match exec.side {
+        ExecutionSide::Bought => Side::Buy,
+        ExecutionSide::Sold => Side::Sell,
     };
 
     let price = parse_decimal_or_warn(exec.price, "exec.price");
@@ -165,7 +158,7 @@ fn build_trade(
 
     let time_exchange = parse_ib_timestamp(&exec.time).unwrap_or_else(Utc::now);
 
-    Some(Trade {
+    Trade {
         id: TradeId::new(&exec.execution_id),
         order_id: crate::order::id::OrderId::new(&pending.client_order_id.0),
         instrument: pending.instrument,
@@ -179,20 +172,6 @@ fn build_trade(
             fees: commission_amount,
             fees_quote: None, // Indexer computes based on fee asset vs instrument quote
         },
-    })
-}
-
-/// Parse IB side string to rustrade Side.
-///
-/// IB sends uppercase: "BOT" (bought), "SLD" (sold), "BUY", "SELL",
-/// "SSHORT" (short sell), "SLONG" (sell long).
-///
-/// Returns `None` for unrecognized values to avoid silent data corruption.
-pub fn parse_ib_side(s: &str) -> Option<Side> {
-    match s {
-        "BOT" | "BUY" => Some(Side::Buy),
-        "SLD" | "SELL" | "SSHORT" | "SLONG" => Some(Side::Sell),
-        _ => None,
     }
 }
 
@@ -295,17 +274,5 @@ mod tests {
     fn test_parse_ib_timestamp_invalid() {
         assert!(parse_ib_timestamp("invalid").is_none());
         assert!(parse_ib_timestamp("").is_none());
-    }
-
-    #[test]
-    fn test_parse_ib_side() {
-        assert_eq!(parse_ib_side("BOT"), Some(Side::Buy));
-        assert_eq!(parse_ib_side("BUY"), Some(Side::Buy));
-        assert_eq!(parse_ib_side("SLD"), Some(Side::Sell));
-        assert_eq!(parse_ib_side("SELL"), Some(Side::Sell));
-        assert_eq!(parse_ib_side("SSHORT"), Some(Side::Sell));
-        assert_eq!(parse_ib_side("SLONG"), Some(Side::Sell));
-        // Unknown returns None
-        assert_eq!(parse_ib_side("UNKNOWN"), None);
     }
 }

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -86,7 +86,7 @@ use crate::{
 };
 use account::BalanceAggregator;
 use chrono::{DateTime, Utc};
-use execution::{ExecutionBuffer, parse_decimal_or_warn, parse_ib_side};
+use execution::{ExecutionBuffer, parse_decimal_or_warn};
 use futures::stream::BoxStream;
 use ibapi::{
     accounts::{AccountSummaryResult, types::AccountGroup},
@@ -150,8 +150,8 @@ pub struct ContractConfig {
 }
 
 impl ContractConfig {
-    fn to_contract(&self) -> ibapi::contracts::Contract {
-        match self.security_type.as_str() {
+    fn to_contract(&self) -> Result<ibapi::contracts::Contract, contract::InvalidOptionRight> {
+        Ok(match self.security_type.as_str() {
             "STK" => contract::stock_contract(&self.symbol, &self.exchange, &self.currency),
             "FUT" => contract::futures_contract(
                 &self.symbol,
@@ -166,13 +166,13 @@ impl ContractConfig {
                 self.right.as_deref().unwrap_or("C"),
                 &self.exchange,
                 &self.currency,
-            ),
+            )?,
             "CASH" => contract::forex_contract(&self.symbol, &self.currency),
             other => {
                 warn!(security_type = %other, symbol = %self.symbol, "Unknown security_type, defaulting to STK");
                 contract::stock_contract(&self.symbol, &self.exchange, &self.currency)
             }
-        }
+        })
     }
 }
 
@@ -183,6 +183,149 @@ static ACCOUNT_GROUP_ALL: std::sync::LazyLock<AccountGroup> =
 /// Timeout for position stream iteration.
 /// Workaround for ibapi bug where `PositionEnd` isn't routed to subscription.
 const POSITION_STREAM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Maximum time to await an initial `OrderStatus` on an order-placement
+/// subscription before giving up. Bounds the placement loops so a silent TWS
+/// (e.g. a half-open socket) cannot hang them indefinitely. A timeout yields
+/// [`PlacementOutcome::NoStatus`]; the order may still have been submitted, so
+/// callers resolve the final state via the order-update/account stream.
+const PLACEMENT_STATUS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// IBKR "Order Message" codes that are informational rather than rejections.
+///
+/// ibapi classifies the whole `200..=399` range as order rejections
+/// (`ORDER_REJECTION_CODE_RANGE`), but IBKR uses code 399 as a generic order
+/// message — e.g. *"Your order will not be placed at the exchange until
+/// 09:30:00 US/Eastern"* — for an order that is in fact **accepted and held**
+/// (it proceeds to `PreSubmitted`). ibapi surfaces such codes as
+/// `Err(Error::Notice)` and terminates the subscription, so the eventual
+/// `OrderStatus(PreSubmitted)` is observable only via the order-update/account
+/// stream, never on the placement subscription itself. We therefore report the
+/// order as live-but-pending ([`PlacementOutcome::HeldPending`]) rather than
+/// rejected when one of these codes arrives.
+///
+/// This list documents the known gap between ibapi's range heuristic and IBKR's
+/// actual protocol semantics. If IBKR adds further informational codes in the
+/// 200-399 range, an out-of-RTH placement test will surface them and they can be
+/// added here.
+const INFORMATIONAL_ORDER_CODES: &[i32] = &[399];
+
+/// Outcome of awaiting the initial status on an order-placement subscription.
+///
+/// The authoritative acceptance/rejection signal in the IBKR protocol is the
+/// `OrderStatus` event, not an error notice — see [`await_order_placement`].
+///
+/// Every variant carries a distinct order-placement outcome that callers must
+/// dispatch on; dropping a value would silently discard the order's status.
+#[must_use]
+enum PlacementOutcome {
+    /// The order was acknowledged by IB and its order-id mapping must be
+    /// retained so the account stream can resolve its terminal/fill state. This
+    /// covers the working statuses (`Submitted`/`PreSubmitted`/`PendingSubmit`),
+    /// an immediate `Filled`, and the transitional cancel states
+    /// (`ApiCancelled`/`PendingCancel`) that precede a confirmed terminal status.
+    /// Carries the filled quantity reported with the status.
+    Accepted { filled: f64 },
+    /// A terminal rejection: a `Cancelled`/`Inactive` `OrderStatus`, a genuine
+    /// non-informational TWS notice, or a transport error. Carries the
+    /// human-readable reason.
+    Rejected(String),
+    /// An informational notice (see [`INFORMATIONAL_ORDER_CODES`]) closed the
+    /// subscription. The order is live/held; its authoritative status will
+    /// arrive via the order-update/account stream. Carries the notice text.
+    HeldPending(String),
+    /// The subscription ended — or [`PLACEMENT_STATUS_TIMEOUT`] elapsed —
+    /// without any terminal status or informational notice. The order may or
+    /// may not have been accepted; resolve via the order-update/account stream.
+    NoStatus,
+}
+
+/// Drive an order-placement subscription to its initial [`PlacementOutcome`].
+///
+/// Shared by the single-order and bracket-leg placement paths. Consumes events
+/// from a `place_order` subscription (typically `sub.timeout_iter_data(..)`)
+/// until a decisive outcome is reached.
+///
+/// # Why notices are not blanket rejections
+///
+/// ibapi 3.x delivers any TWS error frame outside the warning range
+/// (`2100..=2169`) as `Err(Error::Notice)` and then closes the subscription. IB
+/// emits informational order messages (e.g. code 399, order held until RTH) the
+/// same way, so treating every `Err` as a rejection would falsely reject orders
+/// that are actually live. We instead key off the notice code: known
+/// informational codes yield [`PlacementOutcome::HeldPending`]; all other
+/// notices and transport errors yield [`PlacementOutcome::Rejected`]. The
+/// `OrderStatus` event — when one is delivered before the closing notice —
+/// remains authoritative.
+fn await_order_placement<I>(events: I) -> PlacementOutcome
+where
+    I: IntoIterator<Item = Result<ibapi::orders::PlaceOrder, ibapi::Error>>,
+{
+    use ibapi::orders::PlaceOrder;
+
+    for event in events {
+        let event = match event {
+            Ok(event) => event,
+            // Informational order message (e.g. 399 held-until-RTH): the order
+            // is accepted; ibapi has closed the subscription, so stop here and
+            // let the update stream carry the real status.
+            Err(ibapi::Error::Notice(n)) if INFORMATIONAL_ORDER_CODES.contains(&n.code) => {
+                return PlacementOutcome::HeldPending(format!("[{}] {}", n.code, n.message));
+            }
+            // Genuine notice (e.g. 201 reject) or transport error.
+            Err(e) => return PlacementOutcome::Rejected(e.to_string()),
+        };
+
+        if let PlaceOrder::OrderStatus(status) = event {
+            use ibapi::orders::OrderStatusKind;
+            match status.status {
+                OrderStatusKind::Submitted
+                | OrderStatusKind::PreSubmitted
+                | OrderStatusKind::PendingSubmit
+                // A marketable order can fill before any working status is
+                // delivered on the placement subscription — ibapi 3.x sends
+                // `OrderStatus(Filled)` directly in that case. The order is
+                // live, not rejected; its authoritative terminal/fill state
+                // arrives via the account stream. Report it accepted so the
+                // order-id mapping is retained and the stream's
+                // executions/commissions are captured (treating it as a
+                // rejection would remove the mapping and drop those events).
+                | OrderStatusKind::Filled => {
+                    return PlacementOutcome::Accepted {
+                        filled: status.filled,
+                    };
+                }
+                OrderStatusKind::Cancelled | OrderStatusKind::Inactive => {
+                    return PlacementOutcome::Rejected(status.status.to_string());
+                }
+                // Transitional cancel states: a cancellation was already requested
+                // (e.g. a fast cancel racing the placement ack), but the order was
+                // submitted — we have a placement subscription — and is still live.
+                // `ApiCancelled` always precedes a confirmed `Cancelled`; both it
+                // and `PendingCancel` resolve to a terminal status on the account
+                // stream, which is authoritative. Report accepted so the order-id
+                // mapping is retained and the stream's terminal/execution/commission
+                // events are captured (treating these as a rejection would remove
+                // the mapping and drop those events).
+                OrderStatusKind::ApiCancelled | OrderStatusKind::PendingCancel => {
+                    return PlacementOutcome::Accepted {
+                        filled: status.filled,
+                    };
+                }
+                // Pre-transmission state: ibapi has not yet sent the order to IB
+                // (e.g. awaiting a security-definition lookup). This is not a
+                // placement decision — keep waiting for a definitive status. The
+                // `PLACEMENT_STATUS_TIMEOUT` backstop yields `NoStatus` if none
+                // arrives.
+                OrderStatusKind::ApiPending => {}
+            }
+        }
+        // Non-status events (OpenOrder, ExecutionData, CommissionReport): keep
+        // waiting for the OrderStatus.
+    }
+
+    PlacementOutcome::NoStatus
+}
 
 /// Interactive Brokers execution client.
 ///
@@ -231,7 +374,13 @@ impl IbkrClient {
         let contracts = ContractRegistry::new();
 
         for contract_config in &config.contracts {
-            let contract = contract_config.to_contract();
+            let contract = match contract_config.to_contract() {
+                Ok(contract) => contract,
+                Err(e) => {
+                    warn!(name = %contract_config.name, error = %e, "Invalid contract config, skipping");
+                    continue;
+                }
+            };
             let name = InstrumentNameExchange::from(contract_config.name.as_str());
 
             match client.contract_details(&contract) {
@@ -390,6 +539,14 @@ impl IbkrClient {
     /// If any leg is rejected by IB (e.g., insufficient margin, invalid price),
     /// this method cancels all other legs and returns all three as `Inactive`.
     /// You will never receive a mix of active and inactive legs.
+    ///
+    /// The same all-legs cancellation applies if any leg fails to report a
+    /// terminal status within the placement timeout (an unknown/no-status
+    /// outcome): leaving part of a bracket working while the rest is in an
+    /// unknown state is unsafe, so all three legs are cancelled and an error is
+    /// returned. This is intentionally stricter than single-order placement
+    /// (`open_order`), where a no-status outcome retains the order and defers
+    /// resolution to the account stream.
     ///
     /// # Cancellation Safety
     ///
@@ -559,8 +716,6 @@ impl IbkrClient {
         // Place all three orders in spawn_blocking
         let client = self.client.clone();
         let result = tokio::task::spawn_blocking(move || {
-            use ibapi::orders::PlaceOrder;
-
             // Place parent (transmit=false, held until SL is sent)
             let parent_sub = match client.place_order(parent_ib_id, &contract, &ib_orders[0]) {
                 Ok(s) => s,
@@ -588,74 +743,32 @@ impl IbkrClient {
                 }
             };
 
-            // Wait for first status from each subscription
-            let mut parent_status = None;
-            let mut tp_status = None;
-            let mut sl_status = None;
-
-            // Poll parent subscription
-            for event in parent_sub {
-                if let PlaceOrder::OrderStatus(status) = event {
-                    match status.status.as_str() {
-                        "Submitted" | "PreSubmitted" | "PendingSubmit" => {
-                            parent_status = Some(Ok(status.filled));
-                            break;
-                        }
-                        "Cancelled" | "Inactive" => {
-                            parent_status = Some(Err(status.status));
-                            break;
-                        }
-                        // Any other terminal status (e.g. "Filled", "ApiCancelled",
-                        // "PendingCancel") is treated as a rejection rather than
-                        // silently ignored — preserves observable failure semantics.
-                        other => {
-                            parent_status = Some(Err(format!("unexpected parent status: {other}")));
-                            break;
-                        }
-                    }
+            // Await the first status from each subscription. A leg held until
+            // RTH (informational notice, e.g. 399) is treated as live with an
+            // unknown fill (0.0) — the order is working, not rejected. `None`
+            // means the subscription closed/timed out without a terminal status.
+            let leg_status = |outcome: PlacementOutcome, leg: &str| match outcome {
+                PlacementOutcome::Accepted { filled } => Some(Ok(filled)),
+                PlacementOutcome::HeldPending(notice) => {
+                    warn!(leg, %notice, "bracket leg held/pending; tracking via stream");
+                    Some(Ok(0.0))
                 }
-            }
+                PlacementOutcome::Rejected(reason) => Some(Err(reason)),
+                PlacementOutcome::NoStatus => None,
+            };
 
-            // Poll TP subscription
-            for event in tp_sub {
-                if let PlaceOrder::OrderStatus(status) = event {
-                    match status.status.as_str() {
-                        "Submitted" | "PreSubmitted" | "PendingSubmit" => {
-                            tp_status = Some(Ok(status.filled));
-                            break;
-                        }
-                        "Cancelled" | "Inactive" => {
-                            tp_status = Some(Err(status.status));
-                            break;
-                        }
-                        other => {
-                            tp_status =
-                                Some(Err(format!("unexpected take_profit status: {other}")));
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Poll SL subscription
-            for event in sl_sub {
-                if let PlaceOrder::OrderStatus(status) = event {
-                    match status.status.as_str() {
-                        "Submitted" | "PreSubmitted" | "PendingSubmit" => {
-                            sl_status = Some(Ok(status.filled));
-                            break;
-                        }
-                        "Cancelled" | "Inactive" => {
-                            sl_status = Some(Err(status.status));
-                            break;
-                        }
-                        other => {
-                            sl_status = Some(Err(format!("unexpected stop_loss status: {other}")));
-                            break;
-                        }
-                    }
-                }
-            }
+            let parent_status = leg_status(
+                await_order_placement(parent_sub.timeout_iter_data(PLACEMENT_STATUS_TIMEOUT)),
+                "parent",
+            );
+            let tp_status = leg_status(
+                await_order_placement(tp_sub.timeout_iter_data(PLACEMENT_STATUS_TIMEOUT)),
+                "take_profit",
+            );
+            let sl_status = leg_status(
+                await_order_placement(sl_sub.timeout_iter_data(PLACEMENT_STATUS_TIMEOUT)),
+                "stop_loss",
+            );
 
             // Verify all three legs reported a successful status. A `None` here
             // means the subscription closed without producing a recognised event
@@ -923,10 +1036,21 @@ impl ExecutionClient for IbkrClient {
             let mut snapshots = Vec::new();
             let mut seen = HashSet::new();
 
-            // Use next_timeout() instead of blocking iterator to avoid hang.
-            // ibapi bug: PositionEnd has no request_id so it's not routed to the
-            // subscription, causing the iterator to block forever.
-            while let Some(pos_update) = positions_sub.next_timeout(POSITION_STREAM_TIMEOUT) {
+            // Use the timeout-bounded data iterator instead of the plain blocking
+            // iterator to avoid hang. ibapi bug: PositionEnd has no request_id so it
+            // is not routed to the subscription, causing iteration to block forever;
+            // the per-item timeout yields `None` to end the loop instead.
+            for pos_update in positions_sub.timeout_iter_data(POSITION_STREAM_TIMEOUT) {
+                // Surface subscription errors rather than returning partial positions
+                // (a truncated snapshot could be misread as positions having closed).
+                let pos_update = match pos_update {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return Err(UnindexedClientError::Internal(format!(
+                            "positions subscription: {e}"
+                        )));
+                    }
+                };
                 let PositionUpdate::Position(pos) = pos_update else {
                     trace!(?pos_update, "Ignoring non-Position variant");
                     continue;
@@ -1029,15 +1153,32 @@ impl ExecutionClient for IbkrClient {
                 // (ContractRegistry, OrderIdMap, etc.) remains usable. On panic the
                 // thread exits, tx is dropped, and the stream closes — caller observes EOF.
                 let result = catch_unwind(AssertUnwindSafe(|| {
-                    use ibapi::orders::OrderUpdate;
+                    use ibapi::orders::{OrderStatusKind, OrderUpdate};
 
-                    for update in order_sub {
+                    for update in order_sub.iter_data() {
+                        let update = match update {
+                            Ok(u) => u,
+                            Err(e) => {
+                                // Channel carries UnindexedAccountEvent, not Result —
+                                // cannot forward the error. Log and close the stream so
+                                // the caller observes EOF (consistent with the panic path).
+                                error!(error = %e, "Order stream subscription error");
+                                break;
+                            }
+                        };
                         let event = match update {
                             OrderUpdate::OrderStatus(status) => {
                                 let ib_id = status.order_id;
-                                // Use single-lock method for terminal status to avoid read+write
-                                let is_terminal =
-                                    matches!(status.status.as_str(), "Cancelled" | "Inactive");
+                                // Use single-lock method for terminal status to avoid read+write.
+                                // Only `Cancelled`/`Inactive` remove the mapping here: a `Filled`
+                                // order's mapping is intentionally retained so late-arriving
+                                // ExecutionData/CommissionReport events still resolve it (reaped
+                                // later by `OrderIdMap::clear_stale`), so this is deliberately
+                                // narrower than `OrderStatusKind::is_terminal()`.
+                                let is_terminal = matches!(
+                                    status.status,
+                                    OrderStatusKind::Cancelled | OrderStatusKind::Inactive
+                                );
 
                                 let lookup_result = if is_terminal {
                                     order_ids_clone.remove_and_get_context(ib_id)
@@ -1310,35 +1451,33 @@ impl ExecutionClient for IbkrClient {
         // Move both place_order AND subscription iteration into spawn_blocking
         // to avoid blocking Tokio worker threads on IB's synchronous iterator.
         let result = tokio::task::spawn_blocking(move || {
-            use ibapi::orders::PlaceOrder;
-
             let sub = match client.place_order(ib_order_id, &contract, &ib_order) {
                 Ok(s) => s,
                 Err(e) => return Err(e.to_string()),
             };
 
-            for event in sub {
-                if let PlaceOrder::OrderStatus(status) = event {
-                    match status.status.as_str() {
-                        "Submitted" | "PreSubmitted" | "PendingSubmit" => {
-                            let filled = parse_decimal_or_warn(status.filled, "status.filled");
-                            return Ok(Some((ib_order_id, filled)));
-                        }
-                        "Cancelled" | "Inactive" => {
-                            // Don't remove here - let outer match at line 726 handle cleanup
-                            // to centralize all error-path removals in one place
-                            return Err(status.status);
-                        }
-                        _ => continue,
-                    }
+            match await_order_placement(sub.timeout_iter_data(PLACEMENT_STATUS_TIMEOUT)) {
+                PlacementOutcome::Accepted { filled } => {
+                    let filled = parse_decimal_or_warn(filled, "status.filled");
+                    Ok(Some((ib_order_id, filled)))
                 }
+                // Cancelled/Inactive/unexpected status or a genuine notice/error.
+                // Don't remove the mapping here — the outer match centralizes all
+                // error-path removals.
+                PlacementOutcome::Rejected(reason) => Err(reason),
+                // Held until RTH (informational notice): the order is live; its
+                // authoritative status arrives via account_stream. Surface as
+                // "no terminal status yet" (Open with zero fill), same as below.
+                PlacementOutcome::HeldPending(notice) => {
+                    warn!(ib_order_id, %notice, "order held/pending; tracking via stream");
+                    Ok(None)
+                }
+                // Subscription exhausted/timed out without a terminal status.
+                // Do NOT remove the mapping — ExecutionData/CommissionReport may
+                // still arrive via account_stream; clear_stale_order_ids() handles
+                // stale mappings.
+                PlacementOutcome::NoStatus => Ok(None),
             }
-
-            // Subscription exhausted without terminal status.
-            // Do NOT remove mapping here - ExecutionData/CommissionReport may still
-            // arrive via account_stream. Time-based cleanup via clear_stale_order_ids()
-            // handles stale mappings.
-            Ok(None)
         })
         .await;
 
@@ -1441,7 +1580,10 @@ impl ExecutionClient for IbkrClient {
                 .map_err(|e| UnindexedClientError::Internal(format!("account_summary: {e}")))?;
 
             let mut aggregator = BalanceAggregator::new();
-            for summary in sub {
+            for summary in sub.iter_data() {
+                // Surface errors rather than returning a partial balance set.
+                let summary = summary
+                    .map_err(|e| UnindexedClientError::Internal(format!("account_summary: {e}")))?;
                 match summary {
                     AccountSummaryResult::Summary(s) => aggregator.process(&s),
                     AccountSummaryResult::End => break,
@@ -1493,7 +1635,11 @@ impl ExecutionClient for IbkrClient {
                 .map_err(|e| UnindexedClientError::Internal(format!("open_orders: {e}")))?;
 
             let mut orders = Vec::new();
-            for order_item in sub {
+            for order_item in sub.iter_data() {
+                // Surface errors rather than returning a partial open-order set,
+                // which the caller could misread during order reconciliation.
+                let order_item = order_item
+                    .map_err(|e| UnindexedClientError::Internal(format!("open_orders: {e}")))?;
                 let order_data = match order_item {
                     Orders::OrderData(data) => data,
                     _ => continue,
@@ -1592,7 +1738,7 @@ impl ExecutionClient for IbkrClient {
         };
 
         tokio::task::spawn_blocking(move || {
-            use ibapi::orders::Executions;
+            use ibapi::orders::{ExecutionSide, Executions};
 
             let exec_filter = ibapi::orders::ExecutionFilter::default();
             // Note: ibapi errors are unstructured — see comment in account_snapshot() re: Internal
@@ -1601,7 +1747,11 @@ impl ExecutionClient for IbkrClient {
                 .map_err(|e| UnindexedClientError::Internal(format!("executions: {e}")))?;
 
             let mut trades = Vec::new();
-            for exec_item in sub {
+            for exec_item in sub.iter_data() {
+                // Surface errors rather than returning a partial fill set, which the
+                // caller could misread during fill recovery.
+                let exec_item = exec_item
+                    .map_err(|e| UnindexedClientError::Internal(format!("executions: {e}")))?;
                 let exec_data = match exec_item {
                     Executions::ExecutionData(data) => data,
                     _ => continue,
@@ -1637,16 +1787,11 @@ impl ExecutionClient for IbkrClient {
                     continue;
                 }
 
-                let side = match parse_ib_side(&exec.side) {
-                    Some(s) => s,
-                    None => {
-                        warn!(
-                            side = %exec.side,
-                            exec_id = %exec.execution_id,
-                            "Unknown IB side string, skipping trade"
-                        );
-                        continue;
-                    }
+                // `ExecutionSide` is a closed two-variant enum in ibapi 3.x
+                // (the decoder rejects unknown wire values), so this is total.
+                let side = match exec.side {
+                    ExecutionSide::Bought => Side::Buy,
+                    ExecutionSide::Sold => Side::Sell,
                 };
 
                 let client_id = order_ids
@@ -1679,12 +1824,16 @@ impl ExecutionClient for IbkrClient {
 ///
 /// # IBKR Status Mapping
 ///
-/// | IB Status    | → OrderState          | Rationale                                    |
-/// |--------------|-----------------------|----------------------------------------------|
-/// | "Inactive"   | OpenFailed(Rejected)  | Order blocked by validation/margin/exchange  |
-/// | "Cancelled"  | Cancelled or Expired  | See differentiation logic below              |
-/// | "Filled"     | FullyFilled           | Order fully executed                         |
-/// | Other        | Active(Open)          | Order working on exchange                    |
+/// | `OrderStatusKind`                           | → OrderState         | Rationale                                   |
+/// |---------------------------------------------|----------------------|---------------------------------------------|
+/// | `Inactive`                                  | OpenFailed(Rejected) | Order blocked by validation/margin/exchange |
+/// | `Cancelled`                                 | Cancelled or Expired | See differentiation logic below             |
+/// | `Filled`                                    | FullyFilled          | Order fully executed                        |
+/// | `Submitted`/`PreSubmitted`/`PendingSubmit`  | Active(Open)         | Order working on exchange                   |
+/// | `ApiPending`/`PendingCancel`/`ApiCancelled` | Active(Open)         | Transitional; await a confirmed terminal    |
+///
+/// The match is exhaustive over `OrderStatusKind` (no wildcard), so a new ibapi
+/// status variant becomes a compile error rather than a silent `Active(Open)`.
 ///
 /// # Cancelled vs Expired Differentiation
 ///
@@ -1707,12 +1856,14 @@ fn make_order_from_status(
     pending_cancels: &PendingCancels,
 ) -> Order<ExchangeId, InstrumentNameExchange, OrderState<AssetNameExchange, InstrumentNameExchange>>
 {
+    use ibapi::orders::OrderStatusKind;
+
     let ib_id = status.order_id;
     let order_id = OrderId::new(format_smolstr!("{}", ib_id));
 
     let filled_qty = parse_decimal_or_warn(status.filled, "status.filled");
-    let state = match status.status.as_str() {
-        "Inactive" => {
+    let state = match status.status {
+        OrderStatusKind::Inactive => {
             // "Inactive" means the order was accepted by IB but is not working:
             // validation failure, margin issue, exchange closed, share location hold.
             // This is a placement failure, not a cancellation.
@@ -1720,7 +1871,7 @@ fn make_order_from_status(
                 "IB status: Inactive (order blocked by validation/margin/exchange)".into(),
             )))
         }
-        "Cancelled" => {
+        OrderStatusKind::Cancelled => {
             // Differentiate user-cancel from time-expiration
             let was_user_cancel = pending_cancels.remove(ib_id);
 
@@ -1735,9 +1886,23 @@ fn make_order_from_status(
                 OrderState::inactive(Cancelled::new(order_id, Utc::now(), filled_qty))
             }
         }
-        "Filled" => OrderState::fully_filled(Filled::new(order_id, Utc::now(), filled_qty, None)),
-        _ => {
-            // "Submitted", "PreSubmitted", "PendingSubmit", "PendingCancel", etc.
+        OrderStatusKind::Filled => {
+            OrderState::fully_filled(Filled::new(order_id, Utc::now(), filled_qty, None))
+        }
+        // Working states (Submitted/PreSubmitted/PendingSubmit) and the
+        // transitional ones (ApiPending/PendingCancel/ApiCancelled) are reported
+        // as active/Open until a confirmed Cancelled/Inactive/Filled arrives.
+        // ApiCancelled is deliberately NOT treated as terminal here: it precedes
+        // a confirmed Cancelled, whose event reaps the order-id mapping (or
+        // clear_stale does), mirroring the account_stream `is_terminal` guard.
+        // Enumerated explicitly so a future ibapi variant fails to compile rather
+        // than silently defaulting to Open.
+        OrderStatusKind::Submitted
+        | OrderStatusKind::PreSubmitted
+        | OrderStatusKind::PendingSubmit
+        | OrderStatusKind::ApiPending
+        | OrderStatusKind::PendingCancel
+        | OrderStatusKind::ApiCancelled => {
             OrderState::active(Open::new(order_id, Utc::now(), filled_qty))
         }
     };

--- a/rustrade-instrument/Cargo.toml
+++ b/rustrade-instrument/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true }
 
 [dependencies]
 # IBKR (optional, behind "ibkr" feature)
-ibapi = { version = "=2.12.0", optional = true, default-features = false, features = ["sync"] }
+ibapi = { version = "=3.0.1", optional = true, default-features = false, features = ["sync"] }
 fnv = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 # SerDe


### PR DESCRIPTION
Supersedes Dependabot PR #114 (`dependabot/cargo/develop/ibapi-eq-3.0.1`) — that PR only bumped the version pin; ibapi 3.0 is a major release whose breaking API changes require a hand-written migration of the IBKR connectors.

## Summary

Migrates `ibapi` from `=2.12.0` to `=3.0.1` across `rustrade-data`, `rustrade-execution`, and `rustrade-instrument`, absorbing all upstream breaking changes and adding error handling that surfaces previously-silent failures.

## Migration highlights

- **Subscription model**: all subscription APIs now yield `Result<T, Error>` via `iter_data()`; iteration surfaces subscription-level errors instead of silently truncating (quotes, depth, trades, Greeks, account summary, open orders, option chain, executions).
- **Historical data**: migrated to builder-style requests (`fetch_candles` / `fetch_historical_ticks` / `fetch_historical_bid_ask`); `Bar.date` is now the `BarTimestamp` enum — `bar_to_candle` pattern-matches both variants and anchors date-only bars to midnight UTC.
- **Market depth / tick-by-tick**: builder APIs (`.market_depth(...).subscribe()`, `.tick_by_tick(...).all_last()`).
- **Typed enums replace strings**: `Contract.right` → `Option<OptionRight>`, `OrderStatus.status` → `OrderStatusKind`, `Execution.side` → `ExecutionSide`. Status/side matches are now exhaustive (a new upstream variant becomes a compile error, not a silent default).
- **Order placement robustness**: new `PlacementOutcome` classification + `await_order_placement` — informational codes (e.g. 399 held-until-RTH) and `Filled` are treated correctly rather than as rejections, with a `PLACEMENT_STATUS_TIMEOUT` backstop against silent hangs; bracket legs fail fast on missing terminal status.

## Breaking changes (`ibkr` feature)

- `client::ibkr::contract::option_contract` now returns `Result<Contract, InvalidOptionRight>` (new public error type with a `right()` accessor) — invalid/empty option rights are rejected at construction instead of at IBKR submission.
- `client::ibkr::execution::parse_ib_side` removed — `Execution.side` is now the typed `ExecutionSide` enum upstream, so the string parser is obsolete.

## Operational requirement

ibapi 3.x speaks only the protobuf transport and refuses to connect to TWS/IB Gateway older than **server version 213**. Operators must run a recent ("latest"-channel) build.

See `CHANGELOG.md` for full notes.