### PR TITLE
feat(execution): emit in-band StreamTerminated at every venue's stream death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **In-band stream-termination signal** (`rustrade-execution`). New
   `AccountEventKind::StreamTerminated(StreamTerminationReason)` variant delivers *why* an account
-  event stream ended — `ReconnectBudgetExhausted { attempts, last_error }` / `Error(String)` /
-  `ConsumerDropped` / `GracefulShutdown` — on the existing account feed, so stream death is a
-  programmatic signal rather than something inferred from channel EOF or read from logs. The engine
-  surfaces it via `warn!` instead of dropping it. This change adds the type plumbing; emitting the
+  event stream ended — `ReconnectBudgetExhausted { attempts, last_error }` (venues with
+  library-managed reconnection) or `Error(String)` (unrecoverable, no retry) — on the existing
+  account feed, so stream death is a programmatic signal rather than something inferred from channel
+  EOF or read from logs. The engine surfaces it via `warn!` instead of dropping it. The
+  `#[non_exhaustive]` `StreamTerminationReason` carries only terminations the library can deliver
+  in-band (a consumer-initiated drop is excluded — the channel is already closed by the time it is
+  observed, so the signal would be undeliverable). This change adds the type plumbing; emitting the
   variant at each venue's terminal stream site is a follow-up.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-band (a consumer-initiated drop is excluded — the channel is already closed by the time it is
   observed, so the signal would be undeliverable). This change adds the type plumbing; emitting the
   variant at each venue's terminal stream site is a follow-up.
+- **`StreamTerminated` is now emitted at every venue's terminal stream death** (`rustrade-execution`).
+  Each integration client emits the variant in-band on the account feed when its event stream truly
+  dies: `ReconnectBudgetExhausted { attempts, last_error }` after a venue's library-managed
+  reconnection gives up (Binance spot/margin, Alpaca), and `Error(String)` for unrecoverable closes
+  with no retry (IBKR, Hyperliquid perp/spot, Mock). A consumer-initiated drop emits nothing — the
+  channel is already closed by the time it is observed. All venues funnel through one feature-agnostic
+  `emit_stream_terminated` helper, so silent-EOF is now a programmatic signal at every venue. Closes #123.
 
 ### Changed
 

--- a/rustrade-execution/src/client/alpaca/mod.rs
+++ b/rustrade-execution/src/client/alpaca/mod.rs
@@ -2124,7 +2124,7 @@ async fn connection_manager(
         // meaningful `last_error`. The consumer-drop arm uses `break 'outer` and never yields one.
         enum DisconnectReason {
             ServerClose,
-            Error,
+            Error(String),
             StreamEnded,
             HeartbeatTimeout,
         }
@@ -2161,7 +2161,7 @@ async fn connection_manager(
                         Some(Ok(_)) => {} // Pong, Frame — ignore
                         Some(Err(e)) => {
                             warn!(%e, "Alpaca WS error, reconnecting");
-                            break DisconnectReason::Error;
+                            break DisconnectReason::Error(e.to_string());
                         }
                         None => {
                             warn!("Alpaca WS stream ended, reconnecting");
@@ -2216,7 +2216,7 @@ async fn connection_manager(
                     format!("heartbeat timeout ({HEARTBEAT_TIMEOUT_SECS}s)")
                 }
                 DisconnectReason::ServerClose => "WebSocket closed by server".to_string(),
-                DisconnectReason::Error => "WebSocket error".to_string(),
+                DisconnectReason::Error(e) => e,
                 DisconnectReason::StreamEnded => "WebSocket stream ended".to_string(),
             };
             emit_stream_terminated(

--- a/rustrade-execution/src/client/alpaca/mod.rs
+++ b/rustrade-execution/src/client/alpaca/mod.rs
@@ -36,7 +36,11 @@ use crate::{
     UnindexedAccountSnapshot,
     balance::{AssetBalance, Balance},
     client::{BracketOrderClient, ExecutionClient},
-    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
+    emit_stream_terminated,
+    error::{
+        ApiError, ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
+        UnindexedOrderError,
+    },
     order::{
         Order, OrderKey, OrderKind, TimeInForce, TrailingOffsetType,
         bracket::{
@@ -254,6 +258,15 @@ impl ExponentialBackoff {
 
     fn reset(&mut self) {
         self.attempt = 0;
+    }
+
+    /// Number of reconnect attempts consumed so far.
+    ///
+    /// After [`wait`](Self::wait) has returned `false` this equals `max_attempts` — the number of
+    /// attempts made before the budget was exhausted. Used to populate
+    /// [`StreamTerminationReason::ReconnectBudgetExhausted`].
+    fn attempts(&self) -> u32 {
+        self.attempt
     }
 
     /// Waits for the current backoff duration. Returns `false` if max attempts exhausted.
@@ -2022,6 +2035,15 @@ async fn connection_manager(
                     error!(%e, "Alpaca WS connect/subscribe failed");
                     if !backoff.wait().await {
                         error!("Alpaca max reconnect attempts exhausted");
+                        // Signal terminal stream death in-band before tx drops.
+                        emit_stream_terminated(
+                            &tx,
+                            ExchangeId::AlpacaBroker,
+                            StreamTerminationReason::ReconnectBudgetExhausted {
+                                attempts: backoff.attempts(),
+                                last_error: e.to_string(),
+                            },
+                        );
                         break;
                     }
                     continue;
@@ -2098,7 +2120,15 @@ async fn connection_manager(
                 last_message_time = Utc::now();
             };
         }
-        loop {
+        // Distinguishes why the inner stream loop exited so the terminal emit below can report a
+        // meaningful `last_error`. The consumer-drop arm uses `break 'outer` and never yields one.
+        enum DisconnectReason {
+            ServerClose,
+            Error,
+            StreamEnded,
+            HeartbeatTimeout,
+        }
+        let reason = loop {
             tokio::select! {
                 msg = ws.next() => {
                     match msg {
@@ -2126,16 +2156,16 @@ async fn connection_manager(
                         }
                         Some(Ok(WsMessage::Close(frame))) => {
                             warn!(frame = ?frame, "Alpaca WS closed by server");
-                            break;
+                            break DisconnectReason::ServerClose;
                         }
                         Some(Ok(_)) => {} // Pong, Frame — ignore
                         Some(Err(e)) => {
                             warn!(%e, "Alpaca WS error, reconnecting");
-                            break;
+                            break DisconnectReason::Error;
                         }
                         None => {
                             warn!("Alpaca WS stream ended, reconnecting");
-                            break;
+                            break DisconnectReason::StreamEnded;
                         }
                     }
                 }
@@ -2146,7 +2176,7 @@ async fn connection_manager(
                     );
                     // Heartbeat timeout is a failure — do NOT reset backoff here.
                     // Backoff resets on successful event receipt in process_ws_text.
-                    break;
+                    break DisconnectReason::HeartbeatTimeout;
                 }
                 _ = tx.closed() => {
                     debug!("Alpaca account_stream consumer dropped, terminating");
@@ -2154,10 +2184,12 @@ async fn connection_manager(
                         Duration::from_secs(WS_CLOSE_TIMEOUT_SECS),
                         ws.close(None),
                     ).await;
+                    // Consumer dropped the receiver — no StreamTerminated emit (channel already
+                    // closed, so it would be a no-op; see emit_stream_terminated docs).
                     break 'outer;
                 }
             }
-        }
+        };
 
         // --- Record disconnect time for fill recovery ---
         // Anchor to last_message_time, not Utc::now(). For heartbeat-triggered
@@ -2171,10 +2203,30 @@ async fn connection_manager(
             tokio::time::timeout(Duration::from_secs(WS_CLOSE_TIMEOUT_SECS), ws.close(None)).await;
 
         if tx.is_closed() {
+            // Consumer dropped the receiver — no StreamTerminated emit (channel already closed,
+            // so it would be a no-op; see emit_stream_terminated docs).
             break;
         }
         if !backoff.wait().await {
             error!("Alpaca max reconnect attempts exhausted, stream terminating");
+            // Surrender after repeated reconnects: report the failure that triggered this round
+            // (consumer-drop already broke out via `break 'outer`).
+            let last_error = match reason {
+                DisconnectReason::HeartbeatTimeout => {
+                    format!("heartbeat timeout ({HEARTBEAT_TIMEOUT_SECS}s)")
+                }
+                DisconnectReason::ServerClose => "WebSocket closed by server".to_string(),
+                DisconnectReason::Error => "WebSocket error".to_string(),
+                DisconnectReason::StreamEnded => "WebSocket stream ended".to_string(),
+            };
+            emit_stream_terminated(
+                &tx,
+                ExchangeId::AlpacaBroker,
+                StreamTerminationReason::ReconnectBudgetExhausted {
+                    attempts: backoff.attempts(),
+                    last_error,
+                },
+            );
             break;
         }
     }

--- a/rustrade-execution/src/client/binance/margin.rs
+++ b/rustrade-execution/src/client/binance/margin.rs
@@ -38,16 +38,19 @@ use super::shared::{
     AbortOnDropStream, BINANCE_MAX_TRADES, BinanceOrderType, BinanceTimeInForce,
     CONNECT_TIMEOUT_SECS, ExponentialBackoff, FILL_RECOVERY_TIMEOUT_SECS, HEARTBEAT_TIMEOUT_SECS,
     RateLimitTracker, SIGNAL_RECOVERY_LOOKBACK_MS, SharedDedupCache, classify_order_kind_tif,
-    classify_rest_order_error, connectivity_error, dedup_key_from_event, emit_reconnect_exhausted,
-    is_duplicate, new_dedup_cache, parse_order_kind, parse_side, parse_time_in_force,
-    rest_call_with_retry,
+    classify_rest_order_error, connectivity_error, dedup_key_from_event, is_duplicate,
+    new_dedup_cache, parse_order_kind, parse_side, parse_time_in_force, rest_call_with_retry,
 };
 use crate::{
     AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot, InstrumentBalanceUpdate,
     IsolatedInstrumentState, IsolatedMarginRisk, UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::{AssetBalance, AssetBalanceUpdate, Balance, BalanceUpdate},
     client::ExecutionClient,
-    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
+    emit_stream_terminated,
+    error::{
+        ApiError, ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
+        UnindexedOrderError,
+    },
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
@@ -2296,11 +2299,13 @@ async fn margin_connection_manager(
                     error!(%e, "BinanceMargin userListenToken acquisition failed");
                     if !backoff.wait().await {
                         error!("BinanceMargin max reconnect attempts exhausted");
-                        emit_reconnect_exhausted(
+                        emit_stream_terminated(
                             &tx,
                             ExchangeId::BinanceMargin,
-                            backoff.attempts(),
-                            e.to_string(),
+                            StreamTerminationReason::ReconnectBudgetExhausted {
+                                attempts: backoff.attempts(),
+                                last_error: e.to_string(),
+                            },
                         );
                         break;
                     }
@@ -2318,11 +2323,13 @@ async fn margin_connection_manager(
                     error!(%e, "BinanceMargin WS connect failed");
                     if !backoff.wait().await {
                         error!("BinanceMargin max reconnect attempts exhausted");
-                        emit_reconnect_exhausted(
+                        emit_stream_terminated(
                             &tx,
                             ExchangeId::BinanceMargin,
-                            backoff.attempts(),
-                            e.to_string(),
+                            StreamTerminationReason::ReconnectBudgetExhausted {
+                                attempts: backoff.attempts(),
+                                last_error: e.to_string(),
+                            },
                         );
                         break;
                     }
@@ -2356,11 +2363,13 @@ async fn margin_connection_manager(
             // token left consumed → next iteration acquires a fresh one (auth/expiry-safe).
             if !backoff.wait().await {
                 error!("BinanceMargin max reconnect attempts exhausted");
-                emit_reconnect_exhausted(
+                emit_stream_terminated(
                     &tx,
                     ExchangeId::BinanceMargin,
-                    backoff.attempts(),
-                    e.to_string(),
+                    StreamTerminationReason::ReconnectBudgetExhausted {
+                        attempts: backoff.attempts(),
+                        last_error: e.to_string(),
+                    },
                 );
                 break;
             }
@@ -2473,11 +2482,13 @@ async fn margin_connection_manager(
                 }
                 _ => "WebSocket disconnected (server close/error)".to_string(),
             };
-            emit_reconnect_exhausted(
+            emit_stream_terminated(
                 &tx,
                 ExchangeId::BinanceMargin,
-                backoff.attempts(),
-                last_error,
+                StreamTerminationReason::ReconnectBudgetExhausted {
+                    attempts: backoff.attempts(),
+                    last_error,
+                },
             );
             break;
         }
@@ -2721,11 +2732,13 @@ async fn isolated_connection_manager(
                         error!(%e, "BinanceMargin isolated userListenToken acquisition failed");
                         if !backoff.wait().await {
                             error!("BinanceMargin isolated max reconnect attempts exhausted");
-                            emit_reconnect_exhausted(
+                            emit_stream_terminated(
                                 &tx,
                                 ExchangeId::BinanceMargin,
-                                backoff.attempts(),
-                                e.to_string(),
+                                StreamTerminationReason::ReconnectBudgetExhausted {
+                                    attempts: backoff.attempts(),
+                                    last_error: e.to_string(),
+                                },
                             );
                             break;
                         }
@@ -2740,11 +2753,13 @@ async fn isolated_connection_manager(
                         error!(%e, "BinanceMargin isolated connect/subscribe failed");
                         if !backoff.wait().await {
                             error!("BinanceMargin isolated max reconnect attempts exhausted");
-                            emit_reconnect_exhausted(
+                            emit_stream_terminated(
                                 &tx,
                                 ExchangeId::BinanceMargin,
-                                backoff.attempts(),
-                                e.to_string(),
+                                StreamTerminationReason::ReconnectBudgetExhausted {
+                                    attempts: backoff.attempts(),
+                                    last_error: e.to_string(),
+                                },
                             );
                             break;
                         }
@@ -2856,11 +2871,13 @@ async fn isolated_connection_manager(
                 }
                 _ => "WebSocket disconnected (server close/error)".to_string(),
             };
-            emit_reconnect_exhausted(
+            emit_stream_terminated(
                 &tx,
                 ExchangeId::BinanceMargin,
-                backoff.attempts(),
-                last_error,
+                StreamTerminationReason::ReconnectBudgetExhausted {
+                    attempts: backoff.attempts(),
+                    last_error,
+                },
             );
             break;
         }

--- a/rustrade-execution/src/client/binance/margin.rs
+++ b/rustrade-execution/src/client/binance/margin.rs
@@ -38,8 +38,9 @@ use super::shared::{
     AbortOnDropStream, BINANCE_MAX_TRADES, BinanceOrderType, BinanceTimeInForce,
     CONNECT_TIMEOUT_SECS, ExponentialBackoff, FILL_RECOVERY_TIMEOUT_SECS, HEARTBEAT_TIMEOUT_SECS,
     RateLimitTracker, SIGNAL_RECOVERY_LOOKBACK_MS, SharedDedupCache, classify_order_kind_tif,
-    classify_rest_order_error, connectivity_error, dedup_key_from_event, is_duplicate,
-    new_dedup_cache, parse_order_kind, parse_side, parse_time_in_force, rest_call_with_retry,
+    classify_rest_order_error, connectivity_error, dedup_key_from_event, emit_reconnect_exhausted,
+    is_duplicate, new_dedup_cache, parse_order_kind, parse_side, parse_time_in_force,
+    rest_call_with_retry,
 };
 use crate::{
     AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot, InstrumentBalanceUpdate,
@@ -2295,6 +2296,12 @@ async fn margin_connection_manager(
                     error!(%e, "BinanceMargin userListenToken acquisition failed");
                     if !backoff.wait().await {
                         error!("BinanceMargin max reconnect attempts exhausted");
+                        emit_reconnect_exhausted(
+                            &tx,
+                            ExchangeId::BinanceMargin,
+                            backoff.attempts(),
+                            e.to_string(),
+                        );
                         break;
                     }
                     continue;
@@ -2311,6 +2318,12 @@ async fn margin_connection_manager(
                     error!(%e, "BinanceMargin WS connect failed");
                     if !backoff.wait().await {
                         error!("BinanceMargin max reconnect attempts exhausted");
+                        emit_reconnect_exhausted(
+                            &tx,
+                            ExchangeId::BinanceMargin,
+                            backoff.attempts(),
+                            e.to_string(),
+                        );
                         break;
                     }
                     continue;
@@ -2343,6 +2356,12 @@ async fn margin_connection_manager(
             // token left consumed → next iteration acquires a fresh one (auth/expiry-safe).
             if !backoff.wait().await {
                 error!("BinanceMargin max reconnect attempts exhausted");
+                emit_reconnect_exhausted(
+                    &tx,
+                    ExchangeId::BinanceMargin,
+                    backoff.attempts(),
+                    e.to_string(),
+                );
                 break;
             }
             continue;
@@ -2437,6 +2456,7 @@ async fn margin_connection_manager(
         }
 
         if !should_reconnect || tx.is_closed() {
+            // Consumer dropped the receiver — no StreamTerminated emit (channel already closed).
             debug!("BinanceMargin connection manager exiting");
             break;
         }
@@ -2445,6 +2465,20 @@ async fn margin_connection_manager(
         // `current_token` and `current_ws` are already None, forcing a fresh token + connection.
         if !matches!(reason, DisconnectReason::TokenRefresh) && !backoff.wait().await {
             error!("BinanceMargin max reconnect attempts exhausted, stream terminating");
+            // reason here is Signal or HeartbeatTimeout (TokenRefresh is guarded above,
+            // ConsumerDropped already broke out earlier).
+            let last_error = match reason {
+                DisconnectReason::HeartbeatTimeout => {
+                    format!("heartbeat timeout ({HEARTBEAT_TIMEOUT_SECS}s)")
+                }
+                _ => "WebSocket disconnected (server close/error)".to_string(),
+            };
+            emit_reconnect_exhausted(
+                &tx,
+                ExchangeId::BinanceMargin,
+                backoff.attempts(),
+                last_error,
+            );
             break;
         }
     }
@@ -2687,6 +2721,12 @@ async fn isolated_connection_manager(
                         error!(%e, "BinanceMargin isolated userListenToken acquisition failed");
                         if !backoff.wait().await {
                             error!("BinanceMargin isolated max reconnect attempts exhausted");
+                            emit_reconnect_exhausted(
+                                &tx,
+                                ExchangeId::BinanceMargin,
+                                backoff.attempts(),
+                                e.to_string(),
+                            );
                             break;
                         }
                         continue;
@@ -2700,6 +2740,12 @@ async fn isolated_connection_manager(
                         error!(%e, "BinanceMargin isolated connect/subscribe failed");
                         if !backoff.wait().await {
                             error!("BinanceMargin isolated max reconnect attempts exhausted");
+                            emit_reconnect_exhausted(
+                                &tx,
+                                ExchangeId::BinanceMargin,
+                                backoff.attempts(),
+                                e.to_string(),
+                            );
                             break;
                         }
                         continue;
@@ -2793,6 +2839,7 @@ async fn isolated_connection_manager(
         }
 
         if !should_reconnect || tx.is_closed() {
+            // Consumer dropped the receiver — no StreamTerminated emit (channel already closed).
             debug!("BinanceMargin isolated connection manager exiting");
             break;
         }
@@ -2801,6 +2848,20 @@ async fn isolated_connection_manager(
         // is already None, forcing fresh tokens + a fresh connection next iteration.
         if !matches!(reason, DisconnectReason::TokenRefresh) && !backoff.wait().await {
             error!("BinanceMargin isolated max reconnect attempts exhausted, stream terminating");
+            // reason here is Signal or HeartbeatTimeout (TokenRefresh guarded above,
+            // ConsumerDropped already broke out earlier).
+            let last_error = match reason {
+                DisconnectReason::HeartbeatTimeout => {
+                    format!("heartbeat timeout ({HEARTBEAT_TIMEOUT_SECS}s)")
+                }
+                _ => "WebSocket disconnected (server close/error)".to_string(),
+            };
+            emit_reconnect_exhausted(
+                &tx,
+                ExchangeId::BinanceMargin,
+                backoff.attempts(),
+                last_error,
+            );
             break;
         }
     }

--- a/rustrade-execution/src/client/binance/shared.rs
+++ b/rustrade-execution/src/client/binance/shared.rs
@@ -12,17 +12,14 @@
 //! params) deliberately stay in their respective modules.
 
 use crate::{
-    AccountEvent, AccountEventKind, UnindexedAccountEvent,
-    error::{
-        ApiError, ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
-    },
+    AccountEventKind, UnindexedAccountEvent,
+    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError},
     order::{OrderKind, TimeInForce, TrailingOffsetType, state::OrderState},
 };
 use binance_sdk::common::errors::{ConnectorError, WebsocketError};
 use lru::LruCache;
 use rustrade_instrument::{
-    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    Side, asset::name::AssetNameExchange, instrument::name::InstrumentNameExchange,
 };
 use smol_str::SmolStr;
 use std::{
@@ -32,7 +29,6 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 // ---------------------------------------------------------------------------
@@ -390,7 +386,7 @@ impl ExponentialBackoff {
     ///
     /// After [`wait`](Self::wait) has returned `false` this equals `max_attempts` — i.e. the
     /// number of attempts made before the budget was exhausted. Used to populate
-    /// [`StreamTerminationReason::ReconnectBudgetExhausted`].
+    /// [`crate::error::StreamTerminationReason::ReconnectBudgetExhausted`].
     pub(crate) fn attempts(&self) -> u32 {
         self.attempt
     }
@@ -414,30 +410,6 @@ impl ExponentialBackoff {
         tokio::time::sleep(Duration::from_millis(delay_ms)).await;
         true
     }
-}
-
-/// Best-effort in-band emit of a terminal
-/// [`StreamTerminated`](AccountEventKind::StreamTerminated) carrying
-/// [`ReconnectBudgetExhausted`](StreamTerminationReason::ReconnectBudgetExhausted), sent on the
-/// account-event channel just before a connection manager exits.
-///
-/// Shared by the venues whose connection managers reconnect internally (Binance spot/margin,
-/// Alpaca) so stream death is delivered in-band rather than inferred from channel EOF. The send is
-/// best-effort: if the consumer already dropped the receiver it is a silent no-op — which is the
-/// consumer-initiated-drop case, deliberately *not* signalled (there is no one left to deliver to).
-pub(crate) fn emit_reconnect_exhausted(
-    tx: &mpsc::UnboundedSender<UnindexedAccountEvent>,
-    exchange: ExchangeId,
-    attempts: u32,
-    last_error: String,
-) {
-    let _ = tx.send(AccountEvent::new(
-        exchange,
-        AccountEventKind::StreamTerminated(StreamTerminationReason::ReconnectBudgetExhausted {
-            attempts,
-            last_error,
-        }),
-    ));
 }
 
 // ---------------------------------------------------------------------------

--- a/rustrade-execution/src/client/binance/shared.rs
+++ b/rustrade-execution/src/client/binance/shared.rs
@@ -12,14 +12,17 @@
 //! params) deliberately stay in their respective modules.
 
 use crate::{
-    AccountEventKind, UnindexedAccountEvent,
-    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError},
+    AccountEvent, AccountEventKind, UnindexedAccountEvent,
+    error::{
+        ApiError, ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
+    },
     order::{OrderKind, TimeInForce, TrailingOffsetType, state::OrderState},
 };
 use binance_sdk::common::errors::{ConnectorError, WebsocketError};
 use lru::LruCache;
 use rustrade_instrument::{
-    Side, asset::name::AssetNameExchange, instrument::name::InstrumentNameExchange,
+    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
+    instrument::name::InstrumentNameExchange,
 };
 use smol_str::SmolStr;
 use std::{
@@ -29,6 +32,7 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
+use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 // ---------------------------------------------------------------------------
@@ -382,6 +386,15 @@ impl ExponentialBackoff {
         self.attempt = 0;
     }
 
+    /// Number of reconnect attempts consumed so far.
+    ///
+    /// After [`wait`](Self::wait) has returned `false` this equals `max_attempts` — i.e. the
+    /// number of attempts made before the budget was exhausted. Used to populate
+    /// [`StreamTerminationReason::ReconnectBudgetExhausted`].
+    pub(crate) fn attempts(&self) -> u32 {
+        self.attempt
+    }
+
     /// Wait for the current backoff duration. Returns `false` if max attempts exhausted.
     pub(crate) async fn wait(&mut self) -> bool {
         if self.attempt >= self.max_attempts {
@@ -401,6 +414,30 @@ impl ExponentialBackoff {
         tokio::time::sleep(Duration::from_millis(delay_ms)).await;
         true
     }
+}
+
+/// Best-effort in-band emit of a terminal
+/// [`StreamTerminated`](AccountEventKind::StreamTerminated) carrying
+/// [`ReconnectBudgetExhausted`](StreamTerminationReason::ReconnectBudgetExhausted), sent on the
+/// account-event channel just before a connection manager exits.
+///
+/// Shared by the venues whose connection managers reconnect internally (Binance spot/margin,
+/// Alpaca) so stream death is delivered in-band rather than inferred from channel EOF. The send is
+/// best-effort: if the consumer already dropped the receiver it is a silent no-op — which is the
+/// consumer-initiated-drop case, deliberately *not* signalled (there is no one left to deliver to).
+pub(crate) fn emit_reconnect_exhausted(
+    tx: &mpsc::UnboundedSender<UnindexedAccountEvent>,
+    exchange: ExchangeId,
+    attempts: u32,
+    last_error: String,
+) {
+    let _ = tx.send(AccountEvent::new(
+        exchange,
+        AccountEventKind::StreamTerminated(StreamTerminationReason::ReconnectBudgetExhausted {
+            attempts,
+            last_error,
+        }),
+    ));
 }
 
 // ---------------------------------------------------------------------------

--- a/rustrade-execution/src/client/binance/spot.rs
+++ b/rustrade-execution/src/client/binance/spot.rs
@@ -31,16 +31,20 @@ use super::shared::{
     AbortOnDropStream, BINANCE_MAX_TRADES, BinanceOrderType, BinanceTimeInForce,
     CONNECT_TIMEOUT_SECS, ExponentialBackoff, FILL_RECOVERY_TIMEOUT_SECS, HEARTBEAT_TIMEOUT_SECS,
     RateLimitTracker, SIGNAL_RECOVERY_LOOKBACK_MS, SharedDedupCache, classify_order_kind_tif,
-    connectivity_error, dedup_key_from_event, emit_reconnect_exhausted, is_api_rejection_error,
-    is_duplicate, is_rate_limit_error, new_dedup_cache, parse_binance_api_error, parse_order_kind,
-    parse_side, parse_time_in_force, rest_call_with_retry,
+    connectivity_error, dedup_key_from_event, is_api_rejection_error, is_duplicate,
+    is_rate_limit_error, new_dedup_cache, parse_binance_api_error, parse_order_kind, parse_side,
+    parse_time_in_force, rest_call_with_retry,
 };
 use crate::{
     AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot, UnindexedAccountEvent,
     UnindexedAccountSnapshot,
     balance::{AssetBalance, AssetBalanceUpdate, Balance, BalanceUpdate},
     client::ExecutionClient,
-    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
+    emit_stream_terminated,
+    error::{
+        ApiError, ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
+        UnindexedOrderError,
+    },
     order::{
         Order, OrderKey, OrderKind, TimeInForce, TrailingOffsetType,
         id::{ClientOrderId, OrderId, StrategyId},
@@ -1245,11 +1249,13 @@ async fn connection_manager(
                     if !backoff.wait().await {
                         error!("BinanceSpot max reconnect attempts exhausted");
                         // Signal terminal stream death in-band before tx drops.
-                        emit_reconnect_exhausted(
+                        emit_stream_terminated(
                             &tx,
                             ExchangeId::BinanceSpot,
-                            backoff.attempts(),
-                            e.to_string(),
+                            StreamTerminationReason::ReconnectBudgetExhausted {
+                                attempts: backoff.attempts(),
+                                last_error: e.to_string(),
+                            },
                         );
                         break;
                     }
@@ -1462,7 +1468,7 @@ async fn connection_manager(
 
         if !should_reconnect || tx.is_closed() {
             // Consumer dropped the receiver — no StreamTerminated emit (the channel is already
-            // closed, so it would be a no-op; see emit_reconnect_exhausted docs).
+            // closed, so it would be a no-op; see emit_stream_terminated docs).
             debug!("BinanceSpot connection manager exiting");
             break;
         }
@@ -1476,7 +1482,14 @@ async fn connection_manager(
                 }
                 _ => "WebSocket disconnected (server close/error)".to_string(),
             };
-            emit_reconnect_exhausted(&tx, ExchangeId::BinanceSpot, backoff.attempts(), last_error);
+            emit_stream_terminated(
+                &tx,
+                ExchangeId::BinanceSpot,
+                StreamTerminationReason::ReconnectBudgetExhausted {
+                    attempts: backoff.attempts(),
+                    last_error,
+                },
+            );
             break;
         }
     }

--- a/rustrade-execution/src/client/binance/spot.rs
+++ b/rustrade-execution/src/client/binance/spot.rs
@@ -1390,9 +1390,6 @@ async fn connection_manager(
         }
 
         // --- Monitor: wait for disconnect, heartbeat timeout, or consumer drop ---
-        // Copy so `reason` survives the `match` that derives `disconnect_time` below and is
-        // still readable at the terminal-break emit.
-        #[derive(Clone, Copy)]
         enum DisconnectReason {
             Signal,
             HeartbeatTimeout,

--- a/rustrade-execution/src/client/binance/spot.rs
+++ b/rustrade-execution/src/client/binance/spot.rs
@@ -31,9 +31,9 @@ use super::shared::{
     AbortOnDropStream, BINANCE_MAX_TRADES, BinanceOrderType, BinanceTimeInForce,
     CONNECT_TIMEOUT_SECS, ExponentialBackoff, FILL_RECOVERY_TIMEOUT_SECS, HEARTBEAT_TIMEOUT_SECS,
     RateLimitTracker, SIGNAL_RECOVERY_LOOKBACK_MS, SharedDedupCache, classify_order_kind_tif,
-    connectivity_error, dedup_key_from_event, is_api_rejection_error, is_duplicate,
-    is_rate_limit_error, new_dedup_cache, parse_binance_api_error, parse_order_kind, parse_side,
-    parse_time_in_force, rest_call_with_retry,
+    connectivity_error, dedup_key_from_event, emit_reconnect_exhausted, is_api_rejection_error,
+    is_duplicate, is_rate_limit_error, new_dedup_cache, parse_binance_api_error, parse_order_kind,
+    parse_side, parse_time_in_force, rest_call_with_retry,
 };
 use crate::{
     AccountEventKind, AccountSnapshot, InstrumentAccountSnapshot, UnindexedAccountEvent,
@@ -1244,6 +1244,13 @@ async fn connection_manager(
                     error!(%e, "BinanceSpot WS connect/subscribe failed");
                     if !backoff.wait().await {
                         error!("BinanceSpot max reconnect attempts exhausted");
+                        // Signal terminal stream death in-band before tx drops.
+                        emit_reconnect_exhausted(
+                            &tx,
+                            ExchangeId::BinanceSpot,
+                            backoff.attempts(),
+                            e.to_string(),
+                        );
                         break;
                     }
                     continue;
@@ -1383,6 +1390,9 @@ async fn connection_manager(
         }
 
         // --- Monitor: wait for disconnect, heartbeat timeout, or consumer drop ---
+        // Copy so `reason` survives the `match` that derives `disconnect_time` below and is
+        // still readable at the terminal-break emit.
+        #[derive(Clone, Copy)]
         enum DisconnectReason {
             Signal,
             HeartbeatTimeout,
@@ -1454,11 +1464,22 @@ async fn connection_manager(
         }
 
         if !should_reconnect || tx.is_closed() {
+            // Consumer dropped the receiver — no StreamTerminated emit (the channel is already
+            // closed, so it would be a no-op; see emit_reconnect_exhausted docs).
             debug!("BinanceSpot connection manager exiting");
             break;
         }
         if !backoff.wait().await {
             error!("BinanceSpot max reconnect attempts exhausted, stream terminating");
+            // Surrender after repeated reconnects: the most recent failure is the disconnect
+            // that triggered this round (ConsumerDropped already broke out above).
+            let last_error = match reason {
+                DisconnectReason::HeartbeatTimeout => {
+                    format!("heartbeat timeout ({HEARTBEAT_TIMEOUT_SECS}s)")
+                }
+                _ => "WebSocket disconnected (server close/error)".to_string(),
+            };
+            emit_reconnect_exhausted(&tx, ExchangeId::BinanceSpot, backoff.attempts(), last_error);
             break;
         }
     }

--- a/rustrade-execution/src/client/hyperliquid/mod.rs
+++ b/rustrade-execution/src/client/hyperliquid/mod.rs
@@ -468,7 +468,8 @@ impl ExecutionClient for HyperliquidClient {
 
         // Both tasks share `event_tx` and both observe `recv() -> None` when the SDK gives up on the
         // socket, so guard the terminal emit with a shared flag — only the first non-cancellation
-        // terminal sends `StreamTerminated`, avoiding a double-emit.
+        // terminal sends `StreamTerminated`, avoiding a double-emit. Relaxed ordering suffices: the
+        // flag has no associated payload to synchronise; the channel send is the synchronisation point.
         let terminated = Arc::new(AtomicBool::new(false));
 
         // Spawn task to process fills
@@ -489,7 +490,7 @@ impl ExecutionClient for HyperliquidClient {
                             // SDK gave up on the stream (channel closed). Emit a single terminal
                             // StreamTerminated across both tasks (guarded by the shared flag).
                             if fills_terminated
-                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
                                 .is_ok()
                             {
                                 emit_stream_terminated(
@@ -551,7 +552,7 @@ impl ExecutionClient for HyperliquidClient {
                             // SDK gave up on the stream (channel closed). Emit a single terminal
                             // StreamTerminated across both tasks (guarded by the shared flag).
                             if orders_terminated
-                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
                                 .is_ok()
                             {
                                 emit_stream_terminated(

--- a/rustrade-execution/src/client/hyperliquid/mod.rs
+++ b/rustrade-execution/src/client/hyperliquid/mod.rs
@@ -72,7 +72,11 @@ use crate::{
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::{AssetBalance, Balance},
     client::ExecutionClient,
-    error::{ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
+    emit_stream_terminated,
+    error::{
+        ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
+        UnindexedOrderError,
+    },
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
@@ -99,7 +103,13 @@ use rustrade_instrument::{
 };
 use rustrade_integration::collection::snapshot::Snapshot;
 use smol_str::{SmolStr, format_smolstr};
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -456,9 +466,15 @@ impl ExecutionClient for HyperliquidClient {
         // CancellationToken ensures tasks exit when stream is dropped
         let cancel_token = CancellationToken::new();
 
+        // Both tasks share `event_tx` and both observe `recv() -> None` when the SDK gives up on the
+        // socket, so guard the terminal emit with a shared flag — only the first non-cancellation
+        // terminal sends `StreamTerminated`, avoiding a double-emit.
+        let terminated = Arc::new(AtomicBool::new(false));
+
         // Spawn task to process fills
         let fills_event_tx = event_tx.clone();
         let fills_cancel = cancel_token.clone();
+        let fills_terminated = terminated.clone();
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -470,6 +486,20 @@ impl ExecutionClient for HyperliquidClient {
                     msg = fills_rx.recv() => {
                         let Some(msg) = msg else {
                             debug!("Fills receiver closed");
+                            // SDK gave up on the stream (channel closed). Emit a single terminal
+                            // StreamTerminated across both tasks (guarded by the shared flag).
+                            if fills_terminated
+                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                                .is_ok()
+                            {
+                                emit_stream_terminated(
+                                    &fills_event_tx,
+                                    ExchangeId::HyperliquidPerp,
+                                    StreamTerminationReason::Error(
+                                        "hyperliquid account stream closed".to_string(),
+                                    ),
+                                );
+                            }
                             return;
                         };
                         match msg {
@@ -504,6 +534,7 @@ impl ExecutionClient for HyperliquidClient {
         // which causes fills_rx to also close.
         let orders_event_tx = event_tx;
         let orders_cancel = cancel_token.clone();
+        let orders_terminated = terminated;
         tokio::spawn(async move {
             let _ws_client = ws_client;
 
@@ -517,6 +548,20 @@ impl ExecutionClient for HyperliquidClient {
                     msg = orders_rx.recv() => {
                         let Some(msg) = msg else {
                             debug!("Orders receiver closed");
+                            // SDK gave up on the stream (channel closed). Emit a single terminal
+                            // StreamTerminated across both tasks (guarded by the shared flag).
+                            if orders_terminated
+                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                                .is_ok()
+                            {
+                                emit_stream_terminated(
+                                    &orders_event_tx,
+                                    ExchangeId::HyperliquidPerp,
+                                    StreamTerminationReason::Error(
+                                        "hyperliquid account stream closed".to_string(),
+                                    ),
+                                );
+                            }
                             return;
                         };
                         match msg {

--- a/rustrade-execution/src/client/hyperliquid/spot.rs
+++ b/rustrade-execution/src/client/hyperliquid/spot.rs
@@ -47,7 +47,11 @@ use crate::{
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::{AssetBalance, Balance},
     client::ExecutionClient,
-    error::{ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
+    emit_stream_terminated,
+    error::{
+        ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
+        UnindexedOrderError,
+    },
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         id::{ClientOrderId, OrderId, StrategyId},
@@ -67,7 +71,13 @@ use rustrade_instrument::{
 };
 use rustrade_integration::collection::snapshot::Snapshot;
 use smol_str::{SmolStr, format_smolstr};
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -347,9 +357,15 @@ impl ExecutionClient for HyperliquidSpotClient {
         let (event_tx, event_rx) = mpsc::unbounded_channel::<UnindexedAccountEvent>();
         let cancel_token = CancellationToken::new();
 
+        // Both tasks share `event_tx` and both observe `recv() -> None` when the SDK gives up on the
+        // socket, so guard the terminal emit with a shared flag — only the first non-cancellation
+        // terminal sends `StreamTerminated`, avoiding a double-emit.
+        let terminated = Arc::new(AtomicBool::new(false));
+
         // Spawn task to process fills (filtered to spot only)
         let fills_event_tx = event_tx.clone();
         let fills_cancel = cancel_token.clone();
+        let fills_terminated = terminated.clone();
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -361,6 +377,20 @@ impl ExecutionClient for HyperliquidSpotClient {
                     msg = fills_rx.recv() => {
                         let Some(msg) = msg else {
                             debug!("Spot fills receiver closed");
+                            // SDK gave up on the stream (channel closed). Emit a single terminal
+                            // StreamTerminated across both tasks (guarded by the shared flag).
+                            if fills_terminated
+                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                                .is_ok()
+                            {
+                                emit_stream_terminated(
+                                    &fills_event_tx,
+                                    ExchangeId::HyperliquidSpot,
+                                    StreamTerminationReason::Error(
+                                        "hyperliquid spot account stream closed".to_string(),
+                                    ),
+                                );
+                            }
                             return;
                         };
                         match msg {
@@ -399,6 +429,7 @@ impl ExecutionClient for HyperliquidSpotClient {
         // which causes fills_rx to also close.
         let orders_event_tx = event_tx;
         let orders_cancel = cancel_token.clone();
+        let orders_terminated = terminated;
         tokio::spawn(async move {
             let _ws_client = ws_client;
 
@@ -412,6 +443,20 @@ impl ExecutionClient for HyperliquidSpotClient {
                     msg = orders_rx.recv() => {
                         let Some(msg) = msg else {
                             debug!("Spot orders receiver closed");
+                            // SDK gave up on the stream (channel closed). Emit a single terminal
+                            // StreamTerminated across both tasks (guarded by the shared flag).
+                            if orders_terminated
+                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                                .is_ok()
+                            {
+                                emit_stream_terminated(
+                                    &orders_event_tx,
+                                    ExchangeId::HyperliquidSpot,
+                                    StreamTerminationReason::Error(
+                                        "hyperliquid spot account stream closed".to_string(),
+                                    ),
+                                );
+                            }
                             return;
                         };
                         match msg {

--- a/rustrade-execution/src/client/hyperliquid/spot.rs
+++ b/rustrade-execution/src/client/hyperliquid/spot.rs
@@ -380,7 +380,7 @@ impl ExecutionClient for HyperliquidSpotClient {
                             // SDK gave up on the stream (channel closed). Emit a single terminal
                             // StreamTerminated across both tasks (guarded by the shared flag).
                             if fills_terminated
-                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
                                 .is_ok()
                             {
                                 emit_stream_terminated(
@@ -446,7 +446,7 @@ impl ExecutionClient for HyperliquidSpotClient {
                             // SDK gave up on the stream (channel closed). Emit a single terminal
                             // StreamTerminated across both tasks (guarded by the shared flag).
                             if orders_terminated
-                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
                                 .is_ok()
                             {
                                 emit_stream_terminated(

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -1176,8 +1176,10 @@ impl ExecutionClient for IbkrClient {
             .name("ibkr-order-stream".to_string())
             .spawn(move || {
                 // Panic safety: parking_lot mutexes do not poison on panic, so shared state
-                // (ContractRegistry, OrderIdMap, etc.) remains usable. On panic the
-                // thread exits, tx is dropped, and the stream closes — caller observes EOF.
+                // (ContractRegistry, OrderIdMap, etc.) remains usable. catch_unwind unwinds only
+                // the inner closure — `tx` lives in this outer thread closure and is still open
+                // afterward, so the panic handler below emits a terminal StreamTerminated before
+                // `tx` drops (a panic is a terminal stream death like any other).
                 let result = catch_unwind(AssertUnwindSafe(|| {
                     use ibapi::orders::{OrderStatusKind, OrderUpdate};
 
@@ -1297,8 +1299,16 @@ impl ExecutionClient for IbkrClient {
                         .or_else(|| panic_info.downcast_ref::<String>().cloned())
                         .unwrap_or_else(|| "unknown panic".to_string());
                     error!("Order stream worker panicked: {msg}");
-                    // Channel type is UnindexedAccountEvent, not Result — cannot send error.
-                    // Caller observes stream close; they can check logs for panic message.
+                    // A panic is a terminal stream death — surface it in-band before tx drops so
+                    // the consumer gets a programmatic signal rather than inferring EOF.
+                    // Best-effort: a no-op if the consumer already dropped rx.
+                    emit_stream_terminated(
+                        &tx,
+                        ExchangeId::Ibkr,
+                        StreamTerminationReason::Error(format!(
+                            "IBKR order-update worker panicked: {msg}"
+                        )),
+                    );
                 }
             })
             .map_err(|e| UnindexedClientError::TaskFailed(format!("thread spawn: {e}")))?;

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -69,6 +69,7 @@ use crate::{
     UnindexedAccountSnapshot,
     balance::AssetBalance,
     client::{BracketOrderClient, ExecutionClient},
+    emit_stream_terminated,
     error::{
         ApiError, ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
     },
@@ -1190,12 +1191,11 @@ impl ExecutionClient for IbkrClient {
                                 // programmatic signal rather than inferring EOF. (best-effort
                                 // send — if the consumer already dropped rx it is a no-op.)
                                 error!(error = %e, "Order stream subscription error");
-                                let _ = tx.send(UnindexedAccountEvent {
-                                    exchange: ExchangeId::Ibkr,
-                                    kind: AccountEventKind::StreamTerminated(
-                                        StreamTerminationReason::Error(e.to_string()),
-                                    ),
-                                });
+                                emit_stream_terminated(
+                                    &tx,
+                                    ExchangeId::Ibkr,
+                                    StreamTerminationReason::Error(e.to_string()),
+                                );
                                 return;
                             }
                         };
@@ -1281,12 +1281,13 @@ impl ExecutionClient for IbkrClient {
                     // The subscription iterator ended without an error (e.g. clean
                     // disconnect/unsubscribe). Still a terminal stream death — surface it
                     // in-band so the consumer doesn't have to infer it from channel EOF.
-                    let _ = tx.send(UnindexedAccountEvent {
-                        exchange: ExchangeId::Ibkr,
-                        kind: AccountEventKind::StreamTerminated(StreamTerminationReason::Error(
+                    emit_stream_terminated(
+                        &tx,
+                        ExchangeId::Ibkr,
+                        StreamTerminationReason::Error(
                             "IBKR order-update stream ended".to_string(),
-                        )),
-                    });
+                        ),
+                    );
                 }));
 
                 if let Err(panic_info) = result {

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -69,7 +69,9 @@ use crate::{
     UnindexedAccountSnapshot,
     balance::AssetBalance,
     client::{BracketOrderClient, ExecutionClient},
-    error::{ApiError, ConnectivityError, OrderError, UnindexedClientError},
+    error::{
+        ApiError, ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
+    },
     order::{
         Order, OrderKey, OrderKind, TimeInForce,
         bracket::{
@@ -1182,11 +1184,19 @@ impl ExecutionClient for IbkrClient {
                         let update = match update {
                             Ok(u) => u,
                             Err(e) => {
-                                // Channel carries UnindexedAccountEvent, not Result —
-                                // cannot forward the error. Log and close the stream so
-                                // the caller observes EOF (consistent with the panic path).
+                                // IBKR has no library-managed reconnection: a subscription
+                                // error ends the stream. Surface it in-band as a terminal
+                                // StreamTerminated(Error) before tx drops so the caller gets a
+                                // programmatic signal rather than inferring EOF. (best-effort
+                                // send — if the consumer already dropped rx it is a no-op.)
                                 error!(error = %e, "Order stream subscription error");
-                                break;
+                                let _ = tx.send(UnindexedAccountEvent {
+                                    exchange: ExchangeId::Ibkr,
+                                    kind: AccountEventKind::StreamTerminated(
+                                        StreamTerminationReason::Error(e.to_string()),
+                                    ),
+                                });
+                                return;
                             }
                         };
                         let event = match update {
@@ -1262,9 +1272,21 @@ impl ExecutionClient for IbkrClient {
                         if let Some(e) = event
                             && tx.send(e).is_err()
                         {
-                            break;
+                            // Consumer dropped rx: no point emitting StreamTerminated
+                            // (the channel is already closed — it would be a no-op).
+                            return;
                         }
                     }
+
+                    // The subscription iterator ended without an error (e.g. clean
+                    // disconnect/unsubscribe). Still a terminal stream death — surface it
+                    // in-band so the consumer doesn't have to infer it from channel EOF.
+                    let _ = tx.send(UnindexedAccountEvent {
+                        exchange: ExchangeId::Ibkr,
+                        kind: AccountEventKind::StreamTerminated(StreamTerminationReason::Error(
+                            "IBKR order-update stream ended".to_string(),
+                        )),
+                    });
                 }));
 
                 if let Err(panic_info) = result {

--- a/rustrade-execution/src/client/mock/mod.rs
+++ b/rustrade-execution/src/client/mock/mod.rs
@@ -2,7 +2,10 @@ use crate::{
     UnindexedAccountEvent, UnindexedAccountSnapshot,
     balance::AssetBalance,
     client::ExecutionClient,
-    error::{ConnectivityError, OrderError, UnindexedClientError, UnindexedOrderError},
+    error::{
+        ConnectivityError, OrderError, StreamTerminationReason, UnindexedClientError,
+        UnindexedOrderError,
+    },
     exchange::mock::request::{MarketPrices, MockExchangeRequest},
     fee::FeeModelConfig,
     fill::SimFillConfig,
@@ -15,13 +18,13 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use derive_more::Constructor;
-use futures::stream::BoxStream;
+use futures::{StreamExt, stream::BoxStream};
 use rustrade_instrument::{
     asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, mpsc, oneshot};
-use tokio_stream::{StreamExt, wrappers::BroadcastStream};
+use tokio_stream::wrappers::BroadcastStream;
 use tracing::error;
 
 #[derive(
@@ -148,18 +151,37 @@ where
         _: &[AssetNameExchange],
         _: &[InstrumentNameExchange],
     ) -> Result<Self::AccountStream, UnindexedClientError> {
-        Ok(futures::StreamExt::boxed(
-            BroadcastStream::new(self.event_rx.resubscribe()).map_while(|result| match result {
-                Ok(event) => Some(event),
-                Err(error) => {
-                    error!(
-                        ?error,
-                        "MockExchange Broadcast AccountStream lagged - terminating"
-                    );
+        // `scan` (not `map_while`) so the broadcast-lag terminal is delivered in-band: on lag we
+        // yield one StreamTerminated event, set `done`, and the next poll ends the stream — whereas
+        // `map_while` would end on lag with a silent EOF and no terminal event.
+        let exchange = self.mocked_exchange;
+        Ok(BroadcastStream::new(self.event_rx.resubscribe())
+            .scan(false, move |done, result| {
+                // `futures::StreamExt::scan` ends the stream when the closure resolves to None.
+                let item = if *done {
+                    // Terminal already emitted on the prior poll — end the stream now.
                     None
-                }
-            }),
-        ))
+                } else {
+                    match result {
+                        Ok(event) => Some(event),
+                        Err(error) => {
+                            error!(
+                                ?error,
+                                "MockExchange Broadcast AccountStream lagged - terminating"
+                            );
+                            *done = true;
+                            Some(UnindexedAccountEvent::stream_terminated(
+                                exchange,
+                                StreamTerminationReason::Error(
+                                    "mock broadcast stream lagged".to_string(),
+                                ),
+                            ))
+                        }
+                    }
+                };
+                futures::future::ready(item)
+            })
+            .boxed())
     }
 
     async fn cancel_order(
@@ -350,5 +372,64 @@ fn into_owned_request<Kind>(
             cid,
         },
         state,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::{AccountEventKind, balance::Balance};
+    use rust_decimal::Decimal;
+    use rustrade_integration::collection::snapshot::Snapshot;
+
+    fn filler_event() -> UnindexedAccountEvent {
+        // Content is irrelevant — these events are overwritten by the lag before they can be
+        // delivered; they exist only to overflow the broadcast buffer.
+        UnindexedAccountEvent::new(
+            ExchangeId::Mock,
+            AccountEventKind::BalanceSnapshot(Snapshot::new(AssetBalance {
+                asset: AssetNameExchange::new("btc"),
+                balance: Balance::new(Decimal::ONE, Decimal::ONE),
+                time_exchange: Utc::now(),
+            })),
+        )
+    }
+
+    /// Broadcast lag is a terminal stream death: the account stream must deliver an in-band
+    /// `StreamTerminated(Error)` (not a silent EOF) and then end.
+    #[tokio::test]
+    async fn account_stream_emits_stream_terminated_on_broadcast_lag() {
+        // Capacity 1 so a burst of sends with no reader immediately overflows → lag.
+        let (event_tx, event_rx) = broadcast::channel::<UnindexedAccountEvent>(1);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        // `MockExecution` derives `Constructor`, so its inherent `new` takes the four fields
+        // directly (the `ExecutionClient::new(config)` trait method is shadowed here).
+        let client = MockExecution::new(ExchangeId::Mock, Utc::now, request_tx, event_rx);
+
+        let mut stream = client.account_stream(&[], &[]).await.unwrap();
+
+        // Overflow the buffer before the stream's receiver reads anything → force a lag.
+        for _ in 0..3 {
+            event_tx.send(filler_event()).unwrap();
+        }
+
+        // The lag is surfaced in-band as the terminal event...
+        let event = stream.next().await.expect("expected a terminal event");
+        assert!(
+            matches!(
+                event.kind,
+                AccountEventKind::StreamTerminated(StreamTerminationReason::Error(_))
+            ),
+            "expected StreamTerminated(Error) on broadcast lag, got {:?}",
+            event.kind
+        );
+        assert_eq!(event.exchange, ExchangeId::Mock);
+
+        // ...after which the stream ends.
+        assert!(
+            stream.next().await.is_none(),
+            "stream must end after the terminal event"
+        );
     }
 }

--- a/rustrade-execution/src/error.rs
+++ b/rustrade-execution/src/error.rs
@@ -324,8 +324,16 @@ impl<AssetKey, InstrumentKey> OrderError<AssetKey, InstrumentKey> {
 /// consumer can react (re-sync via REST, re-establish the stream, halt trading) according to its
 /// own policy — the library reports *why* the stream ended without prescribing the response.
 ///
+/// # Only in-band-deliverable terminations are represented
+///
+/// Every variant here is a termination the library can actually deliver to a consumer that is
+/// still listening. A consumer-initiated drop is deliberately **not** a variant: by the time a
+/// stream task observes the drop, the receiving half of the channel is already gone, so a
+/// `StreamTerminated` send would be a guaranteed no-op. `StreamTerminated` therefore always means
+/// "the stream died while you were still listening".
+///
 /// `#[non_exhaustive]` so venues may distinguish further termination causes in future without a
-/// breaking change.
+/// breaking change (e.g. a venue able to signal a graceful shutdown over a still-open channel).
 #[non_exhaustive]
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Error)]
 pub enum StreamTerminationReason {
@@ -345,21 +353,12 @@ pub enum StreamTerminationReason {
 
     /// The stream ended on an unrecoverable error with no automatic recovery.
     ///
-    /// Emitted by venues without built-in reconnection (e.g. IBKR): the underlying stream errored
-    /// and the client does not retry. The consumer is responsible for any re-establishment.
+    /// Emitted by venues without library-managed reconnection — e.g. IBKR (the underlying
+    /// subscription errored and the client does not retry), Hyperliquid (the SDK's internal
+    /// reconnection gave up and closed the channel), or the mock exchange (its broadcast stream
+    /// lagged past the buffer). The consumer is responsible for any re-establishment.
     #[error("unrecoverable stream error: {0}")]
     Error(String),
-
-    /// The consumer dropped the receiving half of the account event channel.
-    ///
-    /// The stream task observed that sends now fail and exited. Not an error condition — it
-    /// indicates intentional teardown on the consumer side.
-    #[error("consumer dropped the stream receiver")]
-    ConsumerDropped,
-
-    /// The venue closed the stream as part of a graceful shutdown.
-    #[error("graceful shutdown by venue")]
-    GracefulShutdown,
 }
 
 /// Represents errors related to exchange, asset and instrument identifier key lookups.

--- a/rustrade-execution/src/lib.rs
+++ b/rustrade-execution/src/lib.rs
@@ -54,6 +54,7 @@ use rustrade_instrument::{
 };
 use rustrade_integration::collection::snapshot::Snapshot;
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
 
 pub mod balance;
 pub mod client;
@@ -99,6 +100,36 @@ impl<ExchangeKey, AssetKey, InstrumentKey> AccountEvent<ExchangeKey, AssetKey, I
             kind: kind.into(),
         }
     }
+
+    /// Named constructor for the terminal [`StreamTerminated`](AccountEventKind::StreamTerminated)
+    /// event carrying the given [`StreamTerminationReason`].
+    pub(crate) fn stream_terminated(
+        exchange: ExchangeKey,
+        reason: StreamTerminationReason,
+    ) -> Self {
+        Self {
+            exchange,
+            kind: AccountEventKind::StreamTerminated(reason),
+        }
+    }
+}
+
+/// Best-effort in-band emit of a terminal
+/// [`StreamTerminated`](AccountEventKind::StreamTerminated) on the account-event channel, sent just
+/// before a venue's stream task exits so stream death is delivered in-band rather than inferred from
+/// channel EOF.
+///
+/// Shared by every venue connector (Binance spot/margin, Alpaca, IBKR, Hyperliquid, Mock) so the
+/// single construction/send of the terminal event lives in one place, at the abstraction level where
+/// [`AccountEvent`] is defined rather than inside any one vendor module. The send is best-effort: if
+/// the consumer already dropped the receiver it is a silent no-op — which is the
+/// consumer-initiated-drop case, deliberately *not* signalled (there is no one left to deliver to).
+pub(crate) fn emit_stream_terminated(
+    tx: &mpsc::UnboundedSender<UnindexedAccountEvent>,
+    exchange: ExchangeId,
+    reason: StreamTerminationReason,
+) {
+    let _ = tx.send(UnindexedAccountEvent::stream_terminated(exchange, reason));
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, From)]
@@ -155,10 +186,13 @@ pub enum AccountEventKind<ExchangeKey, AssetKey, InstrumentKey> {
     /// This is the in-band, programmatic signal that a stream died — delivered on the **same**
     /// account feed as every other event rather than being inferred from channel EOF or read from
     /// logs. The [`StreamTerminationReason`] distinguishes a venue that exhausted its reconnect
-    /// budget from an unrecoverable error, a consumer-side drop, or a graceful shutdown, so the
-    /// consumer can apply its own recovery policy (re-establish the stream, re-sync via REST, halt
-    /// trading). The library reports *that* and *why* the stream ended; it does not prescribe the
-    /// response.
+    /// budget from an unrecoverable error, so the consumer can apply its own recovery policy
+    /// (re-establish the stream, re-sync via REST, halt trading). The library reports *that* and
+    /// *why* the stream ended; it does not prescribe the response.
+    ///
+    /// Only terminations deliverable while the consumer is still listening are signalled: a
+    /// consumer-initiated drop closes the receiver, so there is no one left to deliver to (see
+    /// [`StreamTerminationReason`] for the deliverable-only rationale).
     StreamTerminated(StreamTerminationReason),
 }
 
@@ -315,5 +349,46 @@ impl<ExchangeKey, AssetKey, InstrumentKey> AccountSnapshot<ExchangeKey, AssetKey
 
     pub fn instruments(&self) -> impl Iterator<Item = &InstrumentKey> {
         self.instruments.iter().map(|snapshot| &snapshot.instrument)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+
+    /// The shared terminal-emit helper every venue connector funnels through must deliver an
+    /// in-band [`AccountEventKind::StreamTerminated`] carrying the given exchange and reason.
+    #[test]
+    fn emit_stream_terminated_delivers_event_in_band() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<UnindexedAccountEvent>();
+        let reason = StreamTerminationReason::ReconnectBudgetExhausted {
+            attempts: 7,
+            last_error: "socket reset".to_string(),
+        };
+
+        emit_stream_terminated(&tx, ExchangeId::BinanceSpot, reason.clone());
+
+        let event = rx.try_recv().expect("expected a terminal event");
+        assert_eq!(event.exchange, ExchangeId::BinanceSpot);
+        assert!(
+            matches!(event.kind, AccountEventKind::StreamTerminated(r) if r == reason),
+            "expected StreamTerminated carrying the supplied reason",
+        );
+    }
+
+    /// Per the D6 consumer-drop decision, emitting after the consumer dropped the receiver is a
+    /// best-effort silent no-op — it must not panic (there is no one left to deliver to).
+    #[test]
+    fn emit_stream_terminated_is_noop_when_receiver_dropped() {
+        let (tx, rx) = mpsc::unbounded_channel::<UnindexedAccountEvent>();
+        drop(rx);
+
+        // Must not panic even though the send is dropped on the floor.
+        emit_stream_terminated(
+            &tx,
+            ExchangeId::HyperliquidPerp,
+            StreamTerminationReason::Error("stream closed".to_string()),
+        );
     }
 }


### PR DESCRIPTION
## What this does
Emits `AccountEventKind::StreamTerminated(StreamTerminationReason)` in-band on the
account feed at every venue's *true* stream death, so silent-EOF becomes a programmatic
signal instead of something inferred from channel close or read from logs.

- `ReconnectBudgetExhausted { attempts, last_error }` — venues with library-managed
  reconnection that gave up: Binance spot, Binance margin, Alpaca.
- `Error(String)` — unrecoverable closes with no retry: IBKR, Hyperliquid perp/spot, Mock.
- A consumer-initiated drop emits nothing (the channel is already closed by the time it
  is observed, so the signal would be undeliverable).

Builds on the type plumbing already on `develop` (the variant, the
`StreamTerminationReason` enum, indexer passthrough, engine `warn!` arm).

## Key design decision — single feature-agnostic helper
The original plan was to reuse Binance's `emit_reconnect_exhausted` for Alpaca, but that
was infeasible: `alpaca` and `binance` are mutually-independent Cargo features
(`default = []`), so importing `crate::client::binance::shared::*` breaks
`--features alpaca`. Instead, all venues now funnel through one helper in the
always-compiled `lib.rs`:

- `pub(crate) fn emit_stream_terminated(tx, exchange, reason)`
- `UnindexedAccountEvent::stream_terminated(exchange, reason)`

The old binance-only `emit_reconnect_exhausted` was deleted. `ExponentialBackoff::attempts()`
stays per-venue (Binance `shared.rs` + a new Alpaca-local accessor).

## Testing caveat
IBKR / Binance / Alpaca / Hyperliquid have no per-venue termination test — they require
WS/REST mocking or aren't deterministically drivable. Coverage rests on: the Mock
end-to-end lag test, the two `emit_stream_terminated` unit tests (every venue funnels
through this one helper), and the existing indexer round-trip. Forcing brittle
live-stream tests was deliberately avoided.

## Verification
- `cargo check -p rustrade-execution --all-features`
- `cargo check -p rustrade-execution --features alpaca` (proves feature-isolated build)
- `cargo test -p rustrade-execution --all-features --lib` -> 368 passed
- clippy clean (workspace, all-targets, all-features)

Closes #123.
