### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-19
+
 ### Changed
 
 - **`RestRequest::timeout` is now an instance method (`&self`)** (`rustrade-integration`). Previously a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-data"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "chrono",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-execution"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "binance-sdk",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-instrument"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "derive_more 2.1.1",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-integration"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "rustrade-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ categories = ["finance", "simulation"]
 
 [workspace.dependencies]
 # Rustrade Ecosystem
-rustrade-integration = { path = "./rustrade-integration", version = "0.4.0" }
-rustrade-instrument = { path = "./rustrade-instrument", version = "0.4.0" }
-rustrade-data = { path = "./rustrade-data", version = "0.4.0" }
-rustrade-execution = { path = "./rustrade-execution", version = "0.4.0" }
-rustrade-macro = { path = "./rustrade-macro", version = "0.4.0" }
+rustrade-integration = { path = "./rustrade-integration", version = "0.5.0" }
+rustrade-instrument = { path = "./rustrade-instrument", version = "0.5.0" }
+rustrade-data = { path = "./rustrade-data", version = "0.5.0" }
+rustrade-execution = { path = "./rustrade-execution", version = "0.5.0" }
+rustrade-macro = { path = "./rustrade-macro", version = "0.5.0" }
 
 # Logging
 tracing = { version = "0.1.41" }

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustrade = "0.4"
-rustrade-data = { version = "0.4", features = ["hyperliquid"] }
-rustrade-execution = { version = "0.4", features = ["binance"] }
+rustrade = "0.5"
+rustrade-data = { version = "0.5", features = ["hyperliquid"] }
+rustrade-execution = { version = "0.5", features = ["binance"] }
 ```
 
 See the [examples](https://github.com/Niqnil/rustrade/tree/main/rustrade/examples) for complete working code.

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-data"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-execution/Cargo.toml
+++ b/rustrade-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-execution"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-instrument/Cargo.toml
+++ b/rustrade-instrument/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-instrument"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-integration/Cargo.toml
+++ b/rustrade-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-integration"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade-macro/Cargo.toml
+++ b/rustrade-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade-macro"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rustrade/Cargo.toml
+++ b/rustrade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustrade"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release prep: v0.5.0

Version bump + changelog finalize for the **v0.5.0** release (step 3 of the two-PR flow in `CONTRIBUTING.md`). Targets `develop`.

### Contents since v0.4.0
- **#155** — `refactor(rustrade-integration)`: make `RestRequest::timeout` instance-aware (`&self`).
- Dependabot bumps merged into `develop`: rust-patch group (#148), serial_test (#149), rust_decimal (#154), databento (#153), tokio (#151), indexmap (#150), binance-sdk 52→55 (#152).

### Why 0.5.0 (not 0.4.1)
#155 changes the public `RestRequest::timeout` trait method signature (`fn timeout()` → `fn timeout(&self)`) — a breaking change for downstream impls that override it. Under SemVer for `0.x`, a breaking change bumps the minor.

### Changes in this PR
- Bump all 6 workspace crates `0.4.0` → `0.5.0` (`Cargo.toml` package versions + workspace dependency entries).
- Re-sync `Cargo.lock` via `cargo update --workspace` (only the 6 rustrade crates; no registry deps touched — CI runs `--locked`).
- `CHANGELOG.md`: rename `[Unreleased]` → `[0.5.0] - 2026-06-19`, add fresh empty `[Unreleased]`.
- `README.md`: install snippets `0.4` → `0.5`.

### Next step
After this merges, open the release PR `develop` → `main`, then tag `v0.5.0`.
