### PR TITLE
feat(databento): OHLCV candle support for historical and live feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with no retry (IBKR, Hyperliquid perp/spot, Mock). A consumer-initiated drop emits nothing — the
   channel is already closed by the time it is observed. All venues funnel through one feature-agnostic
   `emit_stream_terminated` helper, so silent-EOF is now a programmatic signal at every venue. Closes #123.
+- **Databento OHLCV candles** (`rustrade-data`). The Databento integration now produces normalised
+  `Candle`s from Databento's native OHLCV schemas, both historical and live, alongside its existing
+  trades + L1. Historical: `DatabentoHistorical::fetch_candles` / `fetch_candles_stream` take a typed
+  `DatabentoOhlcvParams { dataset, symbols, time_range, interval }` (chrono types only — no
+  `databento`/`time` types or caller-supplied `Schema`); the DBN schema is derived internally from
+  the interval so the interval/schema pair cannot diverge. Live: `DatabentoLive::subscribe_candles`
+  streams `DataKind::Candle` events, deriving each bar's interval from its own record `rtype` so one
+  connection may carry multiple OHLCV intervals. Bars are stamped at the **open** instant and
+  normalised to the shared `close_time = open + interval` contract via `close_time_from_open`.
+  Databento's native intervals are `1s`/`1m`/`1h`/`1d`; the other 12 `CandleInterval` variants are
+  rejected with `DataError::UnsupportedInterval`. Live is scoped to `1s`/`1m` (the larger bars are
+  historical-only, as Databento's live gateway does not reliably stream them); `ohlcv-eod` and the
+  deprecated OHLCV rtype are out of scope and skipped observably. `OhlcvMsg` carries no trade count,
+  so `Candle::trade_count` is reported as `0` rather than fabricated. Enables Databento's `chrono`
+  feature.
 
 ### Changed
 

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -75,8 +75,11 @@ time = { version = "0.3", optional = true, features = ["macros"] }
 hyperliquid_rust_sdk = { version = "0.6", optional = true }
 
 # Databento (optional, behind "databento" feature)
-# Note: databento re-exports dbn, so we don't need a separate dbn dependency
-databento = { version = "0.52", optional = true }
+# Note: databento re-exports dbn, so we don't need a separate dbn dependency.
+# `chrono` enables `DateTimeRange: From<(DateTime<Utc>, DateTime<Utc>)>`, so the
+# candle historical path can build `GetRangeParams` from a chrono range without a
+# manual chrono->time conversion (chrono is already a core dependency).
+databento = { version = "0.52", optional = true, features = ["chrono"] }
 
 # Massive (optional, behind "massive" feature)
 tokio-tungstenite = { version = "0.29", optional = true, features = ["native-tls"] }

--- a/rustrade-data/src/exchange/databento/historical.rs
+++ b/rustrade-data/src/exchange/databento/historical.rs
@@ -22,15 +22,19 @@
 //! ```
 
 use super::error::{DatabentoResultExt, decode_error};
-use super::transformer::{dbn_mbp1_to_quote, dbn_trade_to_public_trade};
+use super::transformer::{
+    dbn_mbp1_to_quote, dbn_ohlcv_to_candle, dbn_trade_to_public_trade,
+    ensure_databento_ohlcv_supports,
+};
 use crate::error::DataError;
 use crate::event::MarketEvent;
+use crate::subscription::candle::{Candle, CandleInterval};
 use crate::subscription::{quote::Quote, trade::PublicTrade};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use databento::HistoricalClient;
 use databento::dbn::decode::DynDecoder;
 use databento::dbn::enums::VersionUpgradePolicy;
-use databento::dbn::{self, decode::DecodeRecord};
+use databento::dbn::{self, RType, Schema, decode::DecodeRecord};
 use databento::historical::timeseries::GetRangeParams;
 use futures::Stream;
 use rustrade_instrument::exchange::ExchangeId;
@@ -208,6 +212,151 @@ impl DatabentoHistorical {
         Ok(quotes)
     }
 
+    /// Fetch historical OHLCV candles for the given parameters.
+    ///
+    /// Collects all records into memory before returning. For large queries,
+    /// consider [`fetch_candles_stream`](Self::fetch_candles_stream).
+    ///
+    /// # Schema derivation
+    ///
+    /// The DBN schema is derived **internally** from
+    /// [`DatabentoOhlcvParams::interval`] via the crate-internal
+    /// `ensure_databento_ohlcv_supports`, so the interval and schema cannot
+    /// diverge — the caller never supplies a [`Schema`]. The interval is also
+    /// load-bearing for each candle's `close_time`
+    /// (see [`Candle::close_time`](crate::subscription::candle::Candle::close_time)).
+    ///
+    /// # Time range
+    ///
+    /// [`DatabentoOhlcvParams::time_range`] is `(start, end)` with **inclusive
+    /// start and exclusive end**, filtering on the bar's `ts_event` — i.e. the
+    /// bar **open** instant, Databento's native OHLCV filter field — not the
+    /// normalised `close_time`. (Unlike the Hyperliquid path, no close-time
+    /// range-widening/trimming is applied; the range is passed through to
+    /// Databento's native open-time filter.)
+    ///
+    /// # Arguments
+    ///
+    /// * `params` - Typed OHLCV query parameters (dataset, symbols, range, interval)
+    /// * `exchange` - ExchangeId to tag events with (should match dataset)
+    /// * `instrument` - Instrument key to tag events with (use `Arc<K>` for efficiency)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataError::UnsupportedInterval`] if `params.interval` is not one
+    /// of Databento's native intervals (`1s`/`1m`/`1h`/`1d`); [`DataError::Databento`]
+    /// if the request fails, a record fails to decode, a price field carries the
+    /// `UNDEF_PRICE` sentinel, or a candle's `close_time` overflows. A conversion
+    /// failure is **propagated**, never silently skipped (native OHLCV bars have no
+    /// skippable-malformed mode).
+    pub async fn fetch_candles<K: Clone>(
+        &mut self,
+        params: &DatabentoOhlcvParams,
+        exchange: ExchangeId,
+        instrument: K,
+    ) -> Result<Vec<MarketEvent<K, Candle>>, DataError> {
+        let schema = ensure_databento_ohlcv_supports(exchange, params.interval)?;
+        let get_range = build_ohlcv_get_range(params, schema);
+
+        debug!(?get_range, "Fetching historical candles from Databento");
+
+        let mut decoder = self
+            .client
+            .timeseries()
+            .get_range(&get_range)
+            .await
+            .with_context("fetching candles")?;
+
+        let mut candles = Vec::with_capacity(4096);
+
+        while let Some(record) = decoder
+            .decode_record::<dbn::OhlcvMsg>()
+            .await
+            .with_context("decoding OHLCV record")?
+        {
+            assert_ohlcv_rtype_matches(record.hd.rtype, schema)?;
+            let (time_exchange, candle) = dbn_ohlcv_to_candle(record, params.interval)?;
+            candles.push(MarketEvent {
+                time_exchange,
+                time_received: Utc::now(),
+                exchange,
+                instrument: instrument.clone(),
+                kind: candle,
+            });
+        }
+
+        info!(count = candles.len(), "Fetched historical candles");
+        Ok(candles)
+    }
+
+    /// Stream historical OHLCV candles without collecting into memory.
+    ///
+    /// Unlike [`fetch_candles`](Self::fetch_candles), this returns a stream that
+    /// yields records as they're decoded, avoiding memory spikes for large queries.
+    ///
+    /// See [`fetch_candles`](Self::fetch_candles) for schema-derivation and
+    /// time-range semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataError::UnsupportedInterval`] up front if `params.interval` is
+    /// unsupported, or [`DataError::Databento`] if the initial `get_range` request
+    /// fails. Per-item errors are yielded as `Err` items: a DBN decode failure (the
+    /// decoder is then in an unspecified state — drop the stream), an rtype/schema
+    /// contract violation (`assert_ohlcv_rtype_matches`; the stream keeps polling
+    /// but every record is likely to fail the same way — drop the stream), or a
+    /// candle conversion failure (an `UNDEF_PRICE` sentinel or `close_time`
+    /// overflow — surfaced, never skipped).
+    pub async fn fetch_candles_stream<K: Clone + Send + 'static>(
+        &mut self,
+        params: &DatabentoOhlcvParams,
+        exchange: ExchangeId,
+        instrument: K,
+    ) -> Result<impl Stream<Item = Result<MarketEvent<K, Candle>, DataError>>, DataError> {
+        let schema = ensure_databento_ohlcv_supports(exchange, params.interval)?;
+        let get_range = build_ohlcv_get_range(params, schema);
+
+        debug!(?get_range, "Streaming historical candles from Databento");
+
+        let decoder = self
+            .client
+            .timeseries()
+            .get_range(&get_range)
+            .await
+            .with_context("fetching candles")?;
+
+        Ok(futures::stream::unfold(
+            CandleStreamState {
+                decoder,
+                exchange,
+                instrument,
+                interval: params.interval,
+                schema,
+            },
+            |mut state| async move {
+                match state.decoder.decode_record::<dbn::OhlcvMsg>().await {
+                    Ok(Some(record)) => {
+                        if let Err(e) = assert_ohlcv_rtype_matches(record.hd.rtype, state.schema) {
+                            return Some((Err(e), state));
+                        }
+                        let event = dbn_ohlcv_to_candle(record, state.interval).map(
+                            |(time_exchange, candle)| MarketEvent {
+                                time_exchange,
+                                time_received: Utc::now(),
+                                exchange: state.exchange,
+                                instrument: state.instrument.clone(),
+                                kind: candle,
+                            },
+                        );
+                        Some((event, state))
+                    }
+                    Ok(None) => None,
+                    Err(e) => Some((Err(decode_error(e.to_string())), state)),
+                }
+            },
+        ))
+    }
+
     /// Stream historical trades without collecting into memory.
     ///
     /// Unlike [`fetch_trades`](Self::fetch_trades), this returns a stream that
@@ -365,6 +514,63 @@ impl DatabentoHistorical {
     }
 }
 
+/// Typed parameters for a historical OHLCV candle query.
+///
+/// Deliberately carries **no** [`Schema`]: the schema is derived internally from
+/// [`interval`](Self::interval) (via the crate-internal
+/// `ensure_databento_ohlcv_supports`), making an interval/schema mismatch
+/// unrepresentable by construction. The schema is
+/// load-bearing for each candle's `close_time`, so letting a caller supply it
+/// independently of the interval would be a footgun.
+///
+/// All fields use standard/`chrono` types so consumers need not depend on the
+/// `databento` or `time` crates to build a request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DatabentoOhlcvParams {
+    /// Dataset code (e.g. `"GLBX.MDP3"`, `"XNAS.ITCH"`).
+    pub dataset: String,
+    /// Symbols to filter for (raw symbology, e.g. `["ESM5", "NQM5"]`).
+    pub symbols: Vec<String>,
+    /// Query range as `(start, end)` — inclusive start, exclusive end — filtering
+    /// on the bar `ts_event` (open). `start` must be strictly before `end`; an
+    /// inverted or empty range is not validated here and surfaces as a
+    /// [`DataError::Databento`] from the API call. See
+    /// [`DatabentoHistorical::fetch_candles`].
+    pub time_range: (DateTime<Utc>, DateTime<Utc>),
+    /// Candle interval/resolution. Must be one of Databento's native intervals
+    /// (`Sec1`/`Min1`/`Hour1`/`Day1`), else the fetch returns
+    /// [`DataError::UnsupportedInterval`].
+    pub interval: CandleInterval,
+}
+
+/// Build a [`GetRangeParams`] for an OHLCV query from typed params + derived schema.
+fn build_ohlcv_get_range(params: &DatabentoOhlcvParams, schema: Schema) -> GetRangeParams {
+    GetRangeParams::builder()
+        // `.dataset()` takes `impl ToString` and stringifies internally, so pass
+        // `&str` to avoid an extra `String` allocation from a redundant `.clone()`.
+        .dataset(params.dataset.as_str())
+        .symbols(params.symbols.clone())
+        .schema(schema)
+        .date_time_range(params.time_range)
+        .build()
+}
+
+/// Defensive backstop: assert a decoded record's `rtype` maps to the schema we
+/// requested.
+///
+/// Because the schema is derived from the interval ([`ensure_databento_ohlcv_supports`]),
+/// this should *always* hold; a mismatch signals a `dbn` API contract violation
+/// (not caller error) and is surfaced as [`DataError`], never silently skipped.
+fn assert_ohlcv_rtype_matches(rtype: u8, schema: Schema) -> Result<(), DataError> {
+    if RType::try_into_schema(rtype) == Some(schema) {
+        Ok(())
+    } else {
+        Err(decode_error(format!(
+            "OHLCV record rtype {rtype:#04x} does not map to requested schema {schema:?} (dbn contract violation)"
+        )))
+    }
+}
+
 /// Load trades from a pre-downloaded DBN file.
 ///
 /// Returns an iterator to avoid loading entire file into memory.
@@ -427,6 +633,14 @@ struct TradeStreamState<K, D> {
     decoder: D,
     exchange: ExchangeId,
     instrument: K,
+}
+
+struct CandleStreamState<K, D> {
+    decoder: D,
+    exchange: ExchangeId,
+    instrument: K,
+    interval: CandleInterval,
+    schema: Schema,
 }
 
 struct QuoteStreamState<K, D> {
@@ -504,5 +718,41 @@ impl<K: Clone> Iterator for DbnQuoteIterator<K> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use databento::dbn::enums::rtype;
+
+    #[test]
+    fn assert_ohlcv_rtype_matches_accepts_match_and_surfaces_mismatch() {
+        // Matching rtype/schema pair: Ok.
+        assert!(assert_ohlcv_rtype_matches(rtype::OHLCV_1M, Schema::Ohlcv1M).is_ok());
+        assert!(assert_ohlcv_rtype_matches(rtype::OHLCV_1D, Schema::Ohlcv1D).is_ok());
+
+        // Mismatch (record 1h vs requested 1m): a dbn contract violation, surfaced
+        // as DataError rather than silently skipped.
+        assert!(assert_ohlcv_rtype_matches(rtype::OHLCV_1H, Schema::Ohlcv1M).is_err());
+        // A non-OHLCV rtype is also rejected.
+        assert!(assert_ohlcv_rtype_matches(rtype::MBP_0, Schema::Ohlcv1M).is_err());
+    }
+
+    #[test]
+    fn build_ohlcv_get_range_threads_schema_and_dataset() {
+        let params = DatabentoOhlcvParams {
+            dataset: "GLBX.MDP3".to_string(),
+            symbols: vec!["ESM5".to_string()],
+            time_range: (
+                "2024-01-01T00:00:00Z".parse().unwrap(),
+                "2024-01-02T00:00:00Z".parse().unwrap(),
+            ),
+            interval: CandleInterval::Min1,
+        };
+        let get_range = build_ohlcv_get_range(&params, Schema::Ohlcv1M);
+        assert_eq!(get_range.schema, Schema::Ohlcv1M);
+        assert_eq!(get_range.dataset, "GLBX.MDP3");
     }
 }

--- a/rustrade-data/src/exchange/databento/live.rs
+++ b/rustrade-data/src/exchange/databento/live.rs
@@ -47,12 +47,16 @@
 //! ```
 
 use super::error::{DatabentoErrorKind, DatabentoResultExt};
-use super::transformer::{dbn_mbp1_to_orderbook_l1, dbn_trade_to_public_trade};
+use super::transformer::{
+    dbn_mbp1_to_orderbook_l1, dbn_ohlcv_to_candle, dbn_trade_to_public_trade,
+    ensure_databento_ohlcv_supports, rtype_to_candle_interval,
+};
 use crate::error::DataError;
 use crate::event::{DataKind, MarketEvent};
+use crate::subscription::candle::CandleInterval;
 use chrono::Utc;
 use databento::LiveClient;
-use databento::dbn::{Mbp1Msg, PitSymbolMap, RecordRef, Schema, TradeMsg};
+use databento::dbn::{Mbp1Msg, OhlcvMsg, PitSymbolMap, RecordRef, Schema, TradeMsg};
 use databento::live::Subscription;
 use futures::Stream;
 use rustrade_instrument::exchange::ExchangeId;
@@ -165,6 +169,16 @@ impl<K> DatabentoLive<K> {
     /// * `symbols` - Symbol identifiers (e.g., `["ESM5", "NQM5"]`)
     /// * `schema` - Data schema to subscribe to (e.g., `Schema::Trades`, `Schema::Mbp1`)
     ///
+    /// # OHLCV note
+    ///
+    /// This is the low-level escape hatch: it subscribes to any `Schema` as-is and
+    /// performs **no** interval validation. Subscribing to an OHLCV schema here
+    /// (e.g. `Schema::Ohlcv1H`/`Schema::Ohlcv1D`) bypasses the `Sec1`/`Min1`
+    /// live-only check in [`subscribe_candles`](Self::subscribe_candles), and any
+    /// resulting bars whose `rtype` maps to a [`CandleInterval`] will be emitted as
+    /// `DataKind::Candle`. Prefer [`subscribe_candles`](Self::subscribe_candles) for
+    /// candles unless you deliberately want that lower-level behaviour.
+    ///
     /// # Errors
     ///
     /// Returns error if subscription request fails.
@@ -182,6 +196,36 @@ impl<K> DatabentoLive<K> {
             .with_context("subscribing to live feed")?;
 
         Ok(())
+    }
+
+    /// Subscribe to OHLCV candles for `symbols` at the given interval.
+    ///
+    /// Validates the interval and maps it to the Databento OHLCV schema before
+    /// subscribing. The resulting stream emits [`DataKind::Candle`] events whose
+    /// interval is derived per-record from each bar's `rtype`, so a single
+    /// connection may safely carry multiple OHLCV intervals.
+    ///
+    /// # Live interval scope
+    ///
+    /// Only `Sec1`/`Min1` are accepted live. Databento's live gateway does not
+    /// reliably stream the larger `Hour1`/`Day1` bars, so those are
+    /// **historical-only** here — use [`DatabentoHistorical::fetch_candles`].
+    /// They are rejected at subscribe time (observable failure) rather than
+    /// yielding a silently empty stream.
+    ///
+    /// [`DatabentoHistorical::fetch_candles`]: super::historical::DatabentoHistorical::fetch_candles
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataError::UnsupportedInterval`] for any interval other than
+    /// `Sec1`/`Min1`, or [`DataError::Databento`] if the subscription request fails.
+    pub async fn subscribe_candles(
+        &mut self,
+        symbols: &[&str],
+        interval: CandleInterval,
+    ) -> Result<(), DataError> {
+        let schema = ensure_databento_live_ohlcv_supports(self.exchange, interval)?;
+        self.subscribe(symbols, schema).await
     }
 
     /// Returns a reference to the underlying client for advanced use cases.
@@ -203,8 +247,8 @@ impl<K: Clone + Send + 'static> DatabentoLive<K> {
     ///
     /// # Returns
     ///
-    /// A stream of `MarketEvent<K, DataKind>` where `DataKind` is either `Trade` or
-    /// `OrderBookL1` depending on the subscribed schema.
+    /// A stream of `MarketEvent<K, DataKind>` where `DataKind` is one of `Trade`,
+    /// `OrderBookL1`, or `Candle` depending on the subscribed schema(s).
     ///
     /// Records for symbols not in the `instruments` map are skipped with a warning.
     ///
@@ -348,6 +392,100 @@ fn process_record<K: Clone>(
         }
     }
 
+    // Try OhlcvMsg for candles
+    if let Some(ohlcv) = record.get::<OhlcvMsg>() {
+        // Derive the interval from this record's own rtype: one connection may
+        // interleave multiple OHLCV schemas. `None` => an rtype with no
+        // CandleInterval (ohlcv-eod / ohlcv-deprecated); skip it observably
+        // rather than crashing the stream (a caller can subscribe ohlcv-eod).
+        let interval = match rtype_to_candle_interval(ohlcv.hd.rtype) {
+            Some(interval) => interval,
+            None => {
+                debug!(
+                    rtype = ohlcv.hd.rtype,
+                    "Skipping OHLCV record with no CandleInterval (eod/deprecated)"
+                );
+                return None;
+            }
+        };
+
+        let symbol = symbol_map.get(ohlcv.hd.instrument_id)?;
+
+        let instrument = match instruments.get(symbol) {
+            Some(key) => key.clone(),
+            None => {
+                trace!(%symbol, "Skipping candle for unknown symbol");
+                return None;
+            }
+        };
+
+        // Native OHLCV bars are always final/closed, so every record yields a
+        // candle. Conversion only fails on timestamp/close_time overflow, which
+        // the close_time contract requires be surfaced, never skipped.
+        return Some(
+            dbn_ohlcv_to_candle(ohlcv, interval).map(|(time_exchange, candle)| MarketEvent {
+                time_exchange,
+                time_received: Utc::now(),
+                exchange,
+                instrument,
+                kind: DataKind::Candle(candle),
+            }),
+        );
+    }
+
     // Other record types (InstrumentDefMsg, etc.) are silently skipped
     None
+}
+
+/// Validate and map a candle interval for the **live** feed (`Sec1`/`Min1` only).
+///
+/// First rejects the intervals Databento serves on no OHLCV path (via
+/// [`ensure_databento_ohlcv_supports`]), then additionally rejects `Hour1`/`Day1`:
+/// those are valid Databento schemas but are not reliably emitted by the live
+/// gateway, so they are historical-only here (the G21.1 hedge). Widening this is
+/// an additive change if a live key later confirms the larger bars stream.
+fn ensure_databento_live_ohlcv_supports(
+    exchange: ExchangeId,
+    interval: CandleInterval,
+) -> Result<Schema, DataError> {
+    let schema = ensure_databento_ohlcv_supports(exchange, interval)?;
+    match interval {
+        CandleInterval::Sec1 | CandleInterval::Min1 => Ok(schema),
+        _ => Err(DataError::UnsupportedInterval { exchange, interval }),
+    }
+}
+
+#[cfg(test)]
+// Test code may unwrap freely since panics indicate test failure
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_ohlcv_accepts_only_sec1_and_min1() {
+        let ex = ExchangeId::DatabentoGlbx;
+        assert_eq!(
+            ensure_databento_live_ohlcv_supports(ex, CandleInterval::Sec1).unwrap(),
+            Schema::Ohlcv1S
+        );
+        assert_eq!(
+            ensure_databento_live_ohlcv_supports(ex, CandleInterval::Min1).unwrap(),
+            Schema::Ohlcv1M
+        );
+
+        // 1h/1d are valid Databento schemas but historical-only on the live feed
+        // (G21.1 hedge): rejected observably, not silently subscribed.
+        for interval in [CandleInterval::Hour1, CandleInterval::Day1] {
+            assert!(
+                matches!(
+                    ensure_databento_live_ohlcv_supports(ex, interval),
+                    Err(DataError::UnsupportedInterval { interval: i, .. }) if i == interval
+                ),
+                "expected {interval} to be rejected live"
+            );
+        }
+
+        // A non-native interval is rejected too.
+        assert!(ensure_databento_live_ohlcv_supports(ex, CandleInterval::Min5).is_err());
+    }
 }

--- a/rustrade-data/src/exchange/databento/mod.rs
+++ b/rustrade-data/src/exchange/databento/mod.rs
@@ -49,5 +49,7 @@ pub mod live;
 pub(crate) mod transformer;
 
 pub use error::DatabentoErrorKind;
-pub use historical::{DatabentoHistorical, load_quotes_from_dbn, load_trades_from_dbn};
+pub use historical::{
+    DatabentoHistorical, DatabentoOhlcvParams, load_quotes_from_dbn, load_trades_from_dbn,
+};
 pub use live::DatabentoLive;

--- a/rustrade-data/src/exchange/databento/transformer.rs
+++ b/rustrade-data/src/exchange/databento/transformer.rs
@@ -13,12 +13,17 @@
 //! - `ts_event`: Exchange timestamp (used as `time_exchange`)
 //! - `ts_recv`: Databento receive timestamp
 
+use super::error::DatabentoErrorKind;
 use crate::books::Level;
-use crate::subscription::{book::OrderBookL1, quote::Quote, trade::PublicTrade};
+use crate::error::DataError;
+use crate::subscription::book::OrderBookL1;
+use crate::subscription::candle::{Candle, CandleInterval, close_time_from_open};
+use crate::subscription::{quote::Quote, trade::PublicTrade};
 use chrono::{DateTime, TimeZone, Utc};
-use databento::dbn::{Mbp1Msg, TradeMsg};
+use databento::dbn::{Mbp1Msg, OhlcvMsg, Schema, TradeMsg};
 use rust_decimal::Decimal;
 use rustrade_instrument::Side;
+use rustrade_instrument::exchange::ExchangeId;
 use smol_str::format_smolstr;
 
 const UNDEF_PRICE: i64 = i64::MAX;
@@ -166,6 +171,166 @@ fn nanos_to_datetime(nanos: u64) -> Result<DateTime<Utc>, &'static str> {
         .ok_or("invalid timestamp")
 }
 
+/// Build a Databento conversion [`DataError`] for an OHLCV record.
+fn ohlcv_conversion_error(message: String) -> DataError {
+    DataError::Databento {
+        kind: DatabentoErrorKind::Decode,
+        context: "converting OHLCV record".to_string(),
+        message,
+    }
+}
+
+/// Convert a DBN [`OhlcvMsg`] to a [`Candle`], returning the exchange timestamp
+/// (`time_exchange`) alongside it.
+///
+/// # Timing contract
+///
+/// Databento stamps OHLCV `ts_event` at the bar's **open** instant. This function
+/// normalises it to the exclusive `close_time` boundary
+/// (`close_time = open + interval`) via the shared
+/// [`close_time_from_open`](crate::subscription::candle::close_time_from_open)
+/// helper, exactly as the Binance and Hyperliquid candle paths do, so the
+/// [`Candle::close_time`](crate::subscription::candle::Candle::close_time)
+/// contract holds. `time_exchange` is set equal to `close_time`.
+///
+/// # Native OHLCV vs aggregate-from-trades
+///
+/// These are Databento's **native** OHLCV bars. For some venues Databento
+/// recommends aggregating from the trades schema instead; that is a consumer
+/// policy choice and is not performed here.
+///
+/// # `trade_count`
+///
+/// [`OhlcvMsg`] carries no trade-count field, so [`Candle::trade_count`] is set to
+/// `0` rather than fabricated.
+///
+/// # Errors
+///
+/// Returns [`DataError::Databento`] if any price field is the DBN `UNDEF_PRICE`
+/// sentinel (`i64::MAX`), if `ts_event` is unrepresentable, or if the computed
+/// `close_time` overflows the [`DateTime<Utc>`] range. The latter two are
+/// defensively unreachable in practice: DBN `ts_event` is `u64` nanoseconds and
+/// caps near year 2554, far inside the representable range even after adding a
+/// daily step — but the contract surfaces the failure rather than silently
+/// fabricating a timestamp, and stays correct if DBN ever widens the field.
+/// Unlike the
+/// trade/quote transformers in this module — which return `&'static str` and are
+/// `debug!`-skipped by their callers for malformed/undefined-price records — this
+/// returns a typed [`DataError`] that callers **propagate**: native OHLCV bars
+/// have no skippable-malformed mode (Databento only emits a bar when data
+/// exists), so the only realistic failures are an undefined-price sentinel or a
+/// timestamp/boundary overflow, which the `close_time` contract requires be
+/// surfaced, never silently skipped.
+pub fn dbn_ohlcv_to_candle(
+    msg: &OhlcvMsg,
+    interval: CandleInterval,
+) -> Result<(DateTime<Utc>, Candle), DataError> {
+    // Guard the DBN undefined-price sentinel (`i64::MAX`), consistent with the
+    // trade/quote paths in this module. Native OHLCV bars should never carry it
+    // (Databento only emits a bar when data exists), but if one ever does, decoding
+    // it as `Decimal::new(i64::MAX, 9)` would silently yield a garbage ~9.2e9 price
+    // that flows downstream unflagged — exactly the silent failure the close_time
+    // contract requires be surfaced, never fabricated.
+    if msg.open == UNDEF_PRICE
+        || msg.high == UNDEF_PRICE
+        || msg.low == UNDEF_PRICE
+        || msg.close == UNDEF_PRICE
+    {
+        return Err(ohlcv_conversion_error(
+            "undefined price (UNDEF_PRICE sentinel) in OHLCV record".to_string(),
+        ));
+    }
+
+    let open_time = nanos_to_datetime(msg.hd.ts_event)
+        .map_err(|e| ohlcv_conversion_error(format!("OHLCV ts_event: {e}")))?;
+
+    let close_time = close_time_from_open(open_time, interval.to_step()).ok_or_else(|| {
+        ohlcv_conversion_error(format!(
+            "OHLCV close_time overflow: open={open_time}, interval={}",
+            interval.as_str()
+        ))
+    })?;
+
+    Ok((
+        close_time,
+        Candle {
+            close_time,
+            open: Decimal::new(msg.open, 9),
+            high: Decimal::new(msg.high, 9),
+            low: Decimal::new(msg.low, 9),
+            close: Decimal::new(msg.close, 9),
+            volume: Decimal::from(msg.volume),
+            // OhlcvMsg has no trade-count field; report 0 rather than fabricate (G21.2).
+            trade_count: 0,
+        },
+    ))
+}
+
+/// Map a [`CandleInterval`] to the Databento OHLCV [`Schema`] that produces it,
+/// rejecting intervals Databento does not natively offer.
+///
+/// Databento's native OHLCV schemas cover only `1s`/`1m`/`1h`/`1d` (plus
+/// session-based `ohlcv-eod`, which has no [`CandleInterval`] equivalent and is
+/// out of scope). The shared [`CandleInterval`] is the venue-agnostic union, so
+/// the unsupported variants must be rejected before they reach the API.
+///
+/// The match is intentionally exhaustive (no `_` arm): adding a [`CandleInterval`]
+/// variant is a compile error here, forcing a conscious decision on whether
+/// Databento can serve it rather than silently passing it through.
+///
+/// Returning the [`Schema`] (not `()`) lets the historical caller thread the
+/// derived schema straight into its request, so interval and schema cannot
+/// diverge.
+///
+/// # Errors
+///
+/// Returns [`DataError::UnsupportedInterval`] for the 12 intervals Databento does
+/// not serve.
+pub fn ensure_databento_ohlcv_supports(
+    exchange: ExchangeId,
+    interval: CandleInterval,
+) -> Result<Schema, DataError> {
+    match interval {
+        CandleInterval::Sec1 => Ok(Schema::Ohlcv1S),
+        CandleInterval::Min1 => Ok(Schema::Ohlcv1M),
+        CandleInterval::Hour1 => Ok(Schema::Ohlcv1H),
+        CandleInterval::Day1 => Ok(Schema::Ohlcv1D),
+        CandleInterval::Min3
+        | CandleInterval::Min5
+        | CandleInterval::Min15
+        | CandleInterval::Min30
+        | CandleInterval::Hour2
+        | CandleInterval::Hour4
+        | CandleInterval::Hour6
+        | CandleInterval::Hour8
+        | CandleInterval::Hour12
+        | CandleInterval::Day3
+        | CandleInterval::Week1
+        | CandleInterval::Month1 => Err(DataError::UnsupportedInterval { exchange, interval }),
+    }
+}
+
+/// Derive the [`CandleInterval`] for an OHLCV record from its `rtype` discriminant.
+///
+/// A single Databento live connection can interleave multiple OHLCV schemas (e.g.
+/// `1m` and `1h`) on one stream, so the live transform must read each record's
+/// interval from its own `rtype`, not from a connection-wide subscription value.
+///
+/// Returns `None` for rtypes with no [`CandleInterval`] equivalent —
+/// `ohlcv-eod` (session-close daily) and the deprecated `ohlcv-deprecated` — and
+/// for any non-OHLCV rtype. Callers skip `None` observably rather than panicking.
+#[must_use]
+pub fn rtype_to_candle_interval(rtype: u8) -> Option<CandleInterval> {
+    use databento::dbn::enums::rtype;
+    match rtype {
+        rtype::OHLCV_1S => Some(CandleInterval::Sec1),
+        rtype::OHLCV_1M => Some(CandleInterval::Min1),
+        rtype::OHLCV_1H => Some(CandleInterval::Hour1),
+        rtype::OHLCV_1D => Some(CandleInterval::Day1),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 // Test code may unwrap freely since panics indicate test failure
 #[allow(clippy::unwrap_used)]
@@ -294,5 +459,189 @@ mod tests {
 
         assert!(l1.best_bid.is_none());
         assert!(l1.best_ask.is_none());
+    }
+
+    // --- OHLCV / candle transforms (TG21) ---
+
+    /// Build an `OhlcvMsg` with the given open-instant (`ts_event`) and OHLCV
+    /// values in DBN fixed-point (1e-9) / integer-volume units.
+    fn ohlcv(ts_event: u64, open: i64, high: i64, low: i64, close: i64, volume: u64) -> OhlcvMsg {
+        // OhlcvMsg has no `Default` (it maps to multiple rtypes); seed from a
+        // schema. `dbn_ohlcv_to_candle` ignores the record's rtype (the interval
+        // is passed explicitly), so the seed schema does not constrain the test.
+        let mut msg = OhlcvMsg::default_for_schema(Schema::Ohlcv1M);
+        msg.hd.ts_event = ts_event;
+        msg.open = open;
+        msg.high = high;
+        msg.low = low;
+        msg.close = close;
+        msg.volume = volume;
+        msg
+    }
+
+    #[test]
+    fn ohlcv_to_candle_normalises_close_time_from_open() {
+        use rust_decimal_macros::dec;
+
+        // open = 2024-01-01 00:00:00 UTC. A 1-minute bar must close at open + 60s.
+        let msg = ohlcv(
+            1_704_067_200_000_000_000,
+            45_000_500_000_000, // 45000.5
+            45_500_000_000_000, // 45500.0
+            44_800_000_000_000, // 44800.0
+            45_250_000_000_000, // 45250.0
+            1234,
+        );
+
+        let (time_exchange, candle) = dbn_ohlcv_to_candle(&msg, CandleInterval::Min1).unwrap();
+
+        // close_time = open + 1m, and time_exchange == close_time (period END).
+        assert_eq!(candle.close_time.timestamp(), 1_704_067_260);
+        assert_eq!(time_exchange, candle.close_time);
+        // Fixed-point 1e-9 decode is lossless.
+        assert_eq!(candle.open, dec!(45000.5));
+        assert_eq!(candle.high, dec!(45500.0));
+        assert_eq!(candle.low, dec!(44800.0));
+        assert_eq!(candle.close, dec!(45250.0));
+        // Volume is an integer count, not fixed-point.
+        assert_eq!(candle.volume, dec!(1234));
+        // OhlcvMsg carries no trade-count (G21.2).
+        assert_eq!(candle.trade_count, 0);
+    }
+
+    #[test]
+    fn ohlcv_to_candle_close_time_per_interval() {
+        let open_ns = 1_704_067_200_000_000_000; // 2024-01-01 00:00:00 UTC
+        let cases = [
+            (CandleInterval::Sec1, 1_704_067_201),  // +1s
+            (CandleInterval::Min1, 1_704_067_260),  // +60s
+            (CandleInterval::Hour1, 1_704_070_800), // +3600s
+            (CandleInterval::Day1, 1_704_153_600),  // +86400s
+        ];
+        for (interval, expected_close_secs) in cases {
+            let msg = ohlcv(
+                open_ns,
+                1_000_000_000,
+                1_000_000_000,
+                1_000_000_000,
+                1_000_000_000,
+                1,
+            );
+            let (_, candle) = dbn_ohlcv_to_candle(&msg, interval).unwrap();
+            assert_eq!(
+                candle.close_time.timestamp(),
+                expected_close_secs,
+                "interval {interval}"
+            );
+        }
+    }
+
+    #[test]
+    fn ohlcv_to_candle_never_overflows_for_max_u64_ts_event() {
+        // The conversion's overflow arms (ts_event unrepresentable / close_time
+        // overflow) are defensively unreachable given the `u64`-nanosecond input
+        // domain: u64::MAX ns is only ~year 2554, far inside chrono's range even
+        // after adding the largest native step (1 day). This documents that no
+        // OhlcvMsg fixture can exercise the error path — the path exists to
+        // *surface* (never skip) a failure if DBN ever widens the field, per the
+        // close_time contract (21.2). The structural "return DataError, propagate"
+        // guarantee is enforced by the signature, not reachable via fixture.
+        let msg = ohlcv(u64::MAX, 1, 1, 1, 1, 1);
+        let (time_exchange, candle) = dbn_ohlcv_to_candle(&msg, CandleInterval::Day1).unwrap();
+        assert_eq!(time_exchange, candle.close_time);
+    }
+
+    #[test]
+    fn ohlcv_to_candle_rejects_undef_price_in_any_field() {
+        // A bar should never carry UNDEF_PRICE, but if one does, the conversion
+        // surfaces a DataError rather than decoding i64::MAX into a garbage ~9.2e9
+        // price — mirroring the trade/quote UNDEF_PRICE guards in this module.
+        let open_ns = 1_704_067_200_000_000_000; // 2024-01-01 00:00:00 UTC
+        for field in 0..4 {
+            let mut vals = [1_000_000_000_i64; 4];
+            vals[field] = UNDEF_PRICE;
+            let msg = ohlcv(open_ns, vals[0], vals[1], vals[2], vals[3], 1);
+            assert!(
+                dbn_ohlcv_to_candle(&msg, CandleInterval::Min1).is_err(),
+                "expected UNDEF_PRICE in field {field} to be rejected"
+            );
+        }
+        // A fully-defined bar still converts.
+        let msg = ohlcv(open_ns, 1, 1, 1, 1, 1);
+        assert!(dbn_ohlcv_to_candle(&msg, CandleInterval::Min1).is_ok());
+    }
+
+    #[test]
+    fn ensure_databento_ohlcv_supports_maps_native_intervals() {
+        let ex = ExchangeId::DatabentoGlbx;
+        assert_eq!(
+            ensure_databento_ohlcv_supports(ex, CandleInterval::Sec1).unwrap(),
+            Schema::Ohlcv1S
+        );
+        assert_eq!(
+            ensure_databento_ohlcv_supports(ex, CandleInterval::Min1).unwrap(),
+            Schema::Ohlcv1M
+        );
+        assert_eq!(
+            ensure_databento_ohlcv_supports(ex, CandleInterval::Hour1).unwrap(),
+            Schema::Ohlcv1H
+        );
+        assert_eq!(
+            ensure_databento_ohlcv_supports(ex, CandleInterval::Day1).unwrap(),
+            Schema::Ohlcv1D
+        );
+    }
+
+    #[test]
+    fn ensure_databento_ohlcv_supports_rejects_non_native_intervals() {
+        let ex = ExchangeId::DatabentoGlbx;
+        for interval in CandleInterval::ALL {
+            let native = matches!(
+                interval,
+                CandleInterval::Sec1
+                    | CandleInterval::Min1
+                    | CandleInterval::Hour1
+                    | CandleInterval::Day1
+            );
+            let result = ensure_databento_ohlcv_supports(ex, interval);
+            assert_eq!(result.is_ok(), native, "interval {interval}");
+            if !native {
+                assert!(
+                    matches!(
+                        result,
+                        Err(DataError::UnsupportedInterval { interval: i, .. }) if i == interval
+                    ),
+                    "expected UnsupportedInterval for {interval}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rtype_to_candle_interval_maps_native_and_skips_others() {
+        use databento::dbn::enums::rtype;
+        assert_eq!(
+            rtype_to_candle_interval(rtype::OHLCV_1S),
+            Some(CandleInterval::Sec1)
+        );
+        assert_eq!(
+            rtype_to_candle_interval(rtype::OHLCV_1M),
+            Some(CandleInterval::Min1)
+        );
+        assert_eq!(
+            rtype_to_candle_interval(rtype::OHLCV_1H),
+            Some(CandleInterval::Hour1)
+        );
+        assert_eq!(
+            rtype_to_candle_interval(rtype::OHLCV_1D),
+            Some(CandleInterval::Day1)
+        );
+        // No CandleInterval equivalent => graceful skip (None), not panic.
+        assert_eq!(rtype_to_candle_interval(rtype::OHLCV_EOD), None);
+        // ohlcv-deprecated rtype (0x11) — referenced by literal to avoid the
+        // deprecated `RType::OhlcvDeprecated`/`OHLCV_DEPRECATED` symbols.
+        assert_eq!(rtype_to_candle_interval(0x11), None);
+        // A non-OHLCV rtype is also None.
+        assert_eq!(rtype_to_candle_interval(rtype::MBP_1), None);
     }
 }


### PR DESCRIPTION
Adds complete OHLCV candle integration to the Databento exchange alongside existing trades + L1. Both paths enforce interval/schema consistency at the type level, derive `close_time` from the bar open instant, validate native intervals (1s/1m/1h/1d), and surface failures observably rather than silently skipping or fabricating values.

## Changes

- **Historical**: `DatabentoHistorical::fetch_candles` and `fetch_candles_stream` accept a typed `DatabentoOhlcvParams` (chrono types only); schema is derived from interval to prevent divergence.
- **Live**: `DatabentoLive::subscribe_candles` validates and maps intervals, with a 1s/1m live-only constraint (1h/1d are historical-only); derives interval per-record from `rtype` to support multiple intervals on one connection.
- **Transformer**: `dbn_ohlcv_to_candle` normalizes bars to the `close_time` contract via `close_time_from_open`; `ensure_databento_ohlcv_supports` enforces native intervals exhaustively; `rtype_to_candle_interval` gracefully skips eod/deprecated rtypes.
- `Candle::trade_count` reported as 0 (`OhlcvMsg` has no trade count field).
- Enable the databento `chrono` feature for `DateTimeRange` conversion without a manual chrono→time bridge.

## Tests

Comprehensive coverage: conversion, `close_time` per interval, UNDEF_PRICE guards, interval validation, rtype mapping, stream state.
