### PR TITLE
feat(rustrade-data): Add OrderBook liveness timestamps for every venue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     used by range-bounded fetches to widen the venue request window. It round-trips exactly for the
     closes this library produces (monthly boundaries always land on a calendar 1st); it is not a
     universal identity, since `Months` day-clamping is asymmetric for non-1st anchors.
+- **`OrderBook` liveness timestamps** (`rustrade-data`): new accessors give a maintained L2
+  `OrderBook` a usable liveness signal on every venue (previously `time_engine()` was the only
+  timestamp and was `None` for a Binance-spot book's entire life).
+  - `OrderBook::time_exchange() -> Option<DateTime<Utc>>` — the venue's latest event/broadcast time
+    (`"E"` on Binance, `ts` on Bybit). Feed-lag-aware staleness where present (`now - time_exchange`
+    catches data that is old despite being just received). `None` when the venue supplies no
+    broadcast timestamp (IBKR; Binance spot REST seed before the first diff) — a capability signal,
+    not a defect. Note the asymmetry with `MarketEvent::time_exchange` (non-`Option`, with a local
+    fallback): on `OrderBook`, `None` means "the venue gave nothing".
+  - `OrderBook::time_received() -> DateTime<Utc>` — the local ingestion wall-clock, **always
+    present** once a revision is applied, on **every** venue (including IBKR, where it is the only
+    liveness signal). The universal liveness floor; skew-immune (`now - time_received` is a
+    same-clock comparison). Prefer it as the fallback when `time_exchange()` is `None`. A
+    default/pre-population book reports the epoch (1970), so it reads as stale until the first
+    revision — the intended fail-closed behaviour.
+  - `OrderBook::times() -> OrderBookTimes` — convenience accessor returning all three revision
+    timestamps as a single `Copy` value, for forwarding the whole set in one move.
 
 ### Changed
 
@@ -175,6 +192,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrapped). Migration: pass an `IntervalStep` (via `timespan_to_step`) instead of a `Duration`, and
   handle the `Result`. The free function `timespan_to_duration` was correspondingly replaced by
   `timespan_to_step`.
+- **BREAKING (`rustrade-data`): `OrderBook` now stores a nested `OrderBookTimes` instead of a bare
+  `time_engine`.** The new public `OrderBookTimes` struct groups the three revision timestamps
+  (`time_engine` + `time_exchange` + `time_received`) and serves double duty as both the constructor
+  argument and the stored field (its named fields prevent transposing the two same-typed `Option`
+  times).
+  - `OrderBook::new` and `OrderBook::from_sides` now take an `OrderBookTimes` in place of the former
+    `time_engine: Option<DateTime<Utc>>` argument. Callers constructing `OrderBook`s directly must
+    migrate (e.g. `OrderBookTimes { time_engine, time_exchange, time_received }`, or
+    `OrderBookTimes::default()`).
+  - The serialized shape changes: the timestamps are now nested under a `times` object rather than a
+    flat `time_engine` field. (Cross-version reads of serialized `OrderBook`s are out of scope, so
+    there is no wire back-compat path.)
+  - `time_engine()`'s signature and "matching-engine time" contract are unchanged, **but its value
+    on Bybit and Hyperliquid changes from `Some(broadcast_time)` to `None`.** Those venues only
+    broadcast an event time, which previously leaked into `time_engine()` (conflating broadcast with
+    matching-engine time); it now lives solely in the new `time_exchange()`. Read `time_exchange()`
+    for that value instead.
+  - `OrderBook` equality (`PartialEq`/`Eq`) is still derived over all fields, so it now also reflects
+    `time_exchange`/`time_received`. Two content-identical books observed at different instants
+    compare **unequal** — compare via the accessors (`sequence()`/`bids()`/`asks()`) for content
+    equality.
+  - `DepthAggregator::update` (IBKR, `ibkr` feature) now takes a second argument
+    `time_received: DateTime<Utc>`, the local ingestion wall-clock stamped into the produced
+    `OrderBook`'s `time_received`. Callers must pass the same timestamp used for the wrapping
+    `MarketEvent`.
 
 ### Fixed
 

--- a/rustrade-data/src/books/mod.rs
+++ b/rustrade-data/src/books/mod.rs
@@ -13,11 +13,46 @@ pub mod manager;
 /// Provides an abstract collection of cheaply cloneable shared-state [`OrderBook`].
 pub mod map;
 
+/// Venue + local timestamps for an [`OrderBook`] revision.
+///
+/// Serves double duty as both the constructor argument
+/// ([`OrderBook::new`]/[`OrderBook::from_sides`]) and the stored field, so
+/// `update`/`snapshot` are one-line copies. The named fields prevent
+/// transposition of the two same-typed `Option<DateTime<Utc>>` times.
+///
+/// Each timestamp carries exactly one honest meaning; staleness *policy* is left
+/// to the consumer (compose over the accessors).
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Deserialize, Serialize)]
+pub struct OrderBookTimes {
+    /// Matching-engine time (`"T"` on Binance futures). `None` when the venue
+    /// doesn't supply it (Binance spot, IBKR, ...). Latency/engine audit — not a
+    /// liveness signal.
+    pub time_engine: Option<DateTime<Utc>>,
+    /// Venue event/broadcast time (`"E"` on Binance, `ts` on Bybit). `None` when
+    /// the venue supplies none (IBKR; Binance spot REST seed). Feed-lag-aware
+    /// liveness where present.
+    pub time_exchange: Option<DateTime<Utc>>,
+    /// Local ingestion wall-clock — ALWAYS present once a revision is applied.
+    /// Universal liveness floor; use when `time_exchange` is `None` (e.g. IBKR).
+    ///
+    /// NOTE: a default/pre-population book ([`OrderBook::default`], used as the
+    /// manager placeholder before the first event) carries the epoch (1970) here
+    /// — desirable for a liveness floor (reads as stale → consumer fail-closes
+    /// until the first revision), but it is NOT a real ingestion time.
+    pub time_received: DateTime<Utc>,
+}
+
 /// Normalised Barter [`OrderBook`] snapshot.
+///
+/// ### Equality
+/// `PartialEq`/`Eq` is derived over **all** fields, including the [`OrderBookTimes`]
+/// timestamps. Because `time_received` is stamped per construction, two
+/// content-identical books observed at different instants compare **unequal**. For
+/// content comparison use the accessors (`sequence()`/`bids()`/`asks()`).
 #[derive(Clone, PartialEq, Eq, Debug, Default, Deserialize, Serialize)]
 pub struct OrderBook {
     sequence: u64,
-    time_engine: Option<DateTime<Utc>>,
+    times: OrderBookTimes,
     bids: OrderBookSide<Bids>,
     asks: OrderBookSide<Asks>,
 }
@@ -28,7 +63,7 @@ impl OrderBook {
     /// Note that the passed bid and asks levels do not need to be pre-sorted.
     pub fn new<IterBids, IterAsks, L>(
         sequence: u64,
-        time_engine: Option<DateTime<Utc>>,
+        times: OrderBookTimes,
         bids: IterBids,
         asks: IterAsks,
     ) -> Self
@@ -39,7 +74,7 @@ impl OrderBook {
     {
         Self {
             sequence,
-            time_engine,
+            times,
             bids: OrderBookSide::bids(bids),
             asks: OrderBookSide::asks(asks),
         }
@@ -51,7 +86,7 @@ impl OrderBook {
     /// Caller must ensure sides are correctly sorted (bids descending, asks ascending).
     pub fn from_sides(
         sequence: u64,
-        time_engine: Option<DateTime<Utc>>,
+        times: OrderBookTimes,
         bids: OrderBookSide<Bids>,
         asks: OrderBookSide<Asks>,
     ) -> Self {
@@ -65,7 +100,7 @@ impl OrderBook {
         );
         Self {
             sequence,
-            time_engine,
+            times,
             bids,
             asks,
         }
@@ -76,22 +111,73 @@ impl OrderBook {
         self.sequence
     }
 
-    /// Current engine time associated with the [`OrderBook`].
+    /// Matching-engine time associated with the [`OrderBook`] (`"T"` on Binance
+    /// futures).
+    ///
+    /// `None` when the venue doesn't supply matching-engine time (Binance spot,
+    /// IBKR, ...). This is for latency / engine audit — **not** a liveness signal;
+    /// use [`OrderBook::time_exchange`]/[`OrderBook::time_received`] for staleness.
     pub fn time_engine(&self) -> Option<DateTime<Utc>> {
-        self.time_engine
+        self.times.time_engine
+    }
+
+    /// Venue event/broadcast time associated with the [`OrderBook`] (`"E"` on
+    /// Binance, `ts` on Bybit).
+    ///
+    /// Feed-lag-aware liveness where present: `now - time_exchange` catches data
+    /// that is old despite being just received. `None` when the venue supplies no
+    /// broadcast timestamp (IBKR; Binance spot REST seed before the first diff).
+    /// `None` is a capability signal, not a defect — fall back to
+    /// [`OrderBook::time_received`].
+    ///
+    /// Note the asymmetry with `MarketEvent::time_exchange` (non-`Option`, with a
+    /// local fallback): here `None` means "the venue gave nothing".
+    pub fn time_exchange(&self) -> Option<DateTime<Utc>> {
+        self.times.time_exchange
+    }
+
+    /// Local ingestion wall-clock associated with the [`OrderBook`].
+    ///
+    /// The **universal liveness floor** — always present once a revision is
+    /// applied, on every venue (including IBKR, where it is the only liveness
+    /// signal). Skew-immune: `now - time_received` is a same-clock comparison.
+    /// Prefer it as the fallback when [`OrderBook::time_exchange`] is `None`.
+    ///
+    /// A default/pre-population book ([`OrderBook::default`]) reports the epoch
+    /// (1970) here, so it reads as stale until the first revision — the intended
+    /// liveness-floor behaviour.
+    pub fn time_received(&self) -> DateTime<Utc> {
+        self.times.time_received
+    }
+
+    /// All revision timestamps for this [`OrderBook`] as a single
+    /// [`OrderBookTimes`].
+    ///
+    /// Convenience over the individual `time_engine`/`time_exchange`/
+    /// `time_received` accessors for forwarding the whole set in one (`Copy`) move
+    /// — e.g. reconstructing a book that shares this revision's times.
+    pub fn times(&self) -> OrderBookTimes {
+        self.times
     }
 
     /// Generate a sorted [`OrderBook`] snapshot with a maximum depth.
+    ///
+    /// The returned snapshot carries the same [`OrderBookTimes`] as the source
+    /// book (timestamps are not reset).
     pub fn snapshot(&self, depth: usize) -> Self {
         Self {
             sequence: self.sequence,
-            time_engine: self.time_engine,
+            times: self.times,
             bids: OrderBookSide::bids(self.bids.levels.iter().take(depth).copied()),
             asks: OrderBookSide::asks(self.asks.levels.iter().take(depth).copied()),
         }
     }
 
     /// Update the local [`OrderBook`] from a new [`OrderBookEvent`].
+    ///
+    /// `Update` advances the book's [`OrderBookTimes`] wholesale (alongside
+    /// upserting the changed levels); `Snapshot` replaces the book in its
+    /// entirety, including its times.
     pub fn update(&mut self, event: &OrderBookEvent) {
         match event {
             OrderBookEvent::Snapshot(snapshot) => {
@@ -99,7 +185,7 @@ impl OrderBook {
             }
             OrderBookEvent::Update(update) => {
                 self.sequence = update.sequence;
-                self.time_engine = update.time_engine;
+                self.times = update.times;
                 self.upsert_bids(&update.bids);
                 self.upsert_asks(&update.asks);
             }
@@ -342,6 +428,7 @@ pub fn volume_weighted_mid_price(best_bid: Level, best_ask: Level) -> Decimal {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
 
@@ -478,6 +565,67 @@ mod tests {
     mod order_book {
         use super::*;
         use rust_decimal_macros::dec;
+
+        fn times(received_ms: i64) -> OrderBookTimes {
+            OrderBookTimes {
+                time_engine: Some(DateTime::from_timestamp_millis(1).unwrap()),
+                time_exchange: Some(DateTime::from_timestamp_millis(2).unwrap()),
+                time_received: DateTime::from_timestamp_millis(received_ms).unwrap(),
+            }
+        }
+
+        #[test]
+        fn test_update_replaces_times_wholesale() {
+            let mut book = OrderBook::new(1, times(100), vec![Level::new(50, 1)], vec![]);
+
+            let newer = OrderBookTimes {
+                time_engine: None,
+                time_exchange: Some(DateTime::from_timestamp_millis(999).unwrap()),
+                time_received: DateTime::from_timestamp_millis(1000).unwrap(),
+            };
+            let update = OrderBook::new(2, newer, vec![Level::new(50, 1)], vec![]);
+            book.update(&OrderBookEvent::Update(update));
+
+            assert_eq!(book.time_engine(), newer.time_engine);
+            assert_eq!(book.time_exchange(), newer.time_exchange);
+            assert_eq!(book.time_received(), newer.time_received);
+        }
+
+        #[test]
+        fn test_update_snapshot_propagates_times_wholesale() {
+            // The `Snapshot` arm replaces the live book via `*self = snapshot.clone()`,
+            // so it must carry the snapshot's `times` (not retain the old ones).
+            let mut book = OrderBook::new(1, times(100), vec![Level::new(50, 1)], vec![]);
+
+            let newer = OrderBookTimes {
+                time_engine: None,
+                time_exchange: Some(DateTime::from_timestamp_millis(999).unwrap()),
+                time_received: DateTime::from_timestamp_millis(1000).unwrap(),
+            };
+            let snapshot = OrderBook::new(2, newer, vec![Level::new(60, 1)], vec![]);
+            book.update(&OrderBookEvent::Snapshot(snapshot));
+
+            assert_eq!(book.time_engine(), newer.time_engine);
+            assert_eq!(book.time_exchange(), newer.time_exchange);
+            assert_eq!(book.time_received(), newer.time_received);
+        }
+
+        #[test]
+        fn test_snapshot_copies_times() {
+            let book = OrderBook::new(1, times(100), vec![Level::new(50, 1)], vec![]);
+            let snap = book.snapshot(10);
+            assert_eq!(snap.time_engine(), book.time_engine());
+            assert_eq!(snap.time_exchange(), book.time_exchange());
+            assert_eq!(snap.time_received(), book.time_received());
+        }
+
+        #[test]
+        fn test_equality_reflects_timestamps() {
+            // Two content-identical books with different `time_received` are unequal.
+            let a = OrderBook::new(1, times(100), vec![Level::new(50, 1)], vec![]);
+            let b = OrderBook::new(1, times(200), vec![Level::new(50, 1)], vec![]);
+            assert_ne!(a, b);
+        }
 
         #[test]
         fn test_mid_price() {

--- a/rustrade-data/src/exchange/binance/book/l2.rs
+++ b/rustrade-data/src/exchange/binance/book/l2.rs
@@ -1,6 +1,9 @@
 use super::{super::channel::BinanceChannel, BinanceLevel};
 use crate::{
-    Identifier, books::OrderBook, event::MarketEvent, exchange::subscription::ExchangeSub,
+    Identifier,
+    books::{OrderBook, OrderBookTimes},
+    event::MarketEvent,
+    exchange::subscription::ExchangeSub,
     subscription::book::OrderBookEvent,
 };
 use chrono::{DateTime, Utc};
@@ -68,25 +71,34 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BinanceOrderBookL2Snapshot)
     fn from(
         (exchange, instrument, snapshot): (ExchangeId, InstrumentKey, BinanceOrderBookL2Snapshot),
     ) -> Self {
+        // `time_received` must be shared between the MarketEvent envelope and the
+        // OrderBook's `OrderBookTimes`, so the book is built here (the only scope
+        // where the binding exists) rather than via a `From<Snapshot>` that has no
+        // timestamp argument. Spot `/api/v3/depth` carries neither "E" nor "T"
+        // (both `None`) → `time_received` is the only liveness signal until the
+        // first diff sets `time_exchange`.
+        //
+        // Deliberate envelope/book asymmetry: the `MarketEvent.time_exchange`
+        // below falls back to `time_received` (its non-`Option` contract always
+        // yields a value), whereas the book's `OrderBookTimes.time_exchange` keeps
+        // the raw `snapshot.time_exchange` (`None` = "the venue gave nothing").
         let time_received = Utc::now();
         Self {
             time_exchange: snapshot.time_exchange.unwrap_or(time_received),
             time_received,
             exchange,
             instrument,
-            kind: OrderBookEvent::from(snapshot),
+            kind: OrderBookEvent::Snapshot(OrderBook::new(
+                snapshot.last_update_id,
+                OrderBookTimes {
+                    time_engine: snapshot.time_engine,
+                    time_exchange: snapshot.time_exchange,
+                    time_received,
+                },
+                snapshot.bids,
+                snapshot.asks,
+            )),
         }
-    }
-}
-
-impl From<BinanceOrderBookL2Snapshot> for OrderBookEvent {
-    fn from(snapshot: BinanceOrderBookL2Snapshot) -> Self {
-        Self::Snapshot(OrderBook::new(
-            snapshot.last_update_id,
-            snapshot.time_engine,
-            snapshot.bids,
-            snapshot.asks,
-        ))
     }
 }
 
@@ -201,6 +213,64 @@ mod tests {
                     index
                 );
             }
+        }
+    }
+
+    mod seed {
+        use super::*;
+        use rust_decimal_macros::dec;
+
+        fn snapshot(
+            time_exchange: Option<DateTime<Utc>>,
+            time_engine: Option<DateTime<Utc>>,
+        ) -> BinanceOrderBookL2Snapshot {
+            BinanceOrderBookL2Snapshot {
+                last_update_id: 1,
+                time_exchange,
+                time_engine,
+                bids: vec![BinanceLevel {
+                    price: dec!(100),
+                    amount: dec!(1),
+                }],
+                asks: vec![],
+            }
+        }
+
+        #[test]
+        fn futures_seed_carries_distinct_times_not_transposed() {
+            // Futures REST seed carries both "E" and "T": the second site (with the
+            // futures diff) where both are `Some` and differ — guards field ordering.
+            let e = DateTime::from_timestamp_millis(1589436922972).unwrap(); // "E"
+            let t = DateTime::from_timestamp_millis(1589436922959).unwrap(); // "T"
+            assert_ne!(e, t);
+
+            let event: MarketEvent<&str, OrderBookEvent> = (
+                ExchangeId::BinanceFuturesUsd,
+                "inst",
+                snapshot(Some(e), Some(t)),
+            )
+                .into();
+            let OrderBookEvent::Snapshot(book) = event.kind else {
+                panic!("expected Snapshot");
+            };
+            assert_eq!(book.time_exchange(), Some(e), "time_exchange must be \"E\"");
+            assert_eq!(book.time_engine(), Some(t), "time_engine must be \"T\"");
+            // Book's local ingestion time matches the envelope's.
+            assert_eq!(book.time_received(), event.time_received);
+        }
+
+        #[test]
+        fn spot_seed_has_no_venue_times_only_time_received() {
+            // Spot `/api/v3/depth` carries neither "E" nor "T" → both `None`;
+            // `time_received` is the only liveness signal until the first diff.
+            let event: MarketEvent<&str, OrderBookEvent> =
+                (ExchangeId::BinanceSpot, "inst", snapshot(None, None)).into();
+            let OrderBookEvent::Snapshot(book) = event.kind else {
+                panic!("expected Snapshot");
+            };
+            assert_eq!(book.time_exchange(), None);
+            assert_eq!(book.time_engine(), None);
+            assert_eq!(book.time_received(), event.time_received);
         }
     }
 }

--- a/rustrade-data/src/exchange/binance/futures/l2.rs
+++ b/rustrade-data/src/exchange/binance/futures/l2.rs
@@ -1,7 +1,7 @@
 use super::super::book::BinanceLevel;
 use crate::{
     Identifier, SnapshotFetcher,
-    books::OrderBook,
+    books::{OrderBook, OrderBookTimes},
     error::DataError,
     event::{MarketEvent, MarketIter},
     exchange::{
@@ -345,14 +345,20 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BinanceFuturesOrderBookL2Up
             BinanceFuturesOrderBookL2Update,
         ),
     ) -> Self {
+        let time_received = Utc::now();
         Self(vec![Ok(MarketEvent {
             time_exchange: update.time_exchange,
-            time_received: Utc::now(),
+            time_received,
             exchange,
             instrument,
             kind: OrderBookEvent::Update(OrderBook::new(
                 update.last_update_id,
-                Some(update.time_engine),
+                // Futures diffs carry both "T" (matching-engine) and "E" (broadcast).
+                OrderBookTimes {
+                    time_engine: Some(update.time_engine),
+                    time_exchange: Some(update.time_exchange),
+                    time_received,
+                },
                 update.bids,
                 update.asks,
             )),
@@ -366,6 +372,41 @@ mod tests {
     use super::*;
     use crate::books::Level;
     use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_futures_order_book_times_distinct_not_transposed() {
+        // Futures diffs carry BOTH "E" (broadcast) and "T" (matching-engine) time.
+        // This is one of only two sites where both are `Some` and differ, so it
+        // guards `OrderBookTimes` field ordering: a transposition would swap them.
+        let e = DateTime::from_timestamp_millis(1571889248277).unwrap(); // "E"
+        let t = DateTime::from_timestamp_millis(1571889248276).unwrap(); // "T"
+        assert_ne!(e, t);
+
+        let update = BinanceFuturesOrderBookL2Update {
+            subscription_id: SubscriptionId::from("@depth@100ms|BTCUSDT"),
+            time_exchange: e,
+            time_engine: t,
+            first_update_id: 157,
+            last_update_id: 160,
+            prev_last_update_id: 149,
+            bids: vec![BinanceLevel {
+                price: dec!(100),
+                amount: dec!(1),
+            }],
+            asks: vec![],
+        };
+
+        let MarketIter(mut events) = MarketIter::<&str, OrderBookEvent>::from((
+            ExchangeId::BinanceFuturesUsd,
+            "inst",
+            update,
+        ));
+        let OrderBookEvent::Update(book) = events.remove(0).unwrap().kind else {
+            panic!("expected Update");
+        };
+        assert_eq!(book.time_exchange(), Some(e), "time_exchange must be \"E\"");
+        assert_eq!(book.time_engine(), Some(t), "time_engine must be \"T\"");
+    }
 
     #[test]
     fn test_de_binance_futures_order_book_l2_update() {
@@ -643,7 +684,12 @@ mod tests {
                     updates_processed: 100,
                     last_update_id: 100,
                 },
-                book: OrderBook::new(0, None, vec![Level::new(50, 1)], vec![Level::new(100, 1)]),
+                book: OrderBook::new(
+                    0,
+                    OrderBookTimes::default(),
+                    vec![Level::new(50, 1)],
+                    vec![Level::new(100, 1)],
+                ),
                 input_update: BinanceFuturesOrderBookL2Update {
                     subscription_id: SubscriptionId::from("subscription_id"),
                     time_exchange: Default::default(),
@@ -656,7 +702,7 @@ mod tests {
                 },
                 expected: OrderBook::new(
                     0,
-                    None,
+                    OrderBookTimes::default(),
                     vec![Level::new(50, 1)],
                     vec![Level::new(100, 1)],
                 ),
@@ -669,7 +715,7 @@ mod tests {
                 },
                 book: OrderBook::new(
                     100,
-                    None,
+                    OrderBookTimes::default(),
                     vec![Level::new(80, 1), Level::new(100, 1), Level::new(90, 1)],
                     vec![Level::new(150, 1), Level::new(110, 1), Level::new(120, 1)],
                 ),
@@ -707,7 +753,7 @@ mod tests {
                 },
                 expected: OrderBook::new(
                     110,
-                    None,
+                    OrderBookTimes::default(),
                     vec![Level::new(100, 1), Level::new(90, 10)],
                     vec![
                         Level::new(110, 1),
@@ -724,7 +770,7 @@ mod tests {
             {
                 let rustrade_update = OrderBookEvent::Update(OrderBook::new(
                     valid_update.last_update_id,
-                    None,
+                    OrderBookTimes::default(),
                     valid_update.bids,
                     valid_update.asks,
                 ));

--- a/rustrade-data/src/exchange/binance/spot/l2.rs
+++ b/rustrade-data/src/exchange/binance/spot/l2.rs
@@ -1,7 +1,7 @@
 use super::super::book::BinanceLevel;
 use crate::{
     Identifier, SnapshotFetcher,
-    books::OrderBook,
+    books::{OrderBook, OrderBookTimes},
     error::DataError,
     event::{MarketEvent, MarketIter},
     exchange::{
@@ -329,14 +329,20 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BinanceSpotOrderBookL2Updat
             BinanceSpotOrderBookL2Update,
         ),
     ) -> Self {
+        let time_received = Utc::now();
         Self(vec![Ok(MarketEvent {
             time_exchange: update.time_exchange,
-            time_received: Utc::now(),
+            time_received,
             exchange: exchange_id,
             instrument,
             kind: OrderBookEvent::Update(OrderBook::new(
                 update.last_update_id,
-                None,
+                // Spot diffs carry "E" (broadcast) but no "T" (matching-engine) time.
+                OrderBookTimes {
+                    time_engine: None,
+                    time_exchange: Some(update.time_exchange),
+                    time_received,
+                },
                 update.bids,
                 update.asks,
             )),
@@ -350,6 +356,54 @@ mod tests {
     use super::*;
     use crate::books::Level;
     use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_spot_order_book_times() {
+        // Spot diffs carry "E" (broadcast) but no "T" (matching-engine) time, so a
+        // converted book exposes `time_exchange == "E"`, `time_engine == None`, and a
+        // populated `time_received`. Applying a later diff advances `time_exchange`
+        // (never resets it to `None`).
+        let e0 = DateTime::from_timestamp_millis(1671656397761).unwrap();
+        let e1 = DateTime::from_timestamp_millis(1671656397800).unwrap();
+
+        let update = |last_update_id, time_exchange| BinanceSpotOrderBookL2Update {
+            subscription_id: SubscriptionId::from("@depth@100ms|ETHUSDT"),
+            time_exchange,
+            first_update_id: last_update_id,
+            last_update_id,
+            bids: vec![BinanceLevel {
+                price: dec!(100),
+                amount: dec!(1),
+            }],
+            asks: vec![],
+        };
+
+        let MarketIter(mut events) = MarketIter::<&str, OrderBookEvent>::from((
+            ExchangeId::BinanceSpot,
+            "inst",
+            update(1, e0),
+        ));
+        let event = events.remove(0).unwrap();
+        let envelope_time_received = event.time_received;
+        let OrderBookEvent::Update(mut book) = event.kind else {
+            panic!("expected Update");
+        };
+        assert_eq!(book.time_exchange(), Some(e0));
+        assert_eq!(book.time_engine(), None);
+        // The book's local ingestion time shares the envelope's `time_received`.
+        assert_eq!(book.time_received(), envelope_time_received);
+
+        // A later diff advances `time_exchange` and keeps `time_engine` None.
+        let MarketIter(mut next) = MarketIter::<&str, OrderBookEvent>::from((
+            ExchangeId::BinanceSpot,
+            "inst",
+            update(2, e1),
+        ));
+        let event = next.remove(0).unwrap().kind;
+        book.update(&event);
+        assert_eq!(book.time_exchange(), Some(e1));
+        assert_eq!(book.time_engine(), None);
+    }
 
     #[test]
     fn test_de_binance_spot_order_book_l2_update() {
@@ -615,7 +669,12 @@ mod tests {
                     last_update_id: 100,
                     prev_last_update_id: 0,
                 },
-                book: OrderBook::new(100, None, vec![Level::new(50, 1)], vec![Level::new(100, 1)]),
+                book: OrderBook::new(
+                    100,
+                    OrderBookTimes::default(),
+                    vec![Level::new(50, 1)],
+                    vec![Level::new(100, 1)],
+                ),
                 input_update: BinanceSpotOrderBookL2Update {
                     subscription_id: SubscriptionId::from("subscription_id"),
                     time_exchange: Default::default(),
@@ -626,7 +685,7 @@ mod tests {
                 },
                 expected: OrderBook::new(
                     100,
-                    None,
+                    OrderBookTimes::default(),
                     vec![Level::new(50, 1)],
                     vec![Level::new(100, 1)],
                 ),
@@ -640,7 +699,7 @@ mod tests {
                 },
                 book: OrderBook::new(
                     100,
-                    None,
+                    OrderBookTimes::default(),
                     vec![Level::new(80, 1), Level::new(100, 1), Level::new(90, 1)],
                     vec![Level::new(150, 1), Level::new(110, 1), Level::new(120, 1)],
                 ),
@@ -676,7 +735,7 @@ mod tests {
                 },
                 expected: OrderBook::new(
                     110,
-                    None,
+                    OrderBookTimes::default(),
                     vec![Level::new(100, 1), Level::new(90, 10)],
                     vec![
                         Level::new(110, 1),
@@ -693,7 +752,7 @@ mod tests {
             {
                 let rustrade_update = OrderBookEvent::Update(OrderBook::new(
                     valid_update.last_update_id,
-                    None,
+                    OrderBookTimes::default(),
                     valid_update.bids,
                     valid_update.asks,
                 ));

--- a/rustrade-data/src/exchange/bybit/book/mod.rs
+++ b/rustrade-data/src/exchange/bybit/book/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    books::{Level, OrderBook},
+    books::{Level, OrderBook, OrderBookTimes},
     event::{MarketEvent, MarketIter},
     subscription::book::OrderBookEvent,
 };
@@ -40,9 +40,20 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BybitOrderBookMessage)>
     fn from(
         (exchange, instrument, message): (ExchangeId, InstrumentKey, BybitOrderBookMessage),
     ) -> Self {
+        let time_received = Utc::now();
+        // Bybit's `ts` broadcast time feeds both the book's `time_exchange` and the
+        // `MarketEvent` envelope's `time_exchange` below — bind once so the shared
+        // source is explicit.
+        let time_exchange = message.time;
         let orderbook = OrderBook::new(
             message.data.sequence,
-            Some(message.time),
+            // `time_exchange` is Bybit's `ts` broadcast time → `time_exchange` only.
+            // Bybit sends no matching-engine time, so `time_engine` is `None`.
+            OrderBookTimes {
+                time_engine: None,
+                time_exchange: Some(time_exchange),
+                time_received,
+            },
             message.data.bids,
             message.data.asks,
         );
@@ -53,8 +64,8 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, BybitOrderBookMessage)>
         };
 
         Self(vec![Ok(MarketEvent {
-            time_exchange: message.time,
-            time_received: Utc::now(),
+            time_exchange,
+            time_received,
             exchange,
             instrument,
             kind,

--- a/rustrade-data/src/exchange/hyperliquid/book.rs
+++ b/rustrade-data/src/exchange/hyperliquid/book.rs
@@ -1,7 +1,7 @@
 use super::HyperliquidChannel;
 use crate::{
     Identifier,
-    books::{Level, OrderBook},
+    books::{Level, OrderBook, OrderBookTimes},
     error::DataError,
     event::{MarketEvent, MarketIter},
     exchange::ExchangeSub,
@@ -139,13 +139,26 @@ where
             (vec![], vec![])
         };
 
+        let time_received = Utc::now();
+
         // Hyperliquid L2 book messages carry no sequence number; use the message
         // timestamp (millis) as a monotonic proxy for snapshot ordering.
-        let order_book = OrderBook::new(data.time, Some(time_exchange), bids, asks);
+        let order_book = OrderBook::new(
+            data.time,
+            // `time` is Hyperliquid's broadcast time → `time_exchange` only.
+            // Hyperliquid sends no matching-engine time, so `time_engine` is `None`.
+            OrderBookTimes {
+                time_engine: None,
+                time_exchange: Some(time_exchange),
+                time_received,
+            },
+            bids,
+            asks,
+        );
 
         Self(vec![Ok(MarketEvent {
             time_exchange,
-            time_received: Utc::now(),
+            time_received,
             exchange: exchange_id,
             instrument,
             kind: OrderBookEvent::Snapshot(order_book),

--- a/rustrade-data/src/exchange/ibkr/depth.rs
+++ b/rustrade-data/src/exchange/ibkr/depth.rs
@@ -5,9 +5,10 @@
 //! [`OrderBookEvent`] updates.
 
 use crate::{
-    books::{Asks, Bids, Level, OrderBook, OrderBookSide},
+    books::{Asks, Bids, Level, OrderBook, OrderBookSide, OrderBookTimes},
     subscription::book::OrderBookEvent,
 };
+use chrono::{DateTime, Utc};
 use ibapi::market_data::realtime::{MarketDepth, MarketDepths};
 use rust_decimal::Decimal;
 
@@ -42,9 +43,18 @@ impl DepthAggregator {
     /// Note: as of ibapi 3.x, server notices are delivered through the
     /// subscription's `SubscriptionItem::Notice` arm rather than as a variant of
     /// [`MarketDepths`], so they never reach this method.
-    pub fn update(&mut self, depth: &MarketDepths) -> Option<OrderBookEvent> {
+    ///
+    /// `time_received` is the local ingestion wall-clock; it is threaded in from
+    /// the caller so the emitted book's `time_received` matches the
+    /// `MarketEvent`'s. IB market-depth carries no venue timestamp, so it is the
+    /// only liveness signal on IBKR (`time_engine`/`time_exchange` are `None`).
+    pub fn update(
+        &mut self,
+        depth: &MarketDepths,
+        time_received: DateTime<Utc>,
+    ) -> Option<OrderBookEvent> {
         match depth {
-            MarketDepths::MarketDepth(d) => self.process_depth(d),
+            MarketDepths::MarketDepth(d) => self.process_depth(d, time_received),
             MarketDepths::MarketDepthL2(_) => {
                 // MarketDepthL2 includes market maker attribution - we aggregate
                 // into a simple book without tracking individual market makers
@@ -54,7 +64,11 @@ impl DepthAggregator {
         }
     }
 
-    fn process_depth(&mut self, depth: &MarketDepth) -> Option<OrderBookEvent> {
+    fn process_depth(
+        &mut self,
+        depth: &MarketDepth,
+        time_received: DateTime<Utc>,
+    ) -> Option<OrderBookEvent> {
         // Skip levels with invalid price (e.g., NaN, Inf, DBL_MAX sentinel)
         // Note: depth.position (IB's position-based addressing) is ignored;
         // we use price-keyed book maintenance instead.
@@ -85,7 +99,7 @@ impl DepthAggregator {
         }
 
         self.sequence += 1;
-        Some(OrderBookEvent::Snapshot(self.to_order_book()))
+        Some(OrderBookEvent::Snapshot(self.to_order_book(time_received)))
     }
 
     fn update_bids(&mut self, price: Decimal, size: Decimal) {
@@ -108,8 +122,19 @@ impl DepthAggregator {
             .upsert_single(level, |existing| existing.price.cmp(&level.price));
     }
 
-    fn to_order_book(&self) -> OrderBook {
-        OrderBook::from_sides(self.sequence, None, self.bids.clone(), self.asks.clone())
+    fn to_order_book(&self, time_received: DateTime<Utc>) -> OrderBook {
+        OrderBook::from_sides(
+            self.sequence,
+            // IB market-depth carries no venue timestamp: engine/exchange times are
+            // `None`; `time_received` is the only liveness signal on IBKR.
+            OrderBookTimes {
+                time_engine: None,
+                time_exchange: None,
+                time_received,
+            },
+            self.bids.clone(),
+            self.asks.clone(),
+        )
     }
 
     /// Clear all book state.
@@ -140,11 +165,34 @@ mod tests {
         })
     }
 
+    /// Fixed local-ingestion time for deterministic assertions.
+    fn tr() -> DateTime<Utc> {
+        DateTime::from_timestamp_millis(1_700_000_000_000).unwrap()
+    }
+
+    #[test]
+    fn order_book_has_only_time_received() {
+        // IB market-depth carries no venue timestamp: engine/exchange times must be
+        // `None`, and `time_received` is the (threaded) local ingestion wall-clock —
+        // the only liveness signal on IBKR.
+        let mut agg = DepthAggregator::new();
+
+        let event = agg.update(&depth(1, 0, 100.0, 10.0), tr()).unwrap();
+        match event {
+            OrderBookEvent::Snapshot(book) => {
+                assert_eq!(book.time_engine(), None);
+                assert_eq!(book.time_exchange(), None);
+                assert_eq!(book.time_received(), tr());
+            }
+            _ => panic!("Expected Snapshot"),
+        }
+    }
+
     #[test]
     fn insert_bid() {
         let mut agg = DepthAggregator::new();
 
-        let event = agg.update(&depth(1, 0, 100.0, 10.0)).unwrap();
+        let event = agg.update(&depth(1, 0, 100.0, 10.0), tr()).unwrap();
 
         match event {
             OrderBookEvent::Snapshot(book) => {
@@ -161,7 +209,7 @@ mod tests {
     fn insert_ask() {
         let mut agg = DepthAggregator::new();
 
-        let event = agg.update(&depth(0, 0, 101.0, 5.0)).unwrap();
+        let event = agg.update(&depth(0, 0, 101.0, 5.0), tr()).unwrap();
 
         match event {
             OrderBookEvent::Snapshot(book) => {
@@ -178,8 +226,8 @@ mod tests {
     fn update_level() {
         let mut agg = DepthAggregator::new();
 
-        agg.update(&depth(1, 0, 100.0, 10.0));
-        let event = agg.update(&depth(1, 1, 100.0, 15.0)).unwrap();
+        agg.update(&depth(1, 0, 100.0, 10.0), tr());
+        let event = agg.update(&depth(1, 1, 100.0, 15.0), tr()).unwrap();
 
         match event {
             OrderBookEvent::Snapshot(book) => {
@@ -194,9 +242,9 @@ mod tests {
     fn delete_level() {
         let mut agg = DepthAggregator::new();
 
-        agg.update(&depth(1, 0, 100.0, 10.0));
-        agg.update(&depth(1, 0, 99.0, 5.0));
-        let event = agg.update(&depth(1, 2, 100.0, 0.0)).unwrap();
+        agg.update(&depth(1, 0, 100.0, 10.0), tr());
+        agg.update(&depth(1, 0, 99.0, 5.0), tr());
+        let event = agg.update(&depth(1, 2, 100.0, 0.0), tr()).unwrap();
 
         match event {
             OrderBookEvent::Snapshot(book) => {
@@ -211,10 +259,10 @@ mod tests {
     fn multiple_levels() {
         let mut agg = DepthAggregator::new();
 
-        agg.update(&depth(1, 0, 100.0, 10.0));
-        agg.update(&depth(1, 0, 99.0, 20.0));
-        agg.update(&depth(0, 0, 101.0, 5.0));
-        let event = agg.update(&depth(0, 0, 102.0, 3.0)).unwrap();
+        agg.update(&depth(1, 0, 100.0, 10.0), tr());
+        agg.update(&depth(1, 0, 99.0, 20.0), tr());
+        agg.update(&depth(0, 0, 101.0, 5.0), tr());
+        let event = agg.update(&depth(0, 0, 102.0, 3.0), tr()).unwrap();
 
         match event {
             OrderBookEvent::Snapshot(book) => {
@@ -244,15 +292,15 @@ mod tests {
         let mut agg = DepthAggregator::new();
 
         // NaN price should be skipped
-        let result = agg.update(&depth(1, 0, f64::NAN, 10.0));
+        let result = agg.update(&depth(1, 0, f64::NAN, 10.0), tr());
         assert!(result.is_none());
 
         // Infinity should be skipped
-        let result = agg.update(&depth(1, 0, f64::INFINITY, 10.0));
+        let result = agg.update(&depth(1, 0, f64::INFINITY, 10.0), tr());
         assert!(result.is_none());
 
         // Valid price should work
-        let result = agg.update(&depth(1, 0, 100.0, 10.0));
+        let result = agg.update(&depth(1, 0, 100.0, 10.0), tr());
         assert!(result.is_some());
     }
 
@@ -261,10 +309,10 @@ mod tests {
         let mut agg = DepthAggregator::new();
 
         // Insert a bid level
-        agg.update(&depth(1, 0, 100.0, 10.0));
+        agg.update(&depth(1, 0, 100.0, 10.0), tr());
 
         // Delete with NaN size should still remove the level (size irrelevant for deletes)
-        let event = agg.update(&depth(1, 2, 100.0, f64::NAN)).unwrap();
+        let event = agg.update(&depth(1, 2, 100.0, f64::NAN), tr()).unwrap();
 
         match event {
             OrderBookEvent::Snapshot(book) => {
@@ -282,9 +330,9 @@ mod tests {
         let mut agg = DepthAggregator::new();
 
         // Build up some book state
-        agg.update(&depth(1, 0, 100.0, 10.0));
-        agg.update(&depth(1, 0, 99.0, 5.0));
-        agg.update(&depth(0, 0, 101.0, 8.0));
+        agg.update(&depth(1, 0, 100.0, 10.0), tr());
+        agg.update(&depth(1, 0, 99.0, 5.0), tr());
+        agg.update(&depth(0, 0, 101.0, 8.0), tr());
         assert_eq!(agg.sequence, 3);
 
         // Clear should reset everything
@@ -295,7 +343,7 @@ mod tests {
         assert!(agg.asks.levels().is_empty(), "asks should be empty");
 
         // Next update should work normally with sequence 1
-        let event = agg.update(&depth(1, 0, 50.0, 1.0)).unwrap();
+        let event = agg.update(&depth(1, 0, 50.0, 1.0), tr()).unwrap();
         match event {
             OrderBookEvent::Snapshot(book) => {
                 assert_eq!(book.sequence(), 1);

--- a/rustrade-data/src/exchange/ibkr/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/mod.rs
@@ -386,11 +386,13 @@ where
                                 break;
                             }
                         };
-                        if let Some(book_event) = aggregator.update(&depth) {
-                            // IB's MarketDepth events have no timestamp. We use time_received
-                            // for both fields. Consumers should NOT interpret time_exchange
-                            // as actual exchange timestamp for depth events.
-                            let now = Utc::now();
+                        // IB's MarketDepth events have no timestamp. Stamp `now`
+                        // BEFORE aggregating so the book's `time_received` (threaded
+                        // into the OrderBook) matches the MarketEvent envelope's.
+                        // Consumers should NOT interpret the MarketEvent's
+                        // time_exchange as a real venue timestamp for depth events.
+                        let now = Utc::now();
+                        if let Some(book_event) = aggregator.update(&depth, now) {
                             let event = MarketEvent {
                                 time_exchange: now,
                                 time_received: now,


### PR DESCRIPTION
## Summary

Introduces a new `OrderBookTimes` struct to capture venue and local timestamps on every L2 OrderBook, giving consumers a usable liveness signal across all exchanges (previously `time_engine()` was the only timestamp and was `None` for Binance spot books).

## Changes

- Add `OrderBookTimes` struct with three named fields: `time_engine` (matching-engine time), `time_exchange` (broadcast time), `time_received` (local ingestion wall-clock)
- Replace `OrderBook::time_engine` field with nested `times: OrderBookTimes`
- Add public accessors: `OrderBook::time_exchange()`, `OrderBook::time_received()`, `OrderBook::times()`
- Update `OrderBook::new()` and `OrderBook::from_sides()` to accept `OrderBookTimes`
- Populate `OrderBookTimes` correctly in all exchange converters:
  - Binance spot: no venue times until first diff
  - Binance futures: both "E" (broadcast) and "T" (engine) times
  - Bybit: "ts" broadcast time only
  - Hyperliquid: broadcast time only
  - IBKR: no venue times; `time_received` is the only liveness signal
- Update `DepthAggregator::update()` (IBKR) to accept `time_received` parameter
- Add tests for timestamp handling (Binance spot/futures, IBKR, equality)
- Update CHANGELOG with feature description and breaking changes

## Breaking changes

`OrderBook` now stores a nested `OrderBookTimes` instead of a bare `time_engine` field; `OrderBook::new()` and `OrderBook::from_sides()` signatures change accordingly.
