### PR TITLE
feat(statistic): caller-selectable BalanceBasis (gross/net-asset) for drawdown and balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Caller-selectable `BalanceBasis` for asset statistics** (`rustrade`). Asset drawdown and the
+  end-of-session balance row can now be computed from either gross holdings (`Balance::total`, the
+  default) or net asset value (`Balance::net_asset()`, i.e. `total - borrowed`). Select it once via
+  the new `EngineStateBuilder::balance_basis(BalanceBasis)` builder method (mirrors `oms_mode`); the
+  basis flows to every asset's tear-sheet generator and is reported on the `TradingSummary` (its
+  asset-table "Balance" row labels itself "Balance (gross)" / "Balance (net asset)"). **Default is
+  `Gross`, so existing and cash-only users see no change.** `NetAsset` is only well-defined while net
+  asset stays strictly positive — a zero or negative net peak makes the drawdown ratio undefined and
+  the sample is silently dropped; see the `BalanceBasis::NetAsset` docs for this precondition and the
+  snapshot-freshness caveat.
 - **In-band stream-termination signal** (`rustrade-execution`). New
   `AccountEventKind::StreamTerminated(StreamTerminationReason)` variant delivers *why* an account
   event stream ended — `ReconnectBudgetExhausted { attempts, last_error }` (venues with
@@ -29,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (`rustrade`):** the `BalanceBasis` work changes two signatures. `generate_empty_indexed_asset_states`
+  gains a `basis: BalanceBasis` parameter (the `EngineStateBuilder` is the intended construction path
+  and threads it for you). The `TradingSummary` output struct gains a `basis` field
+  (`#[serde(default)]`, so summaries serialised before this change still deserialize as `Gross`);
+  the `TearSheetAssetGenerator` likewise gains a `#[serde(default)] basis` field. No behavior change
+  under the default `Gross` basis.
 - **Dynamic-streams `SubKind` rejection is now exhaustive** (`rustrade-data`, internal). The
   `Channels::try_from` match that allocates per-`SubKind` channels no longer uses a catch-all
   wildcard for unsupported kinds; it lists the rejected kinds explicitly, so a future `SubKind`

--- a/rustrade/src/engine/state/asset/mod.rs
+++ b/rustrade/src/engine/state/asset/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
-    Timed, engine::state::asset::filter::AssetFilter,
-    statistic::summary::asset::TearSheetAssetGenerator,
+    Timed,
+    engine::state::asset::filter::AssetFilter,
+    statistic::summary::asset::{BalanceBasis, TearSheetAssetGenerator},
 };
 use chrono::Utc;
 use derive_more::Constructor;
@@ -227,8 +228,14 @@ impl From<&AssetState> for AssetBalance<AssetNameExchange> {
 
 /// Generates an indexed [`AssetStates`] containing default asset balance data.
 ///
+/// Each asset's [`TearSheetAssetGenerator`] is seeded with `basis`, the session-wide
+/// [`BalanceBasis`] policy (gross vs net-asset) selected once at engine-state construction.
+///
 /// Note that the `time_exchange` is set to `DateTime::<Utc>::MIN_UTC`
-pub fn generate_empty_indexed_asset_states(instruments: &IndexedInstruments) -> AssetStates {
+pub fn generate_empty_indexed_asset_states(
+    instruments: &IndexedInstruments,
+    basis: BalanceBasis,
+) -> AssetStates {
     AssetStates(
         instruments
             .assets()
@@ -241,7 +248,10 @@ pub fn generate_empty_indexed_asset_states(instruments: &IndexedInstruments) -> 
                     ),
                     AssetState::new(
                         asset.value.asset.clone(),
-                        TearSheetAssetGenerator::default(),
+                        TearSheetAssetGenerator {
+                            basis,
+                            ..Default::default()
+                        },
                         None,
                     ),
                 )

--- a/rustrade/src/engine/state/builder.rs
+++ b/rustrade/src/engine/state/builder.rs
@@ -1,11 +1,14 @@
-use crate::engine::state::{
-    EngineState,
-    asset::generate_empty_indexed_asset_states,
-    connectivity::generate_empty_indexed_connectivity_states,
-    instrument::generate_indexed_instrument_states,
-    order::Orders,
-    position::{OmsMode, PositionManager},
-    trading::TradingState,
+use crate::{
+    engine::state::{
+        EngineState,
+        asset::generate_empty_indexed_asset_states,
+        connectivity::generate_empty_indexed_connectivity_states,
+        instrument::generate_indexed_instrument_states,
+        order::Orders,
+        position::{OmsMode, PositionManager},
+        trading::TradingState,
+    },
+    statistic::summary::asset::BalanceBasis,
 };
 use chrono::{DateTime, Utc};
 use fnv::FnvHashMap;
@@ -34,6 +37,12 @@ pub struct EngineStateBuilder<'a, GlobalData, FnInstrumentData> {
     /// Defaults to [`OmsMode::Netting`]. Use [`OmsMode::Hedging`] for strategies that hold
     /// simultaneous long and short positions on the same instrument (e.g. options writing).
     oms_mode: OmsMode,
+    /// [`BalanceBasis`] applied to every asset's `TearSheetAssetGenerator` at construction.
+    ///
+    /// Defaults to [`BalanceBasis::Gross`] (no change for existing/cash users). Use
+    /// [`BalanceBasis::NetAsset`] to compute drawdown and end-of-session balance from net asset
+    /// value on margin accounts — see its docs for the net-must-stay-positive precondition.
+    balance_basis: BalanceBasis,
 }
 
 impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInstrumentData> {
@@ -57,6 +66,7 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
             balances: FnvHashMap::default(),
             instrument_data_init,
             oms_mode: OmsMode::Netting,
+            balance_basis: BalanceBasis::default(),
         }
     }
 
@@ -103,6 +113,23 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
         }
     }
 
+    /// Optionally set the [`BalanceBasis`] for all asset `TearSheetAssetGenerator`s.
+    ///
+    /// Defaults to [`BalanceBasis::Gross`] (drawdown and end-of-session balance computed from gross
+    /// `Balance::total`), which is unchanged behaviour for existing and cash users. Set to
+    /// [`BalanceBasis::NetAsset`] to compute them from net asset value (`total - borrowed`) on
+    /// margin accounts.
+    ///
+    /// # Precondition (`NetAsset`)
+    /// Net-asset drawdown is only well-defined while net asset stays **strictly positive**; see
+    /// [`BalanceBasis::NetAsset`] for the silent-failure modes when it is not.
+    pub fn balance_basis(self, basis: BalanceBasis) -> Self {
+        Self {
+            balance_basis: basis,
+            ..self
+        }
+    }
+
     /// Optionally provide initial exchange asset `Balance`s.
     ///
     /// Useful for back-test scenarios where seeding EngineState with initial `Balance`s is
@@ -140,6 +167,7 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
             balances,
             instrument_data_init,
             oms_mode,
+            balance_basis,
         } = self;
 
         // Default if not provided
@@ -153,7 +181,7 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
         let connectivity = generate_empty_indexed_connectivity_states(instruments);
 
         // Update empty AssetStates from provided exchange asset Balances
-        let mut assets = generate_empty_indexed_asset_states(instruments);
+        let mut assets = generate_empty_indexed_asset_states(instruments, balance_basis);
         for (key, balance) in balances {
             assets
                 .asset_mut(&key)
@@ -180,5 +208,49 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
             assets,
             instruments,
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::{
+        engine::state::EngineState,
+        statistic::{summary::TradingSummaryGenerator, time::Annual365},
+    };
+    use rust_decimal::Decimal;
+    use rustrade_instrument::{Underlying, instrument::Instrument};
+
+    /// End-to-end seam: `EngineStateBuilder::balance_basis(NetAsset)` rides the asset generators
+    /// into the on-demand `TradingSummaryGenerator` (which clones `AssetState.statistics`) and is
+    /// stamped onto the output `TradingSummary.basis`.
+    #[test]
+    fn balance_basis_reaches_output_trading_summary() {
+        let instruments = IndexedInstruments::builder()
+            .add_instrument(Instrument::spot(
+                ExchangeId::BinanceSpot,
+                "binance_spot_btc_usdt",
+                "BTCUSDT",
+                Underlying::new("btc", "usdt"),
+                None,
+            ))
+            .build();
+
+        let state: EngineState<(), ()> = EngineState::builder(&instruments, (), |_| ())
+            .balance_basis(BalanceBasis::NetAsset)
+            .build();
+
+        // Summary generator is built on-demand by cloning the per-asset generators, so the basis
+        // selected on the builder must surface on the generated summary.
+        let mut generator = TradingSummaryGenerator::init(
+            Decimal::ZERO,
+            DateTime::<Utc>::MIN_UTC,
+            DateTime::<Utc>::MIN_UTC,
+            &state.instruments,
+            &state.assets,
+        );
+
+        assert_eq!(generator.generate(Annual365).basis, BalanceBasis::NetAsset);
     }
 }

--- a/rustrade/src/statistic/summary/asset.rs
+++ b/rustrade/src/statistic/summary/asset.rs
@@ -85,10 +85,17 @@ pub struct TearSheetAsset {
 pub struct TearSheetAssetGenerator {
     /// Which [`Balance`] figure drawdown and end-of-session balance are computed from.
     ///
+    /// `pub(crate)`: set once at construction (via `init`/`init_with_basis`, ultimately the
+    /// [`EngineStateBuilder`](crate::engine::state::builder::EngineStateBuilder)) and never mutated
+    /// afterwards. Keeping it crate-private makes the session-wide uniformity that
+    /// [`TradingSummaryGenerator::generate`](crate::statistic::summary::TradingSummaryGenerator::generate)
+    /// relies on to report a single basis an actual invariant, not a convention an external caller
+    /// could break.
+    ///
     /// See [`BalanceBasis::NetAsset`] for the net-asset precondition. `#[serde(default)]` so state
     /// serialised before this field existed loads as [`BalanceBasis::Gross`].
     #[serde(default)]
-    pub basis: BalanceBasis,
+    pub(crate) basis: BalanceBasis,
     pub balance_now: Option<Balance>,
     pub drawdown: DrawdownGenerator,
     pub drawdown_mean: MeanDrawdownGenerator,
@@ -497,8 +504,11 @@ mod tests {
         gross.update_from_balance_parts(next, time_plus_days(base_time, 1));
         net.update_from_balance_parts(next, time_plus_days(base_time, 1));
 
-        assert_eq!(gross.generate().drawdown, net.generate().drawdown);
-        assert_eq!(gross.generate().drawdown.unwrap().value, dec!(0.2));
+        // `generate` is `&mut self` (it folds the in-progress drawdown into the mean/max sub-
+        // generators), so bind each result once rather than calling it repeatedly.
+        let (gross_sheet, net_sheet) = (gross.generate(), net.generate());
+        assert_eq!(gross_sheet.drawdown, net_sheet.drawdown);
+        assert_eq!(gross_sheet.drawdown.unwrap().value, dec!(0.2));
     }
 
     /// Margin balance: Gross tracks `total` (200 -> 180 = 10% drawdown), while `balance_now.total`
@@ -557,9 +567,10 @@ mod tests {
         let next = Balance::new_margin(dec!(100.0), dec!(0.0), dec!(120.0), dec!(0.0));
         generator.update_from_balance_parts(next, time_plus_days(base_time, 1));
 
-        // Silent: no drawdown recorded, running max stays zero.
-        assert_eq!(generator.generate().drawdown, None);
-        assert_eq!(generator.drawdown.drawdown_max, dec!(0.0));
+        // Silent: the public tear sheet records neither a drawdown nor a max-drawdown.
+        let sheet = generator.generate();
+        assert_eq!(sheet.drawdown, None);
+        assert_eq!(sheet.drawdown_max, None);
     }
 
     /// `reset` preserves the configured basis rather than reverting to Gross.

--- a/rustrade/src/statistic/summary/asset.rs
+++ b/rustrade/src/statistic/summary/asset.rs
@@ -7,9 +7,69 @@ use crate::{
     },
 };
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use rustrade_execution::balance::{AssetBalance, Balance};
 use rustrade_integration::collection::snapshot::Snapshot;
 use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Which figure of a [`Balance`] the asset statistics (drawdown, end-of-session balance) are
+/// computed from.
+///
+/// The library deliberately does **not** hard-code one basis: gross is always safe, but net-asset
+/// is only meaningful for margin accounts that stay solvent (see [`Self::NetAsset`]). Picking the
+/// basis is therefore caller policy, selected once via
+/// [`EngineStateBuilder::balance_basis`](crate::engine::state::builder::EngineStateBuilder::balance_basis)
+/// and defaulting to [`Self::Gross`] so existing/cash users see no change.
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Deserialize, Serialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum BalanceBasis {
+    /// Gross holdings ([`Balance::total`]) — always non-negative, the safe default.
+    #[default]
+    Gross,
+
+    /// Net asset value ([`Balance::net_asset`], `total - borrowed`).
+    ///
+    /// # Caller precondition — net must stay strictly positive
+    /// Drawdown is only well-defined while net asset stays **strictly above zero**. The underlying
+    /// [`DrawdownGenerator`] computes `(peak - point) / peak`, so under this basis:
+    /// - a **zero** peak (fully borrowed, `net == 0`) makes the division return `None` and the
+    ///   sample is silently dropped;
+    /// - a **negative** peak (short held from session open) sign-flips the ratio, so a real loss
+    ///   yields a negative "drawdown" that never exceeds the running max and is silently never
+    ///   recorded.
+    ///
+    /// Both failures are silent. A consumer selecting `NetAsset` is responsible for keeping net
+    /// asset strictly positive (or interpreting the drawdown metrics accordingly).
+    ///
+    /// # Freshness
+    /// [`Balance::net_asset`] excludes accrued interest and reflects debt only as fresh as the last
+    /// [`BalanceSnapshot`](rustrade_execution::AccountEventKind::BalanceSnapshot): WS partial
+    /// updates carry no debt, so between snapshots `net_asset == total` and the value steps at
+    /// snapshot boundaries.
+    NetAsset,
+}
+
+impl BalanceBasis {
+    /// Extract the [`Balance`] figure selected by this basis.
+    pub fn value(self, balance: Balance) -> Decimal {
+        match self {
+            Self::Gross => balance.total,
+            Self::NetAsset => balance.net_asset(),
+        }
+    }
+}
+
+impl fmt::Display for BalanceBasis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Gross => "gross",
+            Self::NetAsset => "net asset",
+        })
+    }
+}
 
 /// TearSheet summarising the trading session changes for an Asset.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
@@ -23,6 +83,12 @@ pub struct TearSheetAsset {
 /// Generator for an [`TearSheetAsset`].
 #[derive(Debug, Clone, PartialEq, PartialOrd, Default, Deserialize, Serialize)]
 pub struct TearSheetAssetGenerator {
+    /// Which [`Balance`] figure drawdown and end-of-session balance are computed from.
+    ///
+    /// See [`BalanceBasis::NetAsset`] for the net-asset precondition. `#[serde(default)]` so state
+    /// serialised before this field existed loads as [`BalanceBasis::Gross`].
+    #[serde(default)]
+    pub basis: BalanceBasis,
     pub balance_now: Option<Balance>,
     pub drawdown: DrawdownGenerator,
     pub drawdown_mean: MeanDrawdownGenerator,
@@ -30,11 +96,23 @@ pub struct TearSheetAssetGenerator {
 }
 
 impl TearSheetAssetGenerator {
-    /// Initialise a [`TearSheetAssetGenerator`] from an initial `AssetState`.
+    /// Initialise a [`TearSheetAssetGenerator`] from an initial `AssetState`, using the default
+    /// [`BalanceBasis::Gross`].
     pub fn init(initial: &Timed<Balance>) -> Self {
+        Self::init_with_basis(initial, BalanceBasis::default())
+    }
+
+    /// Initialise a [`TearSheetAssetGenerator`] from an initial `AssetState` and an explicit
+    /// [`BalanceBasis`].
+    ///
+    /// The drawdown seed and every subsequent update are taken through the same `basis`, so the
+    /// seed-vs-update basis can never disagree. See [`BalanceBasis::NetAsset`] for the net-asset
+    /// precondition.
+    pub fn init_with_basis(initial: &Timed<Balance>, basis: BalanceBasis) -> Self {
         Self {
+            basis,
             balance_now: Some(initial.value),
-            drawdown: DrawdownGenerator::init(Timed::new(initial.value.total, initial.time)),
+            drawdown: DrawdownGenerator::init(Timed::new(basis.value(initial.value), initial.time)),
             drawdown_mean: MeanDrawdownGenerator::default(),
             drawdown_max: MaxDrawdownGenerator::default(),
         }
@@ -64,7 +142,7 @@ impl TearSheetAssetGenerator {
 
         if let Some(next_drawdown) = self
             .drawdown
-            .update(Timed::new(balance.total, time_exchange))
+            .update(Timed::new(self.basis.value(balance), time_exchange))
         {
             self.drawdown_mean.update(&next_drawdown);
             self.drawdown_max.update(&next_drawdown);
@@ -88,12 +166,15 @@ impl TearSheetAssetGenerator {
     }
 
     /// Reset the internal state, using a new starting `Timed<Balance>` as seed.
+    ///
+    /// Preserves the configured [`BalanceBasis`] — a reset re-seeds the session, not the policy.
     pub fn reset(&mut self, balance_start: &Timed<Balance>) {
-        *self = Self::init(balance_start);
+        *self = Self::init_with_basis(balance_start, self.basis);
     }
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
     use crate::test_utils::time_plus_days;
@@ -135,6 +216,7 @@ mod tests {
                     time_plus_days(base_time, 1),
                 ),
                 expected: TearSheetAssetGenerator {
+                    basis: BalanceBasis::Gross,
                     balance_now: Some(Balance::new(dec!(2.0), dec!(2.0))),
                     drawdown: DrawdownGenerator::init(Timed::new(
                         dec!(2.0),
@@ -151,6 +233,7 @@ mod tests {
                     time_plus_days(base_time, 2),
                 ),
                 expected: TearSheetAssetGenerator {
+                    basis: BalanceBasis::Gross,
                     balance_now: Some(Balance::new(dec!(1.5), dec!(1.5))),
                     drawdown: DrawdownGenerator {
                         peak: Some(dec!(2.0)),
@@ -169,6 +252,7 @@ mod tests {
                     time_plus_days(base_time, 3),
                 ),
                 expected: TearSheetAssetGenerator {
+                    basis: BalanceBasis::Gross,
                     balance_now: Some(Balance::new(dec!(1.0), dec!(1.0))),
                     drawdown: DrawdownGenerator {
                         peak: Some(dec!(2.0)),
@@ -187,6 +271,7 @@ mod tests {
                     time_plus_days(base_time, 4),
                 ),
                 expected: TearSheetAssetGenerator {
+                    basis: BalanceBasis::Gross,
                     balance_now: Some(Balance::new(dec!(2.5), dec!(2.5))),
                     drawdown: DrawdownGenerator::init(Timed::new(
                         dec!(2.5),
@@ -218,6 +303,7 @@ mod tests {
                     time_plus_days(base_time, 5),
                 ),
                 expected: TearSheetAssetGenerator {
+                    basis: BalanceBasis::Gross,
                     balance_now: Some(Balance::new(dec!(2.4), dec!(2.4))),
                     drawdown: DrawdownGenerator {
                         peak: Some(dec!(2.5)),
@@ -251,6 +337,7 @@ mod tests {
                     time_plus_days(base_time, 6),
                 ),
                 expected: TearSheetAssetGenerator {
+                    basis: BalanceBasis::Gross,
                     balance_now: Some(Balance::new(dec!(2.4), dec!(2.4))),
                     drawdown: DrawdownGenerator {
                         peak: Some(dec!(2.5)),
@@ -284,6 +371,7 @@ mod tests {
                     time_plus_days(base_time, 7),
                 ),
                 expected: TearSheetAssetGenerator {
+                    basis: BalanceBasis::Gross,
                     balance_now: Some(Balance::new(dec!(2.41), dec!(2.41))),
                     drawdown: DrawdownGenerator {
                         peak: Some(dec!(2.5)),
@@ -317,6 +405,7 @@ mod tests {
                     time_plus_days(base_time, 8),
                 ),
                 expected: TearSheetAssetGenerator {
+                    basis: BalanceBasis::Gross,
                     balance_now: Some(Balance::new(dec!(3.0), dec!(3.0))),
                     drawdown: DrawdownGenerator::init(Timed::new(
                         dec!(3.0),
@@ -350,5 +439,139 @@ mod tests {
             generator.update_from_balance(Snapshot(&test.input));
             assert_eq!(generator, test.expected, "TC{index} failed");
         }
+    }
+
+    #[test]
+    fn balance_basis_value_selects_total_or_net_asset() {
+        let cash = Balance::new(dec!(100.0), dec!(100.0));
+        // Gross == net for cash (no margin).
+        assert_eq!(BalanceBasis::Gross.value(cash), dec!(100.0));
+        assert_eq!(BalanceBasis::NetAsset.value(cash), dec!(100.0));
+
+        // Margin: net deducts borrowed principal (interest excluded).
+        let margin = Balance::new_margin(dec!(200.0), dec!(50.0), dec!(150.0), dec!(5.0));
+        assert_eq!(BalanceBasis::Gross.value(margin), dec!(200.0));
+        assert_eq!(BalanceBasis::NetAsset.value(margin), dec!(50.0));
+
+        // Short: net asset is negative (borrowed base asset exceeds holdings).
+        let short = Balance::new_margin(dec!(0.0), dec!(0.0), dec!(10.0), dec!(0.0));
+        assert_eq!(BalanceBasis::NetAsset.value(short), dec!(-10.0));
+    }
+
+    #[test]
+    fn balance_basis_display() {
+        assert_eq!(BalanceBasis::Gross.to_string(), "gross");
+        assert_eq!(BalanceBasis::NetAsset.to_string(), "net asset");
+    }
+
+    #[test]
+    fn balance_basis_serde_snake_case_and_default() {
+        // Serialises to snake_case.
+        assert_eq!(
+            serde_json::to_string(&BalanceBasis::NetAsset).unwrap(),
+            "\"net_asset\""
+        );
+        assert_eq!(
+            serde_json::from_str::<BalanceBasis>("\"gross\"").unwrap(),
+            BalanceBasis::Gross
+        );
+
+        // A generator serialised before `basis` existed (field absent) loads as Gross.
+        let legacy = r#"{"balance_now":null,"drawdown":{"peak":null,"drawdown_max":"0","time_peak":null,"time_now":"-262143-01-01T00:00:00Z"},"drawdown_mean":{"count":0,"mean_drawdown":null},"drawdown_max":{"max":null}}"#;
+        let generator: TearSheetAssetGenerator = serde_json::from_str(legacy).unwrap();
+        assert_eq!(generator.basis, BalanceBasis::Gross);
+    }
+
+    /// Cash balances are basis-invariant: a Gross generator reports the same drawdown a NetAsset one
+    /// would, because `net_asset == total` with no margin. (Default-Gross ⇒ no change for cash users.)
+    #[test]
+    fn cash_balance_gross_equals_net_asset() {
+        let base_time = DateTime::<Utc>::MIN_UTC;
+        let seed = Timed::new(Balance::new(dec!(100.0), dec!(100.0)), base_time);
+
+        let mut gross = TearSheetAssetGenerator::init(&seed);
+        let mut net = TearSheetAssetGenerator::init_with_basis(&seed, BalanceBasis::NetAsset);
+
+        // total 100 -> 80 (a 20% drawdown either way for a cash balance).
+        let next = Balance::new(dec!(80.0), dec!(80.0));
+        gross.update_from_balance_parts(next, time_plus_days(base_time, 1));
+        net.update_from_balance_parts(next, time_plus_days(base_time, 1));
+
+        assert_eq!(gross.generate().drawdown, net.generate().drawdown);
+        assert_eq!(gross.generate().drawdown.unwrap().value, dec!(0.2));
+    }
+
+    /// Margin balance: Gross tracks `total` (200 -> 180 = 10% drawdown), while `balance_now.total`
+    /// stays the raw gross figure regardless of basis.
+    #[test]
+    fn margin_gross_tracks_total() {
+        let base_time = DateTime::<Utc>::MIN_UTC;
+        let seed = Timed::new(
+            Balance::new_margin(dec!(200.0), dec!(50.0), dec!(150.0), dec!(0.0)),
+            base_time,
+        );
+        let mut generator = TearSheetAssetGenerator::init_with_basis(&seed, BalanceBasis::Gross);
+
+        let next = Balance::new_margin(dec!(180.0), dec!(30.0), dec!(150.0), dec!(0.0));
+        generator.update_from_balance_parts(next, time_plus_days(base_time, 1));
+
+        let tear_sheet = generator.generate();
+        assert_eq!(tear_sheet.drawdown.unwrap().value, dec!(0.1)); // (200 - 180) / 200
+        assert_eq!(tear_sheet.balance_end.unwrap().total, dec!(180.0));
+    }
+
+    /// Margin balance under NetAsset: drawdown tracks net (50 -> 30 = 40% drawdown), but the reported
+    /// `balance_now.total` is still the raw gross 180 — only the drawdown basis changes.
+    #[test]
+    fn margin_net_asset_tracks_net() {
+        let base_time = DateTime::<Utc>::MIN_UTC;
+        let seed = Timed::new(
+            Balance::new_margin(dec!(200.0), dec!(50.0), dec!(150.0), dec!(0.0)),
+            base_time,
+        );
+        let mut generator = TearSheetAssetGenerator::init_with_basis(&seed, BalanceBasis::NetAsset);
+
+        // net: 200-150=50 -> 180-150=30.
+        let next = Balance::new_margin(dec!(180.0), dec!(30.0), dec!(150.0), dec!(0.0));
+        generator.update_from_balance_parts(next, time_plus_days(base_time, 1));
+
+        let tear_sheet = generator.generate();
+        assert_eq!(tear_sheet.drawdown.unwrap().value, dec!(0.4)); // (50 - 30) / 50
+        assert_eq!(tear_sheet.balance_end.unwrap().total, dec!(180.0));
+    }
+
+    /// Known limitation (documented on [`BalanceBasis::NetAsset`]): when the net-asset peak is zero,
+    /// `(peak - point) / peak` divides by zero, `checked_div` returns `None`, and the drawdown sample
+    /// is silently dropped — no drawdown is ever recorded even though net moved.
+    #[test]
+    fn net_asset_zero_peak_silently_drops_drawdown() {
+        let base_time = DateTime::<Utc>::MIN_UTC;
+        // Seed peak at net == 0 (fully borrowed): total 100, borrowed 100.
+        let seed = Timed::new(
+            Balance::new_margin(dec!(100.0), dec!(0.0), dec!(100.0), dec!(0.0)),
+            base_time,
+        );
+        let mut generator = TearSheetAssetGenerator::init_with_basis(&seed, BalanceBasis::NetAsset);
+
+        // net moves 0 -> -20 (a real loss), but the zero peak makes the ratio undefined.
+        let next = Balance::new_margin(dec!(100.0), dec!(0.0), dec!(120.0), dec!(0.0));
+        generator.update_from_balance_parts(next, time_plus_days(base_time, 1));
+
+        // Silent: no drawdown recorded, running max stays zero.
+        assert_eq!(generator.generate().drawdown, None);
+        assert_eq!(generator.drawdown.drawdown_max, dec!(0.0));
+    }
+
+    /// `reset` preserves the configured basis rather than reverting to Gross.
+    #[test]
+    fn reset_preserves_basis() {
+        let base_time = DateTime::<Utc>::MIN_UTC;
+        let seed = Timed::new(Balance::new(dec!(100.0), dec!(100.0)), base_time);
+        let mut generator = TearSheetAssetGenerator::init_with_basis(&seed, BalanceBasis::NetAsset);
+
+        let new_seed = Timed::new(Balance::new(dec!(200.0), dec!(200.0)), base_time);
+        generator.reset(&new_seed);
+
+        assert_eq!(generator.basis, BalanceBasis::NetAsset);
     }
 }

--- a/rustrade/src/statistic/summary/display.rs
+++ b/rustrade/src/statistic/summary/display.rs
@@ -196,10 +196,12 @@ where
         }
         table.add_row(header_row);
 
-        // Add metric rows
-        self.add_asset_metric_row(&mut table, "Balance", |ts| {
+        // Add metric rows. The "Balance" row reflects the session's BalanceBasis in both its label
+        // and its value, so a net-asset summary is never mistaken for a gross one.
+        let basis = self.basis;
+        self.add_asset_metric_row(&mut table, &format!("Balance ({basis})"), move |ts| {
             if let Some(balance) = ts.balance_end {
-                format!("{:.8}", balance.total)
+                format!("{:.8}", basis.value(balance))
             } else {
                 "N/A".to_string()
             }
@@ -255,5 +257,68 @@ fn format_percentage(value: Decimal, precision: usize) -> String {
     match value.checked_mul(Decimal::ONE_HUNDRED) {
         Some(pct) => format!("{pct:.precision$}%"),
         None => "∞%".to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::statistic::{summary::asset::BalanceBasis, time::Annual365};
+    use chrono::{DateTime, Utc};
+    use rust_decimal_macros::dec;
+    use rustrade_execution::balance::Balance;
+    use rustrade_instrument::{
+        asset::{ExchangeAsset, name::AssetNameInternal},
+        exchange::ExchangeId,
+    };
+    use rustrade_integration::collection::FnvIndexMap;
+
+    fn summary_with_basis(basis: BalanceBasis, balance_end: Balance) -> TradingSummary<Annual365> {
+        let mut assets = FnvIndexMap::default();
+        assets.insert(
+            ExchangeAsset::new(ExchangeId::BinanceSpot, AssetNameInternal::new("btc")),
+            TearSheetAsset {
+                balance_end: Some(balance_end),
+                drawdown: None,
+                drawdown_mean: None,
+                drawdown_max: None,
+            },
+        );
+
+        TradingSummary {
+            time_engine_start: DateTime::<Utc>::MIN_UTC,
+            time_engine_end: DateTime::<Utc>::MIN_UTC,
+            instruments: FnvIndexMap::default(),
+            assets,
+            basis,
+        }
+    }
+
+    /// The asset-table "Balance" row labels itself with the session basis and formats the value
+    /// through that basis, so a net-asset summary (net 30, gross 180) is never read as gross.
+    #[test]
+    fn asset_table_balance_row_reflects_net_asset_basis() {
+        // total 180, net asset 30 (borrowed 150).
+        let margin = Balance::new_margin(dec!(180.0), dec!(30.0), dec!(150.0), dec!(0.0));
+        let rendered = summary_with_basis(BalanceBasis::NetAsset, margin)
+            .asset_table()
+            .to_string();
+
+        assert!(rendered.contains("Balance (net asset)"));
+        assert!(rendered.contains("30.00000000")); // net asset, not gross total
+        assert!(!rendered.contains("Balance (gross)"));
+    }
+
+    /// Under the default Gross basis the row labels itself "Balance (gross)" and shows the raw total.
+    #[test]
+    fn asset_table_balance_row_reflects_gross_basis() {
+        let margin = Balance::new_margin(dec!(180.0), dec!(30.0), dec!(150.0), dec!(0.0));
+        let rendered = summary_with_basis(BalanceBasis::Gross, margin)
+            .asset_table()
+            .to_string();
+
+        assert!(rendered.contains("Balance (gross)"));
+        assert!(rendered.contains("180.00000000")); // gross total
     }
 }

--- a/rustrade/src/statistic/summary/mod.rs
+++ b/rustrade/src/statistic/summary/mod.rs
@@ -174,8 +174,9 @@ impl TradingSummaryGenerator {
             .collect();
 
         // Single source of truth: the per-asset generators all carry the session basis (set once at
-        // engine-state construction), so derive the report-level basis from them rather than storing
-        // a redundant field. Empty (no assets) defaults to Gross — there are no rows to label.
+        // engine-state construction; the field is crate-private and never mutated after, so this
+        // uniformity is an enforced invariant), so derive the report-level basis from them rather
+        // than storing a redundant field. Empty (no assets) defaults to Gross — no rows to label.
         let basis = self
             .assets
             .values()

--- a/rustrade/src/statistic/summary/mod.rs
+++ b/rustrade/src/statistic/summary/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     engine::state::{asset::AssetStates, instrument::InstrumentStates, position::PositionExited},
     statistic::{
         summary::{
-            asset::{TearSheetAsset, TearSheetAssetGenerator},
+            asset::{BalanceBasis, TearSheetAsset, TearSheetAssetGenerator},
             instrument::{TearSheet, TearSheetGenerator},
         },
         time::TimeInterval,
@@ -41,6 +41,13 @@ pub struct TradingSummary<Interval> {
 
     /// [`ExchangeAsset`] [`TearSheet`]s.
     pub assets: FnvIndexMap<ExchangeAsset<AssetNameInternal>, TearSheetAsset>,
+
+    /// [`BalanceBasis`] the asset drawdown and end-of-session balance figures were computed from.
+    ///
+    /// Reported once at the summary level (a session uses one basis for all assets). `#[serde(default)]`
+    /// so summaries serialised before this field existed load as [`BalanceBasis::Gross`].
+    #[serde(default)]
+    pub basis: BalanceBasis,
 }
 
 impl<Interval> TradingSummary<Interval> {
@@ -166,11 +173,22 @@ impl TradingSummaryGenerator {
             .map(|(asset, tear_sheet)| (asset.clone(), tear_sheet.generate()))
             .collect();
 
+        // Single source of truth: the per-asset generators all carry the session basis (set once at
+        // engine-state construction), so derive the report-level basis from them rather than storing
+        // a redundant field. Empty (no assets) defaults to Gross — there are no rows to label.
+        let basis = self
+            .assets
+            .values()
+            .next()
+            .map(|generator| generator.basis)
+            .unwrap_or_default();
+
         TradingSummary {
             time_engine_start: self.time_engine_start,
             time_engine_end: self.time_engine_now,
             instruments,
             assets,
+            basis,
         }
     }
 }
@@ -245,5 +263,51 @@ impl AssetTearSheetManager<ExchangeAsset<AssetNameInternal>> for TradingSummaryG
         self.assets
             .get_mut(key)
             .unwrap_or_else(|| panic!("TradingSummaryGenerator does not contain: {key:?}"))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::statistic::{summary::asset::BalanceBasis, time::Annual365};
+    use rust_decimal_macros::dec;
+    use rustrade_instrument::exchange::ExchangeId;
+
+    fn generator_with_assets(
+        assets: FnvIndexMap<ExchangeAsset<AssetNameInternal>, TearSheetAssetGenerator>,
+    ) -> TradingSummaryGenerator {
+        TradingSummaryGenerator::new(
+            dec!(0),
+            DateTime::<Utc>::MIN_UTC,
+            DateTime::<Utc>::MIN_UTC,
+            FnvIndexMap::default(),
+            assets,
+        )
+    }
+
+    /// The report-level basis on the generated `TradingSummary` is derived from the per-asset
+    /// generators (which all carry the session basis), so a net-asset session is reported as such.
+    #[test]
+    fn generate_stamps_basis_from_asset_generators() {
+        let mut assets = FnvIndexMap::default();
+        assets.insert(
+            ExchangeAsset::new(ExchangeId::BinanceSpot, AssetNameInternal::new("btc")),
+            TearSheetAssetGenerator {
+                basis: BalanceBasis::NetAsset,
+                ..Default::default()
+            },
+        );
+
+        let mut generator = generator_with_assets(assets);
+        assert_eq!(generator.generate(Annual365).basis, BalanceBasis::NetAsset);
+    }
+
+    /// With no assets there is nothing to derive a basis from (and no rows to label), so the report
+    /// defaults to Gross.
+    #[test]
+    fn generate_with_no_assets_defaults_basis_to_gross() {
+        let mut generator = generator_with_assets(FnvIndexMap::default());
+        assert_eq!(generator.generate(Annual365).basis, BalanceBasis::Gross);
     }
 }


### PR DESCRIPTION
## Summary

Asset drawdown and the end-of-session balance row are now computed from a caller-selected `BalanceBasis`: gross holdings (`Balance::total`, the default) or net asset value (`Balance::net_asset()`, i.e. `total - borrowed`). Select it once via the new `EngineStateBuilder::balance_basis(BalanceBasis)` knob (mirrors `oms_mode`), set at construction and propagated so the drawdown seed and updates can never desync.

**Default is `Gross`, so existing and cash users see no change.**

## Details

- **`BalanceBasis` enum** (`Gross` | `NetAsset`) with `value()` and a `Display` impl driving the asset-table "Balance (gross)" / "Balance (net asset)" label. Modelled as an enum field — not a generic type param (would ripple through `AssetState`/`EngineState`/`TradingSummary`) and not a stored closure (breaks `Default`/`Serialize`).
- **Single source of truth:** `TearSheetAssetGenerator` carries the basis (first field, `#[serde(default)]` so pre-existing serialized state loads as `Gross`); both the drawdown seed and `update_from_balance_parts` route through `basis.value(..)`, and `reset` re-seeds with the configured basis rather than reverting to `Gross`.
- **Report-level reporting:** `TradingSummary` gains a `#[serde(default)] basis` field, derived in `TradingSummaryGenerator::generate()` from the cloned per-asset generators (uniform by construction; empty defaults to `Gross`) rather than stored redundantly.
- **`NetAsset` precondition documented:** drawdown is only well-defined while net asset stays strictly positive — a zero peak silently drops the sample via `checked_div`, and a negative peak sign-flips the ratio so the loss is never recorded. Also notes the `net_asset()` freshness / accrued-interest caveat.

## Breaking changes

- `generate_empty_indexed_asset_states` gains a `basis: BalanceBasis` parameter (the `EngineStateBuilder` threads it for you).
- The `TradingSummary` output struct gains a `basis` field.

## Tests

Cash output unchanged; margin+Gross (`total 200→180` = 10%); margin+NetAsset (`net 50→30` = 40%, raw `balance_end.total` still 180); the net≤0 silent-drop known-limitation; `BalanceBasis` serde round-trip + missing-field-defaults-to-Gross; and the builder→summary→display label seam.

Closes #118.