### PR TITLE
IBKR event-delivery robustness: reject incomplete contracts, warn on short fetches, in-band stream termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **In-band stream-termination signal** (`rustrade-execution`). New
+  `AccountEventKind::StreamTerminated(StreamTerminationReason)` variant delivers *why* an account
+  event stream ended — `ReconnectBudgetExhausted { attempts, last_error }` / `Error(String)` /
+  `ConsumerDropped` / `GracefulShutdown` — on the existing account feed, so stream death is a
+  programmatic signal rather than something inferred from channel EOF or read from logs. The engine
+  surfaces it via `warn!` instead of dropping it. This change adds the type plumbing; emitting the
+  variant at each venue's terminal stream site is a follow-up.
+
 ### Changed
 
+- **IBKR historical tick fetches now warn on suspiciously short reads** (`rustrade-data`, `ibkr`
+  feature). `fetch_historical_ticks` / `fetch_historical_bid_ask` emit a `warn!` when fewer ticks
+  are returned than requested — a best-effort flag for possible silent truncation. A short read can
+  also be a legitimate end-of-data, so treat it as a prompt to investigate, not a precise error
+  signal.
+- **Breaking (`rustrade-execution`):** removed the `AccountEventKind::StreamError(String)` variant.
+  It was non-terminal (the stream continued after it), already `error!`-logged at each emit site,
+  and dropped unprocessed by the engine — no consumer reacted to it. It is superseded by the
+  terminal, structured `StreamTerminated`. Transient venue errors now remain in logs only.
 - **IBKR contract config now rejects incomplete/unsupported configs instead of silently
   fabricating a wrong contract** (`rustrade-execution`, `ibkr` feature). `ContractConfig::to_contract`
   previously filled missing fields with silent defaults that produced a *different* contract than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **IBKR contract config now rejects incomplete/unsupported configs instead of silently
+  fabricating a wrong contract** (`rustrade-execution`, `ibkr` feature). `ContractConfig::to_contract`
+  previously filled missing fields with silent defaults that produced a *different* contract than
+  intended; each is now a hard error (the startup registration loop already warns-and-skips on a bad
+  config, so a rejected contract is logged and omitted rather than mis-registered):
+  - a missing option `right` on an `OPT` contract no longer defaults to **Call** (`"C"`);
+  - a missing `strike` on an `OPT` no longer defaults to `0.0`;
+  - a missing `last_trade_date` on a `FUT`/`OPT` no longer defaults to `""`;
+  - an unrecognized `security_type` no longer silently falls back to a **stock** (`STK`).
+- **Breaking (`rustrade-execution`, `ibkr` feature):** the `contract::InvalidOptionRight` error type
+  is replaced by a `#[non_exhaustive]` `contract::ContractConfigError` enum
+  (`MissingOptionRight` / `UnrecognizedOptionRight { right }` / `MissingStrike` /
+  `MissingLastTradeDate` / `UnrecognizedSecurityType { security_type }`). `option_contract` now
+  returns `Result<Contract, ContractConfigError>`.
+
 ## [0.3.0] - 2026-06-09
 
 ### Added

--- a/rustrade-data/src/exchange/ibkr/historical.rs
+++ b/rustrade-data/src/exchange/ibkr/historical.rs
@@ -280,8 +280,12 @@ impl IbkrHistoricalData {
     /// - A mid-stream IB API error ends iteration silently: ibapi 3.0.1's
     ///   `TickSubscription` stores the error internally but exposes no public
     ///   accessor, so a shorter-than-requested result may indicate truncation
-    ///   rather than genuine end-of-data. Callers needing completeness
-    ///   guarantees should validate the returned count against expectations.
+    ///   rather than genuine end-of-data. As a best-effort mitigation, this
+    ///   method emits a `warn!` when the number of raw ticks received is less
+    ///   than `request.number_of_ticks`. Because a short batch is also a normal
+    ///   end-of-data signal, treat the warning as a flag for investigation (or a
+    ///   prompt to paginate), **not** as proof of an error. Callers needing
+    ///   completeness guarantees should still validate the returned count.
     pub async fn fetch_historical_ticks(
         &self,
         request: HistoricalTickRequest,
@@ -328,12 +332,22 @@ impl IbkrHistoricalData {
                 Vec::with_capacity(usize::try_from(request.number_of_ticks).unwrap_or(0));
             // `TickSubscription` yields `T` directly and stops silently on a
             // mid-stream error (no public error accessor in ibapi 3.0.1), so a
-            // short result may be truncation rather than end-of-data.
+            // short result may be truncation rather than end-of-data. We count
+            // every *raw* tick received (not `trades.len()`, which also drops
+            // non-finite ticks) so the completeness check below reflects wire
+            // truncation, not data-quality filtering.
+            let mut received = 0usize;
             for (seq, tick) in subscription.into_iter().enumerate() {
+                received += 1;
                 if let Some(trade) = tick_last_to_public_trade(&tick, seq) {
                     trades.push(trade);
                 }
             }
+            warn_if_short_tick_fetch(
+                request.contract.symbol.0.as_str(),
+                received,
+                request.number_of_ticks,
+            );
 
             Ok::<_, DataError>(trades)
         })
@@ -376,8 +390,12 @@ impl IbkrHistoricalData {
     /// - A mid-stream IB API error ends iteration silently: ibapi 3.0.1's
     ///   `TickSubscription` stores the error internally but exposes no public
     ///   accessor, so a shorter-than-requested result may indicate truncation
-    ///   rather than genuine end-of-data. Callers needing completeness
-    ///   guarantees should validate the returned count against expectations.
+    ///   rather than genuine end-of-data. As a best-effort mitigation, this
+    ///   method emits a `warn!` when the number of raw ticks received is less
+    ///   than `request.number_of_ticks`. Because a short batch is also a normal
+    ///   end-of-data signal, treat the warning as a flag for investigation (or a
+    ///   prompt to paginate), **not** as proof of an error. Callers needing
+    ///   completeness guarantees should still validate the returned count.
     pub async fn fetch_historical_bid_ask(
         &self,
         request: HistoricalTickRequest,
@@ -430,12 +448,22 @@ impl IbkrHistoricalData {
                 Vec::with_capacity(usize::try_from(request.number_of_ticks).unwrap_or(0));
             // `TickSubscription` yields `T` directly and stops silently on a
             // mid-stream error (no public error accessor in ibapi 3.0.1), so a
-            // short result may be truncation rather than end-of-data.
+            // short result may be truncation rather than end-of-data. We count
+            // every *raw* tick received (not `quotes.len()`, which also drops
+            // non-finite ticks) so the completeness check below reflects wire
+            // truncation, not data-quality filtering.
+            let mut received = 0usize;
             for tick in subscription {
+                received += 1;
                 if let Some(l1) = tick_bid_ask_to_order_book_l1(&tick) {
                     quotes.push(l1);
                 }
             }
+            warn_if_short_tick_fetch(
+                request.contract.symbol.0.as_str(),
+                received,
+                request.number_of_ticks,
+            );
 
             Ok::<_, DataError>(quotes)
         })
@@ -809,6 +837,37 @@ impl HistoricalTickRequest {
             number_of_ticks: count.min(1000),
             regular_trading_hours_only: true,
         }
+    }
+}
+
+/// Warn when a historical tick fetch returned fewer raw ticks than requested.
+///
+/// ibapi 3.0.1's `TickSubscription` stops iterating silently on a mid-stream
+/// error — the error is stored in a private `Mutex` with no public accessor, so
+/// a short read is indistinguishable, through the public API, from a genuine
+/// end-of-data within the requested range.
+///
+/// This is therefore a **best-effort, flag-for-investigation** signal, **not** a
+/// precise error indicator: it fires on every legitimately short batch (e.g. the
+/// available history ends before `requested` ticks) as well as on truncation.
+/// Callers needing completeness guarantees should treat it as a prompt to retry
+/// or paginate, not as proof of an error.
+///
+/// `received` is the count of *raw* ticks pulled from the subscription, before
+/// non-finite-price filtering — so this reflects wire truncation rather than
+/// data-quality drops (which are warned per-tick elsewhere).
+fn warn_if_short_tick_fetch(symbol: &str, received: usize, requested: i32) {
+    let requested = usize::try_from(requested).unwrap_or(0);
+    if received < requested {
+        warn!(
+            symbol = %symbol,
+            received,
+            requested,
+            "Historical tick fetch returned fewer ticks than requested; this may be \
+             a legitimate end-of-data or a silent mid-stream IB error (ibapi 3.0.1 \
+             exposes no error accessor on TickSubscription). Investigate or paginate \
+             if completeness is required."
+        );
     }
 }
 
@@ -1303,5 +1362,34 @@ mod tests {
 
         assert_eq!(dt.timestamp(), 1700000000);
         assert_eq!(dt.timestamp_subsec_nanos(), 123_456_789);
+    }
+
+    // ========================================================================
+    // Short-fetch completeness mitigation (#122)
+    // ========================================================================
+    //
+    // `warn_if_short_tick_fetch` has no return value to assert on — it only
+    // emits a `tracing` warning. These tests exercise the threshold/conversion
+    // logic for panic-freedom and document the intended boundary (fires on
+    // `received < requested`, silent on `>=`, and the negative-`i32` guard).
+
+    #[test]
+    fn warn_if_short_tick_fetch_threshold_is_panic_free() {
+        // received < requested → would warn
+        warn_if_short_tick_fetch("AAPL", 500, 1000);
+        // received == requested → silent
+        warn_if_short_tick_fetch("AAPL", 1000, 1000);
+        // received > requested (defensive; IB caps at requested) → silent
+        warn_if_short_tick_fetch("AAPL", 1001, 1000);
+        // zero requested → silent (0 < 0 is false)
+        warn_if_short_tick_fetch("AAPL", 0, 0);
+    }
+
+    #[test]
+    fn warn_if_short_tick_fetch_clamps_negative_requested_to_zero() {
+        // A negative `number_of_ticks` must not panic on the i32→usize cast;
+        // it clamps to 0, so any non-negative `received` is treated as complete.
+        warn_if_short_tick_fetch("AAPL", 0, -1);
+        warn_if_short_tick_fetch("AAPL", 5, i32::MIN);
     }
 }

--- a/rustrade-execution/src/client/binance/shared.rs
+++ b/rustrade-execution/src/client/binance/shared.rs
@@ -212,7 +212,7 @@ pub(crate) fn dedup_key_from_event(event: &UnindexedAccountEvent) -> Option<Dedu
             }),
             Err(_) => None, // error responses don't need dedup
         },
-        _ => None, // BalanceSnapshot, BalanceStreamUpdate, Snapshot, StreamError — no dedup needed
+        _ => None, // BalanceSnapshot, BalanceStreamUpdate, InstrumentBalanceUpdate, Snapshot, StreamTerminated — no dedup needed
     }
 }
 

--- a/rustrade-execution/src/client/hyperliquid/mod.rs
+++ b/rustrade-execution/src/client/hyperliquid/mod.rs
@@ -487,11 +487,9 @@ impl ExecutionClient for HyperliquidClient {
                                 warn!("UserFills WebSocket disconnected");
                             }
                             Message::HyperliquidError(e) => {
+                                // Transient, non-terminal: the loop continues. Log only — no
+                                // in-band event (consumers took no action on the old StreamError).
                                 error!(%e, "UserFills WebSocket error");
-                                let _ = fills_event_tx.send(AccountEvent::new(
-                                    ExchangeId::HyperliquidPerp,
-                                    AccountEventKind::StreamError(e),
-                                ));
                             }
                             _ => {}
                         }
@@ -536,11 +534,9 @@ impl ExecutionClient for HyperliquidClient {
                                 warn!("OrderUpdates WebSocket disconnected");
                             }
                             Message::HyperliquidError(e) => {
+                                // Transient, non-terminal: the loop continues. Log only — no
+                                // in-band event (consumers took no action on the old StreamError).
                                 error!(%e, "OrderUpdates WebSocket error");
-                                let _ = orders_event_tx.send(AccountEvent::new(
-                                    ExchangeId::HyperliquidPerp,
-                                    AccountEventKind::StreamError(e),
-                                ));
                             }
                             _ => {}
                         }

--- a/rustrade-execution/src/client/hyperliquid/spot.rs
+++ b/rustrade-execution/src/client/hyperliquid/spot.rs
@@ -382,11 +382,9 @@ impl ExecutionClient for HyperliquidSpotClient {
                                 warn!("Spot UserFills WebSocket disconnected");
                             }
                             Message::HyperliquidError(e) => {
+                                // Transient, non-terminal: the loop continues. Log only — no
+                                // in-band event (consumers took no action on the old StreamError).
                                 error!(%e, "Spot UserFills WebSocket error");
-                                let _ = fills_event_tx.send(AccountEvent::new(
-                                    ExchangeId::HyperliquidSpot,
-                                    AccountEventKind::StreamError(e),
-                                ));
                             }
                             _ => {}
                         }
@@ -435,11 +433,9 @@ impl ExecutionClient for HyperliquidSpotClient {
                                 warn!("Spot OrderUpdates WebSocket disconnected");
                             }
                             Message::HyperliquidError(e) => {
+                                // Transient, non-terminal: the loop continues. Log only — no
+                                // in-band event (consumers took no action on the old StreamError).
                                 error!(%e, "Spot OrderUpdates WebSocket error");
-                                let _ = orders_event_tx.send(AccountEvent::new(
-                                    ExchangeId::HyperliquidSpot,
-                                    AccountEventKind::StreamError(e),
-                                ));
                             }
                             _ => {}
                         }

--- a/rustrade-execution/src/client/ibkr/contract.rs
+++ b/rustrade-execution/src/client/ibkr/contract.rs
@@ -1,38 +1,42 @@
 //! Contract builders for IB integration.
 
 use ibapi::contracts::{Contract, Currency, Exchange, OptionRight, SecurityType, Symbol};
+use thiserror::Error;
 
-/// Error returned by [`option_contract`] when the `right` string cannot be
-/// mapped to an [`OptionRight`].
+/// Reasons a [`ContractConfig`](super::ContractConfig) cannot be mapped to a
+/// valid [`Contract`].
 ///
-/// Carries the offending input so callers can surface it (via [`Display`] or
-/// [`InvalidOptionRight::right`]). Building an option contract without a valid
-/// right is rejected at construction rather than deferred to an opaque IBKR
-/// submission failure.
+/// Every variant represents an input that would otherwise force the builder to
+/// silently fabricate a *wrong* contract (e.g. defaulting a missing option
+/// `right` to Call, or an unknown `security_type` to a stock). Surfacing these
+/// at construction — rather than deferring to an opaque IBKR submission
+/// rejection — keeps failures observable, per the library's contract.
 ///
-/// [`Display`]: std::fmt::Display
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InvalidOptionRight(String);
+/// `#[non_exhaustive]`: new validation reasons may be added without a breaking
+/// change as the contract builders grow.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ContractConfigError {
+    /// An `OPT` contract was configured without a `right`.
+    #[error("OPT contract requires a `right` field (expected one of C/CALL/P/PUT)")]
+    MissingOptionRight,
 
-impl InvalidOptionRight {
-    /// The unrecognized `right` input that triggered this error.
-    #[must_use]
-    pub fn right(&self) -> &str {
-        &self.0
-    }
+    /// A `right` was supplied but is not one of `C`/`CALL`/`P`/`PUT`.
+    #[error("unrecognized option right {right:?} (expected one of C/CALL/P/PUT)")]
+    UnrecognizedOptionRight { right: String },
+
+    /// An `OPT` contract was configured without a `strike`.
+    #[error("OPT contract requires a `strike` field")]
+    MissingStrike,
+
+    /// A `FUT` or `OPT` contract was configured without a `last_trade_date`.
+    #[error("FUT/OPT contract requires a `last_trade_date` field")]
+    MissingLastTradeDate,
+
+    /// The `security_type` is not one of the supported `STK`/`FUT`/`OPT`/`CASH`.
+    #[error("unrecognized security_type {security_type:?} (expected one of STK/FUT/OPT/CASH)")]
+    UnrecognizedSecurityType { security_type: String },
 }
-
-impl std::fmt::Display for InvalidOptionRight {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "unrecognized option right {:?} (expected one of C/CALL/P/PUT)",
-            self.0
-        )
-    }
-}
-
-impl std::error::Error for InvalidOptionRight {}
 
 /// Map a human/wire option-right string to `OptionRight`.
 ///
@@ -78,10 +82,17 @@ pub fn futures_contract(
 ///
 /// # Errors
 ///
-/// Returns [`InvalidOptionRight`] if `right` is not one of `C`/`CALL`/`P`/`PUT`
-/// (case-insensitive; leading and trailing whitespace is ignored). An option
-/// contract is invalid without a right, so this is surfaced at construction
-/// rather than as a later IBKR submission rejection.
+/// Returns [`ContractConfigError::UnrecognizedOptionRight`] if `right` is not
+/// one of `C`/`CALL`/`P`/`PUT` (case-insensitive; leading and trailing
+/// whitespace is ignored). An option contract is invalid without a valid right,
+/// so this is surfaced at construction rather than as a later IBKR submission
+/// rejection.
+///
+/// Only `right` is validated here. `last_trade_date` and `strike` are forwarded
+/// to the IBKR contract as-is; an empty date or a `0.0` strike will build a
+/// (quietly wrong) contract. Presence of those fields is checked one level up in
+/// [`ContractConfig::to_contract`](super::ContractConfig::to_contract), which is
+/// the intended entry point for config-driven construction.
 pub fn option_contract(
     symbol: &str,
     last_trade_date: &str,
@@ -89,8 +100,11 @@ pub fn option_contract(
     right: &str,
     exchange: &str,
     currency: &str,
-) -> Result<Contract, InvalidOptionRight> {
-    let right = parse_option_right(right).ok_or_else(|| InvalidOptionRight(right.to_string()))?;
+) -> Result<Contract, ContractConfigError> {
+    let right =
+        parse_option_right(right).ok_or_else(|| ContractConfigError::UnrecognizedOptionRight {
+            right: right.to_string(),
+        })?;
     Ok(Contract {
         symbol: Symbol::new(symbol),
         security_type: SecurityType::Option,

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -150,27 +150,50 @@ pub struct ContractConfig {
 }
 
 impl ContractConfig {
-    fn to_contract(&self) -> Result<ibapi::contracts::Contract, contract::InvalidOptionRight> {
+    /// Convert this config into an [`ibapi::contracts::Contract`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ContractConfigError`](contract::ContractConfigError) instead of
+    /// silently fabricating a wrong contract when the config is incomplete or
+    /// unsupported:
+    /// - [`UnrecognizedSecurityType`](contract::ContractConfigError::UnrecognizedSecurityType)
+    ///   — `security_type` is not one of `STK`/`FUT`/`OPT`/`CASH`.
+    /// - [`MissingLastTradeDate`](contract::ContractConfigError::MissingLastTradeDate)
+    ///   — `last_trade_date` is absent on a `FUT` or `OPT` contract.
+    /// - [`MissingStrike`](contract::ContractConfigError::MissingStrike) — `strike`
+    ///   is absent on an `OPT` contract.
+    /// - [`MissingOptionRight`](contract::ContractConfigError::MissingOptionRight) —
+    ///   `right` is absent on an `OPT` contract.
+    /// - [`UnrecognizedOptionRight`](contract::ContractConfigError::UnrecognizedOptionRight)
+    ///   — `right` is present but not one of `C`/`CALL`/`P`/`PUT` (case-insensitive).
+    fn to_contract(&self) -> Result<ibapi::contracts::Contract, contract::ContractConfigError> {
+        use contract::ContractConfigError as E;
         Ok(match self.security_type.as_str() {
             "STK" => contract::stock_contract(&self.symbol, &self.exchange, &self.currency),
             "FUT" => contract::futures_contract(
                 &self.symbol,
-                self.last_trade_date.as_deref().unwrap_or(""),
+                self.last_trade_date
+                    .as_deref()
+                    .ok_or(E::MissingLastTradeDate)?,
                 &self.exchange,
                 &self.currency,
             ),
             "OPT" => contract::option_contract(
                 &self.symbol,
-                self.last_trade_date.as_deref().unwrap_or(""),
-                self.strike.unwrap_or(0.0),
-                self.right.as_deref().unwrap_or("C"),
+                self.last_trade_date
+                    .as_deref()
+                    .ok_or(E::MissingLastTradeDate)?,
+                self.strike.ok_or(E::MissingStrike)?,
+                self.right.as_deref().ok_or(E::MissingOptionRight)?,
                 &self.exchange,
                 &self.currency,
             )?,
             "CASH" => contract::forex_contract(&self.symbol, &self.currency),
             other => {
-                warn!(security_type = %other, symbol = %self.symbol, "Unknown security_type, defaulting to STK");
-                contract::stock_contract(&self.symbol, &self.exchange, &self.currency)
+                return Err(E::UnrecognizedSecurityType {
+                    security_type: other.to_string(),
+                });
             }
         })
     }
@@ -1949,5 +1972,97 @@ impl BracketOrderClient for IbkrClient {
             result.take_profit,
             result.stop_loss,
         )
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod contract_config_tests {
+    use super::*;
+    use contract::ContractConfigError as E;
+
+    /// A `ContractConfig` with every optional field present, so individual tests
+    /// can null out exactly the field under test.
+    fn full_config(security_type: &str) -> ContractConfig {
+        ContractConfig {
+            name: "TEST".to_string(),
+            symbol: "AAPL".to_string(),
+            security_type: security_type.to_string(),
+            exchange: "SMART".to_string(),
+            currency: "USD".to_string(),
+            last_trade_date: Some("20260116".to_string()),
+            strike: Some(150.0),
+            right: Some("C".to_string()),
+        }
+    }
+
+    #[test]
+    fn stk_and_cash_ignore_option_fields() {
+        // STK/CASH never read last_trade_date/strike/right, so absence is fine.
+        let mut stk = full_config("STK");
+        stk.last_trade_date = None;
+        stk.strike = None;
+        stk.right = None;
+        assert!(stk.to_contract().is_ok());
+
+        let mut cash = full_config("CASH");
+        cash.last_trade_date = None;
+        cash.strike = None;
+        cash.right = None;
+        assert!(cash.to_contract().is_ok());
+    }
+
+    #[test]
+    fn valid_fut_and_opt_build() {
+        assert!(full_config("FUT").to_contract().is_ok());
+        assert!(full_config("OPT").to_contract().is_ok());
+    }
+
+    #[test]
+    fn opt_missing_right_is_error_not_silent_call() {
+        let mut cfg = full_config("OPT");
+        cfg.right = None;
+        assert_eq!(cfg.to_contract().unwrap_err(), E::MissingOptionRight);
+    }
+
+    #[test]
+    fn opt_unrecognized_right_is_error() {
+        let mut cfg = full_config("OPT");
+        cfg.right = Some("X".to_string());
+        assert_eq!(
+            cfg.to_contract().unwrap_err(),
+            E::UnrecognizedOptionRight {
+                right: "X".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn opt_missing_strike_is_error() {
+        let mut cfg = full_config("OPT");
+        cfg.strike = None;
+        assert_eq!(cfg.to_contract().unwrap_err(), E::MissingStrike);
+    }
+
+    #[test]
+    fn fut_and_opt_missing_last_trade_date_is_error() {
+        let mut fut = full_config("FUT");
+        fut.last_trade_date = None;
+        assert_eq!(fut.to_contract().unwrap_err(), E::MissingLastTradeDate);
+
+        let mut opt = full_config("OPT");
+        opt.last_trade_date = None;
+        assert_eq!(opt.to_contract().unwrap_err(), E::MissingLastTradeDate);
+    }
+
+    #[test]
+    fn unknown_security_type_is_error_not_silent_stk() {
+        let cfg = full_config("BOND");
+        assert_eq!(
+            cfg.to_contract().unwrap_err(),
+            E::UnrecognizedSecurityType {
+                security_type: "BOND".to_string()
+            }
+        );
     }
 }

--- a/rustrade-execution/src/error.rs
+++ b/rustrade-execution/src/error.rs
@@ -316,6 +316,52 @@ impl<AssetKey, InstrumentKey> OrderError<AssetKey, InstrumentKey> {
     }
 }
 
+/// Why an account event stream ended.
+///
+/// Delivered in-band as the payload of
+/// [`AccountEventKind::StreamTerminated`](crate::AccountEventKind::StreamTerminated) so that
+/// stream death is a programmatic signal on the account feed rather than a log-only event. A
+/// consumer can react (re-sync via REST, re-establish the stream, halt trading) according to its
+/// own policy — the library reports *why* the stream ended without prescribing the response.
+///
+/// `#[non_exhaustive]` so venues may distinguish further termination causes in future without a
+/// breaking change.
+#[non_exhaustive]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Error)]
+pub enum StreamTerminationReason {
+    /// A venue with built-in reconnection exhausted its retry budget and gave up.
+    ///
+    /// Emitted by venues that reconnect internally (e.g. Binance spot/margin, Alpaca) once the
+    /// final attempt fails. `last_error` is the most recent underlying failure; `attempts` is the
+    /// number of reconnects tried before surrendering. The stream will not recover on its own —
+    /// the consumer must re-establish it.
+    #[error("reconnect budget exhausted after {attempts} attempts: {last_error}")]
+    ReconnectBudgetExhausted {
+        /// Number of reconnect attempts made before giving up.
+        attempts: u32,
+        /// The most recent underlying error that triggered surrender.
+        last_error: String,
+    },
+
+    /// The stream ended on an unrecoverable error with no automatic recovery.
+    ///
+    /// Emitted by venues without built-in reconnection (e.g. IBKR): the underlying stream errored
+    /// and the client does not retry. The consumer is responsible for any re-establishment.
+    #[error("unrecoverable stream error: {0}")]
+    Error(String),
+
+    /// The consumer dropped the receiving half of the account event channel.
+    ///
+    /// The stream task observed that sends now fail and exited. Not an error condition — it
+    /// indicates intentional teardown on the consumer side.
+    #[error("consumer dropped the stream receiver")]
+    ConsumerDropped,
+
+    /// The venue closed the stream as part of a graceful shutdown.
+    #[error("graceful shutdown by venue")]
+    GracefulShutdown,
+}
+
 /// Represents errors related to exchange, asset and instrument identifier key lookups.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Error)]
 pub enum KeyError {

--- a/rustrade-execution/src/indexer.rs
+++ b/rustrade-execution/src/indexer.rs
@@ -73,6 +73,10 @@ impl AccountEventIndexer {
             }
             AccountEventKind::Trade(trade) => AccountEventKind::Trade(self.trade(trade)?),
             AccountEventKind::StreamError(msg) => AccountEventKind::StreamError(msg),
+            // Termination reason carries no exchange/asset/instrument keys — pass through verbatim.
+            AccountEventKind::StreamTerminated(reason) => {
+                AccountEventKind::StreamTerminated(reason)
+            }
         };
 
         Ok(AccountEvent { exchange, kind })
@@ -429,5 +433,47 @@ impl AccountEventIndexer {
                 fees_quote,
             },
         })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::{error::StreamTerminationReason, map::generate_execution_instrument_map};
+    use rustrade_instrument::{index::IndexedInstruments, test_utils};
+
+    fn binance_indexer() -> AccountEventIndexer {
+        let instruments = IndexedInstruments::new(vec![test_utils::instrument(
+            ExchangeId::BinanceSpot,
+            "BTC",
+            "USDT",
+        )]);
+        let map = generate_execution_instrument_map(&instruments, ExchangeId::BinanceSpot).unwrap();
+        AccountEventIndexer::new(Arc::new(map))
+    }
+
+    /// `StreamTerminated` carries no asset/instrument keys, so it must index by mapping only the
+    /// exchange and passing the reason through verbatim.
+    #[test]
+    fn account_event_passes_stream_terminated_through_verbatim() {
+        let indexer = binance_indexer();
+        let reason = StreamTerminationReason::ReconnectBudgetExhausted {
+            attempts: 3,
+            last_error: "socket reset".to_string(),
+        };
+
+        let indexed = indexer
+            .account_event(UnindexedAccountEvent::new(
+                ExchangeId::BinanceSpot,
+                AccountEventKind::StreamTerminated(reason.clone()),
+            ))
+            .unwrap();
+
+        assert_eq!(indexed.exchange, indexer.map.exchange.key);
+        assert!(
+            matches!(indexed.kind, AccountEventKind::StreamTerminated(r) if r == reason),
+            "expected StreamTerminated to pass through unchanged",
+        );
     }
 }

--- a/rustrade-execution/src/indexer.rs
+++ b/rustrade-execution/src/indexer.rs
@@ -72,7 +72,6 @@ impl AccountEventIndexer {
                 AccountEventKind::OrderCancelled(self.order_response_cancel(response)?)
             }
             AccountEventKind::Trade(trade) => AccountEventKind::Trade(self.trade(trade)?),
-            AccountEventKind::StreamError(msg) => AccountEventKind::StreamError(msg),
             // Termination reason carries no exchange/asset/instrument keys — pass through verbatim.
             AccountEventKind::StreamTerminated(reason) => {
                 AccountEventKind::StreamTerminated(reason)

--- a/rustrade-execution/src/lib.rs
+++ b/rustrade-execution/src/lib.rs
@@ -38,6 +38,7 @@ use wiremock as _;
 
 use crate::{
     balance::{AssetBalance, AssetBalanceUpdate},
+    error::StreamTerminationReason,
     order::{Order, OrderSnapshot, request::OrderResponseCancel},
     position::Position,
     trade::Trade,
@@ -155,6 +156,17 @@ pub enum AccountEventKind<ExchangeKey, AssetKey, InstrumentKey> {
     /// Consumers should treat this as a signal that events may have been missed
     /// and consider re-syncing via REST (e.g., `fetch_trades`, `account_snapshot`).
     StreamError(String),
+
+    /// The account event stream has ended; no further events will arrive on it.
+    ///
+    /// This is the in-band, programmatic signal that a stream died — delivered on the **same**
+    /// account feed as every other event rather than being inferred from channel EOF or read from
+    /// logs. The [`StreamTerminationReason`] distinguishes a venue that exhausted its reconnect
+    /// budget from an unrecoverable error, a consumer-side drop, or a graceful shutdown, so the
+    /// consumer can apply its own recovery policy (re-establish the stream, re-sync via REST, halt
+    /// trading). The library reports *that* and *why* the stream ended; it does not prescribe the
+    /// response.
+    StreamTerminated(StreamTerminationReason),
 }
 
 impl<ExchangeKey, AssetKey, InstrumentKey> AccountEvent<ExchangeKey, AssetKey, InstrumentKey>

--- a/rustrade-execution/src/lib.rs
+++ b/rustrade-execution/src/lib.rs
@@ -150,13 +150,6 @@ pub enum AccountEventKind<ExchangeKey, AssetKey, InstrumentKey> {
     /// when available.
     Trade(Trade<AssetKey, InstrumentKey>),
 
-    /// WebSocket-level error from exchange. Connection may have dropped.
-    ///
-    /// Implementations send this when the underlying stream encounters an error.
-    /// Consumers should treat this as a signal that events may have been missed
-    /// and consider re-syncing via REST (e.g., `fetch_trades`, `account_snapshot`).
-    StreamError(String),
-
     /// The account event stream has ended; no further events will arrive on it.
     ///
     /// This is the in-band, programmatic signal that a stream died — delivered on the **same**

--- a/rustrade/src/engine/state/mod.rs
+++ b/rustrade/src/engine/state/mod.rs
@@ -28,6 +28,7 @@ use rustrade_instrument::{
 use rustrade_integration::collection::{one_or_many::OneOrMany, snapshot::Snapshot};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use tracing::warn;
 
 /// Asset-centric state and associated state management logic.
 pub mod asset;
@@ -168,6 +169,17 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
 
                 instrument_state.data.process(event);
                 instrument_state.update_from_trade(trade)
+            }
+            AccountEventKind::StreamTerminated(reason) => {
+                // Observe stream death rather than silently dropping it. The engine does not own
+                // recovery policy (reconnect/re-sync/halt is consumer-specific), but a terminated
+                // account feed means subsequent state may go stale — surface it loudly.
+                warn!(
+                    exchange = ?event.exchange,
+                    %reason,
+                    "account event stream terminated — no further account events will arrive on it",
+                );
+                None
             }
             _ => None,
         };


### PR DESCRIPTION
## Summary

IBKR-centric event-delivery robustness, theme *observable failures over silent ones*. Closes #121, closes #122 (against the upstream `ibapi` tracker); advances #123 (kept open — see below).

## Changes

### #121 — reject incomplete IBKR contract config (breaking)
`ContractConfig::to_contract` previously filled missing fields with silent defaults that produced a *different* contract than intended. Each silent default is now a hard error via a new `#[non_exhaustive]` `contract::ContractConfigError` enum (`MissingOptionRight` / `UnrecognizedOptionRight` / `MissingStrike` / `MissingLastTradeDate` / `UnrecognizedSecurityType`), replacing the `InvalidOptionRight` newtype:
- missing option `right` on an `OPT` no longer defaults to **Call**;
- missing `strike` no longer defaults to `0.0`;
- missing `last_trade_date` on `FUT`/`OPT` no longer defaults to `""`;
- unrecognized `security_type` no longer falls back to **stock** (`STK`).

The startup registration loop already warns-and-skips on a bad config, so a rejected contract is logged and omitted rather than mis-registered.

### #122 — warn on suspiciously short historical tick fetches
`fetch_historical_ticks` / `fetch_historical_bid_ask` now emit a `warn!` when fewer ticks are returned than requested — a best-effort flag for possible silent truncation. Upstream-blocked from a true fix (ibapi 3.0.1 stores the stream error in a private field, no accessor); an upstream issue has been filed. A short read can also be a legitimate end-of-data, so the warning is a prompt to investigate, not a precise error signal.

### #123 — in-band stream-termination signal
New `AccountEventKind::StreamTerminated(StreamTerminationReason)` variant (`ReconnectBudgetExhausted` / `Error` / `ConsumerDropped` / `GracefulShutdown`) delivers *why* an account event stream ended on the existing account feed, rather than leaving it to be inferred from channel EOF or read from logs. The engine surfaces it via `warn!` instead of dropping it. No `ExecutionClient::AccountStream` item-type change.

Also removes the superseded `AccountEventKind::StreamError(String)` variant (breaking): it was non-terminal, already `error!`-logged at each emit site, and dropped unprocessed by the engine — no consumer reacted to it. Transient venue errors now remain in logs only.

**This PR adds only the type plumbing.** Emitting `StreamTerminated` at each venue's terminal stream site is a follow-up, so **#123 stays open**.

## Testing
- `cargo check` / `clippy --all-targets --all-features` clean on `rustrade-execution` and `rustrade`.
- Added an indexer round-trip test for `StreamTerminated`; existing IBKR contract + Hyperliquid suites pass.

## Breaking changes
- `contract::InvalidOptionRight` → `contract::ContractConfigError`; `option_contract` now returns `Result<Contract, ContractConfigError>`.
- `AccountEventKind::StreamError(String)` removed.
