### PR TITLE
feat(rustrade-data): Standardize Candle.close_time contract with shared time-boundary helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - REST snapshots remain the full `BalanceSnapshot(Snapshot<AssetBalance>)` (replace); WS updates
     apply free/locked while **preserving** existing `margin`, so a partial update structurally cannot
     overwrite known debt.
+- **Shared `Candle` time-boundary helpers** (`rustrade-data`, `subscription::candle`) — the single
+  source of truth every range-computing candle producer routes through (the Massive WS path is the
+  exception: it trusts the venue-supplied boundary directly), so the `close_time` contract is computed
+  in exactly one place:
+  - `IntervalStep { Fixed(chrono::Duration), Months(u32) }` — a primitive step type (`Months` covers
+    calendar `month`/`quarter`/`year`).
+  - `close_time_from_open(open, step) -> Option<DateTime<Utc>>` — computes a candle's exclusive
+    end-of-period boundary (`open + interval`); calendar months use leap-year-correct
+    `checked_add_months`. Returns `None` on overflow (callers surface it as their error type, never a
+    silent fallback).
+  - `open_time_from_close(close, step) -> Option<DateTime<Utc>>` — the inverse (`close − interval`),
+    used by range-bounded fetches to widen the venue request window. It round-trips exactly for the
+    closes this library produces (monthly boundaries always land on a calendar 1st); it is not a
+    universal identity, since `Months` day-clamping is asymmetric for non-1st anchors.
 
 ### Changed
 
@@ -122,6 +136,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Binance `GoodUntilEndOfDay` (GTD) time-in-force is now rejected as `UnsupportedOrderType`** instead of being silently coerced to `GoodTillCancelled` (GTC). Binance has no native end-of-day order, and coercing to GTC dropped the EOD auto-cancel semantics — risking an unintended resting order. This affects both the spot and margin clients.
 - **Binance margin user-data frames are parsed without a full JSON DOM.** The WS receive path now deserializes a borrowed envelope (`serde_json::value::RawValue` for the inner `event`) and reads the event discriminator from a raw slice, so only the matched event type pays for a single typed pass — no intermediate `serde_json::Value` tree is built per frame on this hot path. Internal only; no public API change (the `binance` feature now enables `serde_json/raw_value`).
 - **`InstrumentAccountSnapshot` gained a public `isolated: Option<IsolatedInstrumentState>` field**, and **`AccountEventKind` gained an `InstrumentBalanceUpdate` variant** (both for isolated margin). Both are additive on the wire (`Option` + `#[serde(default)]` / `#[non_exhaustive]` enum), but `InstrumentAccountSnapshot::new()`'s arity went 3→4 (struct-literal / `::new()` call sites must pass the new field) and the library's `indexer.rs` gained one match arm — a minor breaking change for code that directly constructs `InstrumentAccountSnapshot`. The new field sorts/hashes last (`None` before `Some`), so it acts only as a tie-breaker; the cross stream/snapshot paths are unchanged.
+- **Documented the `Candle.close_time` contract** (`rustrade-data`): `close_time` is the **exclusive
+  end-of-period boundary** (`close_time == open_time + interval`); a candle aggregates the half-open
+  window `[close_time − interval, close_time)`, so `close_time` equals the next candle's open instant.
+  The boundary is the UTC period grid, **not** the exchange session close (the library has no session
+  calendar); `month`/`quarter`/`year` use nominal calendar arithmetic. `Candle` carries neither
+  `open_time` nor `interval` — recover them from the originating fetch/subscription.
+- **BREAKING (`ibkr`): IBKR candle `close_time` is now the end-of-period boundary, not the bar start.**
+  `bar_to_candle` previously stuffed the bar's own start timestamp into `close_time` (off by one full
+  interval); it now computes `close_time = bar_open + interval` via the shared helper. **Call out:** an
+  IBKR **daily** bar's `close_time` is now the **next** day's `00:00 UTC` (e.g. a Jan 15 daily bar →
+  `Jan 16 00:00 UTC`), so `close_time.date()` shifts forward by one day — any `group_by(close_time.date())`
+  must subtract one interval (the bar's own date `= close_time − interval`). Monthly bars use calendar
+  arithmetic (`Jan → Feb 1 00:00 UTC`).
+- **BREAKING: standardized the historical-fetch range contract on `close_time`.** `fetch_candles`
+  (Hyperliquid) and `fetch_aggregates` (Massive) now return exactly the candles whose `close_time`
+  falls within the requested `[start, end]` (inclusive) — matched on `close_time`, the field consumers
+  receive — by widening the venue request one interval and trimming the result. Previously both matched
+  the venue-native **open-time** (Hyperliquid by open-time bucket, Massive/Polygon by the bar's
+  open-time), so the candle set near the range boundaries changes. IBKR is unaffected: its venue API is
+  duration-based (`end_date` + `duration`), documented as the exception (its candles still carry the
+  corrected `close_time`).
+- **BREAKING (`massive`): `AggregateBar` candle conversion is now fallible and keyed on `IntervalStep`.**
+  `into_candle_with_duration(Duration) -> Candle` was renamed to `into_candle_with_step(IntervalStep) ->
+  Result<Candle, MassiveError>`, and `into_candle(multiplier, timespan)` likewise now returns
+  `Result<Candle, MassiveError>` (a computed `close_time` overflow is surfaced rather than silently
+  wrapped). Migration: pass an `IntervalStep` (via `timespan_to_step`) instead of a `Duration`, and
+  handle the `Result`. The free function `timespan_to_duration` was correspondingly replaced by
+  `timespan_to_step`.
 
 ### Fixed
 
@@ -129,6 +171,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected the order-type support matrix in `rustrade-execution/README.md` to reflect Binance and Hyperliquid conditional order support (Stop, StopLimit, TakeProfit, TakeProfitLimit), Binance trailing-stop offset limitations, and Hyperliquid's lack of native market orders.
 - **`rustrade-execution` docs.rs builds now use `all-features`.** Every connector module is feature-gated behind `default = []`, so docs.rs previously published a crate documenting no connectors and the connector-comparison intra-doc links broke. The full client surface is now documented and those links resolve.
 - **Binance REST auth-failure errors now carry the numeric Binance code.** `401`/`403` (`UnauthorizedError`/`ForbiddenError`) rejections splice the code into the `ApiError::Unauthenticated` message, so callers can distinguish auth subtypes (e.g. `-2014` invalid key vs `-2015` IP/permission), matching the existing behaviour for client-error rejections.
+- **BREAKING: Massive monthly/quarterly/yearly candle `close_time` now uses calendar arithmetic**
+  (`rustrade-data`). `month`/`quarter`/`year` aggregates previously approximated the boundary as a
+  fixed `+30/91/365 days`, so a January monthly bar's `close_time` was `Jan 31`, not `Feb 1` — it did
+  not equal the next candle's open and did not align with Binance `1M` / IBKR monthly boundaries. They
+  now use leap-year-correct `Months` arithmetic (a January monthly bar → `Feb 1 00:00 UTC`). Fixed
+  intervals (`second`…`week`) are unchanged. Breaking for consumers comparing Massive coarse-interval
+  timestamps.
+- **BREAKING: Hyperliquid candle `close_time` is now computed library-side as `time_open + interval`**
+  (`rustrade-data`), instead of the venue's raw `time_close`. Hyperliquid reports `time_close` as
+  `period-end − 1ms` (the inclusive-last-ms convention, verified against the live API), which does not
+  satisfy the `close_time == open + interval` contract; the boundary is now computed via the shared
+  helper so Hyperliquid aligns with the other producers. Breaking by `+1ms` for consumers comparing
+  Hyperliquid candle timestamps against the raw venue value.
 
 ## [0.2.1] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The boundary is the UTC period grid, **not** the exchange session close (the library has no session
   calendar); `month`/`quarter`/`year` use nominal calendar arithmetic. `Candle` carries neither
   `open_time` nor `interval` — recover them from the originating fetch/subscription.
+- **Documented the `MarketEvent.time_exchange` contract** (`rustrade-data`): `time_exchange` is the
+  event's position on the consuming engine's timeline (the historical/backtest clock derives "current
+  time" and replays events in `time_exchange` order). For point-in-time payloads it is the venue event
+  time; for **aggregated/windowed payloads (candles/OHLCV) it must be the period END (`close_time`)**,
+  never the period start — stamping the open makes a completed bar enter the timeline before it could
+  exist (silent lookahead). Applies to any windowed payload, including a custom event type fed to the
+  engine without this crate's producers. Cross-referenced from the engine `EngineClock`/`TimeExchange`
+  traits and the `Candle.close_time` docs. Documentation only — no behaviour change. A new
+  `engine_backtest_with_candle_market_data` example demonstrates wrapping candles into `MarketEvent`s
+  (stamping `time_exchange = close_time`) and the custom `InstrumentDataState` needed to consume them
+  (the default instrument state tracks only trades + L1).
 - **BREAKING (`ibkr`): IBKR candle `close_time` is now the end-of-period boundary, not the bar start.**
   `bar_to_candle` previously stuffed the bar's own start timestamp into `close_time` (off by one full
   interval); it now computes `close_time = bar_open + interval` via the shared helper. **Call out:** an
@@ -170,6 +181,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Binance `fetch_open_orders` now honours the `ExecutionClient` "return all" contract** for an empty `instruments` slice. Both the spot and margin clients previously iterated the (empty) slice and returned an empty `Vec`, silently violating the trait contract that an empty slice must return open orders across all instruments. They now issue a single no-symbol query (`GET /api/v3/openOrders`, `GET /sapi/v1/margin/openOrders`), recovering each order's instrument from its own `symbol` field. The `fetch_trades` per-symbol limitation (Binance `myTrades` requires a symbol, so an empty slice returns empty) is now an explicitly documented deviation on both clients.
 - Corrected the order-type support matrix in `rustrade-execution/README.md` to reflect Binance and Hyperliquid conditional order support (Stop, StopLimit, TakeProfit, TakeProfitLimit), Binance trailing-stop offset limitations, and Hyperliquid's lack of native market orders.
 - **`rustrade-execution` docs.rs builds now use `all-features`.** Every connector module is feature-gated behind `default = []`, so docs.rs previously published a crate documenting no connectors and the connector-comparison intra-doc links broke. The full client surface is now documented and those links resolve.
+- **Resolved broken intra-doc links in `rustrade-data`** surfaced under `--all-features` (`OptionGreeks`, `Stream`, `AlpacaCredentials`/`AlpacaIex`/`AlpacaSip`/`AlpacaCrypto`, `DatabentoHistorical`/`DatabentoLive`, `MassiveRestClient`/`MassiveLive`): module/header docs referenced these types by short name where they were not in scope. They now use explicit paths, so the published docs link correctly.
 - **Binance REST auth-failure errors now carry the numeric Binance code.** `401`/`403` (`UnauthorizedError`/`ForbiddenError`) rejections splice the code into the `ApiError::Unauthenticated` message, so callers can distinguish auth subtypes (e.g. `-2014` invalid key vs `-2015` IP/permission), matching the existing behaviour for client-error rejections.
 - **BREAKING: Massive monthly/quarterly/yearly candle `close_time` now uses calendar arithmetic**
   (`rustrade-data`). `month`/`quarter`/`year` aggregates previously approximated the boundary as a

--- a/rustrade-data/src/event.rs
+++ b/rustrade-data/src/event.rs
@@ -41,7 +41,31 @@ impl<InstrumentKey, T> FromIterator<Result<MarketEvent<InstrumentKey, T>, DataEr
 /// - [`MarketEvent<DataKind>`](DataKind)
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
 pub struct MarketEvent<InstrumentKey = MarketDataInstrument, T = DataKind> {
+    /// Exchange timestamp of the event — its position on the **engine timeline**.
+    ///
+    /// A consuming engine treats this as *the* time the event occurred: the
+    /// historical/backtest clock derives "current time" from it and replays
+    /// events in `time_exchange` order (see `rustrade`'s `EngineClock` /
+    /// `TimeExchange`).
+    ///
+    /// # Contract for aggregated / windowed payloads (candles, OHLCV bars)
+    ///
+    /// For a point-in-time payload (e.g. [`PublicTrade`], [`OrderBookL1`]) this is
+    /// simply the venue event time. For a payload that aggregates a **time window**
+    /// (a [`Candle`]), `time_exchange` **must be the period END**, i.e. the
+    /// candle's [`close_time`](crate::subscription::candle::Candle::close_time) —
+    /// **never the period start**.
+    ///
+    /// Stamping the open instant makes a *completed* bar enter the engine timeline
+    /// at the moment its period *began*, so a strategy would act on a fully-formed
+    /// bar before it could possibly exist — silent lookahead / repaint bias. This
+    /// applies to **any** windowed payload, including a custom `T` supplied by a
+    /// consumer driving the engine without this crate's producers. The library's
+    /// own candle producers already stamp `close_time` here; when wrapping a
+    /// [`Candle`] into a `MarketEvent` yourself, use its `close_time`.
     pub time_exchange: DateTime<Utc>,
+    /// Local timestamp at which this event was received/decoded. Diagnostic only —
+    /// the engine clock and replay ordering use [`time_exchange`](Self::time_exchange).
     pub time_received: DateTime<Utc>,
     pub exchange: ExchangeId,
     pub instrument: InstrumentKey,

--- a/rustrade-data/src/exchange/alpaca/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/mod.rs
@@ -16,9 +16,9 @@
 //!
 //! # Authentication
 //!
-//! Alpaca requires authentication via [`AlpacaCredentials`]. Credentials can be:
-//! - Loaded from environment variables via [`AlpacaCredentials::from_env()`]
-//! - Provided explicitly via [`AlpacaCredentials::new()`]
+//! Alpaca requires authentication via [`AlpacaCredentials`](crate::exchange::alpaca::AlpacaCredentials). Credentials can be:
+//! - Loaded from environment variables via [`AlpacaCredentials::from_env()`](crate::exchange::alpaca::AlpacaCredentials::from_env)
+//! - Provided explicitly via [`AlpacaCredentials::new()`](crate::exchange::alpaca::AlpacaCredentials::new)
 //!
 //! Auth message is sent immediately after WebSocket connection, before subscriptions.
 //!
@@ -40,9 +40,9 @@
 //!
 //! # Connectors
 //!
-//! - [`AlpacaIex`]: Free IEX feed for US equities
-//! - [`AlpacaSip`]: Paid consolidated SIP feed (untested — requires subscription)
-//! - [`AlpacaCrypto`]: Crypto market data
+//! - [`AlpacaIex`](crate::exchange::alpaca::AlpacaIex): Free IEX feed for US equities
+//! - [`AlpacaSip`](crate::exchange::alpaca::AlpacaSip): Paid consolidated SIP feed (untested — requires subscription)
+//! - [`AlpacaCrypto`](crate::exchange::alpaca::AlpacaCrypto): Crypto market data
 //!
 //! # Supported Streams
 //!
@@ -317,7 +317,7 @@ impl AlpacaSubscriber {
     /// Create a new subscriber using credentials from environment variables.
     ///
     /// Equivalent to `AlpacaSubscriber::new(AlpacaCredentials::from_env()?)`.
-    /// See [`AlpacaCredentials::from_env`] for the variables read and error conditions.
+    /// See [`AlpacaCredentials::from_env`](crate::exchange::alpaca::AlpacaCredentials::from_env) for the variables read and error conditions.
     pub fn from_env() -> Result<Self, SocketError> {
         Ok(Self::new(AlpacaCredentials::from_env()?))
     }

--- a/rustrade-data/src/exchange/alpaca/options/snapshots.rs
+++ b/rustrade-data/src/exchange/alpaca/options/snapshots.rs
@@ -139,7 +139,7 @@ pub struct AlpacaOptionSnapshot {
 impl AlpacaOptionSnapshot {
     /// Get option Greeks in the standard format.
     ///
-    /// Returns [`OptionGreeks`] with delta, gamma, theta, vega populated from the
+    /// Returns [`OptionGreeks`](crate::subscription::greeks::OptionGreeks) with delta, gamma, theta, vega populated from the
     /// Alpaca response. Implied volatility is stored separately in [`Self::implied_volatility`].
     pub fn greeks(&self) -> OptionGreeks {
         let mut greeks: OptionGreeks = self.greeks.unwrap_or_default().into();

--- a/rustrade-data/src/exchange/databento/mod.rs
+++ b/rustrade-data/src/exchange/databento/mod.rs
@@ -8,8 +8,8 @@
 //! Unlike WebSocket-based connectors (Binance, Alpaca), Databento uses high-level
 //! client wrappers that handle connection management internally:
 //!
-//! - [`DatabentoHistorical`]: One-shot queries for data older than 24 hours
-//! - [`DatabentoLive`]: Real-time streaming for live and intraday replay data
+//! - [`DatabentoHistorical`](crate::exchange::databento::DatabentoHistorical): One-shot queries for data older than 24 hours
+//! - [`DatabentoLive`](crate::exchange::databento::DatabentoLive): Real-time streaming for live and intraday replay data
 //!
 //! # Connection Model
 //!

--- a/rustrade-data/src/exchange/hyperliquid/historical.rs
+++ b/rustrade-data/src/exchange/hyperliquid/historical.rs
@@ -23,8 +23,11 @@
 //! let candles = client.fetch_candles(request).await?;
 //! ```
 
-use crate::{error::DataError, subscription::candle::Candle};
-use chrono::{DateTime, TimeZone, Utc};
+use crate::{
+    error::DataError,
+    subscription::candle::{Candle, IntervalStep, close_time_from_open, open_time_from_close},
+};
+use chrono::{DateTime, Duration, TimeZone, Utc};
 use hyperliquid_rust_sdk::{BaseUrl, InfoClient};
 use rust_decimal::Decimal;
 use tracing::debug;
@@ -68,6 +71,16 @@ impl HyperliquidHistoricalData {
 
     /// Fetch historical candles for the given request.
     ///
+    /// # Range contract
+    ///
+    /// Returns exactly the candles whose exclusive `close_time` falls within
+    /// `[request.start_time, request.end_time]` (both inclusive) — matched on
+    /// `close_time`, the field consumers receive (see
+    /// [`Candle::close_time`](crate::subscription::candle::Candle)). Hyperliquid's
+    /// API natively filters by the candle's open-time bucket, so this method
+    /// widens the request by one interval and trims the result by `close_time` to
+    /// honour the contract uniformly with the library's other historical fetches.
+    ///
     /// # Arguments
     ///
     /// * `request` - Historical data request parameters
@@ -78,7 +91,8 @@ impl HyperliquidHistoricalData {
     ///
     /// # Errors
     ///
-    /// Returns `DataError::Socket` if the API request fails.
+    /// Returns `DataError::Socket` if the API request fails or a candle's
+    /// `close_time` cannot be computed (overflow).
     pub async fn fetch_candles(
         &self,
         request: HistoricalRequest,
@@ -91,8 +105,22 @@ impl HyperliquidHistoricalData {
             "Fetching historical candles"
         );
 
+        let step = request.interval.to_step();
+
+        // Range contract: callers receive candles whose `close_time ∈ [start, end]`.
+        // Hyperliquid filters by the candle's native open-time bucket
+        // `[open, open + interval)`, NOT by our normalised `close_time`, so the
+        // candle whose `close_time == start` (open == start − interval) would be
+        // dropped. Widen the request lower bound by one interval to capture it,
+        // then trim the result by `close_time` below.
+        // `None` (underflow near DateTime::MIN_UTC) is not an error: the boundary
+        // candle would have an unrepresentable open and so cannot exist, making the
+        // un-widened bound already correct. See `open_time_from_close`.
+        let request_start =
+            open_time_from_close(request.start_time, step).unwrap_or(request.start_time);
+
         #[allow(clippy::cast_sign_loss)] // Timestamps after 1970 are always positive
-        let start_ms = request.start_time.timestamp_millis() as u64;
+        let start_ms = request_start.timestamp_millis() as u64;
         #[allow(clippy::cast_sign_loss)] // Timestamps after 1970 are always positive
         let end_ms = request.end_time.timestamp_millis() as u64;
 
@@ -109,7 +137,12 @@ impl HyperliquidHistoricalData {
 
         let mut candles = Vec::with_capacity(response.len());
         for sdk_candle in response {
-            candles.push(sdk_candle_to_candle(&sdk_candle)?);
+            let candle = sdk_candle_to_candle(&sdk_candle, request.interval)?;
+            // Trim to the close_time range contract (the venue may return one
+            // extra candle past either boundary due to open-bucket filtering).
+            if candle.close_time >= request.start_time && candle.close_time <= request.end_time {
+                candles.push(candle);
+            }
         }
 
         debug!(coin = %request.coin, count = candles.len(), "Received historical candles");
@@ -213,21 +246,57 @@ impl CandleInterval {
             Self::Month1 => "1M",
         }
     }
+
+    /// Map this interval to the shared [`IntervalStep`] used to compute a
+    /// candle's exclusive `close_time` boundary. All Hyperliquid intervals are
+    /// fixed-length except `1M`, which is a calendar month.
+    fn to_step(self) -> IntervalStep {
+        match self {
+            Self::Min1 => IntervalStep::Fixed(Duration::minutes(1)),
+            Self::Min3 => IntervalStep::Fixed(Duration::minutes(3)),
+            Self::Min5 => IntervalStep::Fixed(Duration::minutes(5)),
+            Self::Min15 => IntervalStep::Fixed(Duration::minutes(15)),
+            Self::Min30 => IntervalStep::Fixed(Duration::minutes(30)),
+            Self::Hour1 => IntervalStep::Fixed(Duration::hours(1)),
+            Self::Hour2 => IntervalStep::Fixed(Duration::hours(2)),
+            Self::Hour4 => IntervalStep::Fixed(Duration::hours(4)),
+            Self::Hour8 => IntervalStep::Fixed(Duration::hours(8)),
+            Self::Hour12 => IntervalStep::Fixed(Duration::hours(12)),
+            Self::Day1 => IntervalStep::Fixed(Duration::days(1)),
+            Self::Day3 => IntervalStep::Fixed(Duration::days(3)),
+            Self::Week1 => IntervalStep::Fixed(Duration::weeks(1)),
+            Self::Month1 => IntervalStep::Months(1),
+        }
+    }
 }
 
 /// Convert SDK's `CandlesSnapshotResponse` to rustrade's `Candle`.
+///
+/// `close_time` is computed library-side as the exclusive end-of-period boundary
+/// (`time_open + interval`) via the shared [`close_time_from_open`] helper — the
+/// venue's raw `time_close` is **discarded** because Hyperliquid reports it as
+/// `period-end − 1ms` (the inclusive-last-ms convention, verified against the live
+/// `candleSnapshot` API), which does not satisfy the [`Candle`] contract.
 fn sdk_candle_to_candle(
     sdk: &hyperliquid_rust_sdk::CandlesSnapshotResponse,
+    interval: CandleInterval,
 ) -> Result<Candle, DataError> {
-    let close_time = Utc
-        .timestamp_millis_opt(sdk.time_close as i64)
+    let open_time = Utc
+        .timestamp_millis_opt(sdk.time_open as i64)
         .single()
         .ok_or_else(|| {
             DataError::Socket(format!(
-                "Hyperliquid timestamp {} out of range",
-                sdk.time_close
+                "Hyperliquid open timestamp {} out of range",
+                sdk.time_open
             ))
         })?;
+
+    let close_time = close_time_from_open(open_time, interval.to_step()).ok_or_else(|| {
+        DataError::Socket(format!(
+            "Hyperliquid candle close_time overflow: open={open_time}, interval={}",
+            interval.as_str()
+        ))
+    })?;
 
     let open = sdk
         .open
@@ -290,12 +359,17 @@ mod tests {
     }
 
     #[test]
-    fn test_sdk_candle_to_candle() {
+    fn test_sdk_candle_to_candle_normalises_close_time_from_open() {
         use rust_decimal_macros::dec;
 
+        // Hyperliquid reports `time_close` as `time_open + interval − 1ms` (the
+        // inclusive-last-ms convention, verified against the live API). The
+        // library must IGNORE that raw value and compute the exclusive boundary
+        // `time_open + interval`. Here time_open = 2024-01-01 00:00:00 UTC and the
+        // raw venue time_close is the `−1ms` value, which must NOT be used.
         let sdk_candle = hyperliquid_rust_sdk::CandlesSnapshotResponse {
-            time_open: 1704067200000,
-            time_close: 1704070800000,
+            time_open: 1_704_067_200_000,  // 2024-01-01 00:00:00.000 UTC
+            time_close: 1_704_070_799_999, // 2024-01-01 00:59:59.999 UTC (1h − 1ms; ignored)
             coin: "BTC".to_string(),
             candle_interval: "1h".to_string(),
             open: "45000.5".to_string(),
@@ -306,13 +380,38 @@ mod tests {
             num_trades: 5000,
         };
 
-        let candle = sdk_candle_to_candle(&sdk_candle).unwrap();
+        let candle = sdk_candle_to_candle(&sdk_candle, CandleInterval::Hour1).unwrap();
 
+        // Normalised boundary: exactly time_open + 1h, NOT the raw −1ms value.
+        assert_eq!(candle.close_time.timestamp_millis(), 1_704_070_800_000);
         assert_eq!(candle.open, dec!(45000.5));
         assert_eq!(candle.high, dec!(45500.0));
         assert_eq!(candle.low, dec!(44800.0));
         assert_eq!(candle.close, dec!(45250.0));
         assert_eq!(candle.volume, dec!(1234.56));
         assert_eq!(candle.trade_count, 5000);
+    }
+
+    #[test]
+    fn test_sdk_candle_to_candle_monthly_calendar_boundary() {
+        // A January monthly bar must close at Feb 1 00:00 UTC via calendar
+        // arithmetic (Months(1)), not open + 30 days.
+        let sdk_candle = hyperliquid_rust_sdk::CandlesSnapshotResponse {
+            time_open: 1_704_067_200_000,  // 2024-01-01 00:00:00 UTC
+            time_close: 1_706_745_599_999, // raw venue value (ignored)
+            coin: "BTC".to_string(),
+            candle_interval: "1M".to_string(),
+            open: "45000.0".to_string(),
+            high: "45000.0".to_string(),
+            low: "45000.0".to_string(),
+            close: "45000.0".to_string(),
+            vlm: "1.0".to_string(),
+            num_trades: 1,
+        };
+
+        let candle = sdk_candle_to_candle(&sdk_candle, CandleInterval::Month1).unwrap();
+
+        // 2024-02-01 00:00:00 UTC.
+        assert_eq!(candle.close_time.timestamp_millis(), 1_706_745_600_000);
     }
 }

--- a/rustrade-data/src/exchange/ibkr/historical.rs
+++ b/rustrade-data/src/exchange/ibkr/historical.rs
@@ -59,9 +59,13 @@ use super::options::{OptionChainEntry, OptionGreeks};
 use crate::{
     books::Level,
     error::DataError,
-    subscription::{book::OrderBookL1, candle::Candle, trade::PublicTrade},
+    subscription::{
+        book::OrderBookL1,
+        candle::{Candle, IntervalStep, close_time_from_open},
+        trade::PublicTrade,
+    },
 };
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use ibapi::{
     client::blocking::Client,
     contracts::{Contract, SecurityType},
@@ -180,10 +184,15 @@ impl IbkrHistoricalData {
     /// - IB rate-limits historical data requests (pacing violations)
     /// - Some data requires paid market data subscriptions
     /// - Volume and trade count are only available for `WhatToShow::Trades`
-    /// - For daily/weekly/monthly bar sizes, IB returns a calendar date with no
-    ///   time component, so each candle's `close_time` is anchored to `00:00:00`
-    ///   UTC of that date — it does **not** represent the exchange session close.
-    ///   Intraday bar sizes carry a full timestamp and are unaffected.
+    /// - Each candle's `close_time` is the exclusive end-of-period boundary
+    ///   `bar_open + interval`, **not** the bar's own start (IB returns the start)
+    ///   and **not** the exchange session close (the library has no session
+    ///   calendar). For daily/weekly/monthly bars this is the **next** UTC period
+    ///   start: a Jan 15 daily bar → `close_time = Jan 16 00:00 UTC`; a January
+    ///   monthly bar → `Feb 1 00:00 UTC` (calendar arithmetic). The bar's own date
+    ///   is `close_time − interval`, so do **not** compare daily bars by
+    ///   `close_time.date()` — it shifts forward by one interval. See
+    ///   [`Candle::close_time`](crate::subscription::candle::Candle).
     pub async fn fetch_candles(
         &self,
         request: HistoricalRequest,
@@ -222,7 +231,7 @@ impl IbkrHistoricalData {
 
             let mut candles = Vec::with_capacity(historical_data.bars.len());
             for bar in &historical_data.bars {
-                candles.push(bar_to_candle(bar)?);
+                candles.push(bar_to_candle(bar, request.bar_size)?);
             }
 
             Ok::<_, DataError>(candles)
@@ -903,29 +912,88 @@ fn tick_bid_ask_to_order_book_l1(tick: &TickBidAsk) -> Option<OrderBookL1> {
     })
 }
 
-/// Convert an ibapi `Bar` to a rustrade `Candle`.
+/// Map an ibapi [`BarSize`] to the shared [`IntervalStep`] used to compute a
+/// candle's exclusive `close_time` boundary.
 ///
-/// Note: `Bar::wap` (volume-weighted average price) is not mapped to `Candle`
-/// as rustrade's `Candle` type does not include VWAP.
+/// Every bar size is a fixed-length step except `Month`, which is a calendar
+/// month (variable length) and must use [`IntervalStep::Months`]. A `Day`/`Week`
+/// step is fixed but can still cross a month boundary (e.g. a Jan 31 daily bar →
+/// `Feb 1 00:00 UTC`).
+fn bar_size_to_step(bar_size: BarSize) -> IntervalStep {
+    match bar_size {
+        BarSize::Sec => IntervalStep::Fixed(ChronoDuration::seconds(1)),
+        BarSize::Sec5 => IntervalStep::Fixed(ChronoDuration::seconds(5)),
+        BarSize::Sec10 => IntervalStep::Fixed(ChronoDuration::seconds(10)),
+        BarSize::Sec15 => IntervalStep::Fixed(ChronoDuration::seconds(15)),
+        BarSize::Sec30 => IntervalStep::Fixed(ChronoDuration::seconds(30)),
+        BarSize::Min => IntervalStep::Fixed(ChronoDuration::minutes(1)),
+        BarSize::Min2 => IntervalStep::Fixed(ChronoDuration::minutes(2)),
+        BarSize::Min3 => IntervalStep::Fixed(ChronoDuration::minutes(3)),
+        BarSize::Min5 => IntervalStep::Fixed(ChronoDuration::minutes(5)),
+        BarSize::Min10 => IntervalStep::Fixed(ChronoDuration::minutes(10)),
+        BarSize::Min15 => IntervalStep::Fixed(ChronoDuration::minutes(15)),
+        BarSize::Min20 => IntervalStep::Fixed(ChronoDuration::minutes(20)),
+        BarSize::Min30 => IntervalStep::Fixed(ChronoDuration::minutes(30)),
+        BarSize::Hour => IntervalStep::Fixed(ChronoDuration::hours(1)),
+        BarSize::Hour2 => IntervalStep::Fixed(ChronoDuration::hours(2)),
+        BarSize::Hour3 => IntervalStep::Fixed(ChronoDuration::hours(3)),
+        BarSize::Hour4 => IntervalStep::Fixed(ChronoDuration::hours(4)),
+        BarSize::Hour8 => IntervalStep::Fixed(ChronoDuration::hours(8)),
+        BarSize::Day => IntervalStep::Fixed(ChronoDuration::days(1)),
+        BarSize::Week => IntervalStep::Fixed(ChronoDuration::weeks(1)),
+        BarSize::Month => IntervalStep::Months(1),
+    }
+}
+
+/// Convert an ibapi `Bar` to a rustrade [`Candle`].
 ///
-/// Returns `Err(DataError::Socket(...))` if any price/volume value cannot be
-/// converted to Decimal (e.g., NaN, Infinity from the IB API).
-fn bar_to_candle(bar: &ibapi::market_data::historical::Bar) -> Result<Candle, DataError> {
+/// `Bar.date` is the bar's **open** instant; the returned [`Candle::close_time`]
+/// is the exclusive end-of-period boundary `open + interval`, computed via the
+/// shared [`close_time_from_open`] helper from the requested `bar_size`.
+///
+/// Consequences of the boundary contract for IBKR consumers:
+/// - **Daily/weekly/monthly** bars carry a calendar `Date` (anchored to midnight
+///   UTC). The boundary is the **next** UTC period start, **not** the exchange
+///   session close — e.g. a Jan 15 daily bar → `close_time = Jan 16 00:00 UTC`,
+///   and a monthly Jan bar → `Feb 1 00:00 UTC` (calendar arithmetic, not
+///   `+ Duration`). The bar's own date is therefore `close_time − interval`;
+///   `close_time.date()` no longer equals the bar's date, so any
+///   `group_by(close_time.date())` shifts by one interval. Do **not** compare
+///   daily bars by `close_time.date()`.
+/// - **Intraday** bars carry a full `OffsetDateTime`; the boundary is `open + interval`.
+///
+/// Note: `Bar::wap` (volume-weighted average price) is not mapped — rustrade's
+/// `Candle` has no VWAP field.
+///
+/// # Errors
+///
+/// Returns `Err(DataError::Socket(...))` if the open timestamp or the computed
+/// `close_time` falls outside the representable [`DateTime<Utc>`] range, or if any
+/// price/volume value cannot be converted to `Decimal` (e.g. NaN/Infinity).
+fn bar_to_candle(
+    bar: &ibapi::market_data::historical::Bar,
+    bar_size: BarSize,
+) -> Result<Candle, DataError> {
     use ibapi::market_data::historical::BarTimestamp;
 
-    // ibapi 3.0 models `Bar.date` as a `BarTimestamp` enum: daily/weekly/monthly
-    // bars carry a calendar `Date` (anchored here to midnight UTC), intraday bars
-    // a full `OffsetDateTime`. NOTE: for date-only bars `close_time` is therefore
-    // 00:00:00 UTC of the bar's date, NOT the exchange session close — consumers
-    // must not treat it as a session-close timestamp and should compare daily
-    // bars by date, not by the full timestamp.
+    // `Bar.date` is the bar's OPEN instant: daily/weekly/monthly bars carry a
+    // calendar `Date` (anchored here to midnight UTC), intraday bars a full
+    // `OffsetDateTime`.
     let (secs, nanos) = match bar.date {
         BarTimestamp::DateTime(dt) => (dt.unix_timestamp(), dt.nanosecond()),
         BarTimestamp::Date(d) => (d.midnight().assume_utc().unix_timestamp(), 0),
     };
-    let close_time = DateTime::from_timestamp(secs, nanos).ok_or_else(|| {
+    let open_time = DateTime::from_timestamp(secs, nanos).ok_or_else(|| {
         DataError::Socket(format!("IB timestamp {secs} out of DateTime<Utc> range"))
     })?;
+
+    // close_time is the exclusive end-of-period boundary (open + interval).
+    let close_time =
+        close_time_from_open(open_time, bar_size_to_step(bar_size)).ok_or_else(|| {
+            DataError::Socket(format!(
+                "IB candle close_time overflow: open={open_time}, bar_size={bar_size:?}"
+            ))
+        })?;
 
     let open =
         Decimal::try_from(bar.open).map_err(|e| DataError::Socket(format!("parse open: {e}")))?;
@@ -955,16 +1023,15 @@ fn bar_to_candle(bar: &ibapi::market_data::historical::Bar) -> Result<Candle, Da
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use chrono::Datelike;
+    use chrono::{Datelike, Timelike};
     use time::macros::datetime;
 
-    #[test]
-    fn bar_to_candle_converts_all_fields() {
-        use rust_decimal_macros::dec;
-
-        let date = datetime!(2024-01-15 16:00 UTC);
-        let bar = ibapi::market_data::historical::Bar {
-            date: date.into(),
+    /// Build an ibapi `Bar` at the given `BarTimestamp` with placeholder OHLCV.
+    fn bar_at(
+        date: ibapi::market_data::historical::BarTimestamp,
+    ) -> ibapi::market_data::historical::Bar {
+        ibapi::market_data::historical::Bar {
+            date,
             open: 150.0,
             high: 155.0,
             low: 149.0,
@@ -972,9 +1039,18 @@ mod tests {
             volume: 1_000_000.0,
             wap: 152.0,
             count: 50_000,
-        };
+        }
+    }
 
-        let candle = bar_to_candle(&bar).unwrap();
+    #[test]
+    fn bar_to_candle_converts_all_fields() {
+        use rust_decimal_macros::dec;
+
+        // Intraday hourly bar opening at 16:00 → close_time = open + 1h = 17:00.
+        let open = datetime!(2024-01-15 16:00 UTC);
+        let bar = bar_at(open.into());
+
+        let candle = bar_to_candle(&bar, BarSize::Hour).unwrap();
 
         assert_eq!(candle.open, dec!(150));
         assert_eq!(candle.high, dec!(155));
@@ -983,30 +1059,70 @@ mod tests {
         assert_eq!(candle.volume, dec!(1_000_000));
         assert_eq!(candle.trade_count, 50_000);
 
-        // Check timestamp conversion
-        assert_eq!(candle.close_time.year(), 2024);
-        assert_eq!(candle.close_time.month(), 1); // January = 1
-        assert_eq!(candle.close_time.day(), 15);
-        assert_eq!(candle.close_time.timestamp(), date.unix_timestamp());
+        // close_time is the exclusive boundary: open + 1 hour.
+        assert_eq!(
+            candle.close_time,
+            DateTime::from_timestamp(open.unix_timestamp(), 0).unwrap() + ChronoDuration::hours(1)
+        );
+        assert_eq!(candle.close_time.hour(), 17);
     }
 
     #[test]
     fn bar_to_candle_handles_negative_count() {
-        let bar = ibapi::market_data::historical::Bar {
-            date: datetime!(2024-01-15 16:00 UTC).into(),
-            open: 100.0,
-            high: 100.0,
-            low: 100.0,
-            close: 100.0,
-            volume: 0.0,
-            wap: 0.0,
-            count: -1, // IB sometimes returns -1 for "not available"
-        };
+        let mut bar = bar_at(datetime!(2024-01-15 16:00 UTC).into());
+        bar.count = -1; // IB sometimes returns -1 for "not available"
 
-        let candle = bar_to_candle(&bar).unwrap();
+        let candle = bar_to_candle(&bar, BarSize::Hour).unwrap();
 
         // Negative count should clamp to 0
         assert_eq!(candle.trade_count, 0);
+    }
+
+    #[test]
+    fn bar_to_candle_daily_boundary_is_next_day() {
+        use ibapi::market_data::historical::BarTimestamp;
+        use time::macros::date;
+
+        // A Jan 15 daily bar (date-only, midnight UTC) → close_time = Jan 16 00:00 UTC.
+        let bar = bar_at(BarTimestamp::Date(date!(2024 - 01 - 15)));
+        let candle = bar_to_candle(&bar, BarSize::Day).unwrap();
+
+        assert_eq!(candle.close_time.year(), 2024);
+        assert_eq!(candle.close_time.month(), 1);
+        assert_eq!(candle.close_time.day(), 16);
+        assert_eq!(candle.close_time.hour(), 0);
+        // close_time.date() no longer equals the bar's own date (it shifted +1 day).
+        assert_ne!(candle.close_time.day(), 15);
+    }
+
+    #[test]
+    fn bar_to_candle_daily_boundary_crosses_month() {
+        use ibapi::market_data::historical::BarTimestamp;
+        use time::macros::date;
+
+        // A Jan 31 daily bar → Feb 1 00:00 UTC via Fixed(1 day).
+        let bar = bar_at(BarTimestamp::Date(date!(2024 - 01 - 31)));
+        let candle = bar_to_candle(&bar, BarSize::Day).unwrap();
+
+        assert_eq!(candle.close_time.month(), 2);
+        assert_eq!(candle.close_time.day(), 1);
+    }
+
+    #[test]
+    fn bar_to_candle_monthly_boundary_is_calendar_month() {
+        use ibapi::market_data::historical::BarTimestamp;
+        use time::macros::date;
+
+        // A January monthly bar → Feb 1 00:00 UTC via Months(1), NOT +30 days.
+        let bar = bar_at(BarTimestamp::Date(date!(2024 - 01 - 01)));
+        let candle = bar_to_candle(&bar, BarSize::Month).unwrap();
+
+        assert_eq!(candle.close_time.year(), 2024);
+        assert_eq!(candle.close_time.month(), 2);
+        assert_eq!(candle.close_time.day(), 1);
+        // Overflow / out-of-range boundary is surfaced as DataError, never a
+        // silent fallback — covered directly by the helper's unit tests
+        // (`close_time_from_open` returns None → DataError here).
     }
 
     #[test]

--- a/rustrade-data/src/exchange/ibkr/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/mod.rs
@@ -31,7 +31,7 @@
 //! # Architecture
 //!
 //! Unlike WebSocket-based exchanges, IB uses TCP sockets with a blocking API.
-//! This module implements [`Stream`] directly rather than using the [`Connector`]
+//! This module implements [`Stream`](futures::Stream) directly rather than using the [`Connector`]
 //! trait designed for WebSocket exchanges.
 //!
 //! # Supported Data Types

--- a/rustrade-data/src/exchange/massive/live.rs
+++ b/rustrade-data/src/exchange/massive/live.rs
@@ -1,6 +1,6 @@
 //! WebSocket live streaming client for Massive real-time market data.
 //!
-//! Provides real-time market data streaming via [`MassiveLive`].
+//! Provides real-time market data streaming via [`MassiveLive`](crate::exchange::massive::MassiveLive).
 //!
 //! # Architecture
 //!

--- a/rustrade-data/src/exchange/massive/mod.rs
+++ b/rustrade-data/src/exchange/massive/mod.rs
@@ -26,8 +26,8 @@
 //!
 //! # Architecture
 //!
-//! - [`MassiveRestClient`]: Historical and intraday data via REST API
-//! - [`MassiveLive`]: Real-time streaming via WebSocket
+//! - [`MassiveRestClient`](crate::exchange::massive::MassiveRestClient): Historical and intraday data via REST API
+//! - [`MassiveLive`](crate::exchange::massive::MassiveLive): Real-time streaming via WebSocket
 //!
 //! # Authentication
 //!

--- a/rustrade-data/src/exchange/massive/rest.rs
+++ b/rustrade-data/src/exchange/massive/rest.rs
@@ -5,9 +5,13 @@
 use super::error::MassiveError;
 use super::transformer::{
     AggregatesResponse, QuotesResponse, TradesResponse, parse_aggregates_response,
-    parse_quotes_response, parse_trades_response, timespan_to_duration,
+    parse_quotes_response, parse_trades_response, timespan_to_step,
 };
-use crate::subscription::{book::OrderBookL1, candle::Candle, trade::PublicTrade};
+use crate::subscription::{
+    book::OrderBookL1,
+    candle::{Candle, open_time_from_close},
+    trade::PublicTrade,
+};
 use async_stream::try_stream;
 use futures::Stream;
 use reqwest::{Client, StatusCode, header};
@@ -181,6 +185,22 @@ impl MassiveRestClient {
     /// Returns a stream that handles pagination automatically. Does not collect
     /// results into memory — processes each page as it arrives.
     ///
+    /// Each [`Candle`]'s `close_time` is the exclusive end-of-period boundary
+    /// `bar_open + interval` (see [`Candle::close_time`](crate::subscription::candle::Candle)).
+    /// Fixed units (`second`…`week`) are exact in UTC; **calendar units
+    /// (`month`/`quarter`/`year`) use leap-year-correct calendar arithmetic** —
+    /// e.g. a January monthly bar closes at `Feb 1 00:00 UTC`, aligning with
+    /// Binance `1M` / IBKR monthly boundaries (previously an approximate
+    /// `+30/91/365 days`).
+    ///
+    /// # Range contract
+    ///
+    /// Yields exactly the candles whose `close_time ∈ [from, to]` (both inclusive),
+    /// matched on `close_time` — the field consumers receive. Massive's endpoint
+    /// natively filters by the bar's open-time, so this method widens the request
+    /// by one interval and trims by `close_time`, consistent with the library's
+    /// other historical fetches.
+    ///
     /// # Arguments
     ///
     /// * `ticker` - Symbol with asset class prefix (e.g., `X:BTCUSD`, `C:EURUSD`, `AAPL`)
@@ -205,7 +225,21 @@ impl MassiveRestClient {
         try_stream! {
             Self::validate_ticker(ticker)?;
 
-            let from_ms = from.timestamp_millis();
+            // Map the interval to a step once; the boundary is still computed
+            // per-bar (calendar months are variable-length, so a single Duration
+            // for the whole stream would be wrong for month/quarter/year).
+            let bar_step = timespan_to_step(multiplier, timespan);
+
+            // Range contract: yield candles whose `close_time ∈ [from, to]`. The
+            // Massive (Polygon) endpoint filters by the bar's open-time, so widen
+            // the lower bound by one interval to capture the candle whose
+            // `close_time == from` (open == from − interval), then trim by
+            // `close_time` below — consistent with the library's other fetches.
+            // `None` (underflow near DateTime::MIN_UTC) is not an error: the boundary
+            // candle would have an unrepresentable open and so cannot exist, making
+            // the un-widened bound already correct. See `open_time_from_close`.
+            let request_from = open_time_from_close(from, bar_step).unwrap_or(from);
+            let from_ms = request_from.timestamp_millis();
             let to_ms = to.timestamp_millis();
 
             let initial_url = format!(
@@ -214,9 +248,6 @@ impl MassiveRestClient {
             );
 
             let mut next_url: Option<String> = Some(initial_url);
-
-            // Pre-compute duration once for all bars in this stream
-            let bar_duration = timespan_to_duration(multiplier, timespan);
 
             while let Some(url) = next_url.take() {
                 debug!(url = %url, "Fetching aggregates page");
@@ -231,7 +262,10 @@ impl MassiveRestClient {
 
                 if let Some(results) = parsed.results {
                     for bar in results {
-                        yield bar.into_candle_with_duration(bar_duration);
+                        let candle = bar.into_candle_with_step(bar_step)?;
+                        if candle.close_time >= from && candle.close_time <= to {
+                            yield candle;
+                        }
                     }
                 }
 

--- a/rustrade-data/src/exchange/massive/transformer.rs
+++ b/rustrade-data/src/exchange/massive/transformer.rs
@@ -3,7 +3,11 @@
 use super::error::MassiveError;
 use crate::{
     books::Level,
-    subscription::{book::OrderBookL1, candle::Candle, trade::PublicTrade},
+    subscription::{
+        book::OrderBookL1,
+        candle::{Candle, IntervalStep, close_time_from_open},
+        trade::PublicTrade,
+    },
 };
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use rust_decimal::Decimal;
@@ -114,20 +118,36 @@ pub struct AggregateBar {
 }
 
 impl AggregateBar {
-    /// Convert to rustrade Candle type.
+    /// Convert to rustrade [`Candle`], mapping `(multiplier, timespan)` to the
+    /// shared [`IntervalStep`].
     ///
-    /// The `close_time` is calculated as `timestamp + (multiplier * timespan_duration)`.
-    #[allow(dead_code)] // Public API; internal code uses into_candle_with_duration
-    pub fn into_candle(self, multiplier: u32, timespan: &str) -> Candle {
-        let duration = timespan_to_duration(multiplier, timespan);
-        self.into_candle_with_duration(duration)
+    /// `close_time` is the exclusive end-of-period boundary `open + interval`,
+    /// computed per-bar via [`close_time_from_open`] — calendar intervals
+    /// (`month`/`quarter`/`year`) therefore use leap-year-correct month
+    /// arithmetic, not an approximate fixed `Duration`.
+    // Public convenience API; the internal REST stream uses `into_candle_with_step`
+    // (pre-computes the step once per stream), so this is unused in-crate.
+    #[allow(dead_code)]
+    pub fn into_candle(self, multiplier: u32, timespan: &str) -> Result<Candle, MassiveError> {
+        self.into_candle_with_step(timespan_to_step(multiplier, timespan))
     }
 
-    /// Convert to rustrade Candle type with a pre-computed duration.
+    /// Convert to rustrade [`Candle`] with a pre-computed [`IntervalStep`].
     ///
-    /// Use this variant when processing multiple bars with the same timespan
-    /// to avoid recomputing the duration for each bar.
-    pub fn into_candle_with_duration(self, duration: Duration) -> Candle {
+    /// Use this variant when processing multiple bars with the same timespan to
+    /// avoid recomputing the step for each bar. The step is still applied
+    /// **per-bar** (`close_time_from_open(open, step)`) because calendar months
+    /// are variable-length — a single pre-computed `Duration` for the whole
+    /// stream would be wrong for `month`/`quarter`/`year`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MassiveError::InvalidInput`] if the computed `close_time`
+    /// overflows the representable [`DateTime<Utc>`] range. An un-parseable
+    /// *input* `timestamp` is, by contrast, tolerated with a warning and
+    /// `UNIX_EPOCH` (preserving prior behaviour) — only a computed *boundary*
+    /// overflow is a hard error.
+    pub fn into_candle_with_step(self, step: IntervalStep) -> Result<Candle, MassiveError> {
         let start_time = Utc
             .timestamp_millis_opt(self.timestamp)
             .single()
@@ -138,9 +158,12 @@ impl AggregateBar {
                 );
                 DateTime::<Utc>::UNIX_EPOCH
             });
-        let close_time = start_time + duration;
+        let close_time =
+            close_time_from_open(start_time, step).ok_or_else(|| MassiveError::InvalidInput {
+                message: format!("candle close_time overflow: open={start_time}, step={step:?}"),
+            })?;
 
-        Candle {
+        Ok(Candle {
             close_time,
             open: self.open,
             high: self.high,
@@ -148,7 +171,7 @@ impl AggregateBar {
             close: self.close,
             volume: self.volume,
             trade_count: self.trade_count.unwrap_or(0),
-        }
+        })
     }
 }
 
@@ -160,21 +183,26 @@ pub fn parse_aggregates_response(body: &str) -> Result<AggregatesResponse, Massi
     })
 }
 
-/// Convert timespan string to chrono Duration.
-pub fn timespan_to_duration(multiplier: u32, timespan: &str) -> Duration {
-    let mult = multiplier as i64;
+/// Map a Massive `(multiplier, timespan)` to the shared [`IntervalStep`].
+///
+/// Fixed-length units (`second`…`week`) become [`IntervalStep::Fixed`], exact in
+/// UTC. Calendar units (`month`/`quarter`/`year`) become [`IntervalStep::Months`]
+/// (1 / 3 / 12 months per multiplier) so the boundary uses leap-year-correct
+/// calendar arithmetic instead of the previous approximate `+30/91/365 days`.
+pub fn timespan_to_step(multiplier: u32, timespan: &str) -> IntervalStep {
+    let mult = i64::from(multiplier);
     match timespan {
-        "second" => Duration::seconds(mult),
-        "minute" => Duration::minutes(mult),
-        "hour" => Duration::hours(mult),
-        "day" => Duration::days(mult),
-        "week" => Duration::weeks(mult),
-        "month" => Duration::days(mult * 30),   // Approximate
-        "quarter" => Duration::days(mult * 91), // Approximate
-        "year" => Duration::days(mult * 365),   // Approximate
+        "second" => IntervalStep::Fixed(Duration::seconds(mult)),
+        "minute" => IntervalStep::Fixed(Duration::minutes(mult)),
+        "hour" => IntervalStep::Fixed(Duration::hours(mult)),
+        "day" => IntervalStep::Fixed(Duration::days(mult)),
+        "week" => IntervalStep::Fixed(Duration::weeks(mult)),
+        "month" => IntervalStep::Months(multiplier),
+        "quarter" => IntervalStep::Months(multiplier.saturating_mul(3)),
+        "year" => IntervalStep::Months(multiplier.saturating_mul(12)),
         _ => {
             tracing::warn!(timespan = %timespan, "unknown timespan, defaulting to minutes");
-            Duration::minutes(mult)
+            IntervalStep::Fixed(Duration::minutes(mult))
         }
     }
 }
@@ -629,7 +657,19 @@ pub(crate) struct WsAggregateMsg {
 }
 
 impl WsAggregateMsg {
-    /// Convert to Candle with exchange timestamp.
+    /// Convert to [`Candle`] with exchange timestamp.
+    ///
+    /// `close_time` is taken directly from the wire `end_timestamp` (`e`), which
+    /// the venue already supplies as the **exclusive end-of-period boundary**
+    /// (`e == start (s) + interval`) — for the second/minute aggregates this path
+    /// emits, `e` equals `s + 1s`/`s + 60s` exactly. It therefore satisfies the
+    /// [`Candle::close_time`] contract **without** re-normalising through
+    /// [`close_time_from_open`](crate::subscription::candle::close_time_from_open):
+    /// re-deriving a boundary the venue already provides correctly would add no
+    /// value. A regression test pins `e == s + interval` so a future wire change
+    /// can't silently drift this off the contract. (If a Massive WS aggregate ever
+    /// carried a coarser-than-minute interval, this trust assumption must be
+    /// revisited.)
     pub fn into_candle(self) -> (DateTime<Utc>, Candle) {
         let time = millis_to_datetime(self.end_timestamp);
 
@@ -812,7 +852,7 @@ mod tests {
             trade_count: Some(150),
         };
 
-        let candle = bar.into_candle(1, "minute");
+        let candle = bar.into_candle(1, "minute").unwrap();
 
         assert_eq!(candle.open, dec!(65000.0));
         assert_eq!(candle.close, dec!(65100.0));
@@ -822,6 +862,51 @@ mod tests {
         let expected_close =
             Utc.timestamp_millis_opt(1704067200000).single().unwrap() + Duration::minutes(1);
         assert_eq!(candle.close_time, expected_close);
+    }
+
+    #[test]
+    fn test_aggregate_bar_monthly_calendar_boundary() {
+        // A January monthly bar must close at Feb 1 00:00 UTC via calendar
+        // arithmetic, NOT open + 30 days (= Jan 31, the previous approximate bug).
+        // `AggregateBar` is not `Clone`, so build a fresh bar per assertion.
+        let bar_at = || AggregateBar {
+            open: dec!(65000.0),
+            high: dec!(65200.0),
+            low: dec!(64900.0),
+            close: dec!(65100.0),
+            volume: dec!(234.5678),
+            vwap: None,
+            timestamp: 1_704_067_200_000, // 2024-01-01 00:00:00 UTC
+            trade_count: Some(150),
+        };
+
+        // Month: Jan 1 -> Feb 1 (not 1704067200000 + 30d = 2024-01-31).
+        assert_eq!(
+            bar_at()
+                .into_candle(1, "month")
+                .unwrap()
+                .close_time
+                .timestamp_millis(),
+            1_706_745_600_000 // 2024-02-01 00:00:00 UTC
+        );
+        // Quarter: Jan 1 -> Apr 1.
+        assert_eq!(
+            bar_at()
+                .into_candle(1, "quarter")
+                .unwrap()
+                .close_time
+                .timestamp_millis(),
+            1_711_929_600_000 // 2024-04-01 00:00:00 UTC
+        );
+        // Year: Jan 1 -> next Jan 1.
+        assert_eq!(
+            bar_at()
+                .into_candle(1, "year")
+                .unwrap()
+                .close_time
+                .timestamp_millis(),
+            1_735_689_600_000 // 2025-01-01 00:00:00 UTC
+        );
     }
 
     #[test]
@@ -854,12 +939,31 @@ mod tests {
     }
 
     #[test]
-    fn test_timespan_to_duration() {
-        assert_eq!(timespan_to_duration(1, "second"), Duration::seconds(1));
-        assert_eq!(timespan_to_duration(5, "minute"), Duration::minutes(5));
-        assert_eq!(timespan_to_duration(1, "hour"), Duration::hours(1));
-        assert_eq!(timespan_to_duration(1, "day"), Duration::days(1));
-        assert_eq!(timespan_to_duration(1, "week"), Duration::weeks(1));
+    fn test_timespan_to_step() {
+        assert_eq!(
+            timespan_to_step(1, "second"),
+            IntervalStep::Fixed(Duration::seconds(1))
+        );
+        assert_eq!(
+            timespan_to_step(5, "minute"),
+            IntervalStep::Fixed(Duration::minutes(5))
+        );
+        assert_eq!(
+            timespan_to_step(1, "hour"),
+            IntervalStep::Fixed(Duration::hours(1))
+        );
+        assert_eq!(
+            timespan_to_step(1, "day"),
+            IntervalStep::Fixed(Duration::days(1))
+        );
+        assert_eq!(
+            timespan_to_step(1, "week"),
+            IntervalStep::Fixed(Duration::weeks(1))
+        );
+        // Calendar units map to month counts (multiplier-scaled), not Durations.
+        assert_eq!(timespan_to_step(1, "month"), IntervalStep::Months(1));
+        assert_eq!(timespan_to_step(2, "quarter"), IntervalStep::Months(6));
+        assert_eq!(timespan_to_step(1, "year"), IntervalStep::Months(12));
     }
 
     #[test]
@@ -1157,6 +1261,7 @@ mod tests {
             trade_count: Some(150),
         };
 
+        let start_ms = agg.start_timestamp;
         let (time, candle) = agg.into_candle();
 
         assert_eq!(candle.open, dec!(45200.0));
@@ -1168,6 +1273,16 @@ mod tests {
         assert_eq!(
             time,
             Utc.timestamp_millis_opt(1704067260000).single().unwrap()
+        );
+
+        // Contract lock (TG20): the venue-supplied `e` is the exclusive boundary
+        // and equals `s + interval` (here a 1-minute aggregate: s + 60_000 ms).
+        // If a future wire change drifts `e` off `s + interval`, this fails.
+        assert_eq!(candle.close_time, time);
+        assert_eq!(
+            candle.close_time.timestamp_millis(),
+            start_ms + 60_000,
+            "WS aggregate close_time must equal start (s) + 1 minute"
         );
     }
 

--- a/rustrade-data/src/subscription/candle.rs
+++ b/rustrade-data/src/subscription/candle.rs
@@ -193,6 +193,15 @@ mod tests {
 /// exactly one place (the Massive WS path uses the venue-supplied boundary
 /// directly — see [`close_time_from_open`] for the full producer list).
 ///
+/// # Using a `Candle` with the engine
+///
+/// When wrapping a `Candle` into a [`MarketEvent`](crate::event::MarketEvent) for
+/// a consuming engine (live or backtest), set
+/// [`time_exchange`](crate::event::MarketEvent::time_exchange) to this
+/// `close_time` — it is the period-END instant, the only choice that avoids
+/// lookahead (see that field's contract). The library's own candle producers
+/// already do this.
+///
 /// [`Months`]: chrono::Months
 /// [`Duration`]: chrono::Duration
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]

--- a/rustrade-data/src/subscription/candle.rs
+++ b/rustrade-data/src/subscription/candle.rs
@@ -24,7 +24,177 @@ impl std::fmt::Display for Candles {
     }
 }
 
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    /// Parse an RFC3339 UTC instant in tests.
+    fn dt(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn fixed_step_adds_duration_exactly() {
+        let open = dt("2024-01-15T12:00:00Z");
+        assert_eq!(
+            close_time_from_open(open, IntervalStep::Fixed(Duration::minutes(1))),
+            Some(dt("2024-01-15T12:01:00Z"))
+        );
+        assert_eq!(
+            close_time_from_open(open, IntervalStep::Fixed(Duration::hours(1))),
+            Some(dt("2024-01-15T13:00:00Z"))
+        );
+        // Daily/weekly are exact fixed durations in UTC (no DST).
+        assert_eq!(
+            close_time_from_open(
+                dt("2024-01-15T00:00:00Z"),
+                IntervalStep::Fixed(Duration::days(1))
+            ),
+            Some(dt("2024-01-16T00:00:00Z"))
+        );
+        assert_eq!(
+            close_time_from_open(
+                dt("2024-01-15T00:00:00Z"),
+                IntervalStep::Fixed(Duration::weeks(1))
+            ),
+            Some(dt("2024-01-22T00:00:00Z"))
+        );
+    }
+
+    #[test]
+    fn fixed_daily_step_crosses_month_boundary() {
+        // A Jan 31 daily bar closes at Feb 1 00:00 UTC via Fixed(1 day).
+        assert_eq!(
+            close_time_from_open(
+                dt("2024-01-31T00:00:00Z"),
+                IntervalStep::Fixed(Duration::days(1))
+            ),
+            Some(dt("2024-02-01T00:00:00Z"))
+        );
+    }
+
+    #[test]
+    fn months_step_uses_calendar_arithmetic() {
+        // Jan -> Feb (not +30 days = Jan 31).
+        assert_eq!(
+            close_time_from_open(dt("2024-01-01T00:00:00Z"), IntervalStep::Months(1)),
+            Some(dt("2024-02-01T00:00:00Z"))
+        );
+        // Leap-year Feb -> Mar (Feb has 29 days in 2024).
+        assert_eq!(
+            close_time_from_open(dt("2024-02-01T00:00:00Z"), IntervalStep::Months(1)),
+            Some(dt("2024-03-01T00:00:00Z"))
+        );
+        // Quarter = 3 months.
+        assert_eq!(
+            close_time_from_open(dt("2024-01-01T00:00:00Z"), IntervalStep::Months(3)),
+            Some(dt("2024-04-01T00:00:00Z"))
+        );
+        // Year = 12 months.
+        assert_eq!(
+            close_time_from_open(dt("2024-01-01T00:00:00Z"), IntervalStep::Months(12)),
+            Some(dt("2025-01-01T00:00:00Z"))
+        );
+    }
+
+    #[test]
+    fn months_step_clamps_jan_31_anchor() {
+        // Monthly bar opens always land on the 1st from all known producers, so
+        // this clamping is unreachable in practice; the test pins chrono's
+        // documented behaviour for the variable-length-month edge case.
+        // chrono clamps to the last valid day: Jan 31 + 1 month -> Feb 29 (leap year).
+        assert_eq!(
+            close_time_from_open(dt("2024-01-31T00:00:00Z"), IntervalStep::Months(1)),
+            Some(dt("2024-02-29T00:00:00Z"))
+        );
+    }
+
+    #[test]
+    fn overflow_returns_none_not_panic() {
+        let max = DateTime::<Utc>::MAX_UTC;
+        assert_eq!(close_time_from_open(max, IntervalStep::Months(1)), None);
+        assert_eq!(
+            close_time_from_open(max, IntervalStep::Fixed(Duration::days(1))),
+            None
+        );
+    }
+
+    #[test]
+    fn open_time_from_close_is_inverse() {
+        // open = close − interval, for both Fixed and Months steps.
+        assert_eq!(
+            open_time_from_close(
+                dt("2024-01-15T13:00:00Z"),
+                IntervalStep::Fixed(Duration::hours(1))
+            ),
+            Some(dt("2024-01-15T12:00:00Z"))
+        );
+        // Feb 1 close of a January monthly bar → Jan 1 open.
+        assert_eq!(
+            open_time_from_close(dt("2024-02-01T00:00:00Z"), IntervalStep::Months(1)),
+            Some(dt("2024-01-01T00:00:00Z"))
+        );
+        // Round-trip identity for the inputs this library actually produces:
+        // monthly/quarterly closes always land on a calendar 1st, where chrono's
+        // month arithmetic round-trips exactly. (It is NOT a universal identity —
+        // `Months` day-clamping is asymmetric for non-1st anchors, e.g.
+        // Feb 29 −1mo → Jan 29, +1mo → Feb 29; see `months_step_clamps_jan_31_anchor`.)
+        let close = dt("2024-04-01T00:00:00Z");
+        let open = open_time_from_close(close, IntervalStep::Months(3)).unwrap();
+        assert_eq!(
+            close_time_from_open(open, IntervalStep::Months(3)),
+            Some(close)
+        );
+    }
+
+    #[test]
+    fn open_time_from_close_underflow_returns_none() {
+        let min = DateTime::<Utc>::MIN_UTC;
+        assert_eq!(open_time_from_close(min, IntervalStep::Months(1)), None);
+        assert_eq!(
+            open_time_from_close(min, IntervalStep::Fixed(Duration::days(1))),
+            None
+        );
+    }
+}
+
 /// Normalised Barter OHLCV [`Candle`] model.
+///
+/// # `close_time` contract
+///
+/// `close_time` is the **exclusive end-of-period boundary** of the candle:
+///
+/// ```text
+/// close_time == open_time + interval
+/// ```
+///
+/// A candle aggregates the trades that fall in the **half-open interval**
+/// `[close_time − interval, close_time)` — i.e. trades with
+/// `open_time ≤ ts < close_time`. A trade landing exactly on `close_time`
+/// belongs to the **next** candle, so `close_time` equals the next candle's
+/// open instant.
+///
+/// Two distinct caveats apply to the boundary — do not conflate them:
+///
+/// - **Not session-aligned** (daily/weekly/monthly): the boundary is the UTC
+///   period grid (`day → next 00:00 UTC`, etc.), **not** an exchange session
+///   close. The library has no session calendar.
+/// - **Variable-length calendar arithmetic** (month/quarter/year only): these
+///   are nominal boundaries computed with calendar months (chrono [`Months`]),
+///   not fixed [`Duration`]s. Daily and weekly are exact fixed durations in UTC
+///   (no DST), exact to the millisecond.
+///
+/// `Candle` deliberately carries **neither `open_time` nor `interval`** — recover
+/// them from the originating fetch request / subscription resolution
+/// (`open_time ≡ close_time − interval`). Range-computing producers derive
+/// `close_time` through [`close_time_from_open`] so the boundary is defined in
+/// exactly one place (the Massive WS path uses the venue-supplied boundary
+/// directly — see [`close_time_from_open`] for the full producer list).
+///
+/// [`Months`]: chrono::Months
+/// [`Duration`]: chrono::Duration
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct Candle {
     pub close_time: DateTime<Utc>,
@@ -34,4 +204,79 @@ pub struct Candle {
     pub close: Decimal,
     pub volume: Decimal,
     pub trade_count: u64,
+}
+
+/// One step from a candle's open instant to its exclusive close boundary.
+///
+/// Keyed on a primitive step type (not on any per-exchange interval enum) so
+/// every producer — regardless of how it names its native intervals — maps to
+/// the same two cases and routes through [`close_time_from_open`]. This is the
+/// mechanism that makes the [`Candle::close_time`] contract *enforced by
+/// construction* rather than merely documented.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum IntervalStep {
+    /// A fixed-length step (seconds through weeks — exact in UTC, no DST).
+    Fixed(chrono::Duration),
+    /// A variable-length calendar step in whole months. Covers calendar
+    /// `month` (1), `quarter` (3) and `year` (12) — leap-year-correct via
+    /// chrono's [`checked_add_months`](DateTime::checked_add_months).
+    Months(u32),
+}
+
+/// Compute a candle's exclusive `close_time` boundary from its `open` instant.
+///
+/// This is the single shared boundary helper that every range-computing
+/// [`Candle`] producer routes through (Massive REST, Hyperliquid, IBKR), so the
+/// `close_time == open + interval` contract is computed in exactly one place. The
+/// Massive WS path is the lone exception: it trusts the venue-supplied boundary
+/// directly (see `WsAggregateMsg::into_candle` for the rationale).
+///
+/// - [`IntervalStep::Fixed`] adds a [`chrono::Duration`].
+/// - [`IntervalStep::Months`] uses calendar-correct month arithmetic
+///   ([`checked_add_months`](DateTime::checked_add_months)), so a Jan monthly
+///   bar yields `Feb 1 00:00 UTC` and a leap-year Feb monthly bar yields
+///   `Mar 1 00:00 UTC`.
+///
+/// # Returns
+///
+/// `None` on overflow — when the computed boundary falls outside the
+/// representable [`DateTime<Utc>`] range. Callers **must** surface this as their
+/// producer error type (an observable failure), **never** a silent fallback to a
+/// plausible-but-wrong timestamp such as `UNIX_EPOCH`.
+#[must_use]
+pub fn close_time_from_open(open: DateTime<Utc>, step: IntervalStep) -> Option<DateTime<Utc>> {
+    match step {
+        IntervalStep::Fixed(duration) => open.checked_add_signed(duration),
+        IntervalStep::Months(n) => open.checked_add_months(chrono::Months::new(n)),
+    }
+}
+
+/// Inverse of [`close_time_from_open`]: recover a candle's `open` instant from its
+/// exclusive `close_time` boundary (`open == close − interval`).
+///
+/// Used by range-bounded historical fetches to widen the venue request window:
+/// the candle whose `close_time == start` has `open == start − interval`, so a
+/// fetch that wants `close_time ∈ [start, end]` must ask the venue for opens down
+/// to `start − interval` (then trim the result by `close_time`). See
+/// [`Candle::close_time`].
+///
+/// # Returns
+///
+/// `None` on underflow (the computed open falls below the representable
+/// [`DateTime<Utc>`] range).
+///
+/// For the range-widening use-case this `None` is **not** an error: it means the
+/// candle whose `close_time == start` would have an unrepresentable open
+/// (`start − interval` below [`DateTime<Utc>`] minimum) and therefore cannot
+/// exist. Callers should fall back to the original lower bound — the un-widened
+/// fetch already yields the complete, correct result set, so this is the right
+/// outcome rather than a silent failure. (Contrast [`close_time_from_open`],
+/// whose `None` *does* signal data loss for a real candle and must be surfaced
+/// as an error.)
+#[must_use]
+pub fn open_time_from_close(close: DateTime<Utc>, step: IntervalStep) -> Option<DateTime<Utc>> {
+    match step {
+        IntervalStep::Fixed(duration) => close.checked_sub_signed(duration),
+        IntervalStep::Months(n) => close.checked_sub_months(chrono::Months::new(n)),
+    }
 }

--- a/rustrade-data/src/subscription/greeks.rs
+++ b/rustrade-data/src/subscription/greeks.rs
@@ -1,6 +1,6 @@
 //! Option Greeks subscription type.
 //!
-//! This module defines the [`OptionGreeks`] data type for option analytics
+//! This module defines the [`OptionGreeks`](crate::subscription::greeks::OptionGreeks) data type for option analytics
 //! (delta, gamma, theta, vega, implied volatility).
 //!
 //! Unlike other subscription types in this module, Greeks are typically

--- a/rustrade/examples/engine_backtest_with_candle_market_data.rs
+++ b/rustrade/examples/engine_backtest_with_candle_market_data.rs
@@ -1,0 +1,215 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
+//! Backtest driven by **candle** market data.
+//!
+//! This example exists to demonstrate two things that are easy to get wrong when
+//! feeding candles (rather than trades / L1) into the engine:
+//!
+//! 1. **`time_exchange` must be the candle's `close_time` (the period END).**
+//!    The backtest clock derives "current time" — and replays events in that
+//!    order — from each event's `time_exchange`. A candle aggregates a whole time
+//!    window; stamping its *open* would make a completed bar enter the timeline at
+//!    the instant its period *began*, i.e. silent lookahead. We compute the
+//!    boundary with the library's shared [`close_time_from_open`] helper and use it
+//!    for both `Candle::close_time` and the wrapping `MarketEvent::time_exchange`.
+//!
+//! 2. **Candles need a custom [`InstrumentDataState`].** The built-in
+//!    [`DefaultInstrumentMarketData`](rustrade::engine::state::instrument::data::DefaultInstrumentMarketData)
+//!    only tracks trades + L1 and ignores `DataKind::Candle`, so a candle-driven
+//!    engine must supply its own state. [`CandleInstrumentData`] below is a minimal
+//!    one that exposes the latest candle close as the instrument price.
+
+use chrono::{DateTime, Duration, Utc};
+use rust_decimal::Decimal;
+use rustrade::{
+    backtest::{
+        BacktestArgsConstant, BacktestArgsDynamic, backtest,
+        market_data::{BacktestMarketData, MarketDataInMemory},
+    },
+    engine::{
+        Processor,
+        state::{
+            EngineState, builder::EngineStateBuilder, global::DefaultGlobalData,
+            instrument::data::InstrumentDataState,
+            order::in_flight_recorder::InFlightRequestRecorder, trading::TradingState,
+        },
+    },
+    risk::DefaultRiskManager,
+    statistic::time::Daily,
+    strategy::DefaultStrategy,
+    system::config::SystemConfig,
+};
+use rustrade_data::{
+    event::{DataKind, MarketEvent},
+    streams::consumer::MarketStreamEvent,
+    subscription::candle::{Candle, IntervalStep, close_time_from_open},
+};
+use rustrade_execution::{
+    AccountEvent,
+    order::request::{OrderRequestCancel, OrderRequestOpen},
+};
+use rustrade_instrument::{
+    exchange::ExchangeId, index::IndexedInstruments, instrument::InstrumentIndex,
+};
+use serde::Deserialize;
+use std::{fs::File, io::BufReader, sync::Arc};
+
+const CONFIG_PATH: &str = "rustrade/examples/config/backtest_config.json";
+
+#[derive(Deserialize)]
+pub struct Config {
+    pub risk_free_return: Decimal,
+    pub system: SystemConfig,
+}
+
+#[tokio::main]
+async fn main() {
+    rustrade::logging::init_logging();
+
+    let Config {
+        risk_free_return,
+        system: SystemConfig {
+            instruments,
+            executions,
+        },
+    } = load_config();
+
+    // The backtest_config.json defines three instruments; IndexedInstruments
+    // assigns them indices in order, so BTCUSDT is InstrumentIndex(0). This
+    // example only emits candle events for BTCUSDT — ETHUSDT/SOLUSDT receive no
+    // market data, which is valid (no positions simply open on them).
+    let instruments = IndexedInstruments::new(instruments);
+
+    // Build an in-memory stream of 1h candle MarketEvents for BTCUSDT.
+    let market_events = candle_market_data();
+    let market_data = MarketDataInMemory::new(Arc::new(market_events));
+    let time_engine_start = market_data.time_first_event().await.unwrap();
+
+    // EngineState parameterised with the custom candle state (the default state
+    // would silently ignore every DataKind::Candle event).
+    let engine_state = EngineStateBuilder::new(&instruments, DefaultGlobalData, |_| {
+        CandleInstrumentData::default()
+    })
+    .time_engine_start(time_engine_start)
+    .trading_state(TradingState::Enabled)
+    .build();
+
+    let args_constant = Arc::new(BacktestArgsConstant {
+        instruments,
+        executions,
+        market_data,
+        summary_interval: Daily,
+        engine_state,
+    });
+
+    // DefaultStrategy/DefaultRiskManager are no-ops — this example demonstrates the
+    // candle → MarketEvent → engine wiring and the custom state, not a strategy.
+    let args_dynamic = BacktestArgsDynamic {
+        id: "candle-backtest-demo".into(),
+        risk_free_return,
+        strategy: DefaultStrategy::<EngineState<DefaultGlobalData, CandleInstrumentData>>::default(
+        ),
+        risk: DefaultRiskManager::<EngineState<DefaultGlobalData, CandleInstrumentData>>::default(),
+    };
+
+    let summary = backtest(args_constant, args_dynamic).await.unwrap();
+
+    println!("\nBacktest complete (BacktestId = {})", summary.id);
+    summary.trading_summary.print_summary();
+}
+
+/// Build a deterministic in-memory stream of 1-hour BTCUSDT candle events.
+///
+/// The key line is `time_exchange: candle.close_time` — the period-END instant the
+/// engine clock orders on. Open time is never used for `time_exchange`.
+fn candle_market_data() -> Vec<MarketStreamEvent<InstrumentIndex, DataKind>> {
+    // First candle opens just after the mock account's initial balance timestamp.
+    let first_open: DateTime<Utc> = "2025-03-24T22:00:00Z".parse().unwrap();
+    let step = IntervalStep::Fixed(Duration::hours(1));
+
+    (0..48)
+        .map(|i| {
+            let open_time = first_open + Duration::hours(i);
+            // Derive the exclusive period-end boundary via the shared helper, the
+            // same way the library's candle producers do.
+            let close_time = close_time_from_open(open_time, step)
+                .expect("1h candle boundary is well within DateTime<Utc> range");
+
+            // A gentle deterministic drift so the demo has price movement.
+            let close = Decimal::from(60_000) + Decimal::from(i * 25);
+            let candle = Candle {
+                close_time,
+                open: close - Decimal::from(10),
+                high: close + Decimal::from(20),
+                low: close - Decimal::from(20),
+                close,
+                volume: Decimal::from(5),
+                trade_count: 100,
+            };
+
+            MarketStreamEvent::Item(MarketEvent {
+                // Period END — see the module docs. Stamping `open_time` here would
+                // be lookahead.
+                time_exchange: candle.close_time,
+                // Synthetic: an in-memory backtest has no real receipt instant.
+                // A live producer would stamp local wall-clock here (e.g. `Utc::now()`);
+                // only `time_exchange` drives clock/replay ordering.
+                time_received: candle.close_time,
+                exchange: ExchangeId::BinanceSpot,
+                instrument: InstrumentIndex::new(0),
+                kind: DataKind::Candle(candle),
+            })
+        })
+        .collect()
+}
+
+pub fn load_config() -> Config {
+    let file = File::open(CONFIG_PATH).expect("Failed to open config file");
+    let reader = BufReader::new(file);
+    serde_json::from_reader(reader).expect("Failed to parse config file")
+}
+
+/// Minimal candle-consuming [`InstrumentDataState`].
+///
+/// Tracks the most recent [`Candle`] and exposes its `close` as the instrument
+/// price. A real strategy would maintain rolling windows, indicators, etc. — the
+/// point here is that consuming `DataKind::Candle` requires a custom state because
+/// the default one ignores it.
+#[derive(Debug, Clone, Default)]
+pub struct CandleInstrumentData {
+    pub last_candle: Option<Candle>,
+}
+
+impl InstrumentDataState for CandleInstrumentData {
+    type MarketEventKind = DataKind;
+
+    fn price(&self) -> Option<Decimal> {
+        self.last_candle.as_ref().map(|candle| candle.close)
+    }
+}
+
+impl<InstrumentKey> Processor<&MarketEvent<InstrumentKey, DataKind>> for CandleInstrumentData {
+    type Audit = ();
+
+    fn process(&mut self, event: &MarketEvent<InstrumentKey, DataKind>) -> Self::Audit {
+        if let DataKind::Candle(candle) = &event.kind {
+            self.last_candle = Some(*candle);
+        }
+    }
+}
+
+impl<ExchangeKey, AssetKey, InstrumentKey>
+    Processor<&AccountEvent<ExchangeKey, AssetKey, InstrumentKey>> for CandleInstrumentData
+{
+    type Audit = ();
+
+    fn process(&mut self, _: &AccountEvent<ExchangeKey, AssetKey, InstrumentKey>) -> Self::Audit {}
+}
+
+impl<ExchangeKey, InstrumentKey> InFlightRequestRecorder<ExchangeKey, InstrumentKey>
+    for CandleInstrumentData
+{
+    fn record_in_flight_cancel(&mut self, _: &OrderRequestCancel<ExchangeKey, InstrumentKey>) {}
+
+    fn record_in_flight_open(&mut self, _: &OrderRequestOpen<ExchangeKey, InstrumentKey>) {}
+}

--- a/rustrade/src/engine/clock.rs
+++ b/rustrade/src/engine/clock.rs
@@ -11,6 +11,11 @@ use tracing::{debug, error, warn};
 /// Generally an `Engine` will use a:
 /// * [`LiveClock`] for live-trading.
 /// * [`HistoricalClock`] for back-testing.
+///
+/// A [`HistoricalClock`] derives "current time" — and the engine replays events in
+/// that order — from each event's `time_exchange`. For aggregated payloads such as
+/// candles, `time_exchange` must be the period **end** (`close_time`) to avoid
+/// lookahead; see [`rustrade_data::event::MarketEvent::time_exchange`].
 pub trait EngineClock {
     fn time(&self) -> DateTime<Utc>;
 }
@@ -18,6 +23,9 @@ pub trait EngineClock {
 /// Defines how to extract an "exchange timestamp" from an event.
 ///
 /// Used by a [`HistoricalClock`] to assist deriving the "current" `Engine` time.
+/// The returned instant is the event's position on the engine timeline — for
+/// candles and other windowed data it is the period **end** (`close_time`); see
+/// [`rustrade_data::event::MarketEvent::time_exchange`] for the full contract.
 pub trait TimeExchange {
     fn time_exchange(&self) -> Option<DateTime<Utc>>;
 }


### PR DESCRIPTION
## Summary

Standardizes `Candle.close_time` handling across all `rustrade-data` producers so it always satisfies the contract `close_time == open_time + interval` (exclusive boundary), computed from a single source of truth rather than per-venue ad-hoc logic.

## What changed

- **Shared helpers** in `subscription/candle.rs`: `IntervalStep`, `close_time_from_open()`, and `open_time_from_close()` enforce the boundary contract by construction. Monthly/quarterly/yearly intervals use calendar-correct arithmetic (chrono `checked_add_months`) instead of fixed-day approximations.
- **Hyperliquid** (`historical.rs`): `close_time` is now derived from `time_open + interval` instead of the venue's raw `time_close`.
- **IBKR** (`historical.rs`): `close_time` is now the exclusive boundary instead of the bar's own start. ⚠️ Breaking for consumers: daily bars' `close_time` now points to the next day's midnight UTC.
- **Massive REST** (`rest.rs` / `transformer.rs`): range contract now matches on `close_time`; requests widen by one interval and trim by `close_time` to capture boundary-adjacent candles. Calendar-month handling fixed.
- **Docs & tests**: rustdoc documents the boundary contract and consumer caveats; regression tests pin the calendar arithmetic.

## Breaking changes

Consumers relying on the previous `close_time` semantics (especially daily/monthly bars from IBKR and Hyperliquid) should review the updated contract. See CHANGELOG for details.
