### PR TITLE
refactor(rustrade-integration): make RestRequest::timeout instance-aware (&self)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`RestRequest::timeout` is now an instance method (`&self`)** (`rustrade-integration`). Previously a
+  receiverless associated function, it could only return a compile-time constant; taking `&self` lets an
+  implementation derive the per-request timeout from instance/config state (e.g. an operator-tunable
+  timeout captured at construction). The default still returns the compile-time
+  `DEFAULT_HTTP_REQUEST_TIMEOUT`, so implementations relying on the default are unaffected. **Breaking
+  only** for impls that explicitly override `timeout()` — add `&self` to the signature.
+
 ## [0.4.0] - 2026-06-13
 
 ### Added

--- a/rustrade-integration/src/protocol/http/rest/client.rs
+++ b/rustrade-integration/src/protocol/http/rest/client.rs
@@ -71,7 +71,7 @@ where
         let mut builder = self
             .http_client
             .request(Request::method(), url)
-            .timeout(Request::timeout());
+            .timeout(request.timeout());
 
         // Add optional query parameters
         if let Some(query_params) = request.query_params() {

--- a/rustrade-integration/src/protocol/http/rest/mod.rs
+++ b/rustrade-integration/src/protocol/http/rest/mod.rs
@@ -36,7 +36,11 @@ pub trait RestRequest {
     }
 
     /// Http request timeout [`Duration`].
-    fn timeout() -> Duration {
+    ///
+    /// Takes `&self` so an implementation may derive the timeout from per-instance/config state
+    /// (e.g. an operator-tunable timeout captured at construction). The default returns the
+    /// compile-time [`DEFAULT_HTTP_REQUEST_TIMEOUT`] and ignores `self`.
+    fn timeout(&self) -> Duration {
         DEFAULT_HTTP_REQUEST_TIMEOUT
     }
 }


### PR DESCRIPTION
## Summary

Changes `RestRequest::timeout` from a receiverless associated function to an instance method taking `&self`.

As an associated function, `timeout()` could only return a compile-time constant — an implementation had no way to derive the per-request timeout from instance/config state. Taking `&self` lets an impl return a value captured at construction (e.g. an operator-tunable timeout from config) while keeping default behaviour identical for impls that rely on the default. It also aligns `timeout()` with the trait's other `&self` request accessors (`path` / `query_params` / `body`).

## Changes

- `RestRequest::timeout()` → `RestRequest::timeout(&self)` (default unchanged — still returns `DEFAULT_HTTP_REQUEST_TIMEOUT`).
- Sole call site `RestClient::build` switches `Request::timeout()` → `request.timeout()` (the `request` value is already in scope).
- Rustdoc on the method documents the instance-aware contract.
- CHANGELOG `Changed` entry under `[Unreleased]`.

## Compatibility

Breaking **only** for downstream impls that explicitly override `timeout()` — they add `&self` to the signature. No impl in this workspace overrides it, so nothing else changes; impls relying on the default are unaffected.

## Verification

- `cargo check --workspace --all-features` — clean
- `cargo clippy -p rustrade-integration --all-targets --all-features` (correctness/suspicious/style/perf) — clean
- `cargo test -p rustrade-integration --all-features --lib` — 44 passed
