### PR TITLE
chore: release prep v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-09
+
 ### Added
 
 - **Live Binance klines (candles) over WebSocket** (`rustrade-data`, `SubKind::Candles { interval }`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ categories = ["finance", "simulation"]
 
 [workspace.dependencies]
 # Rustrade Ecosystem
-rustrade-integration = { path = "./rustrade-integration", version = "0.2.1" }
-rustrade-instrument = { path = "./rustrade-instrument", version = "0.2.1" }
-rustrade-data = { path = "./rustrade-data", version = "0.2.1" }
-rustrade-execution = { path = "./rustrade-execution", version = "0.2.1" }
-rustrade-macro = { path = "./rustrade-macro", version = "0.2.1" }
+rustrade-integration = { path = "./rustrade-integration", version = "0.3.0" }
+rustrade-instrument = { path = "./rustrade-instrument", version = "0.3.0" }
+rustrade-data = { path = "./rustrade-data", version = "0.3.0" }
+rustrade-execution = { path = "./rustrade-execution", version = "0.3.0" }
+rustrade-macro = { path = "./rustrade-macro", version = "0.3.0" }
 
 # Logging
 tracing = { version = "0.1.41" }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ rustrade is a collection of Rust libraries for live-trading, paper-trading, and 
 
 | Exchange | Market Data | Execution | Notes |
 |----------|-------------|-----------|-------|
-| **Binance** | ✅ Spot | ✅ Spot | WebSocket + REST |
+| **Binance** | ✅ Spot, USD-M Futures | ✅ Spot, Margin (cross/isolated) | WebSocket + REST |
 | **Alpaca** | ✅ Equities (IEX/SIP), Crypto, Options | ✅ Equities, Options, Crypto | WebSocket + REST |
 | **Hyperliquid** | ✅ Perps, Spot | ✅ Perps, Spot | WebSocket + REST |
 | **Interactive Brokers** | ✅ All asset classes | ✅ All asset classes | TWS/Gateway API |
@@ -66,9 +66,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustrade = "0.2"
-rustrade-data = { version = "0.2", features = ["hyperliquid"] }
-rustrade-execution = { version = "0.2", features = ["binance"] }
+rustrade = "0.3"
+rustrade-data = { version = "0.3", features = ["hyperliquid"] }
+rustrade-execution = { version = "0.3", features = ["binance"] }
 ```
 
 See the [examples](https://github.com/Niqnil/rustrade/tree/main/rustrade/examples) for complete working code.

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-data"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-data/README.md
+++ b/rustrade-data/README.md
@@ -6,8 +6,9 @@ Integration library for streaming public market data from exchanges and data pro
 
 | Exchange | Constructor | InstrumentKinds | SubscriptionKinds |
 |:--------:|:-----------:|:---------------:|:-----------------:|
-| **BinanceSpot** | `BinanceSpot::default()` | Spot | PublicTrades, Quotes, OrderBooksL1, OrderBooksL2 |
-| **BinanceFuturesUsd** | `BinanceFuturesUsd::default()` | Perpetual | PublicTrades, Quotes, OrderBooksL1, OrderBooksL2, Liquidations |
+| **BinanceSpot** | `BinanceSpot::default()` | Spot | PublicTrades, Quotes, OrderBooksL1, OrderBooksL2, Candles |
+| **BinanceFuturesUsd** | `BinanceFuturesUsd::default()` | Perpetual | PublicTrades, Quotes, OrderBooksL1, OrderBooksL2 |
+| **BinanceFuturesUsdMarket** | `BinanceFuturesUsdMarket::default()` | Perpetual | Liquidations, Candles |
 | **Bitfinex** | `Bitfinex` | Spot | PublicTrades |
 | **Bitmex** | `Bitmex` | Perpetual | PublicTrades |
 | **BybitSpot** | `BybitSpot::default()` | Spot | PublicTrades, OrderBooksL1, OrderBooksL2 |
@@ -28,6 +29,12 @@ Integration library for streaming public market data from exchanges and data pro
 | **AlpacaSip** | `AlpacaSip::new(credentials)` | Spot (Equities) | PublicTrades, Quotes |
 | **AlpacaCrypto** | `AlpacaCrypto::new(credentials)` | Spot (Crypto) | PublicTrades, Quotes |
 | **AlpacaOptionsClient** | `AlpacaOptionsClient::new(credentials)` | Option | Quotes, OptionGreeks (REST snapshots) |
+
+> **Binance USD-M futures WebSocket tiers:** Binance routes futures streams across mutually-exclusive
+> WebSocket tiers, so the typed `Streams` path splits them across two server types. `Liquidations`
+> (`@forceOrder`) and `Candles` (`@continuousKline_`) are served only on the `/market` tier, exposed as
+> `BinanceFuturesUsdMarket`; trades and order books stay on `BinanceFuturesUsd`. The `DynamicStreams` /
+> `ExchangeId` path handles this routing automatically.
 
 ## Data Providers
 

--- a/rustrade-execution/Cargo.toml
+++ b/rustrade-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-execution"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-execution/README.md
+++ b/rustrade-execution/README.md
@@ -7,6 +7,7 @@ Execution client library for streaming private account data and executing orders
 | Exchange | Constructor | InstrumentKinds | Features |
 |:--------:|:-----------:|:---------------:|:--------:|
 | **Binance** | `BinanceClient::connect()` | Spot | Orders, Balances, Positions |
+| **BinanceMargin** | `BinanceMargin::new(config)` | Spot (cross/isolated margin) | Orders, Balances, Positions |
 | **Alpaca** | `AlpacaClient::connect()` | Spot (Equities, Crypto), Option | Orders, Balances, Positions, BracketOrders |
 | **Hyperliquid** | `HyperliquidClient::connect()` | Perpetual | Orders, Balances, Positions |
 | **HyperliquidSpot** | `HyperliquidSpotClient::connect()` | Spot | Orders, Balances, Positions |
@@ -30,6 +31,8 @@ Additional order types:
 ⚠️ Binance `TrailingStop` supports `BasisPoints` and `Percentage` offsets only;
 `Absolute` offsets are rejected as unsupported. Hyperliquid trigger orders (Stop,
 StopLimit, TakeProfit, TakeProfitLimit) require a UUID-format client order ID
-(`ClientOrderId::uuid()`).
+(`ClientOrderId::uuid()`). `BinanceMargin` matches Binance spot except that both
+`TrailingStop` and `TrailingStopLimit` are rejected as unsupported (the SDK margin
+binding omits `trailingDelta`).
 
 See the [workspace README](../README.md) for documentation, examples, and contributing guidelines.

--- a/rustrade-instrument/Cargo.toml
+++ b/rustrade-instrument/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-instrument"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-integration/Cargo.toml
+++ b/rustrade-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-integration"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-macro/Cargo.toml
+++ b/rustrade-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-macro"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade/Cargo.toml
+++ b/rustrade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Release-prep for **v0.3.0**. Promotes `develop` → `main` + tag after merge.

## Changes
- **Versions** `0.2.1` → `0.3.0` across all 6 crates (+ root workspace dep refs, `Cargo.lock` workspace entries only — no dependency drift).
- **CHANGELOG**: `[Unreleased]` → `## [0.3.0] - 2026-06-09`, new empty `[Unreleased]` added.
- **READMEs** refreshed for changes since 0.2.1:
  - Root: Binance support matrix (Spot + USD-M Futures / Spot + Margin); Quick Start pins → `0.3`.
  - `rustrade-data`: added `Candles` to BinanceSpot; moved `Liquidations` off `BinanceFuturesUsd` to the new `/market`-tier `BinanceFuturesUsdMarket` (+ `Candles`); added tier-routing note.
  - `rustrade-execution`: added `BinanceMargin` client row + trailing-stop limitation note.

## Versioning
Pre-1.0 with multiple BREAKING entries in the changelog → minor bump (`0.3.0`) per SemVer.