### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-13
+
 ### Added
 
 - **`impl Borrow<str> for SubscriptionId`** (`rustrade-integration`). An instrument map keyed on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing to rustrade!
 | `main` | Stable release branch. |
 | `develop` | Integration and testing. All feature PRs target this branch. |
 | `feature/*` | Your feature branches. Branch off `develop`. |
+| `release/*` | Release-prep branches (version bump + changelog finalize). Branch off `develop`. |
 
 ### Workflow
 
@@ -101,12 +102,17 @@ Before cutting a release, verify documentation is current:
 - [ ] Version numbers are consistent across all `Cargo.toml` files
 
 **Release process (maintainers):**
-1. Complete the pre-release checklist above
-2. Create release prep PR: bump versions in all Cargo.toml files
-3. Rename `[Unreleased]` → `[x.y.z] - YYYY-MM-DD`, add new empty `[Unreleased]`
-4. Merge to main
-5. Tag: `git tag v0.1.0 && git push origin v0.1.0`
-6. Publish workflow runs automatically
+
+We use a **two-PR flow** so `develop` and `main` stay in sync — the version bump lands on `develop` first, so there's no post-release back-merge:
+
+1. Complete the pre-release checklist above.
+2. Create a release-prep branch off `develop` (e.g. `release/x.y.z`):
+   - Bump versions in all `Cargo.toml` files and re-sync `Cargo.lock` (CI runs `--locked`, so the lock must stay consistent).
+   - Rename `[Unreleased]` → `[x.y.z] - YYYY-MM-DD` and add a fresh empty `[Unreleased]`.
+3. Open the release-prep PR targeting **`develop`**; merge after CI is green.
+4. Open the release PR **`develop` → `main`**; merge after CI is green.
+5. Tag the release: `git tag vx.y.z && git push origin vx.y.z`.
+6. The publish workflow runs automatically on the tag.
 
 ## What NOT to Contribute
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-data"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "chrono",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-execution"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "binance-sdk",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-instrument"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "derive_more 2.1.1",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-integration"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-macro"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ categories = ["finance", "simulation"]
 
 [workspace.dependencies]
 # Rustrade Ecosystem
-rustrade-integration = { path = "./rustrade-integration", version = "0.3.0" }
-rustrade-instrument = { path = "./rustrade-instrument", version = "0.3.0" }
-rustrade-data = { path = "./rustrade-data", version = "0.3.0" }
-rustrade-execution = { path = "./rustrade-execution", version = "0.3.0" }
-rustrade-macro = { path = "./rustrade-macro", version = "0.3.0" }
+rustrade-integration = { path = "./rustrade-integration", version = "0.4.0" }
+rustrade-instrument = { path = "./rustrade-instrument", version = "0.4.0" }
+rustrade-data = { path = "./rustrade-data", version = "0.4.0" }
+rustrade-execution = { path = "./rustrade-execution", version = "0.4.0" }
+rustrade-macro = { path = "./rustrade-macro", version = "0.4.0" }
 
 # Logging
 tracing = { version = "0.1.41" }

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustrade = "0.3"
-rustrade-data = { version = "0.3", features = ["hyperliquid"] }
-rustrade-execution = { version = "0.3", features = ["binance"] }
+rustrade = "0.4"
+rustrade-data = { version = "0.4", features = ["hyperliquid"] }
+rustrade-execution = { version = "0.4", features = ["binance"] }
 ```
 
 See the [examples](https://github.com/Niqnil/rustrade/tree/main/rustrade/examples) for complete working code.

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-data"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-data/README.md
+++ b/rustrade-data/README.md
@@ -41,6 +41,6 @@ Integration library for streaming public market data from exchanges and data pro
 | Provider | Constructor | InstrumentKinds | SubscriptionKinds |
 |:--------:|:-----------:|:---------------:|:-----------------:|
 | **Massive** | `MassiveRestClient` / `MassiveLive` | Spot, Future, Option | PublicTrades, Quotes, Candles |
-| **Databento** | `DatabentoHistorical` / `DatabentoLive` | Spot, Future, Option | PublicTrades, Quotes |
+| **Databento** | `DatabentoHistorical` / `DatabentoLive` | Spot, Future, Option | PublicTrades, Quotes, Candles |
 
 See the [workspace README](../README.md) for documentation, examples, and contributing guidelines.

--- a/rustrade-execution/Cargo.toml
+++ b/rustrade-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-execution"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-instrument/Cargo.toml
+++ b/rustrade-instrument/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-instrument"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-integration/Cargo.toml
+++ b/rustrade-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-integration"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-macro/Cargo.toml
+++ b/rustrade-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-macro"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade/Cargo.toml
+++ b/rustrade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Release-prep for **v0.4.0**. Lands on `develop` first; a follow-up `develop → main` PR promotes the release and `v0.4.0` is tagged from `main`.

This branch adds a single prep commit on top of `develop` — no functional code changes.

## Changes

- **Version bump `0.3.0` → `0.4.0`** across all 6 crates + the 5 `workspace.dependencies` path-version pins, with `Cargo.lock` synced (only the 6 workspace entries change; verified `--locked`-consistent).
- **CHANGELOG**: `[Unreleased]` → `[0.4.0] - 2026-06-13`, fresh empty `[Unreleased]` added.
- **Docs**: root README install snippet `0.3` → `0.4`; `rustrade-data` README Databento row gains `Candles` (verified against `databento/{live,historical}.rs`).

## Why a minor bump

`[Unreleased]` accumulated several breaking changes since 0.3.0 — config-loader signatures and safe-simulation defaults, Binance kline wire fields, removal of `AccountEventKind::StreamError`, IBKR `ContractConfigError`, and the `TradingSummary`/`TearSheet` `basis` fields. Under pre-1.0 SemVer, breaking changes bump the minor.

## Issues shipped in this release

Addressed in `develop` and shipping with 0.4.0: #110, #124, #132, #136, #142.

(Issue auto-close fires on the `develop → main` merge, since footers only trigger on the default branch. #110/#124/#132/#136 will be closed with commit-pointing comments after tagging.)