### PR TITLE
refactor(rustrade-data): make Channels::try_from SubKind match exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Dynamic-streams `SubKind` rejection is now exhaustive** (`rustrade-data`, internal). The
+  `Channels::try_from` match that allocates per-`SubKind` channels no longer uses a catch-all
+  wildcard for unsupported kinds; it lists the rejected kinds explicitly, so a future `SubKind`
+  variant is a compile error here rather than a silent runtime fall-through. Unsupported dynamic
+  subscriptions now return `DataError::Unsupported { exchange, sub_kind }` (matching the sibling
+  stream-init path), so the error names the exchange as well as the kind. No behavior change for
+  supported kinds.
 - **IBKR historical tick fetches now warn on suspiciously short reads** (`rustrade-data`, `ibkr`
   feature). `fetch_historical_ticks` / `fetch_historical_bid_ask` emit a `warn!` when fewer ticks
   are returned than requested — a best-effort flag for possible silent truncation. A short read can

--- a/rustrade-data/src/streams/builder/dynamic/mod.rs
+++ b/rustrade-data/src/streams/builder/dynamic/mod.rs
@@ -1023,7 +1023,12 @@ where
                         rxs.candles.insert(sub.exchange, rx);
                     }
                 }
-                unsupported => return Err(DataError::UnsupportedSubKind(unsupported)),
+                sub_kind @ (SubKind::OrderBooksL3 | SubKind::Quotes) => {
+                    return Err(DataError::Unsupported {
+                        exchange: sub.exchange,
+                        sub_kind,
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Replace the catch-all wildcard in the dynamic-streams `Channels::try_from` channel-allocation match with explicit rejected arms (`SubKind::OrderBooksL3 | SubKind::Quotes`). A future `SubKind` variant is now a **compile error** here instead of a silent runtime fall-through.

Unsupported dynamic subscriptions now return `DataError::Unsupported { exchange, sub_kind }` (matching the sibling stream-init path), so the error names the exchange as well as the kind.

## Details

- The other channel-allocation arms already cover `PublicTrades` / `OrderBooksL1` / `OrderBooksL2` / `Liquidations` / `Candles { .. }`, so the wildcard only ever caught `OrderBooksL3` and `Quotes` — both of which remain rejected, just explicitly now.
- The sibling `init` arm is keyed on the `(exchange, sub_kind)` tuple (it enumerates exchange×kind combinations) so it legitimately can't be exhaustive; this `SubKind`-only match can and now is.
- `DataError::UnsupportedSubKind` is left in place (now unused, but a public enum variant — removing it would be an out-of-scope breaking API change; no dead-code warning since public enum variants are exempt).

No behavior change for supported kinds.

## Verification

- `cargo check -p rustrade-data` — clean
- `cargo clippy -p rustrade-data --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious -D clippy::style -W clippy::complexity -D clippy::perf` — no issues

closes #127
