### PR TITLE
feat(corporate-action): Stock & reverse split handling for backtest + live, stocks + options

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,6 +17,12 @@ IBKR_PORT=7497
 # Client ID for API connection (any unique integer, default: random)
 # IBKR_CLIENT_ID=1
 
+# Flex Web Service (HTTPS corporate-action reconciliation — independent of TWS/Gateway).
+# Create a token under Account Management → Reports → Flex Queries → Flex Web Service Configuration,
+# and a saved Activity query (with the Corporate Actions section) whose Query ID goes below.
+IBKR_FLEX_TOKEN=
+IBKR_FLEX_QUERY_ID=
+
 # =============================================================================
 # Hyperliquid
 # =============================================================================

--- a/.github/tier2-dependencies.txt
+++ b/.github/tier2-dependencies.txt
@@ -18,3 +18,4 @@ binance-sdk=52.0.0  # 2026-06-04 | Exchange SDK, signing/IO. PINNED: margin user
 #   2. ws.common.events.subscribe (WebsocketEventEmitter) — receive/event-callback path (margin WS event delivery)
 #   3. common::utils::send_request                        — signature + HMAC signing + X-MBX-APIKEY header (hand-rolled `userListenToken` POST; SDK binds no endpoint for it)
 # Background: legacy margin listen-key user-data API retired 2026-02-20; SDK binds only the dead endpoint, so the live `userListenToken` flow is hand-rolled atop these internals.
+quick-xml  # 2026-06-24 | New direct dep (XML parsing of broker Flex statements). Reviewed @ 0.38.4: #![forbid(unsafe_code)] crate-wide, zero net-new transitive deps (serde+memchr only, both already in tree), no RUSTSEC advisories, de-facto-standard parser. Not pinned — any version bump still needs review.

--- a/.github/tier2-dependencies.txt
+++ b/.github/tier2-dependencies.txt
@@ -18,4 +18,4 @@ binance-sdk=52.0.0  # 2026-06-04 | Exchange SDK, signing/IO. PINNED: margin user
 #   2. ws.common.events.subscribe (WebsocketEventEmitter) — receive/event-callback path (margin WS event delivery)
 #   3. common::utils::send_request                        — signature + HMAC signing + X-MBX-APIKEY header (hand-rolled `userListenToken` POST; SDK binds no endpoint for it)
 # Background: legacy margin listen-key user-data API retired 2026-02-20; SDK binds only the dead endpoint, so the live `userListenToken` flow is hand-rolled atop these internals.
-quick-xml  # 2026-06-24 | New direct dep (XML parsing of broker Flex statements). Reviewed @ 0.38.4: #![forbid(unsafe_code)] crate-wide, zero net-new transitive deps (serde+memchr only, both already in tree), no RUSTSEC advisories, de-facto-standard parser. Not pinned — any version bump still needs review.
+quick-xml  # 2026-07-08 | New direct dep (XML parsing of broker Flex statements). Reviewed @ 0.41.0: #![forbid(unsafe_code)] crate-wide, zero net-new transitive deps (serde+memchr only, both already in tree), no RUSTSEC advisories, de-facto-standard parser. Not pinned — any version bump still needs review.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # The `--all-features` debug build + link of the whole workspace (ethers,
+      # aws-lc-sys, ring, the exchange SDKs, ...) can exhaust the runner's disk
+      # ("No space left on device" during the mold link step). Reclaim ~12 GB of
+      # preinstalled toolchains we never use instead of adding a third-party action.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup
+          df -h /
+
       - name: Install mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `OptionPositionsUnadjustedForSplit`, and `UnsupportedCorporateAction`. Application is idempotent
   per-instrument via a caller-assigned action `id`; a reverse split that floors a position to zero
   quantity closes it with a `PositionExit`.
+- **Backtest auxiliary-event injection seam** (`rustrade`). New `AuxEventSource` trait, `NoAuxEvents`
+  (zero-cost default), and `AuxEventsInMemory` interleave non-market `EngineEvent`s (e.g. corporate
+  actions, contract expiries) with the market stream in simulated-time order during a backtest — the
+  backtest equivalent of live trading's direct `EngineEvent` injection. The harness pre-merges the
+  two sources into one time-ordered stream before the engine feed, so an injected event lands at the
+  correct point in the timeline (aux events win ties).
 
 ### Changed
 
 - **`EngineOutput` is now `#[non_exhaustive]`** (`rustrade`). New engine-driven outputs (e.g. the
   corporate-action observables above) can be added without further breaking changes. **Breaking**
   for downstream code matching `EngineOutput` exhaustively — add a wildcard (`_`) arm.
+- **`BacktestArgsConstant` gains a required `aux_events` field** (`rustrade`). **Breaking** for
+  downstream code constructing it via a struct literal — add `aux_events: NoAuxEvents` (the new
+  generic parameter `AuxEvents` defaults to `NoAuxEvents`) or supply a custom `AuxEventSource`.
 
 ## [0.5.0] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behind the new `corporate-action` feature, on by default) model fetching splits by symbol +
   effective-date range; they yield the new generic `CorporateAction<K>` descriptor
   (`rustrade-instrument`), keyed by an unresolved provider symbol (`SmolStr`) at the source boundary.
+  Both `CorporateActionFilter` and `CorporateAction<K>` are `#[non_exhaustive]`, so adding a field is
+  non-breaking for downstream code that only reads or matches them (matches must use `..`). They are
+  constructed via the derived `::new`, whose arity grows with each field — so a new field is still a
+  breaking change for direct `::new` callers (`CorporateActionFilter` also derives `Default`, making
+  `Default::default()` + per-field assignment its forward-compatible construction path). `#[non_exhaustive]`
+  shields only Rust-code matching/construction: `CorporateAction<K>` also derives serde `Deserialize`,
+  so adding a field without `#[serde(default)]` is still a breaking change at the data layer (it fails
+  to deserialize payloads written before the field existed).
   A shared `CorporateActionKind::stock_split(split_to, split_from)` helper computes the ratio
   identically across providers as a validated `SplitRatio` newtype (strictly `> 0`, making a
   degenerate ratio unconstructible; build it via `SplitRatio::new` → `Option` or
@@ -80,7 +88,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dependency (pulled in only by the `ibkr` feature). The Flex `token` is passed as a `t=` URL query
   parameter, so transport errors strip the request URL before it reaches `IbkrFlexError::Http`
   (`reqwest`'s `Error: Display` would otherwise embed the full URL, leaking the token into logs); the
-  variant is documented to never carry the URL. A runnable example
+  variant is documented to never carry the URL. The HTTP client also enforces HTTPS-only transport
+  and rejects redirects (`https_only(true)` + `redirect::Policy::none()`), so the token cannot leak
+  via an HTTPS→HTTP downgrade redirect. A runnable example
   (`ibkr_flex_corporate_actions`, `--features ibkr`) sketches the wrapper-side reconcile.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   effective-date range; they yield the new generic `CorporateAction<K>` descriptor
   (`rustrade-instrument`), keyed by an unresolved provider symbol (`SmolStr`) at the source boundary.
   A shared `CorporateActionKind::stock_split(split_to, split_from)` helper computes the ratio
-  identically across providers. A reference implementation for the Massive REST client is feature-
+  identically across providers as a validated `SplitRatio` newtype (strictly `> 0`, making a
+  degenerate ratio unconstructible; build it via `SplitRatio::new` → `Option` or
+  `TryFrom<Decimal>` → `InvalidSplitRatio`, with transparent, validated serde). A reference implementation for the Massive REST client is feature-
   gated behind `massive` in `rustrade-data`. The action *kind* is encoded in the trait name (a
   `DividendSource` sibling is the future path) rather than a unified trait with a kind filter; push /
   account-scoped sources (e.g. IBKR) are intentionally out of this PULL trait. A runnable example
   (`rustrade`, `corporate_action_sourcing`, `--features massive`/`--features alpaca`) shows
   source → resolve → inject.
+- **`rustrade` crate-root re-exports for the corporate-action API.** `CorporateActionKind`,
+  `SplitRatio`, `InvalidSplitRatio`, `SplitAdjustmentKind`, and `split_effective_instant` are now
+  re-exported from `rustrade` (alongside the existing `SplitRoundingPolicy`), and `SplitRatio` gains
+  an infallible `From<SplitRatio> for Decimal` conversion — so callers can build and handle
+  `EngineEvent::CorporateAction` without a direct `rustrade_instrument` dependency.
 - **Alpaca `StockSplitSource` implementation** (`rustrade-data`, feature-gated `alpaca`). A second
   reference source: `impl StockSplitSource for AlpacaRestClient` wraps Alpaca's
   `GET /v1beta1/corporate-actions` endpoint (available on the free/Basic plan), with a new
@@ -58,8 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `payable_date` — which can precede `ex_date` for forward splits and would apply the split early
   (pinned by a provenance test). New shared `AlpacaRestClient` / `AlpacaRestError` transport (auth +
   rate-limit retry) factored out of the options client so every Alpaca REST surface shares one
-  client; the existing `AlpacaOptionsError` is now an alias of `AlpacaRestError` (same variants, no
-  signature change).
+  client; the existing `AlpacaOptionsError` is now a type alias of the (`#[non_exhaustive]`)
+  `AlpacaRestError`, which gains an `InvalidCredential` variant (see the Changed entry below for the
+  error-variant change this implies for the options client).
 - **IBKR Flex Web Service corporate-action reconciliation** (`rustrade-data`, feature-gated `ibkr`).
   A new `rustrade_data::exchange::ibkr::flex` surface fetches an account's *Activity* Flex statement
   over HTTPS (`IbkrFlexClient` / `IbkrFlexConfig`, env vars `IBKR_FLEX_TOKEN` / `IBKR_FLEX_QUERY_ID`)
@@ -87,9 +95,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`EngineOutput` is now `#[non_exhaustive]`** (`rustrade`). New engine-driven outputs (e.g. the
   corporate-action observables above) can be added without further breaking changes. **Breaking**
   for downstream code matching `EngineOutput` exhaustively — add a wildcard (`_`) arm.
-- **`BacktestArgsConstant` gains a required `aux_events` field** (`rustrade`). **Breaking** for
-  downstream code constructing it via a struct literal — add `aux_events: NoAuxEvents` (the new
-  generic parameter `AuxEvents` defaults to `NoAuxEvents`) or supply a custom `AuxEventSource`.
+- **Corporate-action `ratio` fields are typed `SplitRatio`, not `Decimal`** (`rustrade`). The new
+  `EngineOutput::OptionPositionAdjustedForSplit` and `OptionPositionsRequireIdentityChange` outputs
+  carry `ratio: SplitRatio`, preserving the strictly-`> 0` type invariant across the observation
+  boundary (it was previously discarded back to a raw `Decimal`). `InvalidSplitRatio`'s rejected
+  value is now read via `.rejected()` rather than a public tuple field. Relevant only to code
+  tracking this unreleased corporate-action line.
+- **`BacktestArgsConstant` gains a required `aux_events` field, and `run_backtests` / `backtest` gain
+  an `AuxEvents` generic** (`rustrade`). **Breaking** for downstream code constructing
+  `BacktestArgsConstant` via a struct literal — add `aux_events: NoAuxEvents` (the struct's new
+  `AuxEvents` parameter defaults to `NoAuxEvents`) or supply a custom `AuxEventSource`. The
+  `run_backtests` / `backtest` **functions** also gain a trailing `Aux` type parameter; function type
+  parameters cannot carry a default, so callers that spell the generics explicitly (turbofish, or a
+  fully type-annotated function pointer) must account for the extra argument. Callers that rely on
+  inference are unaffected.
+- **Alpaca client error variants** (`rustrade-data`, feature-gated `alpaca`). `AlpacaOptionsError` is
+  now a type alias of the shared `AlpacaRestError`, which adds an `InvalidCredential` variant. The
+  `AlpacaOptionsClient` constructor now reports a credential that cannot be encoded as an HTTP header
+  value as `InvalidCredential`, where the credential-error path previously surfaced as `EnvVar`.
+  `AlpacaRestError` is `#[non_exhaustive]`, so exhaustive matchers already require a wildcard arm;
+  only callers that branched on the specific credential-error variant need to update.
+- **`MarketDataInMemory::new` now hard-asserts sorted input** (`rustrade`). Construction `assert!`s —
+  in all builds, not behind `debug_assert!` — that events are sorted ascending by
+  `MarketEvent::time_exchange`; previously unsorted input was accepted silently and would yield a
+  non-monotonic backtest clock and out-of-order engine feed. Mirrors `AuxEventsInMemory::new`.
+  **Breaking** only for callers that were (incorrectly) supplying unsorted data — observable failure
+  over silent corruption.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backtest equivalent of live trading's direct `EngineEvent` injection. The harness pre-merges the
   two sources into one time-ordered stream before the engine feed, so an injected event lands at the
   correct point in the timeline (aux events win ties).
+- **Corporate-action PULL sourcing abstraction** (`rustrade-instrument`, `rustrade-integration`,
+  `rustrade-data`). New `StockSplitSource` trait + `CorporateActionFilter` (`rustrade-integration`,
+  behind the new `corporate-action` feature, on by default) model fetching splits by symbol +
+  effective-date range; they yield the new generic `CorporateAction<K>` descriptor
+  (`rustrade-instrument`), keyed by an unresolved provider symbol (`SmolStr`) at the source boundary.
+  A shared `CorporateActionKind::stock_split(split_to, split_from)` helper computes the ratio
+  identically across providers. A reference implementation for the Massive REST client is feature-
+  gated behind `massive` in `rustrade-data`. The action *kind* is encoded in the trait name (a
+  `DividendSource` sibling is the future path) rather than a unified trait with a kind filter; push /
+  account-scoped sources (e.g. IBKR) are intentionally out of this PULL trait. A runnable example
+  (`rustrade`, `corporate_action_sourcing`, `--features massive`) shows source → resolve → inject.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gated behind `massive` in `rustrade-data`. The action *kind* is encoded in the trait name (a
   `DividendSource` sibling is the future path) rather than a unified trait with a kind filter; push /
   account-scoped sources (e.g. IBKR) are intentionally out of this PULL trait. A runnable example
-  (`rustrade`, `corporate_action_sourcing`, `--features massive`) shows source → resolve → inject.
+  (`rustrade`, `corporate_action_sourcing`, `--features massive`/`--features alpaca`) shows
+  source → resolve → inject.
+- **Alpaca `StockSplitSource` implementation** (`rustrade-data`, feature-gated `alpaca`). A second
+  reference source: `impl StockSplitSource for AlpacaRestClient` wraps Alpaca's
+  `GET /v1beta1/corporate-actions` endpoint (available on the free/Basic plan), with a new
+  `CorporateActionsQuery` builder, the nested `forward_splits`/`reverse_splits` response shape, a
+  normalised `AlpacaStockSplit`, and automatic `page_token` pagination. `effective_date` maps onto
+  Alpaca's `ex_date` (the market-execution / price re-basing date), deliberately **not**
+  `payable_date` — which can precede `ex_date` for forward splits and would apply the split early
+  (pinned by a provenance test). New shared `AlpacaRestClient` / `AlpacaRestError` transport (auth +
+  rate-limit retry) factored out of the options client so every Alpaca REST surface shares one
+  client; the existing `AlpacaOptionsError` is now an alias of `AlpacaRestError` (same variants, no
+  signature change).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Corporate-action stock-split processing** (`rustrade`). The engine now handles
+  `EngineEvent::CorporateAction` for stock/reverse splits, adjusting every open position on the
+  target Spot instrument via `Position::apply_split` and emitting observables — `SplitRemainder`
+  (cash-in-lieu of the fractional sliver disposed under `SplitRoundingPolicy::Floor`),
+  `OpenOrdersAtSplit` (resting orders are reported, never engine-cancelled),
+  `OptionPositionsUnadjustedForSplit`, and `UnsupportedCorporateAction`. Application is idempotent
+  per-instrument via a caller-assigned action `id`; a reverse split that floors a position to zero
+  quantity closes it with a `PositionExit`.
+
+### Changed
+
+- **`EngineOutput` is now `#[non_exhaustive]`** (`rustrade`). New engine-driven outputs (e.g. the
+  corporate-action observables above) can be added without further breaking changes. **Breaking**
+  for downstream code matching `EngineOutput` exhaustively — add a wildcard (`_`) arm.
+
 ## [0.5.0] - 2026-06-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — account-scoped and post-hoc — **not** a `StockSplitSource`: it derives no split ratio (the raw
   `principal_adjust_factor` is surfaced but is a TIPS field, not a ratio), leaving ratio
   derivation/verification and reconcile policy to the caller. XML is parsed with the new `quick-xml`
-  dependency (pulled in only by the `ibkr` feature). A runnable example
+  dependency (pulled in only by the `ibkr` feature). The Flex `token` is passed as a `t=` URL query
+  parameter, so transport errors strip the request URL before it reaches `IbkrFlexError::Http`
+  (`reqwest`'s `Error: Display` would otherwise embed the full URL, leaking the token into logs); the
+  variant is documented to never carry the URL. A runnable example
   (`ibkr_flex_corporate_actions`, `--features ibkr`) sketches the wrapper-side reconcile.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rate-limit retry) factored out of the options client so every Alpaca REST surface shares one
   client; the existing `AlpacaOptionsError` is now an alias of `AlpacaRestError` (same variants, no
   signature change).
+- **IBKR Flex Web Service corporate-action reconciliation** (`rustrade-data`, feature-gated `ibkr`).
+  A new `rustrade_data::exchange::ibkr::flex` surface fetches an account's *Activity* Flex statement
+  over HTTPS (`IbkrFlexClient` / `IbkrFlexConfig`, env vars `IBKR_FLEX_TOKEN` / `IBKR_FLEX_QUERY_ID`)
+  via the 2-call SendRequest → poll → GetStatement flow, and parses the Corporate Actions section
+  into faithful raw `IbkrFlexCorporateAction` records (`IbkrReorgType` enum + a standalone
+  `parse_corporate_actions` XML parser). This is a broker-confirmed **reconciliation / audit** source
+  — account-scoped and post-hoc — **not** a `StockSplitSource`: it derives no split ratio (the raw
+  `principal_adjust_factor` is surfaced but is a TIPS field, not a ratio), leaving ratio
+  derivation/verification and reconcile policy to the caller. XML is parsed with the new `quick-xml`
+  dependency (pulled in only by the `ibkr` feature). A runnable example
+  (`ibkr_flex_corporate_actions`, `--features ibkr`) sketches the wrapper-side reconcile.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target Spot instrument via `Position::apply_split` and emitting observables — `SplitRemainder`
   (cash-in-lieu of the fractional sliver disposed under `SplitRoundingPolicy::Floor`),
   `OpenOrdersAtSplit` (resting orders are reported, never engine-cancelled),
-  `OptionPositionsUnadjustedForSplit`, and `UnsupportedCorporateAction`. Application is idempotent
+  and `UnsupportedCorporateAction`. Application is idempotent
   per-instrument via a caller-assigned action `id`; a reverse split that floors a position to zero
   quantity closes it with a `PositionExit`.
+- **Corporate-action handling for option positions on a splitting underlying** (`rustrade`,
+  `rustrade-instrument`). When a split targets an underlying equity, the engine now also handles open
+  option positions on that underlying. A **standard** split (a whole-number forward split, per the OCC
+  option-adjustment rules) adjusts each option position **in place** — strike ÷ ratio, contract count
+  × ratio, deliverable/multiplier unchanged — emitting one new `EngineOutput::OptionPositionAdjustedForSplit`
+  per adjusted position, **plus an `OpenOrdersAtSplit` for the adjusted option's own resting orders**
+  (now stale-priced; reported, never engine-cancelled, exactly as on the equity path). A **non-standard**
+  split (every reverse split, every fractional forward split) requires a new contract identity the
+  engine does not register at runtime, so it emits the new `EngineOutput::OptionPositionsRequireIdentityChange`
+  and leaves the options at their pre-split terms; the underlying equity split is still applied and its
+  `id` recorded (so, unlike `UnsupportedCorporateAction`, it is **not** retryable — the wrapper closes
+  the listed options and/or trades a pre-declared new identity). New `CorporateActionKind::split_kind`
+  method (`rustrade-instrument`) returns `Option<SplitAdjustmentKind>` (`Standard`/`NonStandard`),
+  classifying the action per the OCC rule.
 - **Backtest auxiliary-event injection seam** (`rustrade`). New `AuxEventSource` trait, `NoAuxEvents`
   (zero-cost default), and `AuxEventsInMemory` interleave non-market `EngineEvent`s (e.g. corporate
   actions, contract expiries) with the market stream in simulated-time order during a backtest — the
@@ -73,6 +87,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`BacktestArgsConstant` gains a required `aux_events` field** (`rustrade`). **Breaking** for
   downstream code constructing it via a struct literal — add `aux_events: NoAuxEvents` (the new
   generic parameter `AuxEvents` defaults to `NoAuxEvents`) or supply a custom `AuxEventSource`.
+
+### Removed
+
+- **`EngineOutput::OptionPositionsUnadjustedForSplit`** (`rustrade`). The placeholder option-split
+  signal is removed in favour of the precise pair `OptionPositionAdjustedForSplit` (standard, applied)
+  and `OptionPositionsRequireIdentityChange` (non-standard, wrapper-handled). Relevant only to code
+  tracking this unreleased development line, where both the old and new variants are pre-release.
 
 ## [0.5.0] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`EngineEvent` is now `#[non_exhaustive]` and gains a `CorporateAction` variant** (`rustrade`).
+  Marking it non-exhaustive lets future engine-driven event variants be added without further
+  breaking changes. **Breaking** for downstream code matching `EngineEvent` exhaustively — add a
+  wildcard (`_`) arm. **serde/replay note:** the new variant changes the serialized form of
+  `EngineEvent`. Audit logs written by this version may contain `CorporateAction` ticks that older
+  library versions cannot deserialize (unknown variant), so wrappers that persist and replay the
+  audit stream across this version boundary must account for it.
 - **`EngineOutput` is now `#[non_exhaustive]`** (`rustrade`). New engine-driven outputs (e.g. the
   corporate-action observables above) can be added without further breaking changes. **Breaking**
   for downstream code matching `EngineOutput` exhaustively — add a wildcard (`_`) arm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target Spot instrument via `Position::apply_split` and emitting observables — `SplitRemainder`
   (cash-in-lieu of the fractional sliver disposed under `SplitRoundingPolicy::Floor`),
   `OpenOrdersAtSplit` (resting orders are reported, never engine-cancelled),
-  and `UnsupportedCorporateAction`. Application is idempotent
-  per-instrument via a caller-assigned action `id`; a reverse split that floors a position to zero
+  `UnsupportedCorporateAction`, and `CorporateActionAlreadyProcessed`. Application is idempotent
+  per-instrument via a caller-assigned action `id` — a re-submitted `id` is a non-mutating no-op that
+  emits the observable `CorporateActionAlreadyProcessed` (distinct from the retryable
+  `UnsupportedCorporateAction` rejections, so an audit-stream consumer can tell an idempotent skip
+  from a successful split with nothing to adjust); a reverse split that floors a position to zero
   quantity closes it with a `PositionExit`. `Position::apply_split` takes a validated `SplitRatio`
   and is fallible (`Result<SplitResult, SplitError>`, with a companion `Position::validate_split`);
   the engine **pre-validates** every affected position before mutating any, so an
@@ -31,8 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   option positions on that underlying. A **standard** split (a whole-number forward split, per the OCC
   option-adjustment rules) adjusts each option position **in place** — strike ÷ ratio, contract count
   × ratio, deliverable/multiplier unchanged — emitting one new `EngineOutput::OptionPositionAdjustedForSplit`
-  per adjusted position, **plus an `OpenOrdersAtSplit` for the adjusted option's own resting orders**
-  (now stale-priced; reported, never engine-cancelled, exactly as on the equity path). A **non-standard**
+  per adjusted position, **plus an `OpenOrdersAtSplit` for the option's own resting orders**
+  (now stale-priced; reported, never engine-cancelled, exactly as on the equity path — surfaced for
+  **held and unheld** options alike, since an unheld option can carry a working order to open a
+  position that the split silently re-strikes). A **non-standard**
   split (every reverse split, every fractional forward split) requires a new contract identity the
   engine does not register at runtime, so it emits the new `EngineOutput::OptionPositionsRequireIdentityChange`
   and leaves the options at their pre-split terms; the underlying equity split is still applied and its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `OptionPositionsRequireIdentityChange` (non-standard, wrapper-handled). Relevant only to code
   tracking this unreleased development line, where both the old and new variants are pre-release.
 
+### Security
+
+- Upgraded `anyhow` to 1.0.103 and `quick-xml` to 0.41.0 to clear three RUSTSEC advisories:
+  RUSTSEC-2026-0190 (unsoundness in `anyhow::Error::downcast_mut`), RUSTSEC-2026-0194 (quadratic
+  run time when checking a start tag for duplicate attribute names) and RUSTSEC-2026-0195
+  (unbounded namespace-declaration allocation in `NsReader`, a memory-exhaustion DoS). `quick-xml`
+  backs the IBKR Flex XML parser behind the `ibkr` feature; the bump is API-compatible for the
+  `Reader`/`de::from_str` surface in use.
+
 ## [0.5.0] - 2026-06-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `OpenOrdersAtSplit` (resting orders are reported, never engine-cancelled),
   and `UnsupportedCorporateAction`. Application is idempotent
   per-instrument via a caller-assigned action `id`; a reverse split that floors a position to zero
-  quantity closes it with a `PositionExit`.
+  quantity closes it with a `PositionExit`. `Position::apply_split` takes a validated `SplitRatio`
+  and is fallible (`Result<SplitResult, SplitError>`, with a companion `Position::validate_split`);
+  the engine **pre-validates** every affected position before mutating any, so an
+  arithmetically-unrepresentable ratio or a corrupted (non-integer) option contract count rejects the
+  whole action atomically — emitting `UnsupportedCorporateAction` with the new
+  `UnsupportedCorporateActionReason::ArithmeticOverflow` / `PositionStateInvalid` reasons, leaving the
+  `id` unrecorded and no position partially rescaled. The eager post-split `pnl_unrealised` recompute
+  degrades gracefully: an extreme last price that would overflow `Decimal` zeroes the (derived,
+  self-correcting) value and flags `SplitResult::pnl_unrealised_overflowed` rather than panicking
+  part-way through the adjustment, preserving that atomicity.
 - **Corporate-action handling for option positions on a splitting underlying** (`rustrade`,
   `rustrade-instrument`). When a split targets an underlying equity, the engine now also handles open
   option positions on that underlying. A **standard** split (a whole-number forward split, per the OCC
@@ -32,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   method (`rustrade-instrument`) returns `Option<SplitAdjustmentKind>` (`Standard`/`NonStandard`),
   classifying the action per the OCC rule.
 - **Backtest auxiliary-event injection seam** (`rustrade`). New `AuxEventSource` trait, `NoAuxEvents`
-  (zero-cost default), and `AuxEventsInMemory` interleave non-market `EngineEvent`s (e.g. corporate
+  (negligible-overhead default), and `AuxEventsInMemory` interleave non-market `EngineEvent`s (e.g. corporate
   actions, contract expiries) with the market stream in simulated-time order during a backtest — the
   backtest equivalent of live trading's direct `EngineEvent` injection. The harness pre-merges the
   two sources into one time-ordered stream before the engine feed, so an injected event lands at the
@@ -127,7 +136,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AlpacaOptionsClient` constructor now reports a credential that cannot be encoded as an HTTP header
   value as `InvalidCredential`, where the credential-error path previously surfaced as `EnvVar`.
   `AlpacaRestError` is `#[non_exhaustive]`, so exhaustive matchers already require a wildcard arm;
-  only callers that branched on the specific credential-error variant need to update.
+  only callers that branched on the specific credential-error variant need to update. `AlpacaRestError`
+  also gains a `NotCloneable` variant: the shared retry helper now **returns** it (instead of
+  panicking) when a request body cannot be cloned for a retry — unreachable for the GET/query-string
+  requests the client issues today, but recoverable for a future streaming-body caller.
 - **`MarketDataInMemory::new` now hard-asserts sorted input** (`rustrade`). Construction `assert!`s —
   in all builds, not behind `debug_assert!` — that events are sorted ascending by
   `MarketEvent::time_exchange`; previously unsorted input was accepted silently and would yield a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`reqwest`'s `Error: Display` would otherwise embed the full URL, leaking the token into logs); the
   variant is documented to never carry the URL. The HTTP client also enforces HTTPS-only transport
   and rejects redirects (`https_only(true)` + `redirect::Policy::none()`), so the token cannot leak
-  via an HTTPS→HTTP downgrade redirect. A runnable example
+  via an HTTPS→HTTP downgrade redirect. `IbkrFlexConfig::new` / `from_env` trim both credentials and
+  reject an empty (or whitespace-only) value up front (`IbkrFlexError::InvalidCredential`), so a
+  malformed token fails observably at construction rather than as an opaque IBKR `1003` "invalid
+  token" at fetch time. A runnable example
   (`ibkr_flex_corporate_actions`, `--features ibkr`) sketches the wrapper-side reconcile.
 
 ### Changed
@@ -131,6 +134,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-monotonic backtest clock and out-of-order engine feed. Mirrors `AuxEventsInMemory::new`.
   **Breaking** only for callers that were (incorrectly) supplying unsorted data — observable failure
   over silent corruption.
+- **`alpaca` and `massive` features no longer enable global float `Decimal` serialization**
+  (`rustrade-data`). Both features previously enabled `rust_decimal/serde-float`, a **global**
+  feature whose side effect — through Cargo feature unification across the workspace — was to flip
+  every `Decimal`'s default `Serialize`/`Deserialize` to a lossy `f64`. They now enable the
+  field-level `rust_decimal/serde-with-float` instead, so `Decimal` keeps its deterministic,
+  lossless string wire format everywhere by default. **Breaking** for any downstream that built with
+  `--features alpaca` / `--features massive` and relied (intentionally or as a side effect) on the
+  global float form: fields that must serialize as floats now need an explicit
+  `#[serde(with = "rust_decimal::serde::float")]` (or `float_option`). The integration clients that
+  require it already carry this attribute.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (unbounded namespace-declaration allocation in `NsReader`, a memory-exhaustion DoS). `quick-xml`
   backs the IBKR Flex XML parser behind the `ibkr` feature; the bump is API-compatible for the
   `Reader`/`de::from_str` surface in use.
+- Updated `crossbeam-epoch` to 0.9.20 to clear RUSTSEC-2026-0204 (invalid pointer dereference in the
+  `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is null). A transitive
+  dependency (via `ibapi` and, in dev builds, `rayon`/`criterion`); the bump is a `Cargo.lock`-only
+  patch within the existing `0.9` constraint.
 
 ## [0.5.0] - 2026-06-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2496,7 +2496,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -2783,7 +2783,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3142,7 +3142,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3735,6 +3735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3747,7 +3757,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3785,7 +3795,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4300,7 +4310,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4378,7 +4388,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4454,6 +4464,7 @@ dependencies = [
  "ibapi",
  "itertools 0.14.0",
  "parking_lot",
+ "quick-xml",
  "reqwest 0.13.4",
  "rust_decimal",
  "rust_decimal_macros",
@@ -5013,7 +5024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5251,10 +5262,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6191,7 +6202,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ serde = { version = "1.0.216", features = ["derive"] }
 serde_json = { version = "1.0.133" }
 serde_qs = { version = "1.1.1" }
 serde_urlencoded = { version = "0.7.1" }
+# XML deserialisation (IBKR Flex statements). `serialize` enables the serde de/se modules.
+quick-xml = { version = "0.38", features = ["serialize"] }
 
 # Protocol
 url = { version = "2.5.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde_json = { version = "1.0.133" }
 serde_qs = { version = "1.1.1" }
 serde_urlencoded = { version = "0.7.1" }
 # XML deserialisation (IBKR Flex statements). `serialize` enables the serde de/se modules.
-quick-xml = { version = "0.38", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 
 # Protocol
 url = { version = "2.5.4" }

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -13,7 +13,7 @@ description = "High performance & normalised WebSocket intergration for leading 
 
 [features]
 default = []
-ibkr = ["dep:ibapi", "dep:time", "rustrade-instrument/ibkr"]
+ibkr = ["dep:ibapi", "dep:time", "dep:quick-xml", "rustrade-instrument/ibkr"]
 hyperliquid = ["dep:hyperliquid_rust_sdk"]
 # `serde-float` lets the corporate-actions client deserialize `new_rate`/`old_rate` JSON numbers
 # into `Decimal` (same approach as the Massive split client).
@@ -72,6 +72,9 @@ fnv = { workspace = true }
 # IBKR (optional, behind "ibkr" feature)
 ibapi = { version = "=3.0.1", optional = true, default-features = false, features = ["sync"] }
 time = { version = "0.3", optional = true, features = ["macros"] }
+# XML parser for IBKR Flex Web Service statements (corporate-action reconciliation). New normal dep
+# (serde-xml-rs/xml-rs are only a build-dep of time-tz via ibapi, not reusable). Note for tier-2 review.
+quick-xml = { workspace = true, optional = true }
 
 # Hyperliquid (optional, behind "hyperliquid" feature)
 hyperliquid_rust_sdk = { version = "0.6", optional = true }
@@ -112,4 +115,8 @@ required-features = ["ibkr"]
 
 [[example]]
 name = "ibkr_market_data"
+required-features = ["ibkr"]
+
+[[example]]
+name = "ibkr_flex_corporate_actions"
 required-features = ["ibkr"]

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -15,7 +15,9 @@ description = "High performance & normalised WebSocket intergration for leading 
 default = []
 ibkr = ["dep:ibapi", "dep:time", "rustrade-instrument/ibkr"]
 hyperliquid = ["dep:hyperliquid_rust_sdk"]
-alpaca = []
+# `serde-float` lets the corporate-actions client deserialize `new_rate`/`old_rate` JSON numbers
+# into `Decimal` (same approach as the Massive split client).
+alpaca = ["rust_decimal/serde-float"]
 databento = ["dep:databento"]
 massive = ["dep:tokio-tungstenite", "dep:urlencoding", "rust_decimal/serde-float", "serde_json/raw_value"]
 

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -28,7 +28,7 @@ serial_test = { workspace = true }  # For Massive WebSocket tests (1 connection 
 
 [dependencies]
 # Rustrade Ecosystem
-rustrade-integration = { workspace = true, features = ["channel", "collection", "error", "protocol", "serde", "subscription", "stream"] }
+rustrade-integration = { workspace = true, features = ["channel", "collection", "corporate-action", "error", "protocol", "serde", "subscription", "stream"] }
 rustrade-instrument = { workspace = true }
 rustrade-macro = { workspace = true }
 

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -15,11 +15,15 @@ description = "High performance & normalised WebSocket intergration for leading 
 default = []
 ibkr = ["dep:ibapi", "dep:time", "dep:quick-xml", "rustrade-instrument/ibkr"]
 hyperliquid = ["dep:hyperliquid_rust_sdk"]
-# `serde-float` lets the corporate-actions client deserialize `new_rate`/`old_rate` JSON numbers
-# into `Decimal` (same approach as the Massive split client).
-alpaca = ["rust_decimal/serde-float"]
+# `serde-with-float` provides the field-level `rust_decimal::serde::float` / `float_option`
+# helpers the clients use to deserialize `new_rate`/`old_rate` (and Massive's price/size) JSON
+# numbers into `Decimal`. It deliberately does NOT enable the global `serde-float` feature, whose
+# extra effect is to flip every `Decimal`'s default serialization workspace-wide to a lossy f64
+# number (Cargo unifies features across the build). Keeping it field-level preserves the
+# deterministic, lossless string wire format for all other `Decimal` values.
+alpaca = ["rust_decimal/serde-with-float"]
 databento = ["dep:databento"]
-massive = ["dep:tokio-tungstenite", "dep:urlencoding", "rust_decimal/serde-float", "serde_json/raw_value"]
+massive = ["dep:tokio-tungstenite", "dep:urlencoding", "rust_decimal/serde-with-float", "serde_json/raw_value"]
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }

--- a/rustrade-data/examples/ibkr_flex_corporate_actions.rs
+++ b/rustrade-data/examples/ibkr_flex_corporate_actions.rs
@@ -1,0 +1,118 @@
+//! IBKR Flex corporate-action reconciliation example.
+//!
+//! **UNTESTED in CI** — requires IBKR Flex Web Service credentials.
+//!
+//! Demonstrates fetching an account's corporate-action records from the IBKR Flex Web Service and
+//! sketches how a *wrapper* would reconcile them — the library yields faithful raw records and
+//! derives **no** split ratio; ratio derivation/verification and reconcile policy live in the
+//! caller. See `rustrade_data::exchange::ibkr::flex` for the full contract.
+//!
+//! # Prerequisites
+//!
+//! 1. An IBKR account (paper is fine).
+//! 2. A Flex Web Service token and a saved Activity Flex query that includes the Corporate Actions
+//!    section (Account Management → Reports → Flex Queries).
+//! 3. Environment variables (see `.env.template`):
+//!    - `IBKR_FLEX_TOKEN`
+//!    - `IBKR_FLEX_QUERY_ID`
+//!
+//! # Usage
+//!
+//! ```bash
+//! source .env
+//! cargo run --example ibkr_flex_corporate_actions --features ibkr
+//! ```
+
+// Examples use unwrap/expect for brevity — not production code.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rustrade_data::exchange::ibkr::{IbkrFlexClient, IbkrFlexCorporateAction, IbkrReorgType};
+use tracing::{info, warn};
+
+#[tokio::main]
+async fn main() {
+    init_logging();
+
+    let client = match IbkrFlexClient::from_env() {
+        Ok(client) => client,
+        Err(e) => {
+            warn!("Could not build Flex client: {e}");
+            warn!("Set IBKR_FLEX_TOKEN and IBKR_FLEX_QUERY_ID (see .env.template)");
+            return;
+        }
+    };
+
+    info!("Fetching IBKR Flex corporate-action records (SendRequest → poll → GetStatement)...");
+
+    let actions = match client.fetch_corporate_actions().await {
+        Ok(actions) => actions,
+        Err(e) => {
+            warn!("Flex fetch failed: {e}");
+            return;
+        }
+    };
+
+    info!("Fetched {} corporate-action row(s)", actions.len());
+
+    // The library returns ALL reorg rows faithfully; selecting splits is the caller's job.
+    let splits: Vec<&IbkrFlexCorporateAction> = actions
+        .iter()
+        .filter(|a| {
+            matches!(
+                a.action_type,
+                IbkrReorgType::ForwardSplit | IbkrReorgType::ReverseSplit
+            )
+        })
+        .collect();
+
+    if splits.is_empty() {
+        info!("No forward/reverse split rows in this statement (a fresh account often has none).");
+    }
+
+    for split in splits {
+        reconcile_split_sketch(split);
+    }
+}
+
+/// Sketch of the **wrapper-side** reconciliation a downstream consumer would perform.
+///
+/// The library deliberately stops at the raw record. To turn a broker-confirmed split into an
+/// engine adjustment, the wrapper:
+///
+/// 1. Resolves `symbol` → its internal instrument key.
+/// 2. Derives the split *ratio* from a market-reference source — e.g. a `StockSplitSource`
+///    implementation (Alpaca/Massive) cross-referenced by symbol + date. The library does **not**
+///    derive a ratio from the Flex record: `quantity_delta` is an account-scoped delta (not
+///    `new/old` shares), `action_description` is unstable free text, and `principal_adjust_factor`
+///    is a TIPS field, not a split ratio (it is surfaced but must not be trusted as a ratio).
+/// 3. Reconciles the broker-confirmed quantity delta against the engine's own post-split position
+///    (the broker is the source of truth) under its own reconcile policy.
+fn reconcile_split_sketch(split: &IbkrFlexCorporateAction) {
+    let symbol = split.symbol.as_deref().unwrap_or("<unknown>");
+    info!(
+        "Broker-confirmed {:?} for {symbol}: account share delta {} (report_date {:?})",
+        split.action_type, split.quantity_delta, split.report_date,
+    );
+
+    // The raw TIPS factor is shown only to illustrate it is surfaced — NOT used as a ratio.
+    if let Some(factor) = split.principal_adjust_factor {
+        info!(
+            "  (principalAdjustFactor={factor} is a raw TIPS field — NOT a split ratio; ignore for reconciliation)"
+        );
+    }
+
+    info!(
+        "  → wrapper next: resolve symbol → instrument key, derive ratio from a StockSplitSource, reconcile."
+    );
+}
+
+fn init_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::filter::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_ansi(cfg!(debug_assertions))
+        .init()
+}

--- a/rustrade-data/src/exchange/alpaca/corporate_action.rs
+++ b/rustrade-data/src/exchange/alpaca/corporate_action.rs
@@ -1,0 +1,199 @@
+//! [`StockSplitSource`] implementation for the shared Alpaca REST client.
+//!
+//! Adapts the lower-level [`AlpacaRestClient::fetch_splits_raw`](super::reference) raw-split stream into
+//! the provider-agnostic [`CorporateAction`] sourcing descriptor, computing the split ratio via the
+//! shared [`CorporateActionKind::stock_split`] helper so Alpaca derives ratios identically to every
+//! other provider.
+
+use async_stream::try_stream;
+use futures::{Stream, StreamExt};
+use smol_str::SmolStr;
+use tracing::warn;
+
+use rustrade_instrument::corporate_action::{CorporateAction, CorporateActionKind};
+use rustrade_integration::corporate_action::{CorporateActionFilter, StockSplitSource};
+
+use super::reference::{AlpacaStockSplit, CorporateActionsQuery};
+use super::rest::{AlpacaRestClient, AlpacaRestError};
+
+impl StockSplitSource for AlpacaRestClient {
+    type Error = AlpacaRestError;
+
+    /// Fetch stock splits for `filter`'s symbols and effective-date range, mapped to
+    /// [`CorporateAction<SmolStr>`] descriptors.
+    ///
+    /// `effective_date` provenance: this impl maps it onto Alpaca's **`ex_date`** — the session on
+    /// which the share count re-bases and the price adjusts, satisfying the
+    /// [`StockSplitSource::fetch_splits`] market-execution-date contract. It deliberately does NOT
+    /// use `payable_date`: for forward splits Alpaca's `payable_date` can fall a trading day
+    /// *before* `ex_date` (sampled: `APH` ex 2024-06-12 / payable 2024-06-11; `CNQ` ex 2024-06-11 /
+    /// payable 2024-06-10) while the price re-bases on `ex_date` (observed equal to `process_date`
+    /// across the sample), so mapping `payable_date` would apply the split a day early — look-ahead
+    /// corruption. This mapping is pinned by `ex_date_provenance_ignores_payable_date` (in
+    /// [`reference`](super::reference)) and `map_split_maps_ex_date_to_effective_date` below.
+    ///
+    /// Alpaca's endpoint accepts a single comma-joined `symbols` parameter, so — unlike Massive's
+    /// per-symbol fan-out — a multi-symbol filter issues **one** paginated query. An empty `symbols`
+    /// list requests every split in the date range (subject to provider page limits). Splits whose
+    /// `new_rate` / `old_rate` yield a degenerate ratio (zero, negative, or division by zero) are
+    /// logged and skipped — see [`CorporateActionKind::stock_split`].
+    fn fetch_splits(
+        &self,
+        filter: &CorporateActionFilter,
+    ) -> impl Stream<Item = Result<CorporateAction<SmolStr>, Self::Error>> + Send {
+        // Build the owned query eagerly so the returned stream borrows only `self`, not `filter`.
+        let query = build_query(filter);
+
+        try_stream! {
+            // Calls the *inherent* `AlpacaRestClient::fetch_splits_raw` (taking `&CorporateActionsQuery`),
+            // the lower-level raw-split stream this impl adapts. Its distinct name keeps the dispatch
+            // explicit — no collision with this trait's `fetch_splits`, so no risk of recursing into it.
+            let raw = self.fetch_splits_raw(&query);
+            futures::pin_mut!(raw);
+            while let Some(split) = raw.next().await {
+                if let Some(action) = map_split(split?) {
+                    yield action;
+                }
+            }
+        }
+    }
+}
+
+/// Translate a [`CorporateActionFilter`] into a single Alpaca [`CorporateActionsQuery`] (Alpaca
+/// batches symbols into one comma-joined request).
+fn build_query(filter: &CorporateActionFilter) -> CorporateActionsQuery {
+    let mut query = CorporateActionsQuery::new();
+    if !filter.symbols.is_empty() {
+        query = query.symbols(filter.symbols.iter().map(SmolStr::as_str));
+    }
+    if let Some(start) = filter.start {
+        query = query.start(start);
+    }
+    if let Some(end) = filter.end {
+        query = query.end(end);
+    }
+    query
+}
+
+/// Map a raw [`AlpacaStockSplit`] to a [`CorporateAction`] descriptor via the shared ratio helper.
+/// Returns `None` (and logs) for a degenerate ratio so the caller's stream simply omits it.
+fn map_split(split: AlpacaStockSplit) -> Option<CorporateAction<SmolStr>> {
+    match CorporateActionKind::stock_split(split.new_rate, split.old_rate) {
+        // `effective_date` maps to Alpaca's `ex_date` — the split's market execution date, per the
+        // `StockSplitSource::fetch_splits` contract (NOT `payable_date`; see the impl rustdoc).
+        Some(kind) => Some(CorporateAction::new(
+            SmolStr::from(split.symbol),
+            kind,
+            Some(split.ex_date),
+        )),
+        None => {
+            warn!(
+                symbol = %split.symbol,
+                new_rate = %split.new_rate,
+                old_rate = %split.old_rate,
+                "Alpaca stock split has a degenerate ratio; skipping",
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Tests should panic on unexpected values
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+    use rust_decimal::Decimal;
+
+    fn split(symbol: &str, new_rate: i64, old_rate: i64, ex_date: NaiveDate) -> AlpacaStockSplit {
+        AlpacaStockSplit {
+            symbol: symbol.to_string(),
+            ex_date,
+            new_rate: Decimal::from(new_rate),
+            old_rate: Decimal::from(old_rate),
+        }
+    }
+
+    #[test]
+    fn build_query_joins_symbols_and_dates() {
+        let filter = CorporateActionFilter {
+            symbols: vec![SmolStr::new("NVDA"), SmolStr::new("AAPL")],
+            start: NaiveDate::from_ymd_opt(2024, 1, 1),
+            end: NaiveDate::from_ymd_opt(2024, 12, 31),
+        };
+
+        let query = build_query(&filter);
+        assert_eq!(query.symbols, vec!["NVDA".to_string(), "AAPL".to_string()]);
+        assert_eq!(query.start, filter.start);
+        assert_eq!(query.end, filter.end);
+    }
+
+    #[test]
+    fn build_query_empty_symbols_is_unrestricted() {
+        let filter = CorporateActionFilter::default();
+        let query = build_query(&filter);
+        assert!(query.symbols.is_empty());
+        assert!(query.start.is_none());
+        assert!(query.end.is_none());
+    }
+
+    #[test]
+    fn map_split_forward_ratio() {
+        let action = map_split(split(
+            "NVDA",
+            10,
+            1,
+            NaiveDate::from_ymd_opt(2024, 6, 10).unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(action.instrument, SmolStr::new("NVDA"));
+        assert_eq!(
+            action.kind,
+            CorporateActionKind::StockSplit {
+                ratio: Decimal::from(10)
+            }
+        );
+    }
+
+    #[test]
+    fn map_split_reverse_ratio() {
+        // 1-for-25 reverse → ratio 0.04.
+        let action = map_split(split(
+            "ATRA",
+            1,
+            25,
+            NaiveDate::from_ymd_opt(2024, 6, 20).unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(
+            action.kind,
+            CorporateActionKind::StockSplit {
+                ratio: Decimal::new(4, 2)
+            }
+        );
+    }
+
+    #[test]
+    fn map_split_maps_ex_date_to_effective_date() {
+        // Pins the provenance: `effective_date` is the raw split's `ex_date`. Paired with the
+        // `reference::ex_date_provenance_ignores_payable_date` deser test (which proves the parsed
+        // `ex_date` is the JSON `ex_date`, not `payable_date`), this covers the full chain.
+        let ex_date = NaiveDate::from_ymd_opt(2024, 6, 12).unwrap();
+        let action = map_split(split("APH", 2, 1, ex_date)).unwrap();
+        assert_eq!(action.effective_date, Some(ex_date));
+    }
+
+    #[test]
+    fn map_split_drops_degenerate_ratio() {
+        // old_rate == 0 → division by zero → skipped.
+        assert!(
+            map_split(split(
+                "BAD",
+                1,
+                0,
+                NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()
+            ))
+            .is_none()
+        );
+    }
+}

--- a/rustrade-data/src/exchange/alpaca/corporate_action.rs
+++ b/rustrade-data/src/exchange/alpaca/corporate_action.rs
@@ -104,6 +104,7 @@ mod tests {
     use super::*;
     use chrono::NaiveDate;
     use rust_decimal::Decimal;
+    use rustrade_instrument::corporate_action::SplitRatio;
 
     fn split(symbol: &str, new_rate: i64, old_rate: i64, ex_date: NaiveDate) -> AlpacaStockSplit {
         AlpacaStockSplit {
@@ -150,7 +151,7 @@ mod tests {
         assert_eq!(
             action.kind,
             CorporateActionKind::StockSplit {
-                ratio: Decimal::from(10)
+                ratio: SplitRatio::new(Decimal::from(10)).unwrap()
             }
         );
     }
@@ -168,7 +169,7 @@ mod tests {
         assert_eq!(
             action.kind,
             CorporateActionKind::StockSplit {
-                ratio: Decimal::new(4, 2)
+                ratio: SplitRatio::new(Decimal::new(4, 2)).unwrap()
             }
         );
     }

--- a/rustrade-data/src/exchange/alpaca/corporate_action.rs
+++ b/rustrade-data/src/exchange/alpaca/corporate_action.rs
@@ -1,6 +1,6 @@
 //! [`StockSplitSource`] implementation for the shared Alpaca REST client.
 //!
-//! Adapts the lower-level [`AlpacaRestClient::fetch_splits_raw`](super::reference) raw-split stream into
+//! Adapts the lower-level [`AlpacaRestClient::fetch_splits_raw`](super::AlpacaRestClient::fetch_splits_raw) raw-split stream into
 //! the provider-agnostic [`CorporateAction`] sourcing descriptor, computing the split ratio via the
 //! shared [`CorporateActionKind::stock_split`] helper so Alpaca derives ratios identically to every
 //! other provider.
@@ -117,11 +117,11 @@ mod tests {
 
     #[test]
     fn build_query_joins_symbols_and_dates() {
-        let filter = CorporateActionFilter {
-            symbols: vec![SmolStr::new("NVDA"), SmolStr::new("AAPL")],
-            start: NaiveDate::from_ymd_opt(2024, 1, 1),
-            end: NaiveDate::from_ymd_opt(2024, 12, 31),
-        };
+        let filter = CorporateActionFilter::new(
+            vec![SmolStr::new("NVDA"), SmolStr::new("AAPL")],
+            NaiveDate::from_ymd_opt(2024, 1, 1),
+            NaiveDate::from_ymd_opt(2024, 12, 31),
+        );
 
         let query = build_query(&filter);
         assert_eq!(query.symbols, vec!["NVDA".to_string(), "AAPL".to_string()]);

--- a/rustrade-data/src/exchange/alpaca/corporate_action.rs
+++ b/rustrade-data/src/exchange/alpaca/corporate_action.rs
@@ -124,7 +124,10 @@ mod tests {
         );
 
         let query = build_query(&filter);
-        assert_eq!(query.symbols, vec!["NVDA".to_string(), "AAPL".to_string()]);
+        assert_eq!(
+            query.symbols,
+            vec![SmolStr::new("NVDA"), SmolStr::new("AAPL")]
+        );
         assert_eq!(query.start, filter.start);
         assert_eq!(query.end, filter.end);
     }

--- a/rustrade-data/src/exchange/alpaca/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/mod.rs
@@ -79,8 +79,16 @@ pub mod channel;
 pub mod market;
 pub mod options;
 pub mod quote;
+pub mod reference;
+pub mod rest;
 pub mod subscription;
 pub mod trade;
+
+// `StockSplitSource` adapter for `AlpacaRestClient` (no public items of its own — just the impl).
+mod corporate_action;
+
+pub use reference::{AlpacaStockSplit, CorporateActionsQuery};
+pub use rest::{AlpacaRestClient, AlpacaRestError};
 
 /// IEX WebSocket URL (free US equities feed).
 pub const WEBSOCKET_URL_IEX: &str = "wss://stream.data.alpaca.markets/v2/iex";

--- a/rustrade-data/src/exchange/alpaca/options/contracts.rs
+++ b/rustrade-data/src/exchange/alpaca/options/contracts.rs
@@ -300,10 +300,10 @@ impl AlpacaOptionsClient {
                 params.push(("page_token", token.clone()));
             }
 
-            let url = format!("{}/v2/options/contracts", self.broker_base);
-            let request = self.http.get(&url).query(&params);
+            let url = format!("{}/v2/options/contracts", self.rest.broker_base());
+            let request = self.rest.get(&url).query(&params);
 
-            let response: ContractsResponse = self.request_with_retry(request).await?;
+            let response: ContractsResponse = self.rest.request_with_retry(request).await?;
 
             let contracts = response.option_contracts.unwrap_or_default();
             let count = contracts.len();

--- a/rustrade-data/src/exchange/alpaca/options/contracts.rs
+++ b/rustrade-data/src/exchange/alpaca/options/contracts.rs
@@ -8,7 +8,7 @@ use rust_decimal::Decimal;
 use rustrade_instrument::instrument::kind::option::{OptionExercise, OptionKind};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Maximum contracts per page (Alpaca API limit).
 const MAX_PAGE_SIZE: usize = 10_000;
@@ -286,10 +286,10 @@ impl AlpacaOptionsClient {
 
         loop {
             if pages >= MAX_PAGES {
-                debug!(
+                warn!(
                     pages,
                     contracts = all_contracts.len(),
-                    "reached max pages limit"
+                    "Alpaca option contracts hit the max-pages safety limit; returning truncated results"
                 );
                 break;
             }

--- a/rustrade-data/src/exchange/alpaca/options/contracts.rs
+++ b/rustrade-data/src/exchange/alpaca/options/contracts.rs
@@ -160,8 +160,10 @@ impl AlpacaOptionContractQuery {
             ));
         }
         if let Some(style) = self.style {
-            // Alpaca only supports American and European styles; Bermudan is silently
-            // omitted from the request (the API would reject it).
+            // Alpaca only supports American and European styles. Bermudan has no API filter, so it
+            // is omitted here rather than silently returning an unfiltered result set the caller did
+            // not ask for. The omission is warned about once per logical query in `fetch_contracts`
+            // (this builder runs once per page, so warning here would repeat up to MAX_PAGES times).
             let style_str = match style {
                 OptionExercise::American => Some("american"),
                 OptionExercise::European => Some("european"),
@@ -283,6 +285,17 @@ impl AlpacaOptionsClient {
         let mut all_contracts = Vec::new();
         let mut page_token: Option<String> = None;
         let mut pages = 0usize;
+
+        // Warn once per logical query (not once per page) if the caller requested a style Alpaca
+        // cannot filter on. `to_query_params` silently omits the `style` param in that case; this
+        // is where the caller learns their filter was dropped.
+        if query.style == Some(OptionExercise::Bermudan) {
+            warn!(
+                style = ?OptionExercise::Bermudan,
+                "AlpacaOptionContractQuery: exercise style is not supported by Alpaca; \
+                 omitting the `style` filter (results will not be style-restricted)"
+            );
+        }
 
         loop {
             if pages >= MAX_PAGES {

--- a/rustrade-data/src/exchange/alpaca/options/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/options/mod.rs
@@ -59,53 +59,14 @@ mod snapshots;
 pub use contracts::{AlpacaOptionContract, AlpacaOptionContractQuery};
 pub use snapshots::{AlpacaOptionFeed, AlpacaOptionQuote, AlpacaOptionSnapshot, AlpacaOptionTrade};
 
-use reqwest::header::{HeaderMap, HeaderValue};
-use std::{env, time::Duration};
-use thiserror::Error;
-use tracing::{debug, warn};
-
-/// Base URL for Alpaca Broker API (trading + options contracts).
-const BROKER_API_BASE: &str = "https://api.alpaca.markets";
-
-/// Base URL for Alpaca Data API (market data including options snapshots).
-const DATA_API_BASE: &str = "https://data.alpaca.markets";
-
-/// Paper trading base URL.
-const PAPER_API_BASE: &str = "https://paper-api.alpaca.markets";
-
-/// Default timeout for REST requests.
-const REQUEST_TIMEOUT_SECS: u64 = 30;
-
-/// Maximum retry attempts for rate-limited requests.
-const MAX_RETRY_ATTEMPTS: u32 = 3;
-
-/// Default delay when rate-limited (if no Retry-After header).
-const DEFAULT_RATE_LIMIT_DELAY_SECS: u64 = 60;
+use super::rest::AlpacaRestClient;
 
 /// Errors from Alpaca options API operations.
-#[non_exhaustive]
-#[derive(Debug, Error)]
-pub enum AlpacaOptionsError {
-    /// Environment variable not set or invalid.
-    #[error("environment variable error: {0}")]
-    EnvVar(String),
-
-    /// HTTP client error.
-    #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
-
-    /// API returned an error response.
-    #[error("API error ({status}): {message}")]
-    Api { status: u16, message: String },
-
-    /// Rate limit exceeded after retries.
-    #[error("rate limit exceeded after {attempts} attempts")]
-    RateLimitExceeded { attempts: u32 },
-
-    /// Invalid response format.
-    #[error("invalid response: {0}")]
-    InvalidResponse(String),
-}
+///
+/// Alias of the shared [`AlpacaRestError`](super::super::rest::AlpacaRestError): options requests
+/// have no failure modes beyond the common transport/protocol ones, so the single REST error type
+/// is reused rather than duplicated per endpoint family.
+pub use super::rest::AlpacaRestError as AlpacaOptionsError;
 
 /// Alpaca options market data client.
 ///
@@ -116,20 +77,11 @@ pub enum AlpacaOptionsError {
 ///
 /// Use [`AlpacaOptionsClient::from_env`] to create a client using environment variables,
 /// or [`AlpacaOptionsClient::new`] for explicit credentials.
-#[derive(Clone)]
+///
+/// Internally this is a thin wrapper over the shared [`AlpacaRestClient`] transport.
+#[derive(Clone, Debug)]
 pub struct AlpacaOptionsClient {
-    http: reqwest::Client,
-    broker_base: String,
-    data_base: String,
-}
-
-impl std::fmt::Debug for AlpacaOptionsClient {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AlpacaOptionsClient")
-            .field("broker_base", &self.broker_base)
-            .field("data_base", &self.data_base)
-            .finish_non_exhaustive()
-    }
+    rest: AlpacaRestClient,
 }
 
 impl AlpacaOptionsClient {
@@ -145,33 +97,8 @@ impl AlpacaOptionsClient {
     ///
     /// Returns error if the HTTP client cannot be built (invalid headers).
     pub fn new(api_key: &str, api_secret: &str, paper: bool) -> Result<Self, AlpacaOptionsError> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "APCA-API-KEY-ID",
-            HeaderValue::from_str(api_key)
-                .map_err(|e| AlpacaOptionsError::EnvVar(format!("invalid API key: {e}")))?,
-        );
-        headers.insert(
-            "APCA-API-SECRET-KEY",
-            HeaderValue::from_str(api_secret)
-                .map_err(|e| AlpacaOptionsError::EnvVar(format!("invalid API secret: {e}")))?,
-        );
-
-        let http = reqwest::Client::builder()
-            .default_headers(headers)
-            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
-            .build()?;
-
-        let broker_base = if paper {
-            PAPER_API_BASE.to_string()
-        } else {
-            BROKER_API_BASE.to_string()
-        };
-
         Ok(Self {
-            http,
-            broker_base,
-            data_base: DATA_API_BASE.to_string(),
+            rest: AlpacaRestClient::new(api_key, api_secret, paper)?,
         })
     }
 
@@ -186,89 +113,10 @@ impl AlpacaOptionsClient {
     ///
     /// Returns error if required environment variables are missing.
     pub fn from_env() -> Result<Self, AlpacaOptionsError> {
-        let api_key = env::var("ALPACA_API_KEY")
-            .map_err(|e| AlpacaOptionsError::EnvVar(format!("ALPACA_API_KEY: {e}")))?;
-        let api_secret = env::var("ALPACA_SECRET_KEY")
-            .map_err(|e| AlpacaOptionsError::EnvVar(format!("ALPACA_SECRET_KEY: {e}")))?;
-        let paper = env::var("ALPACA_PAPER")
-            .map(|v| v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-
-        Self::new(&api_key, &api_secret, paper)
+        Ok(Self {
+            rest: AlpacaRestClient::from_env()?,
+        })
     }
-
-    /// Execute a request with rate limit retry.
-    async fn request_with_retry<T>(
-        &self,
-        request: reqwest::RequestBuilder,
-    ) -> Result<T, AlpacaOptionsError>
-    where
-        T: serde::de::DeserializeOwned,
-    {
-        let mut attempts = 0u32;
-
-        loop {
-            attempts += 1;
-
-            // `try_clone` returns `None` only for streaming bodies; safe for these GET requests.
-            let response = request
-                .try_clone()
-                .ok_or_else(|| {
-                    AlpacaOptionsError::InvalidResponse(
-                        "request body is not cloneable; cannot retry".into(),
-                    )
-                })?
-                .send()
-                .await?;
-
-            let status = response.status();
-
-            if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                if attempts >= MAX_RETRY_ATTEMPTS {
-                    return Err(AlpacaOptionsError::RateLimitExceeded { attempts });
-                }
-
-                let delay = parse_retry_after(response.headers())
-                    .unwrap_or(Duration::from_secs(DEFAULT_RATE_LIMIT_DELAY_SECS));
-
-                warn!(
-                    attempt = attempts,
-                    delay_secs = delay.as_secs(),
-                    "Alpaca rate limited, retrying"
-                );
-                tokio::time::sleep(delay).await;
-                continue;
-            }
-
-            if !status.is_success() {
-                let message = response.text().await.unwrap_or_default();
-                return Err(AlpacaOptionsError::Api {
-                    status: status.as_u16(),
-                    message,
-                });
-            }
-
-            let body = response.text().await?;
-            debug!(len = body.len(), "Alpaca response received");
-
-            return serde_json::from_str(&body).map_err(|e| {
-                AlpacaOptionsError::InvalidResponse(format!("JSON parse error: {e}"))
-            });
-        }
-    }
-}
-
-/// Parse the `Retry-After` header (delay in seconds).
-///
-/// `x-ratelimit-reset` is intentionally not used as a fallback because it carries
-/// a Unix epoch timestamp, not a duration; mis-interpreting it would produce
-/// sleeps measured in years.
-fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
-    headers
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok())
-        .map(Duration::from_secs)
 }
 
 #[cfg(test)]

--- a/rustrade-data/src/exchange/alpaca/options/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/options/mod.rs
@@ -63,7 +63,7 @@ use super::rest::AlpacaRestClient;
 
 /// Errors from Alpaca options API operations.
 ///
-/// Alias of the shared [`AlpacaRestError`](super::super::rest::AlpacaRestError): options requests
+/// Alias of the shared [`AlpacaRestError`](super::rest::AlpacaRestError): options requests
 /// have no failure modes beyond the common transport/protocol ones, so the single REST error type
 /// is reused rather than duplicated per endpoint family.
 pub use super::rest::AlpacaRestError as AlpacaOptionsError;

--- a/rustrade-data/src/exchange/alpaca/options/snapshots.rs
+++ b/rustrade-data/src/exchange/alpaca/options/snapshots.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Maximum symbols per snapshot request (Alpaca API limit).
 const MAX_SYMBOLS_PER_REQUEST: usize = 100;
@@ -218,10 +218,10 @@ impl AlpacaOptionsClient {
 
         loop {
             if pages >= MAX_PAGES {
-                debug!(
+                warn!(
                     pages,
                     snapshots = all_snapshots.len(),
-                    "reached max pages limit"
+                    "Alpaca option snapshots hit the max-pages safety limit; returning truncated results"
                 );
                 break;
             }

--- a/rustrade-data/src/exchange/alpaca/options/snapshots.rs
+++ b/rustrade-data/src/exchange/alpaca/options/snapshots.rs
@@ -237,10 +237,10 @@ impl AlpacaOptionsClient {
                 params.push(("page_token", &token_string));
             }
 
-            let url = format!("{}/v1beta1/options/snapshots", self.data_base);
-            let request = self.http.get(&url).query(&params);
+            let url = format!("{}/v1beta1/options/snapshots", self.rest.data_base());
+            let request = self.rest.get(&url).query(&params);
 
-            let response: SnapshotsResponse = self.request_with_retry(request).await?;
+            let response: SnapshotsResponse = self.rest.request_with_retry(request).await?;
 
             if let Some(snapshots_map) = response.snapshots {
                 let count = snapshots_map.len();

--- a/rustrade-data/src/exchange/alpaca/reference.rs
+++ b/rustrade-data/src/exchange/alpaca/reference.rs
@@ -1,0 +1,429 @@
+//! Alpaca corporate-actions reference data (`GET /v1beta1/corporate-actions`).
+//!
+//! The raw REST surface behind the [`StockSplitSource`] adapter (see
+//! [`corporate_action`](super::corporate_action)): a [`CorporateActionsQuery`] builder, the nested
+//! response types, and the paginated [`AlpacaRestClient::fetch_splits_raw`] stream. Only stock-split
+//! actions are requested (`types=forward_split,reverse_split`); each row is normalised into an
+//! [`AlpacaStockSplit`].
+//!
+//! # Date semantics
+//!
+//! [`AlpacaStockSplit::ex_date`] is the split's **ex-date** — the session on which the share count
+//! re-bases and the price adjusts (observed equal to `process_date` across every sampled split).
+//! It is the field the [`StockSplitSource`] adapter maps onto the descriptor's `effective_date`.
+//! Alpaca also returns `payable_date`, which can fall a trading day *before* `ex_date` for forward
+//! splits and therefore must NOT be used as the effective date — see
+//! [`corporate_action`](super::corporate_action) for the full rationale.
+//!
+//! [`StockSplitSource`]: rustrade_integration::corporate_action::StockSplitSource
+
+use super::rest::{AlpacaRestClient, AlpacaRestError};
+use async_stream::try_stream;
+use chrono::NaiveDate;
+use futures::Stream;
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use tracing::{debug, warn};
+
+/// Maximum results per page (Alpaca API limit).
+const MAX_LIMIT: u16 = 1000;
+
+/// Maximum pages to fetch before stopping (safety limit against an unbounded `page_token` loop).
+const MAX_PAGES: usize = 1000;
+
+/// The `types` filter value — this surface only fetches stock splits, never other action kinds.
+const SPLIT_TYPES: &str = "forward_split,reverse_split";
+
+// ============================================================================
+// Query Builder
+// ============================================================================
+
+/// Query parameters for the `GET /v1beta1/corporate-actions` splits endpoint.
+///
+/// Construct with [`CorporateActionsQuery::new`] and chain setters. The `types` filter is fixed to
+/// `forward_split,reverse_split`; pagination via `page_token` is handled automatically by
+/// [`AlpacaRestClient::fetch_splits_raw`].
+///
+/// # Example
+///
+/// ```
+/// use rustrade_data::exchange::alpaca::CorporateActionsQuery;
+/// use chrono::NaiveDate;
+///
+/// let query = CorporateActionsQuery::new()
+///     .symbols(["NVDA", "AAPL"])
+///     .start(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap())
+///     .end(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap());
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct CorporateActionsQuery {
+    /// Underlying symbols to filter by; empty means no symbol restriction (all symbols in range).
+    pub symbols: Vec<String>,
+    /// Inclusive lower bound on the action's effective date.
+    pub start: Option<NaiveDate>,
+    /// Inclusive upper bound on the action's effective date.
+    pub end: Option<NaiveDate>,
+    /// Results per page (clamped to [`MAX_LIMIT`]).
+    pub limit: Option<u16>,
+}
+
+impl CorporateActionsQuery {
+    /// Create a new empty query (all symbols, no date bounds, default pagination).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by underlying symbols (joined into Alpaca's comma-separated `symbols` parameter).
+    #[must_use]
+    pub fn symbols<I, S>(mut self, symbols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.symbols = symbols.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Filter to actions effective on or after `date`.
+    #[must_use]
+    pub fn start(mut self, date: NaiveDate) -> Self {
+        self.start = Some(date);
+        self
+    }
+
+    /// Filter to actions effective on or before `date`.
+    #[must_use]
+    pub fn end(mut self, date: NaiveDate) -> Self {
+        self.end = Some(date);
+        self
+    }
+
+    /// Set results per page (clamped to the API maximum of 1000).
+    #[must_use]
+    pub fn limit(mut self, limit: u16) -> Self {
+        self.limit = Some(limit.min(MAX_LIMIT));
+        self
+    }
+
+    /// Build the query-string parameters (excluding `page_token`, which the stream adds per page).
+    fn to_query_params(&self) -> Vec<(&'static str, String)> {
+        let mut params = vec![("types", SPLIT_TYPES.to_string())];
+
+        if !self.symbols.is_empty() {
+            params.push(("symbols", self.symbols.join(",")));
+        }
+        if let Some(start) = self.start {
+            params.push(("start", start.format("%Y-%m-%d").to_string()));
+        }
+        if let Some(end) = self.end {
+            params.push(("end", end.format("%Y-%m-%d").to_string()));
+        }
+        let limit = self.limit.unwrap_or(MAX_LIMIT).min(MAX_LIMIT);
+        params.push(("limit", limit.to_string()));
+
+        params
+    }
+}
+
+// ============================================================================
+// Response Types
+// ============================================================================
+
+/// A normalised Alpaca stock split (forward or reverse).
+///
+/// The direction is encoded by the ratio: a forward split has `new_rate > old_rate`, a reverse
+/// split has `new_rate < old_rate`. These map directly onto the provider-agnostic
+/// `CorporateActionKind::stock_split(split_to, split_from)` helper (`new_rate` = `split_to`,
+/// `old_rate` = `split_from`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlpacaStockSplit {
+    /// Underlying symbol (e.g. `"NVDA"`).
+    pub symbol: String,
+    /// Ex-date — the market execution date on which the split takes effect. See the module docs.
+    pub ex_date: NaiveDate,
+    /// Shares *after* the split (the ratio numerator; `split_to`).
+    pub new_rate: Decimal,
+    /// Shares *before* the split (the ratio denominator; `split_from`).
+    pub old_rate: Decimal,
+}
+
+/// Top-level response from the corporate-actions endpoint.
+#[derive(Debug, Default, Deserialize)]
+struct CorporateActionsResponse {
+    #[serde(default)]
+    corporate_actions: CorporateActions,
+    #[serde(default)]
+    next_page_token: Option<String>,
+}
+
+/// The `corporate_actions` object: split rows partitioned into forward and reverse arrays.
+#[derive(Debug, Default, Deserialize)]
+struct CorporateActions {
+    #[serde(default)]
+    forward_splits: Vec<RawSplit>,
+    #[serde(default)]
+    reverse_splits: Vec<RawSplit>,
+}
+
+impl CorporateActions {
+    /// Flatten both arrays into normalised splits, forward rows first.
+    fn into_stock_splits(self) -> impl Iterator<Item = AlpacaStockSplit> {
+        self.forward_splits
+            .into_iter()
+            .chain(self.reverse_splits)
+            .map(RawSplit::into_stock_split)
+    }
+}
+
+/// A raw split row. Forward and reverse rows share the fields we consume (`symbol`, `new_rate`,
+/// `old_rate`, `ex_date`); they differ only in their CUSIP shape (`cusip` vs `new_cusip`/
+/// `old_cusip`) and other dates (`payable_date`, `process_date`, …), none of which a split source
+/// needs — those are simply ignored, so a single struct deserialises both arrays.
+///
+/// `new_rate` / `old_rate` arrive as JSON numbers (e.g. `10`, `1`), so they use the float decimal
+/// representation — identical to the Massive split client.
+#[derive(Debug, Deserialize)]
+struct RawSplit {
+    symbol: String,
+    #[serde(with = "rust_decimal::serde::float")]
+    new_rate: Decimal,
+    #[serde(with = "rust_decimal::serde::float")]
+    old_rate: Decimal,
+    ex_date: NaiveDate,
+}
+
+impl RawSplit {
+    fn into_stock_split(self) -> AlpacaStockSplit {
+        AlpacaStockSplit {
+            symbol: self.symbol,
+            ex_date: self.ex_date,
+            new_rate: self.new_rate,
+            old_rate: self.old_rate,
+        }
+    }
+}
+
+// ============================================================================
+// Client
+// ============================================================================
+
+impl AlpacaRestClient {
+    /// Fetch stock splits matching `query` from `GET /v1beta1/corporate-actions`.
+    ///
+    /// Returns a stream that handles `page_token` pagination automatically, yielding each
+    /// forward/reverse split as a normalised [`AlpacaStockSplit`]. The stream stops after
+    /// [`MAX_PAGES`] pages as a safety bound and logs a warning if that limit is hit.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use rustrade_data::exchange::alpaca::{AlpacaRestClient, CorporateActionsQuery};
+    /// use futures::StreamExt;
+    ///
+    /// let client = AlpacaRestClient::from_env()?;
+    /// let query = CorporateActionsQuery::new().symbols(["NVDA"]);
+    /// let mut stream = client.fetch_splits_raw(&query);
+    /// while let Some(split) = stream.next().await {
+    ///     println!("{:?}", split?);
+    /// }
+    /// ```
+    pub fn fetch_splits_raw<'a>(
+        &'a self,
+        query: &'a CorporateActionsQuery,
+    ) -> impl Stream<Item = Result<AlpacaStockSplit, AlpacaRestError>> + 'a {
+        try_stream! {
+            let url = format!("{}/v1beta1/corporate-actions", self.data_base());
+            let mut page_token: Option<String> = None;
+            let mut pages = 0usize;
+
+            loop {
+                if pages >= MAX_PAGES {
+                    warn!(pages, "Alpaca corporate-actions hit the max-pages safety limit; stopping");
+                    break;
+                }
+                pages += 1;
+
+                let mut params = query.to_query_params();
+                if let Some(ref token) = page_token {
+                    params.push(("page_token", token.clone()));
+                }
+
+                debug!(url = %url, page = pages, "Fetching Alpaca corporate-actions page");
+                let request = self.get(&url).query(&params);
+                let response: CorporateActionsResponse = self.request_with_retry(request).await?;
+
+                let CorporateActionsResponse { corporate_actions, next_page_token } = response;
+                for split in corporate_actions.into_stock_splits() {
+                    yield split;
+                }
+
+                match next_page_token {
+                    Some(token) if !token.is_empty() => page_token = Some(token),
+                    _ => break,
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Tests should panic on unexpected values
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_empty_sets_only_types_and_limit() {
+        let params = CorporateActionsQuery::new().to_query_params();
+        assert!(params.contains(&("types", SPLIT_TYPES.to_string())));
+        assert!(params.iter().any(|(k, v)| *k == "limit" && v == "1000"));
+        assert!(!params.iter().any(|(k, _)| *k == "symbols"));
+        assert!(!params.iter().any(|(k, _)| *k == "start" || *k == "end"));
+    }
+
+    #[test]
+    fn query_joins_symbols_and_dates() {
+        let params = CorporateActionsQuery::new()
+            .symbols(["NVDA", "AAPL"])
+            .start(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap())
+            .end(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap())
+            .to_query_params();
+
+        assert!(
+            params
+                .iter()
+                .any(|(k, v)| *k == "symbols" && v == "NVDA,AAPL")
+        );
+        assert!(
+            params
+                .iter()
+                .any(|(k, v)| *k == "start" && v == "2024-01-01")
+        );
+        assert!(params.iter().any(|(k, v)| *k == "end" && v == "2024-12-31"));
+    }
+
+    #[test]
+    fn query_limit_clamped_to_max() {
+        let params = CorporateActionsQuery::new().limit(5000).to_query_params();
+        assert!(params.iter().any(|(k, v)| *k == "limit" && v == "1000"));
+    }
+
+    #[test]
+    fn parse_forward_split_response() {
+        // NVDA 10-for-1 forward split (ex == process == payable here).
+        let json = r#"{
+            "corporate_actions": {
+                "forward_splits": [{
+                    "symbol": "NVDA", "cusip": "67066G104",
+                    "new_rate": 10, "old_rate": 1,
+                    "ex_date": "2024-06-10", "process_date": "2024-06-10",
+                    "payable_date": "2024-06-10", "record_date": "2024-06-07",
+                    "due_bill_redemption_date": "2024-06-10",
+                    "id": "50199fac-0af8-43ef-9846-eaf64c6d322d"
+                }]
+            },
+            "next_page_token": null
+        }"#;
+
+        let parsed: CorporateActionsResponse = serde_json::from_str(json).unwrap();
+        assert!(parsed.next_page_token.is_none());
+
+        let splits: Vec<_> = parsed.corporate_actions.into_stock_splits().collect();
+        assert_eq!(splits.len(), 1);
+        assert_eq!(
+            splits[0],
+            AlpacaStockSplit {
+                symbol: "NVDA".to_string(),
+                ex_date: NaiveDate::from_ymd_opt(2024, 6, 10).unwrap(),
+                new_rate: Decimal::from(10),
+                old_rate: Decimal::from(1),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_reverse_split_response_with_dual_cusip() {
+        // ATRA 1-for-25 reverse split — note the `new_cusip`/`old_cusip` shape (ignored).
+        let json = r#"{
+            "corporate_actions": {
+                "reverse_splits": [{
+                    "symbol": "ATRA", "new_rate": 1, "old_rate": 25,
+                    "new_cusip": "046513206", "old_cusip": "046513107",
+                    "ex_date": "2024-06-20", "process_date": "2024-06-20",
+                    "payable_date": "2024-06-20", "record_date": "2024-06-20",
+                    "id": "446f18f3-92fc-42a8-8b93-4700f06bc8e0"
+                }]
+            }
+        }"#;
+
+        let parsed: CorporateActionsResponse = serde_json::from_str(json).unwrap();
+        let splits: Vec<_> = parsed.corporate_actions.into_stock_splits().collect();
+        assert_eq!(splits.len(), 1);
+        assert_eq!(splits[0].symbol, "ATRA");
+        assert_eq!(splits[0].new_rate, Decimal::from(1));
+        assert_eq!(splits[0].old_rate, Decimal::from(25));
+        assert_eq!(
+            splits[0].ex_date,
+            NaiveDate::from_ymd_opt(2024, 6, 20).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_both_arrays_forward_first_with_page_token() {
+        let json = r#"{
+            "corporate_actions": {
+                "forward_splits": [{
+                    "symbol": "NVDA", "new_rate": 10, "old_rate": 1, "ex_date": "2024-06-10"
+                }],
+                "reverse_splits": [{
+                    "symbol": "ATRA", "new_rate": 1, "old_rate": 25, "ex_date": "2024-06-20"
+                }]
+            },
+            "next_page_token": "next123"
+        }"#;
+
+        let parsed: CorporateActionsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.next_page_token.as_deref(), Some("next123"));
+
+        let splits: Vec<_> = parsed.corporate_actions.into_stock_splits().collect();
+        // Forward rows come first.
+        assert_eq!(splits[0].symbol, "NVDA");
+        assert_eq!(splits[1].symbol, "ATRA");
+    }
+
+    #[test]
+    fn parse_empty_response() {
+        let json = r#"{ "corporate_actions": {}, "next_page_token": null }"#;
+        let parsed: CorporateActionsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.corporate_actions.into_stock_splits().count(), 0);
+    }
+
+    #[test]
+    fn ex_date_provenance_ignores_payable_date() {
+        // APH forward split where `payable_date` (2024-06-11) precedes `ex_date` (2024-06-12) by a
+        // trading day. Pins that the parsed `ex_date` is the JSON `ex_date` — NOT `payable_date`
+        // (which would apply the split a day early; see `corporate_action`'s impl rustdoc).
+        let json = r#"{
+            "corporate_actions": {
+                "forward_splits": [{
+                    "symbol": "APH", "new_rate": 2, "old_rate": 1,
+                    "ex_date": "2024-06-12", "process_date": "2024-06-12",
+                    "payable_date": "2024-06-11", "record_date": "2024-05-31"
+                }]
+            }
+        }"#;
+
+        let parsed: CorporateActionsResponse = serde_json::from_str(json).unwrap();
+        let splits: Vec<_> = parsed.corporate_actions.into_stock_splits().collect();
+        assert_eq!(splits.len(), 1);
+        assert_eq!(
+            splits[0].ex_date,
+            NaiveDate::from_ymd_opt(2024, 6, 12).unwrap(),
+            "ex_date must be the JSON ex_date, never payable_date (2024-06-11)"
+        );
+    }
+}

--- a/rustrade-data/src/exchange/alpaca/reference.rs
+++ b/rustrade-data/src/exchange/alpaca/reference.rs
@@ -23,6 +23,7 @@ use chrono::NaiveDate;
 use futures::Stream;
 use rust_decimal::Decimal;
 use serde::Deserialize;
+use smol_str::SmolStr;
 use tracing::{debug, warn};
 
 /// Maximum results per page (Alpaca API limit).
@@ -58,7 +59,7 @@ const SPLIT_TYPES: &str = "forward_split,reverse_split";
 #[derive(Debug, Default, Clone)]
 pub struct CorporateActionsQuery {
     /// Underlying symbols to filter by; empty means no symbol restriction (all symbols in range).
-    pub symbols: Vec<String>,
+    pub symbols: Vec<SmolStr>,
     /// Inclusive lower bound on the action's effective date.
     pub start: Option<NaiveDate>,
     /// Inclusive upper bound on the action's effective date.
@@ -79,7 +80,7 @@ impl CorporateActionsQuery {
     pub fn symbols<I, S>(mut self, symbols: I) -> Self
     where
         I: IntoIterator<Item = S>,
-        S: Into<String>,
+        S: Into<SmolStr>,
     {
         self.symbols = symbols.into_iter().map(Into::into).collect();
         self

--- a/rustrade-data/src/exchange/alpaca/rest.rs
+++ b/rustrade-data/src/exchange/alpaca/rest.rs
@@ -1,0 +1,268 @@
+//! Shared Alpaca REST transport.
+//!
+//! A single authenticated [`reqwest::Client`] with rate-limit retry and JSON deserialisation,
+//! shared by every Alpaca REST surface (options contracts/snapshots, corporate actions, …) so the
+//! authentication, retry policy, and error type live in one place instead of being copied per
+//! endpoint family.
+//!
+//! # Authentication
+//!
+//! Requires `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` (and the optional `ALPACA_PAPER`) environment
+//! variables when constructed via [`AlpacaRestClient::from_env`], or explicit credentials via
+//! [`AlpacaRestClient::new`]. Credentials are sent as the `APCA-API-KEY-ID` / `APCA-API-SECRET-KEY`
+//! headers on every request.
+
+use reqwest::header::{HeaderMap, HeaderValue};
+use std::{env, time::Duration};
+use thiserror::Error;
+use tracing::{debug, warn};
+
+/// Base URL for Alpaca Broker API (trading + options contracts).
+const BROKER_API_BASE: &str = "https://api.alpaca.markets";
+
+/// Base URL for Alpaca Data API (market data, corporate actions, options snapshots).
+const DATA_API_BASE: &str = "https://data.alpaca.markets";
+
+/// Paper trading base URL.
+const PAPER_API_BASE: &str = "https://paper-api.alpaca.markets";
+
+/// Default timeout for REST requests.
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Maximum retry attempts for rate-limited requests.
+const MAX_RETRY_ATTEMPTS: u32 = 3;
+
+/// Default delay when rate-limited (if no `Retry-After` header).
+const DEFAULT_RATE_LIMIT_DELAY_SECS: u64 = 60;
+
+/// Errors from Alpaca REST API operations.
+///
+/// Shared across every Alpaca REST surface (options, corporate actions, …); the variants are
+/// transport/protocol concerns (auth, HTTP, API status, rate limiting, deserialisation) common to
+/// all of them, so there is no endpoint-specific error type to keep in sync.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum AlpacaRestError {
+    /// A required environment variable is not set (see [`AlpacaRestClient::from_env`]).
+    #[error("environment variable error: {0}")]
+    EnvVar(String),
+
+    /// A supplied credential cannot be encoded as an HTTP header value (e.g. non-ASCII bytes).
+    #[error("invalid credential: {0}")]
+    InvalidCredential(String),
+
+    /// HTTP client error.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// API returned an error response.
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+
+    /// Rate limit exceeded after retries.
+    #[error("rate limit exceeded after {attempts} attempts")]
+    RateLimitExceeded { attempts: u32 },
+
+    /// Invalid response format.
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+/// Authenticated Alpaca REST client.
+///
+/// Holds the configured [`reqwest::Client`] (with auth headers + timeout) plus the broker and data
+/// API base URLs. Endpoint-family wrappers (`AlpacaOptionsClient`, the corporate-action source, …)
+/// build requests against these bases and drive them through [`request_with_retry`].
+///
+/// [`request_with_retry`]: AlpacaRestClient::request_with_retry
+#[derive(Clone)]
+pub struct AlpacaRestClient {
+    http: reqwest::Client,
+    broker_base: String,
+    data_base: String,
+}
+
+impl std::fmt::Debug for AlpacaRestClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Deliberately omits the `reqwest::Client` (and therefore its auth headers) so credentials
+        // never leak through `Debug`.
+        f.debug_struct("AlpacaRestClient")
+            .field("broker_base", &self.broker_base)
+            .field("data_base", &self.data_base)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AlpacaRestClient {
+    /// Create a new client with explicit credentials.
+    ///
+    /// # Arguments
+    ///
+    /// * `api_key` - Alpaca API key
+    /// * `api_secret` - Alpaca API secret
+    /// * `paper` - Use the paper trading broker endpoint if true
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be built (e.g. non-ASCII credentials that cannot
+    /// be encoded as header values).
+    pub fn new(api_key: &str, api_secret: &str, paper: bool) -> Result<Self, AlpacaRestError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "APCA-API-KEY-ID",
+            HeaderValue::from_str(api_key)
+                .map_err(|e| AlpacaRestError::InvalidCredential(format!("invalid API key: {e}")))?,
+        );
+        headers.insert(
+            "APCA-API-SECRET-KEY",
+            HeaderValue::from_str(api_secret).map_err(|e| {
+                AlpacaRestError::InvalidCredential(format!("invalid API secret: {e}"))
+            })?,
+        );
+
+        let http = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()?;
+
+        let broker_base = if paper {
+            PAPER_API_BASE.to_string()
+        } else {
+            BROKER_API_BASE.to_string()
+        };
+
+        Ok(Self {
+            http,
+            broker_base,
+            data_base: DATA_API_BASE.to_string(),
+        })
+    }
+
+    /// Create a client from environment variables.
+    ///
+    /// Reads:
+    /// - `ALPACA_API_KEY` - API key (required)
+    /// - `ALPACA_SECRET_KEY` - API secret (required)
+    /// - `ALPACA_PAPER` - Set to "true" for paper trading (optional, defaults to false)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either required environment variable is missing or the client cannot be
+    /// built.
+    pub fn from_env() -> Result<Self, AlpacaRestError> {
+        let api_key = env::var("ALPACA_API_KEY")
+            .map_err(|e| AlpacaRestError::EnvVar(format!("ALPACA_API_KEY: {e}")))?;
+        let api_secret = env::var("ALPACA_SECRET_KEY")
+            .map_err(|e| AlpacaRestError::EnvVar(format!("ALPACA_SECRET_KEY: {e}")))?;
+        let paper = env::var("ALPACA_PAPER")
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        Self::new(&api_key, &api_secret, paper)
+    }
+
+    /// The broker API base URL (`https://api.alpaca.markets`, or the paper endpoint).
+    pub(crate) fn broker_base(&self) -> &str {
+        &self.broker_base
+    }
+
+    /// The data API base URL (`https://data.alpaca.markets`).
+    pub(crate) fn data_base(&self) -> &str {
+        &self.data_base
+    }
+
+    /// Begin a `GET` request against `url`, pre-authenticated with the client's default headers.
+    pub(crate) fn get(&self, url: &str) -> reqwest::RequestBuilder {
+        self.http.get(url)
+    }
+
+    /// Execute a request, retrying on HTTP 429 (rate limited), then deserialise the JSON body.
+    ///
+    /// The request must be cloneable (true for the query-string GET requests used here) so it can
+    /// be re-sent across retries.
+    pub(crate) async fn request_with_retry<T>(
+        &self,
+        request: reqwest::RequestBuilder,
+    ) -> Result<T, AlpacaRestError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let mut attempts = 0u32;
+
+        loop {
+            attempts += 1;
+
+            // `try_clone` returns `None` only for streaming bodies; safe for these GET requests.
+            let response = request
+                .try_clone()
+                .ok_or_else(|| {
+                    AlpacaRestError::InvalidResponse(
+                        "request body is not cloneable; cannot retry".into(),
+                    )
+                })?
+                .send()
+                .await?;
+
+            let status = response.status();
+
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                if attempts >= MAX_RETRY_ATTEMPTS {
+                    return Err(AlpacaRestError::RateLimitExceeded { attempts });
+                }
+
+                let delay = parse_retry_after(response.headers())
+                    .unwrap_or(Duration::from_secs(DEFAULT_RATE_LIMIT_DELAY_SECS));
+
+                warn!(
+                    attempt = attempts,
+                    delay_secs = delay.as_secs(),
+                    "Alpaca rate limited, retrying"
+                );
+                tokio::time::sleep(delay).await;
+                continue;
+            }
+
+            if !status.is_success() {
+                let message = response.text().await.unwrap_or_default();
+                return Err(AlpacaRestError::Api {
+                    status: status.as_u16(),
+                    message,
+                });
+            }
+
+            let body = response.text().await?;
+            debug!(len = body.len(), "Alpaca response received");
+
+            return serde_json::from_str(&body)
+                .map_err(|e| AlpacaRestError::InvalidResponse(format!("JSON parse error: {e}")));
+        }
+    }
+}
+
+/// Parse the `Retry-After` header (delay in seconds).
+///
+/// `x-ratelimit-reset` is intentionally not used as a fallback because it carries a Unix epoch
+/// timestamp, not a duration; mis-interpreting it would produce sleeps measured in years.
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::AlpacaRestClient;
+
+    #[test]
+    fn client_debug_hides_credentials() {
+        let client = AlpacaRestClient::new("test-key-id", "test-secret-value", true)
+            .expect("client construction with ASCII credentials should succeed");
+        let debug_str = format!("{client:?}");
+
+        assert!(!debug_str.contains("test-key-id"));
+        assert!(!debug_str.contains("test-secret-value"));
+    }
+}

--- a/rustrade-data/src/exchange/alpaca/rest.rs
+++ b/rustrade-data/src/exchange/alpaca/rest.rs
@@ -192,14 +192,17 @@ impl AlpacaRestClient {
         loop {
             attempts += 1;
 
-            // `try_clone` returns `None` only for streaming bodies; safe for these GET requests.
+            // `try_clone` returns `None` only for streaming request bodies. This function is
+            // documented (and used) exclusively for GET/query-string requests, which always clone,
+            // so `None` is an unreachable programmer error — a caller passed a streaming-body
+            // request to a retry path that requires cloneability. Panic loudly (the most observable
+            // failure) rather than mislabel it as a server-side `InvalidResponse`. `request_with_retry`
+            // is `pub(crate)`, so every call site is internal and statically auditable; if it is ever
+            // widened to `pub`, return an `Err` here so external callers can recover instead of aborting.
+            #[allow(clippy::expect_used)]
             let response = request
                 .try_clone()
-                .ok_or_else(|| {
-                    AlpacaRestError::InvalidResponse(
-                        "request body is not cloneable; cannot retry".into(),
-                    )
-                })?
+                .expect("request_with_retry requires a cloneable request (GET / no streaming body)")
                 .send()
                 .await?;
 

--- a/rustrade-data/src/exchange/alpaca/rest.rs
+++ b/rustrade-data/src/exchange/alpaca/rest.rs
@@ -66,6 +66,13 @@ pub enum AlpacaRestError {
     /// Invalid response format.
     #[error("invalid response: {0}")]
     InvalidResponse(String),
+
+    /// The request could not be cloned for a retry — `reqwest` returns `None` from `try_clone`
+    /// only for streaming request bodies. Never occurs for the GET/query-string requests this
+    /// client issues today, but returned (not panicked) so a future streaming-body caller of the
+    /// shared retry helper recovers instead of aborting the task.
+    #[error("request body is not cloneable; cannot retry (streaming bodies are unsupported)")]
+    NotCloneable,
 }
 
 /// Authenticated Alpaca REST client.
@@ -180,6 +187,12 @@ impl AlpacaRestClient {
     ///
     /// The request must be cloneable (true for the query-string GET requests used here) so it can
     /// be re-sent across retries.
+    ///
+    /// # Errors
+    /// Returns [`AlpacaRestError::NotCloneable`] if the request carries a streaming body (`reqwest`
+    /// cannot clone it for a retry). This never happens for the GET requests this client issues, but
+    /// is surfaced as a recoverable `Err` — consistent with every other failure mode of this shared
+    /// helper — rather than a panic, so a future streaming-body caller can handle it.
     pub(crate) async fn request_with_retry<T>(
         &self,
         request: reqwest::RequestBuilder,
@@ -192,19 +205,16 @@ impl AlpacaRestClient {
         loop {
             attempts += 1;
 
-            // `try_clone` returns `None` only for streaming request bodies. This function is
-            // documented (and used) exclusively for GET/query-string requests, which always clone,
-            // so `None` is an unreachable programmer error — a caller passed a streaming-body
-            // request to a retry path that requires cloneability. Panic loudly (the most observable
-            // failure) rather than mislabel it as a server-side `InvalidResponse`. `request_with_retry`
-            // is `pub(crate)`, so every call site is internal and statically auditable; if it is ever
-            // widened to `pub`, return an `Err` here so external callers can recover instead of aborting.
-            #[allow(clippy::expect_used)]
-            let response = request
-                .try_clone()
-                .expect("request_with_retry requires a cloneable request (GET / no streaming body)")
-                .send()
-                .await?;
+            // `try_clone` returns `None` only for streaming request bodies. Every current caller
+            // passes a GET/query-string request (no body), so this always clones — but return a
+            // typed `Err` rather than panic: this shared retry helper already surfaces every other
+            // failure (rate limit, HTTP status, deserialisation) as an `AlpacaRestError`, and the
+            // function returns `Result`, so an added error branch is free and lets a future
+            // streaming-body caller recover instead of aborting the task.
+            let response = match request.try_clone() {
+                Some(request) => request.send().await?,
+                None => return Err(AlpacaRestError::NotCloneable),
+            };
 
             let status = response.status();
 

--- a/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
@@ -1,0 +1,544 @@
+//! Faithful, raw IBKR Flex corporate-action records and the XML parser.
+//!
+//! This module turns the `<CorporateAction>` rows of an IBKR **Flex Web Service** statement
+//! (the account *Activity* report's Corporate Actions section) into a list of
+//! [`IbkrFlexCorporateAction`] records, **without** interpreting them. It is a *reconciliation*
+//! surface, not a split-ratio source:
+//!
+//! - **No ratio is derived.** Flex reports a corporate-action *type* (e.g. forward/reverse split)
+//!   plus an account-scoped share **delta**, but carries no standardised split-ratio field. Deriving
+//!   a ratio would mean parsing the unstable free-text `actionDescription`, or dividing the
+//!   post-event by the pre-event holding (account state this library deliberately does not own).
+//!   Both are silent-failure risks (a wrong-but-plausible ratio would mis-scale a position), so the
+//!   library surfaces the raw record and leaves ratio derivation/verification to the caller — e.g.
+//!   cross-referencing a market-reference split source.
+//! - **These records cannot drive a live split.** A Flex statement is *post-hoc*: its `reportDate`
+//!   is the day the broker booked the action (typically T+1 or later), **not** the market execution
+//!   date a backtest/live engine needs. Use these records for reconciliation and audit, not for
+//!   injecting split events at the right point in a timeline.
+//! - **Records are account-scoped.** `quantity_delta` is the change to *this account's* position
+//!   from the action, not a market-wide quantity. Two accounts see different deltas for the same
+//!   corporate action.
+//!
+//! The parser returns **every** reorg row faithfully (forward/reverse splits, spin-offs, dividends,
+//! mergers, …); selecting which rows matter (e.g. only `FS`/`RS`) is the caller's job.
+
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use smol_str::SmolStr;
+
+use super::{IbkrFlexError, nonempty};
+
+/// A single corporate-action row from an IBKR Flex statement, surfaced verbatim.
+///
+/// Every field mirrors a Flex `<CorporateAction>` attribute with no interpretation applied beyond
+/// type coercion (string → `Decimal`/`NaiveDate`) and treating absent/empty attributes as `None`.
+/// See the [module docs](self) for why this is a reconciliation record and not a split-ratio source.
+///
+/// `#[non_exhaustive]`: IBKR may add attributes to the Flex schema; new fields are surfaced
+/// additively without a breaking change. Construct instances via [`parse_corporate_actions`], not a
+/// struct literal.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub struct IbkrFlexCorporateAction {
+    /// IBKR account the action was booked against (`accountId`). Account-scoped — see the module docs.
+    pub account_id: Option<SmolStr>,
+    /// Instrument ticker symbol (`symbol`).
+    pub symbol: Option<SmolStr>,
+    /// IBKR contract id (`conid`), surfaced as a string.
+    pub conid: Option<SmolStr>,
+    /// ISIN identifier (`isin`), when present.
+    pub isin: Option<SmolStr>,
+    /// CUSIP identifier (`cusip`), when present.
+    pub cusip: Option<SmolStr>,
+    /// IBKR asset category (`assetCategory`, e.g. `"STK"`, `"BOND"`).
+    pub asset_category: Option<SmolStr>,
+    /// The reorganisation type (`type`, aliased from `actionType`). See [`IbkrReorgType`].
+    pub action_type: IbkrReorgType,
+    /// Signed change to *this account's* share count from the action (`quantity`).
+    ///
+    /// This is an **account-scoped delta**, not a market-wide quantity, and is **not** a split
+    /// ratio: deriving a ratio from `new_qty / old_qty` would require the pre-event holding, which
+    /// this library does not track. An absent or empty `quantity` is surfaced as `0`.
+    pub quantity_delta: Decimal,
+    /// Free-text action description (`actionDescription`), when present.
+    ///
+    /// **Unstable / human-facing.** The wording is not a stable contract and must **not** be parsed
+    /// to extract a split ratio or other structured data — IBKR can change it at any time. Some rows
+    /// omit it entirely.
+    pub action_description: Option<SmolStr>,
+    /// The date IBKR booked the action (`reportDate`), best-effort parsed from `YYYY-MM-DD`.
+    ///
+    /// This is **not** the market execution date of the corporate action — a Flex statement is
+    /// post-hoc, so `report_date` is typically a trading day (or more) *after* the event took effect
+    /// in the market. Do not treat it as an effective date for engine injection.
+    pub report_date: Option<NaiveDate>,
+    /// Raw `dateTime` attribute, surfaced as-is.
+    ///
+    /// The Flex date/time format is query-configuration-dependent — it can be `"2025-01-15;000000"`
+    /// (date;time) or a bare `"2025-01-15"` depending on the saved query's date/time format settings
+    /// — so it is intentionally **not** parsed here. Callers that need a typed value should parse it
+    /// against the format their own Flex query is configured to emit.
+    pub date_time: Option<SmolStr>,
+    /// Booked value of the action (`value`), when present.
+    pub value: Option<Decimal>,
+    /// Cash proceeds of the action (`proceeds`), when present.
+    pub proceeds: Option<Decimal>,
+    /// Realised FIFO P&L attributed to the action (`fifoPnlRealized`), when present.
+    pub fifo_pnl_realized: Option<Decimal>,
+    /// Raw `principalAdjustFactor` attribute, when present — **surfaced, never interpreted**.
+    ///
+    /// IBKR documents this as the calculated principal-adjustment factor for **Treasury
+    /// Inflation-Protected Securities (TIPS)**, *not* a split ratio. Some synthetic third-party
+    /// fixtures show it populated on split rows in a way that resembles `split_to / split_from`, but
+    /// that has **not** been confirmed against live broker output and may be an artefact of those
+    /// fixtures. It is surfaced here only so the raw record drops no schema field; it must **not** be
+    /// used as a primary source for a split ratio. A caller holding both this record and a
+    /// market-reference ratio is the right place to optionally cross-check it.
+    pub principal_adjust_factor: Option<Decimal>,
+    /// IBKR action identifier (`actionID`), when present.
+    pub action_id: Option<SmolStr>,
+    /// IBKR transaction identifier (`transactionID`), when present.
+    pub transaction_id: Option<SmolStr>,
+}
+
+/// IBKR Flex reorganisation type (the `<CorporateAction>` `type` attribute).
+///
+/// Only the split-related codes the reconciliation use-case cares about are modelled as named
+/// variants; every other code (dividends, spin-offs, mergers, tender offers, bond events, …) is
+/// preserved verbatim in [`Other`](IbkrReorgType::Other) so no information is lost.
+///
+/// `#[non_exhaustive]`: named variants may be added as more codes gain first-class handling, so
+/// downstream `match`es must include a wildcard arm.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum IbkrReorgType {
+    /// Forward split (`FS`).
+    ForwardSplit,
+    /// Reverse split (`RS`).
+    ReverseSplit,
+    /// Forward split issue (`FI`).
+    ForwardSplitIssue,
+    /// Contract split (`CS`).
+    ContractSplit,
+    /// Spin-off (`SO`).
+    SpinOff,
+    /// Contract spin-off (`CO`).
+    ContractSpinOff,
+    /// Any other (or absent) reorg code, preserved verbatim (e.g. `"DI"`, `"TC"`, `"CD"`).
+    Other(SmolStr),
+}
+
+impl From<&str> for IbkrReorgType {
+    /// Map an IBKR reorg code string to a variant. Unknown or empty codes become
+    /// [`Other`](IbkrReorgType::Other) (an empty code yields `Other("")`).
+    ///
+    /// This is the canonical code → variant mapping; it is total (every input maps to a variant)
+    /// so consumers parsing their own Flex records can reconstruct the type from a stored code.
+    fn from(code: &str) -> Self {
+        match code {
+            "FS" => Self::ForwardSplit,
+            "RS" => Self::ReverseSplit,
+            "FI" => Self::ForwardSplitIssue,
+            "CS" => Self::ContractSplit,
+            "SO" => Self::SpinOff,
+            "CO" => Self::ContractSpinOff,
+            other => Self::Other(SmolStr::from(other)),
+        }
+    }
+}
+
+/// Parse the `<CorporateAction>` rows out of an IBKR Flex statement XML document.
+///
+/// Walks every `<FlexStatement>` in the `<FlexQueryResponse>` and returns each `<CorporateAction>`
+/// as a faithful [`IbkrFlexCorporateAction`], in document order. **All** reorg types are returned —
+/// filtering to splits (or any other subset) is the caller's responsibility.
+///
+/// Non-corporate-action sections of the statement (trades, positions, cash transactions, …) are
+/// ignored. A statement with no Corporate Actions section yields an empty vector.
+///
+/// # Errors
+///
+/// Returns [`IbkrFlexError::Parse`] if the document is not well-formed XML or does not match the
+/// expected Flex statement shape.
+pub fn parse_corporate_actions(xml: &str) -> Result<Vec<IbkrFlexCorporateAction>, IbkrFlexError> {
+    let response: RawFlexQueryResponse = quick_xml::de::from_str(xml)
+        .map_err(|e| IbkrFlexError::Parse(format!("failed to parse Flex statement XML: {e}")))?;
+
+    Ok(response
+        .flex_statements
+        .statements
+        .into_iter()
+        .flat_map(|statement| statement.corporate_actions.actions)
+        .map(RawCorporateAction::into_corporate_action)
+        .collect())
+}
+
+// ============================================================================
+// Raw deserialisation layer
+// ============================================================================
+//
+// quick-xml's serde support maps XML *attributes* to fields renamed with a leading `@`. Every
+// attribute is captured as `Option<String>` first, then coerced in `into_corporate_action`, so that
+// empty (`foo=""`) and absent attributes both collapse to `None` and a malformed numeric/date
+// attribute degrades to `None`/`0` rather than failing the whole parse.
+
+#[derive(Debug, Deserialize)]
+struct RawFlexQueryResponse {
+    #[serde(rename = "FlexStatements", default)]
+    flex_statements: RawFlexStatements,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawFlexStatements {
+    #[serde(rename = "FlexStatement", default)]
+    statements: Vec<RawFlexStatement>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawFlexStatement {
+    #[serde(rename = "CorporateActions", default)]
+    corporate_actions: RawCorporateActions,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawCorporateActions {
+    #[serde(rename = "CorporateAction", default)]
+    actions: Vec<RawCorporateAction>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCorporateAction {
+    #[serde(rename = "@accountId", default)]
+    account_id: Option<String>,
+    #[serde(rename = "@symbol", default)]
+    symbol: Option<String>,
+    #[serde(rename = "@conid", default)]
+    conid: Option<String>,
+    #[serde(rename = "@isin", default)]
+    isin: Option<String>,
+    #[serde(rename = "@cusip", default)]
+    cusip: Option<String>,
+    #[serde(rename = "@assetCategory", default)]
+    asset_category: Option<String>,
+    // The reorg type lives in `type`; some statements also (or instead) carry `actionType`. Capture
+    // both separately and prefer `type`, falling back to `actionType` — serde `alias` would reject a
+    // row that carries *both* attributes as a duplicate field.
+    #[serde(rename = "@type", default)]
+    type_attr: Option<String>,
+    #[serde(rename = "@actionType", default)]
+    action_type_attr: Option<String>,
+    #[serde(rename = "@quantity", default)]
+    quantity: Option<String>,
+    #[serde(rename = "@actionDescription", default)]
+    action_description: Option<String>,
+    #[serde(rename = "@reportDate", default)]
+    report_date: Option<String>,
+    #[serde(rename = "@dateTime", default)]
+    date_time: Option<String>,
+    #[serde(rename = "@value", default)]
+    value: Option<String>,
+    #[serde(rename = "@proceeds", default)]
+    proceeds: Option<String>,
+    #[serde(rename = "@fifoPnlRealized", default)]
+    fifo_pnl_realized: Option<String>,
+    #[serde(rename = "@principalAdjustFactor", default)]
+    principal_adjust_factor: Option<String>,
+    #[serde(rename = "@actionID", default)]
+    action_id: Option<String>,
+    #[serde(rename = "@transactionID", default)]
+    transaction_id: Option<String>,
+}
+
+impl RawCorporateAction {
+    fn into_corporate_action(self) -> IbkrFlexCorporateAction {
+        let code = nonempty(self.type_attr)
+            .or_else(|| nonempty(self.action_type_attr))
+            .unwrap_or_default();
+
+        IbkrFlexCorporateAction {
+            account_id: opt_smol(self.account_id),
+            symbol: opt_smol(self.symbol),
+            conid: opt_smol(self.conid),
+            isin: opt_smol(self.isin),
+            cusip: opt_smol(self.cusip),
+            asset_category: opt_smol(self.asset_category),
+            action_type: IbkrReorgType::from(code.as_str()),
+            quantity_delta: opt_decimal(self.quantity).unwrap_or(Decimal::ZERO),
+            action_description: opt_smol(self.action_description),
+            report_date: opt_date(self.report_date),
+            date_time: opt_smol(self.date_time),
+            value: opt_decimal(self.value),
+            proceeds: opt_decimal(self.proceeds),
+            fifo_pnl_realized: opt_decimal(self.fifo_pnl_realized),
+            principal_adjust_factor: opt_decimal(self.principal_adjust_factor),
+            action_id: opt_smol(self.action_id),
+            transaction_id: opt_smol(self.transaction_id),
+        }
+    }
+}
+
+fn opt_smol(value: Option<String>) -> Option<SmolStr> {
+    nonempty(value).map(SmolStr::from)
+}
+
+/// Parse a non-empty attribute as a [`Decimal`], yielding `None` if absent, empty, or malformed.
+fn opt_decimal(value: Option<String>) -> Option<Decimal> {
+    nonempty(value).and_then(|v| v.parse().ok())
+}
+
+/// Best-effort parse a `YYYY-MM-DD` attribute, yielding `None` if absent, empty, or malformed.
+fn opt_date(value: Option<String>) -> Option<NaiveDate> {
+    nonempty(value).and_then(|v| NaiveDate::parse_from_str(&v, "%Y-%m-%d").ok())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Tests should panic on unexpected values.
+mod tests {
+    use super::*;
+
+    const ACTIVITY_FIXTURE: &str =
+        include_str!("../../../../tests/fixtures/ibkr_flex/activity_corporate_actions.xml");
+    const COMPLEX_FIXTURE: &str =
+        include_str!("../../../../tests/fixtures/ibkr_flex/activity_complex_corporate_actions.xml");
+
+    fn find<'a>(
+        actions: &'a [IbkrFlexCorporateAction],
+        symbol: &str,
+    ) -> &'a IbkrFlexCorporateAction {
+        actions
+            .iter()
+            .find(|a| a.symbol.as_deref() == Some(symbol))
+            .unwrap_or_else(|| panic!("no corporate action for symbol {symbol}"))
+    }
+
+    #[test]
+    fn parses_basic_activity_fixture() {
+        let actions = parse_corporate_actions(ACTIVITY_FIXTURE).unwrap();
+        // 8 <CorporateAction> rows: DI, FS, SO, TC, RI, SD, RS, DW.
+        assert_eq!(actions.len(), 8);
+
+        // Forward split (TSLA, 2:1): the named variant + account-scoped +100 share delta.
+        let tsla = find(&actions, "TSLA");
+        assert_eq!(tsla.action_type, IbkrReorgType::ForwardSplit);
+        assert_eq!(tsla.quantity_delta, Decimal::from(100));
+        assert_eq!(tsla.account_id.as_deref(), Some("U1234567"));
+        assert_eq!(tsla.cusip.as_deref(), Some("88160R101"));
+        assert_eq!(tsla.isin.as_deref(), Some("US88160R1014"));
+        assert_eq!(tsla.asset_category.as_deref(), Some("STK"));
+        assert_eq!(tsla.report_date, NaiveDate::from_ymd_opt(2025, 1, 15));
+        // `dateTime` kept raw in the `date;time` format this query emitted.
+        assert_eq!(tsla.date_time.as_deref(), Some("2025-01-15;000000"));
+
+        // Reverse split (SPLIT, 1:10): negative (account-scoped) delta.
+        let split = find(&actions, "SPLIT");
+        assert_eq!(split.action_type, IbkrReorgType::ReverseSplit);
+        assert_eq!(split.quantity_delta, Decimal::from(-900));
+
+        // A non-split code is preserved verbatim, not dropped.
+        let dividend = find(&actions, "AAPL");
+        assert_eq!(
+            dividend.action_type,
+            IbkrReorgType::Other(SmolStr::from("DI"))
+        );
+        assert_eq!(dividend.value, Some(Decimal::from(100)));
+        assert_eq!(dividend.proceeds, Some(Decimal::from(100)));
+
+        // A merger row carries realised P&L and a negative delta.
+        let merger = find(&actions, "ACQUIRED");
+        assert_eq!(
+            merger.action_type,
+            IbkrReorgType::Other(SmolStr::from("TC"))
+        );
+        assert_eq!(merger.quantity_delta, Decimal::from(-100));
+        assert_eq!(merger.fifo_pnl_realized, Some(Decimal::from(1500)));
+    }
+
+    #[test]
+    fn principal_adjust_factor_is_surfaced_raw_not_derived() {
+        // The field is surfaced verbatim (a faithful record drops no attribute) but is NOT a split
+        // ratio — see the field rustdoc. These assertions pin that we read it, nothing more.
+        let actions = parse_corporate_actions(ACTIVITY_FIXTURE).unwrap();
+        assert_eq!(
+            find(&actions, "TSLA").principal_adjust_factor,
+            Some(Decimal::from(2))
+        );
+        assert_eq!(
+            find(&actions, "SPLIT").principal_adjust_factor,
+            Some(Decimal::new(1, 1)) // 0.1
+        );
+        // Empty `principalAdjustFactor=""` collapses to None.
+        assert_eq!(find(&actions, "AAPL").principal_adjust_factor, None);
+    }
+
+    #[test]
+    fn parses_complex_fixture_with_type_and_actiontype_aliasing() {
+        // Every row in this fixture carries BOTH `type` and `actionType` (equal values) plus a bare
+        // `dateTime` (no time component) — exercising the alias coalesce and the second date format.
+        let actions = parse_corporate_actions(COMPLEX_FIXTURE).unwrap();
+        assert_eq!(actions.len(), 10);
+
+        let choice_dividend = &actions[0];
+        assert_eq!(choice_dividend.symbol.as_deref(), Some("XYZ"));
+        assert_eq!(
+            choice_dividend.action_type,
+            IbkrReorgType::Other(SmolStr::from("CD"))
+        );
+        assert_eq!(
+            choice_dividend.action_description.as_deref(),
+            Some("Choice Dividend")
+        );
+        // Bare-date `dateTime` form is kept raw, not coerced.
+        assert_eq!(choice_dividend.date_time.as_deref(), Some("2025-01-15"));
+
+        // A BOND-category row survives intact.
+        let bond = find(&actions, "DEF");
+        assert_eq!(bond.asset_category.as_deref(), Some("BOND"));
+    }
+
+    #[test]
+    fn empty_corporate_actions_section_yields_no_rows() {
+        let xml = r#"<?xml version="1.0"?>
+            <FlexQueryResponse queryName="Activity" type="AF">
+              <FlexStatements count="1">
+                <FlexStatement accountId="U1" fromDate="2025-01-15" toDate="2025-01-15">
+                  <CorporateActions />
+                </FlexStatement>
+              </FlexStatements>
+            </FlexQueryResponse>"#;
+        assert!(parse_corporate_actions(xml).unwrap().is_empty());
+    }
+
+    #[test]
+    fn missing_corporate_actions_section_yields_no_rows() {
+        let xml = r#"<?xml version="1.0"?>
+            <FlexQueryResponse queryName="Activity" type="AF">
+              <FlexStatements count="1">
+                <FlexStatement accountId="U1" fromDate="2025-01-15" toDate="2025-01-15">
+                  <Trades />
+                </FlexStatement>
+              </FlexStatements>
+            </FlexQueryResponse>"#;
+        assert!(parse_corporate_actions(xml).unwrap().is_empty());
+    }
+
+    #[test]
+    fn collects_rows_across_multiple_statements() {
+        let xml = r#"<?xml version="1.0"?>
+            <FlexQueryResponse queryName="Activity" type="AF">
+              <FlexStatements count="2">
+                <FlexStatement accountId="U1">
+                  <CorporateActions>
+                    <CorporateAction accountId="U1" symbol="AAA" type="FS" quantity="10" />
+                  </CorporateActions>
+                </FlexStatement>
+                <FlexStatement accountId="U2">
+                  <CorporateActions>
+                    <CorporateAction accountId="U2" symbol="BBB" type="RS" quantity="-5" />
+                  </CorporateActions>
+                </FlexStatement>
+              </FlexStatements>
+            </FlexQueryResponse>"#;
+
+        let actions = parse_corporate_actions(xml).unwrap();
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0].symbol.as_deref(), Some("AAA"));
+        assert_eq!(actions[0].action_type, IbkrReorgType::ForwardSplit);
+        assert_eq!(actions[1].symbol.as_deref(), Some("BBB"));
+        assert_eq!(actions[1].action_type, IbkrReorgType::ReverseSplit);
+    }
+
+    #[test]
+    fn unknown_type_maps_to_other() {
+        let xml = r#"<FlexQueryResponse><FlexStatements><FlexStatement>
+            <CorporateActions>
+              <CorporateAction symbol="ZZ" type="ZZ" quantity="1" />
+            </CorporateActions>
+        </FlexStatement></FlexStatements></FlexQueryResponse>"#;
+        let actions = parse_corporate_actions(xml).unwrap();
+        assert_eq!(
+            actions[0].action_type,
+            IbkrReorgType::Other(SmolStr::from("ZZ"))
+        );
+    }
+
+    #[test]
+    fn actiontype_used_when_type_absent() {
+        let xml = r#"<FlexQueryResponse><FlexStatements><FlexStatement>
+            <CorporateActions>
+              <CorporateAction symbol="AAA" actionType="FS" quantity="1" />
+            </CorporateActions>
+        </FlexStatement></FlexStatements></FlexQueryResponse>"#;
+        let actions = parse_corporate_actions(xml).unwrap();
+        assert_eq!(actions[0].action_type, IbkrReorgType::ForwardSplit);
+    }
+
+    #[test]
+    fn empty_type_falls_back_to_actiontype() {
+        // An empty `type=""` must not shadow a populated `actionType`.
+        let xml = r#"<FlexQueryResponse><FlexStatements><FlexStatement>
+            <CorporateActions>
+              <CorporateAction symbol="AAA" type="" actionType="RS" quantity="1" />
+            </CorporateActions>
+        </FlexStatement></FlexStatements></FlexQueryResponse>"#;
+        let actions = parse_corporate_actions(xml).unwrap();
+        assert_eq!(actions[0].action_type, IbkrReorgType::ReverseSplit);
+    }
+
+    #[test]
+    fn sparse_row_degrades_gracefully() {
+        // Only `type` present: quantity defaults to 0, every optional field is None, and a missing
+        // `type` (here for a second row) yields `Other("")` rather than failing the parse.
+        let xml = r#"<FlexQueryResponse><FlexStatements><FlexStatement>
+            <CorporateActions>
+              <CorporateAction type="FS" />
+              <CorporateAction symbol="X" cusip="" reportDate="not-a-date" value="" quantity="oops" />
+            </CorporateActions>
+        </FlexStatement></FlexStatements></FlexQueryResponse>"#;
+        let actions = parse_corporate_actions(xml).unwrap();
+        assert_eq!(actions.len(), 2);
+
+        let first = &actions[0];
+        assert_eq!(first.action_type, IbkrReorgType::ForwardSplit);
+        assert_eq!(first.quantity_delta, Decimal::ZERO);
+        assert!(first.symbol.is_none());
+        assert!(first.value.is_none());
+
+        let second = &actions[1];
+        assert_eq!(second.action_type, IbkrReorgType::Other(SmolStr::from("")));
+        assert!(second.cusip.is_none(), "empty cusip must be None");
+        assert!(
+            second.report_date.is_none(),
+            "unparseable date must be None"
+        );
+        assert!(second.value.is_none(), "empty value must be None");
+        assert_eq!(
+            second.quantity_delta,
+            Decimal::ZERO,
+            "unparseable quantity defaults to 0"
+        );
+    }
+
+    #[test]
+    fn reorg_code_mapping_is_total() {
+        assert_eq!(IbkrReorgType::from("FS"), IbkrReorgType::ForwardSplit);
+        assert_eq!(IbkrReorgType::from("RS"), IbkrReorgType::ReverseSplit);
+        assert_eq!(IbkrReorgType::from("FI"), IbkrReorgType::ForwardSplitIssue);
+        assert_eq!(IbkrReorgType::from("CS"), IbkrReorgType::ContractSplit);
+        assert_eq!(IbkrReorgType::from("SO"), IbkrReorgType::SpinOff);
+        assert_eq!(IbkrReorgType::from("CO"), IbkrReorgType::ContractSpinOff);
+        assert_eq!(
+            IbkrReorgType::from("anything"),
+            IbkrReorgType::Other(SmolStr::from("anything"))
+        );
+    }
+
+    #[test]
+    fn malformed_xml_is_an_error() {
+        assert!(matches!(
+            parse_corporate_actions("<FlexQueryResponse><not-closed>"),
+            Err(IbkrFlexError::Parse(_))
+        ));
+    }
+}

--- a/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
@@ -27,6 +27,7 @@ use chrono::NaiveDate;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 use smol_str::SmolStr;
+use tracing::warn;
 
 use super::{IbkrFlexError, nonempty};
 
@@ -60,7 +61,11 @@ pub struct IbkrFlexCorporateAction {
     ///
     /// This is an **account-scoped delta**, not a market-wide quantity, and is **not** a split
     /// ratio: deriving a ratio from `new_qty / old_qty` would require the pre-event holding, which
-    /// this library does not track. An absent or empty `quantity` is surfaced as `0`.
+    /// this library does not track. An absent or empty `quantity` is surfaced as `0`; a **malformed**
+    /// (present-but-unparseable) `quantity` is also coerced to `0` but emits a `warn!` first, since
+    /// `0` here is a valid-looking "no share change" sentinel that would otherwise silently mask a
+    /// real reorg quantity (unlike the other fields, which faithfully surface a malformed value as
+    /// `None`).
     pub quantity_delta: Decimal,
     /// Free-text action description (`actionDescription`), when present.
     ///
@@ -257,6 +262,10 @@ impl RawCorporateAction {
             .or_else(|| nonempty(self.action_type_attr))
             .unwrap_or_default();
 
+        // Computed BEFORE the struct literal so the warn can still reference `symbol` (which the
+        // literal moves). See `quantity_delta_or_warn` for why this field warns and the others do not.
+        let quantity_delta = quantity_delta_or_warn(self.quantity, self.symbol.as_deref());
+
         IbkrFlexCorporateAction {
             account_id: opt_smol(self.account_id),
             symbol: opt_smol(self.symbol),
@@ -265,7 +274,7 @@ impl RawCorporateAction {
             cusip: opt_smol(self.cusip),
             asset_category: opt_smol(self.asset_category),
             action_type: IbkrReorgType::from(code.as_str()),
-            quantity_delta: opt_decimal(self.quantity).unwrap_or(Decimal::ZERO),
+            quantity_delta,
             action_description: opt_smol(self.action_description),
             report_date: opt_date(self.report_date),
             date_time: opt_smol(self.date_time),
@@ -286,6 +295,31 @@ fn opt_smol(value: Option<String>) -> Option<SmolStr> {
 /// Parse a non-empty attribute as a [`Decimal`], yielding `None` if absent, empty, or malformed.
 fn opt_decimal(value: Option<String>) -> Option<Decimal> {
     nonempty(value).and_then(|v| v.parse().ok())
+}
+
+/// Parse the `quantity` attribute into `quantity_delta`, coercing a malformed value to
+/// `Decimal::ZERO` but **warning first**.
+///
+/// Every other field in this module is deliberately faithful — an absent, empty, or malformed
+/// attribute surfaces as `None`, so a downstream reader can tell "not reported" from "reported as
+/// X". `quantity_delta` is the one non-optional coercion: a malformed value collapses to `0`, which
+/// is a *valid-looking* "no share change" sentinel indistinguishable from a genuine zero. That
+/// silent collapse could mask a real reorg quantity, so a present-but-unparseable value is surfaced
+/// as an observable `warn!` (absent/empty stays a quiet `0` — a genuine "not reported", not a parse
+/// failure).
+fn quantity_delta_or_warn(value: Option<String>, symbol: Option<&str>) -> Decimal {
+    match nonempty(value) {
+        Some(raw) => raw.parse().unwrap_or_else(|_| {
+            warn!(
+                quantity = %raw,
+                symbol = ?symbol,
+                "IBKR flex: malformed corporate-action quantity coerced to 0 (a valid-looking \
+                 'no share change' sentinel) — a real reorg quantity may be silently lost."
+            );
+            Decimal::ZERO
+        }),
+        None => Decimal::ZERO,
+    }
 }
 
 /// Best-effort parse a `YYYY-MM-DD` attribute, yielding `None` if absent, empty, or malformed.

--- a/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
@@ -362,11 +362,13 @@ mod tests {
         let actions = parse_corporate_actions(ACTIVITY_FIXTURE).unwrap();
         assert_eq!(
             find(&actions, "TSLA").principal_adjust_factor,
-            Some(Decimal::from(2))
+            // A TIPS-style inflation factor (deliberately NOT a round split-ratio-looking value),
+            // reinforcing that this field is surfaced raw and is not the split ratio.
+            Some(Decimal::new(10023, 4)) // 1.0023
         );
         assert_eq!(
             find(&actions, "SPLIT").principal_adjust_factor,
-            Some(Decimal::new(1, 1)) // 0.1
+            Some(Decimal::new(9977, 4)) // 0.9977 (again a TIPS factor, not a ratio)
         );
         // Empty `principalAdjustFactor=""` collapses to None.
         assert_eq!(find(&actions, "AAPL").principal_adjust_factor, None);

--- a/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
@@ -168,6 +168,28 @@ impl From<&str> for IbkrReorgType {
 /// Returns [`IbkrFlexError::Parse`] if the document is not well-formed XML or does not match the
 /// expected Flex statement shape.
 pub fn parse_corporate_actions(xml: &str) -> Result<Vec<IbkrFlexCorporateAction>, IbkrFlexError> {
+    // Assert the document is actually a `<FlexQueryResponse>` statement BEFORE deserializing.
+    // quick-xml's serde path does not verify the root element, and the raw structs use
+    // `#[serde(default)]`, so an IBKR error/status envelope (`<FlexStatementResponse>`, e.g. an
+    // "Invalid token" `ErrorCode 1003`) would otherwise deserialize into an all-defaults
+    // (empty) `RawFlexQueryResponse` and return `Ok(vec![])` — indistinguishable from a genuine
+    // statement with no Corporate Actions section, and contradicting this function's `# Errors`
+    // contract. Reuse the same root-element helper the blessed `GetStatement` path uses
+    // (`super::root_element_name`, which `super::classify_get_statement` also wraps).
+    match super::root_element_name(xml).as_deref() {
+        Some("FlexQueryResponse") => {}
+        Some(other) => {
+            return Err(IbkrFlexError::Parse(format!(
+                "expected Flex statement root <FlexQueryResponse>, found <{other}>"
+            )));
+        }
+        None => {
+            return Err(IbkrFlexError::Parse(
+                "empty or unreadable Flex statement document".to_owned(),
+            ));
+        }
+    }
+
     let response: RawFlexQueryResponse = quick_xml::de::from_str(xml)
         .map_err(|e| IbkrFlexError::Parse(format!("failed to parse Flex statement XML: {e}")))?;
 
@@ -574,6 +596,36 @@ mod tests {
     fn malformed_xml_is_an_error() {
         assert!(matches!(
             parse_corporate_actions("<FlexQueryResponse><not-closed>"),
+            Err(IbkrFlexError::Parse(_))
+        ));
+    }
+
+    /// An IBKR error/status envelope is a `<FlexStatementResponse>`, NOT a `<FlexQueryResponse>`
+    /// statement. Because `quick-xml` does not verify the root element and the raw structs use
+    /// `#[serde(default)]`, this previously deserialized into an all-defaults `RawFlexQueryResponse`
+    /// and returned `Ok(vec![])` — indistinguishable from a genuine statement with an empty Corporate
+    /// Actions section. It must now be a `Parse` error (honoring the `# Errors` contract), so a
+    /// caller re-parsing a persisted envelope standalone cannot mistake "invalid token" for "no
+    /// corporate actions".
+    #[test]
+    fn error_status_envelope_is_an_error_not_empty_vec() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <FlexStatementResponse timestamp="18 April, 2026 08:00 AM EDT">
+                <Status>Fail</Status>
+                <ErrorCode>1003</ErrorCode>
+                <ErrorMessage>Statement could not be generated at this time. Invalid token.</ErrorMessage>
+            </FlexStatementResponse>"#;
+        assert!(
+            matches!(parse_corporate_actions(xml), Err(IbkrFlexError::Parse(_))),
+            "a <FlexStatementResponse> error envelope must be a Parse error, not Ok(vec![])"
+        );
+    }
+
+    /// An empty / unreadable document is a `Parse` error, not a silent empty `Vec`.
+    #[test]
+    fn empty_document_is_an_error() {
+        assert!(matches!(
+            parse_corporate_actions(""),
             Err(IbkrFlexError::Parse(_))
         ));
     }

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -236,6 +236,13 @@ impl IbkrFlexClient {
     /// plaintext. The poll URL returned by SendRequest is required to be `https://` for the same
     /// reason — the token must never traverse an unencrypted connection.
     ///
+    /// Two IBKR hosts are involved: `ndcdyn.interactivebrokers.com` (the hard-coded `FLEX_BASE_URL`
+    /// that serves `SendRequest`) and `gdcdyn.interactivebrokers.com` (the statement-download host
+    /// that `SendRequest` returns in its poll URL). The poll host is deliberately **not** pinned to
+    /// an allowlist — only its scheme is enforced (`https://`) — so IBKR can relocate statement
+    /// serving without breaking this client, while the `https://` gate keeps the token encrypted
+    /// regardless of which host is returned.
+    ///
     /// # Errors
     ///
     /// - [`IbkrFlexError::Http`] on a transport failure.

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -234,6 +234,18 @@ impl IbkrFlexClient {
     pub fn new(config: IbkrFlexConfig) -> Result<Self, IbkrFlexError> {
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            // Transport-layer token protection. The Flex `token` rides in every request URL's `t=`
+            // query parameter, so it must never traverse an unencrypted connection. Two guards work
+            // together: `redirect::Policy::none()` stops reqwest auto-following any redirect, so a 3xx
+            // can never bounce the token to another (possibly `http://`) URL behind our back; and
+            // `https_only(true)` rejects any request whose own URL is not `https`, catching a
+            // misconfigured `http://` base URL before the token reaches the wire. This client issues
+            // two GETs to known HTTPS endpoints and expects no redirects, so an unexpected 3xx is
+            // returned unfollowed and surfaces downstream as a body-parse error — never as a silent
+            // scheme downgrade. (The content-layer scheme check on the SendRequest poll URL cannot
+            // intercept redirects reqwest would otherwise follow, which is why these guards exist.)
+            .https_only(true)
+            .redirect(reqwest::redirect::Policy::none())
             .build()?;
         Ok(Self {
             http,
@@ -444,7 +456,14 @@ fn classify_get_statement(xml: &str) -> Result<GetStatementOutcome, IbkrFlexErro
                     "failed to parse Flex GetStatement status response: {e}"
                 ))
             })?;
-            if resp.error_code.as_deref() == Some(GENERATION_IN_PROGRESS_CODE) {
+            // "Generation in progress" always arrives as ErrorCode 1019 *with* Status=Warn per the
+            // IBKR Flex v3 protocol (see the `GET_IN_PROGRESS` fixture). Require both: a 1019 under
+            // Status=Fail would be a terminal error IBKR mislabeled, and retrying it would only burn
+            // the poll budget before timing out. The status compare is case-insensitive to tolerate
+            // label-casing variance.
+            if resp.error_code.as_deref() == Some(GENERATION_IN_PROGRESS_CODE)
+                && resp.status.eq_ignore_ascii_case("warn")
+            {
                 Ok(GetStatementOutcome::InProgress)
             } else {
                 Err(flex_error(resp, "GetStatement"))
@@ -597,6 +616,68 @@ mod tests {
             classify_get_statement(GET_IN_PROGRESS).unwrap(),
             GetStatementOutcome::InProgress
         );
+    }
+
+    #[test]
+    fn get_statement_in_progress_code_is_case_insensitive_on_status() {
+        // The `Status=Warn` check uses `eq_ignore_ascii_case`, so casing variance (e.g. all-caps
+        // `WARN`) must still classify a 1019 as retryable rather than fail fast on a terminal error.
+        const WARN_UPPER_1019: &str = r#"<FlexStatementResponse>
+            <Status>WARN</Status>
+            <ErrorCode>1019</ErrorCode>
+            <ErrorMessage>Statement generation in progress. Please try again shortly.</ErrorMessage>
+        </FlexStatementResponse>"#;
+        assert_eq!(
+            classify_get_statement(WARN_UPPER_1019).unwrap(),
+            GetStatementOutcome::InProgress
+        );
+    }
+
+    #[test]
+    fn get_statement_in_progress_code_under_fail_status_is_a_flex_error() {
+        // ErrorCode 1019 is only retryable under Status=Warn. If IBKR ever returns 1019 under
+        // Status=Fail, treat it as a terminal error instead of retrying a failure until the poll
+        // budget is exhausted.
+        const FAIL_1019: &str = r#"<FlexStatementResponse>
+            <Status>Fail</Status>
+            <ErrorCode>1019</ErrorCode>
+            <ErrorMessage>Statement generation in progress. Please try again shortly.</ErrorMessage>
+        </FlexStatementResponse>"#;
+        match classify_get_statement(FAIL_1019) {
+            Err(IbkrFlexError::Flex { code, .. }) => assert_eq!(code, "1019"),
+            other => panic!("expected terminal Flex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_statement_1019_without_status_is_a_flex_error() {
+        // `Status` deserializes via `#[serde(default)]`, so a 1019 envelope with no `<Status>`
+        // element yields `status == ""`. Retryability requires Status=Warn, so a missing status is
+        // treated as terminal rather than retried until the poll budget is exhausted.
+        const NO_STATUS_1019: &str = r#"<FlexStatementResponse>
+            <ErrorCode>1019</ErrorCode>
+            <ErrorMessage>Statement generation in progress. Please try again shortly.</ErrorMessage>
+        </FlexStatementResponse>"#;
+        match classify_get_statement(NO_STATUS_1019) {
+            Err(IbkrFlexError::Flex { code, .. }) => assert_eq!(code, "1019"),
+            other => panic!("expected terminal Flex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn get_statement_1019_under_success_status_is_a_flex_error() {
+        // 1019 is only retryable under Status=Warn. A 1019 reported under Status=Success is a
+        // self-contradictory envelope; treat it as terminal rather than retrying it until the poll
+        // budget is exhausted.
+        const SUCCESS_1019: &str = r#"<FlexStatementResponse>
+            <Status>Success</Status>
+            <ErrorCode>1019</ErrorCode>
+            <ErrorMessage>Statement generation in progress. Please try again shortly.</ErrorMessage>
+        </FlexStatementResponse>"#;
+        match classify_get_statement(SUCCESS_1019) {
+            Err(IbkrFlexError::Flex { code, .. }) => assert_eq!(code, "1019"),
+            other => panic!("expected terminal Flex error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -1,0 +1,602 @@
+//! IBKR **Flex Web Service** corporate-action reconciliation.
+//!
+//! Fetches an account's *Activity* Flex statement over HTTPS and exposes its Corporate Actions
+//! section as faithful [`IbkrFlexCorporateAction`] records. This is a **reconciliation / audit**
+//! surface — broker-confirmed, account-scoped, and post-hoc — *not* a market-reference split source.
+//! It does **not** derive split ratios; a caller that wants a ratio cross-references a dedicated
+//! split source (and owns reconcile policy). See [`corporate_action`] for the record contract.
+//!
+//! # Transport (2-call Flex Web Service flow)
+//!
+//! The Flex Web Service generates statements asynchronously, so a fetch is two calls:
+//!
+//! 1. **SendRequest** — `GET {base}/SendRequest?t={token}&q={queryId}&v=3` returns a
+//!    `<FlexStatementResponse>` with a `ReferenceCode` and a `Url` to poll (or a `Fail` status).
+//! 2. **GetStatement** — `GET {Url}?t={token}&q={referenceCode}&v=3`, polled with a bounded number
+//!    of attempts while the service replies `Warn`/`ErrorCode 1019` ("generation in progress"),
+//!    until it returns the `<FlexQueryResponse>` statement (or a terminal error).
+//!
+//! Non-success statuses (e.g. `1003` invalid token, `1018` throttled, token-expired) surface as
+//! [`IbkrFlexError::Flex`]; exhausting the poll budget surfaces as [`IbkrFlexError::PollTimeout`].
+//!
+//! This service uses an HTTPS token + saved-query id — it does **not** use IB Gateway / TWS, so it
+//! is entirely independent of the socket [`IbkrStreamConfig`](crate::exchange::ibkr::IbkrStreamConfig).
+//!
+//! # Known limitations
+//!
+//! - **Post-hoc (T+1+).** A Flex statement reports actions *after* the broker books them; the
+//!   records are for reconciliation/audit, not for injecting split events into a live/backtest
+//!   timeline at the market execution instant.
+//! - **Account-scoped.** Quantities are this account's deltas, not market-wide figures.
+//! - **No library-derived ratio.** Flex carries no standardised split-ratio field; the wrapper
+//!   derives/verifies ratios from a market-reference source.
+//! - **Query-configuration-dependent date format.** The raw `dateTime` format depends on the saved
+//!   query's settings (see [`IbkrFlexCorporateAction::date_time`]).
+//! - **The saved Flex query must include the Corporate Actions section** over an account-activity
+//!   scope, otherwise the statement contains no `<CorporateAction>` rows to return.
+//!
+//! # Credentials
+//!
+//! Construct from a [`IbkrFlexConfig`] (an Activity-statement Flex `token` + saved-query `query_id`).
+//! [`IbkrFlexClient::from_env`] reads `IBKR_FLEX_TOKEN` and `IBKR_FLEX_QUERY_ID`.
+
+mod corporate_action;
+
+pub use corporate_action::{IbkrFlexCorporateAction, IbkrReorgType, parse_corporate_actions};
+
+use quick_xml::{Reader, events::Event};
+use serde::Deserialize;
+use smol_str::SmolStr;
+use std::{env, fmt, time::Duration};
+use thiserror::Error;
+use tracing::debug;
+
+/// Base URL of the IBKR Flex Web Service (`SendRequest` lives directly under it; the poll URL is
+/// taken from the SendRequest response, not hard-coded).
+const FLEX_BASE_URL: &str =
+    "https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService";
+
+/// Flex Web Service protocol version (`v` query parameter).
+const FLEX_VERSION: &str = "3";
+
+/// Timeout for each individual HTTP request.
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Maximum number of GetStatement poll attempts before giving up.
+const POLL_MAX_ATTEMPTS: u32 = 12;
+
+/// Delay between GetStatement poll attempts while the statement is still generating.
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Flex `ErrorCode` meaning "statement generation in progress, try again shortly" — the only
+/// non-success status that should be retried rather than surfaced as an error.
+const GENERATION_IN_PROGRESS_CODE: &str = "1019";
+
+/// Errors from IBKR Flex Web Service operations.
+///
+/// `#[non_exhaustive]`: the Flex service may introduce new failure conditions over time, so new
+/// variants can be added without a breaking change; downstream `match`es must include a wildcard arm.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum IbkrFlexError {
+    /// A required environment variable is not set (see [`IbkrFlexConfig::from_env`]).
+    #[error("environment variable error: {0}")]
+    EnvVar(String),
+
+    /// Transport-level HTTP error (connection, timeout, or non-2xx status).
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// The Flex service returned a non-success status (e.g. invalid token, throttled, expired).
+    #[error("Flex service error ({code}): {message}")]
+    Flex {
+        /// The Flex `ErrorCode` (empty if the response carried none).
+        code: String,
+        /// The Flex `ErrorMessage` (or a synthesised description).
+        message: String,
+    },
+
+    /// The statement was still generating after [`POLL_MAX_ATTEMPTS`] poll attempts.
+    #[error("Flex statement not ready after {attempts} poll attempts")]
+    PollTimeout {
+        /// Number of poll attempts made before giving up. Currently always [`POLL_MAX_ATTEMPTS`],
+        /// since this error fires only after every attempt reported the statement still generating.
+        attempts: u32,
+    },
+
+    /// The statement or status XML could not be parsed.
+    #[error("Flex XML parse error: {0}")]
+    Parse(String),
+}
+
+/// Credentials for the IBKR Flex Web Service: an Activity-statement Flex `token` and the id of a
+/// saved Flex query that includes the Corporate Actions section.
+///
+/// `Debug` redacts the token so it never leaks through tracing or panic output.
+#[derive(Clone)]
+pub struct IbkrFlexConfig {
+    token: String,
+    query_id: String,
+}
+
+impl fmt::Debug for IbkrFlexConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IbkrFlexConfig")
+            .field("token", &"[REDACTED]")
+            .field("query_id", &self.query_id)
+            .finish()
+    }
+}
+
+impl IbkrFlexConfig {
+    /// Create a config from an explicit Flex token and saved-query id.
+    ///
+    /// `token` and `query_id` are stored **verbatim** — they are not trimmed or validated. Leading
+    /// or trailing whitespace will be sent in the `t=`/`q=` query parameters and rejected by IBKR
+    /// with a confusing `1003` "invalid token" at fetch time. Pass already-clean values, or use
+    /// [`from_env`](Self::from_env), which trims and rejects empty values.
+    pub fn new(token: impl Into<String>, query_id: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+            query_id: query_id.into(),
+        }
+    }
+
+    /// Create a config from environment variables.
+    ///
+    /// Reads `IBKR_FLEX_TOKEN` (the Flex Web Service token) and `IBKR_FLEX_QUERY_ID` (the saved
+    /// query id), both required.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IbkrFlexError::EnvVar`] if either variable is missing or set but empty.
+    pub fn from_env() -> Result<Self, IbkrFlexError> {
+        let token = env::var("IBKR_FLEX_TOKEN")
+            .map_err(|e| IbkrFlexError::EnvVar(format!("IBKR_FLEX_TOKEN: {e}")))?;
+        let query_id = env::var("IBKR_FLEX_QUERY_ID")
+            .map_err(|e| IbkrFlexError::EnvVar(format!("IBKR_FLEX_QUERY_ID: {e}")))?;
+        // Trim before storing so surrounding whitespace can't silently end up in the `t=`/`q=`
+        // query parameters (which IBKR would reject with a confusing 1003 "invalid token" at fetch
+        // time rather than a clear configuration error here).
+        let token = token.trim();
+        let query_id = query_id.trim();
+        if token.is_empty() {
+            return Err(IbkrFlexError::EnvVar(
+                "IBKR_FLEX_TOKEN is set but empty".to_owned(),
+            ));
+        }
+        if query_id.is_empty() {
+            return Err(IbkrFlexError::EnvVar(
+                "IBKR_FLEX_QUERY_ID is set but empty".to_owned(),
+            ));
+        }
+        Ok(Self::new(token, query_id))
+    }
+}
+
+/// Client for fetching corporate-action records from the IBKR Flex Web Service.
+///
+/// `Debug` omits both the token (a credential) and the [`reqwest::Client`], so neither can leak.
+#[derive(Clone)]
+pub struct IbkrFlexClient {
+    http: reqwest::Client,
+    token: String,
+    query_id: String,
+    base_url: String,
+}
+
+impl fmt::Debug for IbkrFlexClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Deliberately omits the token (a credential) and the `reqwest::Client`.
+        f.debug_struct("IbkrFlexClient")
+            .field("query_id", &self.query_id)
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl IbkrFlexClient {
+    /// Create a client from a [`IbkrFlexConfig`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IbkrFlexError::Http`] if the underlying HTTP client cannot be built.
+    pub fn new(config: IbkrFlexConfig) -> Result<Self, IbkrFlexError> {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()?;
+        Ok(Self {
+            http,
+            token: config.token,
+            query_id: config.query_id,
+            base_url: FLEX_BASE_URL.to_owned(),
+        })
+    }
+
+    /// Create a client from environment variables (see [`IbkrFlexConfig::from_env`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IbkrFlexError::EnvVar`] if a required variable is missing, or
+    /// [`IbkrFlexError::Http`] if the HTTP client cannot be built.
+    pub fn from_env() -> Result<Self, IbkrFlexError> {
+        Self::new(IbkrFlexConfig::from_env()?)
+    }
+
+    /// Run the full 2-call Flex flow and return the raw `<FlexQueryResponse>` statement XML.
+    ///
+    /// Issues SendRequest, then polls GetStatement (up to [`POLL_MAX_ATTEMPTS`] times, sleeping
+    /// [`POLL_INTERVAL`] between attempts) until the statement is ready.
+    ///
+    /// # Security
+    ///
+    /// The Flex `token` is transmitted as the `t=` URL **query parameter** (as IBKR's protocol
+    /// requires), so it is part of every request URL. Do not attach request-logging middleware to
+    /// the underlying [`reqwest::Client`] that records full URLs, or the token will be captured in
+    /// plaintext. The poll URL returned by SendRequest is required to be `https://` for the same
+    /// reason — the token must never traverse an unencrypted connection.
+    ///
+    /// # Errors
+    ///
+    /// - [`IbkrFlexError::Http`] on a transport failure.
+    /// - [`IbkrFlexError::Flex`] if the service reports a terminal non-success status.
+    /// - [`IbkrFlexError::PollTimeout`] if the statement is still generating after the poll budget.
+    /// - [`IbkrFlexError::Parse`] if a response cannot be parsed.
+    pub async fn fetch_statement_xml(&self) -> Result<String, IbkrFlexError> {
+        let send_url = format!("{}/SendRequest", self.base_url);
+        debug!("Requesting IBKR Flex statement generation");
+
+        let body = self
+            .http
+            .get(&send_url)
+            .query(&[
+                ("t", self.token.as_str()),
+                ("q", self.query_id.as_str()),
+                ("v", FLEX_VERSION),
+            ])
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
+
+        let SendRequestOk {
+            reference_code,
+            url,
+        } = parse_send_request_response(&body)?;
+
+        for attempt in 1..=POLL_MAX_ATTEMPTS {
+            let body = self
+                .http
+                .get(&url)
+                .query(&[
+                    ("t", self.token.as_str()),
+                    ("q", reference_code.as_str()),
+                    ("v", FLEX_VERSION),
+                ])
+                .send()
+                .await?
+                .error_for_status()?
+                .text()
+                .await?;
+
+            match classify_get_statement(&body)? {
+                GetStatementOutcome::Ready => return Ok(body),
+                GetStatementOutcome::InProgress => {
+                    debug!(
+                        attempt,
+                        max = POLL_MAX_ATTEMPTS,
+                        "Flex statement still generating"
+                    );
+                    if attempt < POLL_MAX_ATTEMPTS {
+                        tokio::time::sleep(POLL_INTERVAL).await;
+                    }
+                }
+            }
+        }
+
+        Err(IbkrFlexError::PollTimeout {
+            attempts: POLL_MAX_ATTEMPTS,
+        })
+    }
+
+    /// Fetch the statement and parse its Corporate Actions section into faithful records.
+    ///
+    /// Convenience over [`fetch_statement_xml`](Self::fetch_statement_xml) +
+    /// [`parse_corporate_actions`]. Returns **all** reorg rows; filtering to splits is the caller's
+    /// job. See [`corporate_action`] for the record contract and limitations.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`fetch_statement_xml`](Self::fetch_statement_xml).
+    pub async fn fetch_corporate_actions(
+        &self,
+    ) -> Result<Vec<IbkrFlexCorporateAction>, IbkrFlexError> {
+        let xml = self.fetch_statement_xml().await?;
+        parse_corporate_actions(&xml)
+    }
+}
+
+// ============================================================================
+// Pure, testable response classification
+// ============================================================================
+
+/// A successful SendRequest result: the reference code + poll URL for GetStatement.
+#[derive(Debug)]
+struct SendRequestOk {
+    reference_code: String,
+    url: String,
+}
+
+/// The outcome of classifying a GetStatement poll response. A terminal failure is returned as an
+/// `Err` from [`classify_get_statement`], so this only models the two non-error outcomes.
+#[derive(Debug, PartialEq, Eq)]
+enum GetStatementOutcome {
+    /// The body is a `<FlexQueryResponse>` statement, ready to parse.
+    Ready,
+    /// The service is still generating the statement; poll again.
+    InProgress,
+}
+
+/// The `<FlexStatementResponse>` envelope (SendRequest result and GetStatement "not ready" / error
+/// status). Its fields are child *elements*, not attributes.
+#[derive(Debug, Deserialize)]
+struct FlexStatementResponse {
+    #[serde(rename = "Status", default)]
+    status: String,
+    #[serde(rename = "ReferenceCode", default)]
+    reference_code: Option<String>,
+    #[serde(rename = "Url", default)]
+    url: Option<String>,
+    #[serde(rename = "ErrorCode", default)]
+    error_code: Option<String>,
+    #[serde(rename = "ErrorMessage", default)]
+    error_message: Option<String>,
+}
+
+/// Parse a SendRequest response: success yields the reference code + poll URL; any other status
+/// becomes an [`IbkrFlexError::Flex`].
+fn parse_send_request_response(xml: &str) -> Result<SendRequestOk, IbkrFlexError> {
+    let resp: FlexStatementResponse = quick_xml::de::from_str(xml).map_err(|e| {
+        IbkrFlexError::Parse(format!("failed to parse Flex SendRequest response: {e}"))
+    })?;
+
+    if resp.status.eq_ignore_ascii_case("Success") {
+        match (nonempty(resp.reference_code), nonempty(resp.url)) {
+            (Some(reference_code), Some(url)) => {
+                // The poll URL is broker-supplied and is fetched next with the Flex token in its
+                // `t=` query parameter. Refuse a non-HTTPS URL so the credential can never be sent
+                // over an unencrypted connection (a scheme check only — no brittle host allowlist).
+                if !url.starts_with("https://") {
+                    return Err(IbkrFlexError::Parse(format!(
+                        "Flex SendRequest returned a non-HTTPS poll URL; refusing to send credentials over it: {url}"
+                    )));
+                }
+                Ok(SendRequestOk {
+                    reference_code,
+                    url,
+                })
+            }
+            _ => Err(IbkrFlexError::Parse(
+                "Flex SendRequest reported success but is missing ReferenceCode/Url".to_owned(),
+            )),
+        }
+    } else {
+        Err(flex_error(resp, "SendRequest"))
+    }
+}
+
+/// Classify a GetStatement poll response by its root element: a `<FlexQueryResponse>` is the ready
+/// statement; a `<FlexStatementResponse>` is either "still generating" (`ErrorCode 1019`) or a
+/// terminal error.
+fn classify_get_statement(xml: &str) -> Result<GetStatementOutcome, IbkrFlexError> {
+    match root_element_name(xml).as_deref() {
+        Some("FlexQueryResponse") => Ok(GetStatementOutcome::Ready),
+        Some("FlexStatementResponse") => {
+            let resp: FlexStatementResponse = quick_xml::de::from_str(xml).map_err(|e| {
+                IbkrFlexError::Parse(format!(
+                    "failed to parse Flex GetStatement status response: {e}"
+                ))
+            })?;
+            if resp.error_code.as_deref() == Some(GENERATION_IN_PROGRESS_CODE) {
+                Ok(GetStatementOutcome::InProgress)
+            } else {
+                Err(flex_error(resp, "GetStatement"))
+            }
+        }
+        Some(other) => Err(IbkrFlexError::Parse(format!(
+            "unexpected Flex GetStatement root element <{other}>"
+        ))),
+        None => Err(IbkrFlexError::Parse(
+            "empty or unreadable Flex GetStatement response".to_owned(),
+        )),
+    }
+}
+
+/// Build an [`IbkrFlexError::Flex`] from a non-success status envelope.
+fn flex_error(resp: FlexStatementResponse, stage: &str) -> IbkrFlexError {
+    IbkrFlexError::Flex {
+        code: resp.error_code.unwrap_or_default(),
+        message: resp
+            .error_message
+            .unwrap_or_else(|| format!("Flex {stage} returned non-success status {}", resp.status)),
+    }
+}
+
+/// Read the name of the first (root) element of an XML document, ignoring the prolog/comments.
+///
+/// Returns a [`SmolStr`] so the expected root names (`FlexQueryResponse`, `FlexStatementResponse`)
+/// are compared without a heap allocation (both fit `SmolStr`'s inline buffer).
+fn root_element_name(xml: &str) -> Option<SmolStr> {
+    let mut reader = Reader::from_str(xml);
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) | Ok(Event::Empty(e)) => {
+                return Some(SmolStr::new(String::from_utf8_lossy(e.name().as_ref())));
+            }
+            Ok(Event::Eof) | Err(_) => return None,
+            Ok(_) => {}
+        }
+    }
+}
+
+/// Trim an optional string, collapsing empty/whitespace-only values to `None`.
+///
+/// Reuses the original allocation when the value needs no trimming (the common case for
+/// well-formed Flex attributes), only allocating when whitespace is actually stripped.
+fn nonempty(value: Option<String>) -> Option<String> {
+    value.and_then(|v| {
+        let trimmed = v.trim();
+        if trimmed.is_empty() {
+            None
+        } else if trimmed.len() == v.len() {
+            Some(v)
+        } else {
+            Some(trimmed.to_owned())
+        }
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Tests should panic on unexpected values.
+mod tests {
+    use super::*;
+
+    const SEND_SUCCESS: &str = r#"<FlexStatementResponse timestamp="15 January, 2025 03:00 PM EST">
+        <Status>Success</Status>
+        <ReferenceCode>1234567890</ReferenceCode>
+        <Url>https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/GetStatement</Url>
+    </FlexStatementResponse>"#;
+
+    const SEND_FAIL: &str = r#"<FlexStatementResponse timestamp="15 January, 2025 03:00 PM EST">
+        <Status>Fail</Status>
+        <ErrorCode>1003</ErrorCode>
+        <ErrorMessage>Statement could not be generated at this time. Please try again shortly.</ErrorMessage>
+    </FlexStatementResponse>"#;
+
+    const GET_IN_PROGRESS: &str = r#"<FlexStatementResponse timestamp="15 January, 2025 03:00 PM EST">
+        <Status>Warn</Status>
+        <ErrorCode>1019</ErrorCode>
+        <ErrorMessage>Statement generation in progress. Please try again shortly.</ErrorMessage>
+    </FlexStatementResponse>"#;
+
+    const GET_FAIL: &str = r#"<FlexStatementResponse>
+        <Status>Fail</Status>
+        <ErrorCode>1020</ErrorCode>
+        <ErrorMessage>Invalid request or unable to validate request.</ErrorMessage>
+    </FlexStatementResponse>"#;
+
+    const GET_READY: &str = r#"<?xml version="1.0"?>
+        <FlexQueryResponse queryName="Activity" type="AF">
+          <FlexStatements count="1">
+            <FlexStatement accountId="U1"><CorporateActions /></FlexStatement>
+          </FlexStatements>
+        </FlexQueryResponse>"#;
+
+    #[test]
+    fn send_request_success_extracts_reference_and_url() {
+        let ok = parse_send_request_response(SEND_SUCCESS).unwrap();
+        assert_eq!(ok.reference_code, "1234567890");
+        assert_eq!(
+            ok.url,
+            "https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/GetStatement"
+        );
+    }
+
+    #[test]
+    fn send_request_failure_is_a_flex_error() {
+        match parse_send_request_response(SEND_FAIL) {
+            Err(IbkrFlexError::Flex { code, message }) => {
+                assert_eq!(code, "1003");
+                assert!(message.contains("could not be generated"));
+            }
+            other => panic!("expected Flex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn send_request_success_without_url_is_a_parse_error() {
+        let xml = r#"<FlexStatementResponse><Status>Success</Status>
+            <ReferenceCode>123</ReferenceCode></FlexStatementResponse>"#;
+        assert!(matches!(
+            parse_send_request_response(xml),
+            Err(IbkrFlexError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn send_request_non_https_url_is_rejected() {
+        // A success response whose poll URL is plain HTTP must be refused: the token rides in that
+        // URL's `t=` query parameter and must never traverse an unencrypted connection.
+        let xml = r#"<FlexStatementResponse><Status>Success</Status>
+            <ReferenceCode>123</ReferenceCode>
+            <Url>http://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/GetStatement</Url></FlexStatementResponse>"#;
+        assert!(matches!(
+            parse_send_request_response(xml),
+            Err(IbkrFlexError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn get_statement_ready_is_classified_ready() {
+        assert_eq!(
+            classify_get_statement(GET_READY).unwrap(),
+            GetStatementOutcome::Ready
+        );
+    }
+
+    #[test]
+    fn get_statement_generation_in_progress_is_classified_in_progress() {
+        assert_eq!(
+            classify_get_statement(GET_IN_PROGRESS).unwrap(),
+            GetStatementOutcome::InProgress
+        );
+    }
+
+    #[test]
+    fn get_statement_terminal_failure_is_a_flex_error() {
+        match classify_get_statement(GET_FAIL) {
+            Err(IbkrFlexError::Flex { code, message }) => {
+                assert_eq!(code, "1020");
+                assert!(message.contains("Invalid request"));
+            }
+            other => panic!("expected Flex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn root_element_name_skips_prolog() {
+        assert_eq!(
+            root_element_name(GET_READY).as_deref(),
+            Some("FlexQueryResponse")
+        );
+        assert_eq!(
+            root_element_name(SEND_SUCCESS).as_deref(),
+            Some("FlexStatementResponse")
+        );
+        assert_eq!(root_element_name("").as_deref(), None);
+    }
+
+    #[test]
+    fn config_debug_redacts_token() {
+        let config = IbkrFlexConfig::new("super-secret-token", "987654");
+        let debug = format!("{config:?}");
+        assert!(
+            !debug.contains("super-secret-token"),
+            "token must be redacted"
+        );
+        assert!(debug.contains("987654"), "query_id is not a secret");
+    }
+
+    #[test]
+    fn client_debug_hides_token() {
+        let client = IbkrFlexClient::new(IbkrFlexConfig::new("super-secret-token", "987654"))
+            .expect("HTTP client should build");
+        let debug = format!("{client:?}");
+        assert!(
+            !debug.contains("super-secret-token"),
+            "token must not leak via Debug"
+        );
+        assert!(debug.contains("987654"));
+    }
+}

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -84,8 +84,19 @@ pub enum IbkrFlexError {
     EnvVar(String),
 
     /// Transport-level HTTP error (connection, timeout, or non-2xx status).
+    ///
+    /// The inner [`reqwest::Error`] **never carries the request URL.** The Flex token is
+    /// transmitted as `t=<TOKEN>` in every request URL, and `reqwest::Error`'s `Display` and
+    /// `Debug` both embed that URL verbatim when present. The `From<reqwest::Error>` conversion
+    /// for this type always strips it via [`reqwest::Error::without_url`] before the error is
+    /// stored, covering every reqwest site that attaches a URL (`send`, `error_for_status`, body
+    /// decode); `Client::build()` errors carry no URL, so the strip is a no-op for them. The
+    /// `source()` chain (hyper/IO transport errors) is preserved and does not independently carry
+    /// the URL.
+    ///
+    /// Safe to log or display without credential scrubbing.
     #[error("HTTP error: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(reqwest::Error),
 
     /// The Flex service returned a non-success status (e.g. invalid token, throttled, expired).
     #[error("Flex service error ({code}): {message}")]
@@ -107,6 +118,25 @@ pub enum IbkrFlexError {
     /// The statement or status XML could not be parsed.
     #[error("Flex XML parse error: {0}")]
     Parse(String),
+}
+
+/// Convert a [`reqwest::Error`] into [`IbkrFlexError::Http`] **with its request URL stripped**.
+///
+/// The Flex `token` rides in the `t=` query parameter (IBKR's protocol), so it is part of every
+/// request URL. `reqwest::Error`'s `Display`/`Debug` embed the stored URL verbatim — e.g.
+/// `"... for url (https://.../SendRequest?t=<TOKEN>&q=...)"` — so an unstripped error would leak the
+/// credential into any log that formats [`IbkrFlexError::Http`] (the shipped example does exactly
+/// that).
+///
+/// Stripping lives in this single conversion rather than per-call-site discipline so the
+/// "[`IbkrFlexError::Http`] never carries the URL" invariant is enforced by the type system: every
+/// `?` on a `reqwest::Error` — at the request sites *and* any path added later — routes through here.
+/// [`reqwest::Error::without_url`] sets the stored URL to `None` (a no-op for `Client::build()`
+/// errors, which carry none) while preserving the diagnostic kind/status and `source()` chain.
+impl From<reqwest::Error> for IbkrFlexError {
+    fn from(error: reqwest::Error) -> Self {
+        IbkrFlexError::Http(error.without_url())
+    }
 }
 
 /// Credentials for the IBKR Flex Web Service: an Activity-statement Flex `token` and the id of a
@@ -236,6 +266,12 @@ impl IbkrFlexClient {
     /// plaintext. The poll URL returned by SendRequest is required to be `https://` for the same
     /// reason — the token must never traverse an unencrypted connection.
     ///
+    /// For the same reason, [`IbkrFlexError::Http`] must never embed the request URL: a
+    /// `reqwest::Error`'s `Display` includes the URL it was building, which would carry `t=<TOKEN>`
+    /// into any log that formats the error. The `From<reqwest::Error>` conversion for
+    /// [`IbkrFlexError`] strips the URL via [`reqwest::Error::without_url`] before the error is
+    /// stored, so a plain `?` is safe here and in any request path added later.
+    ///
     /// Two IBKR hosts are involved: `ndcdyn.interactivebrokers.com` (the hard-coded `FLEX_BASE_URL`
     /// that serves `SendRequest`) and `gdcdyn.interactivebrokers.com` (the statement-download host
     /// that `SendRequest` returns in its poll URL). The poll host is deliberately **not** pinned to
@@ -253,6 +289,8 @@ impl IbkrFlexClient {
         let send_url = format!("{}/SendRequest", self.base_url);
         debug!("Requesting IBKR Flex statement generation");
 
+        // Plain `?` is safe: `IbkrFlexError`'s `From<reqwest::Error>` strips the token-bearing
+        // request URL from every error (see the impl above).
         let body = self
             .http
             .get(&send_url)
@@ -273,6 +311,7 @@ impl IbkrFlexClient {
         } = parse_send_request_response(&body)?;
 
         for attempt in 1..=POLL_MAX_ATTEMPTS {
+            // Plain `?` as above: the `From` impl strips the token-bearing URL from any reqwest error.
             let body = self
                 .http
                 .get(&url)

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -83,6 +83,13 @@ pub enum IbkrFlexError {
     #[error("environment variable error: {0}")]
     EnvVar(String),
 
+    /// A supplied credential (the Flex `token` or `query_id`) is empty after trimming surrounding
+    /// whitespace. Raised by [`IbkrFlexConfig::new`] so a malformed credential fails observably at
+    /// construction, naming the offending field, rather than later as an opaque IBKR `1003`
+    /// "invalid token" after a live fetch.
+    #[error("invalid credential: {0}")]
+    InvalidCredential(String),
+
     /// Transport-level HTTP error (connection, timeout, or non-2xx status).
     ///
     /// The inner [`reqwest::Error`] **never carries the request URL.** The Flex token is
@@ -161,15 +168,23 @@ impl fmt::Debug for IbkrFlexConfig {
 impl IbkrFlexConfig {
     /// Create a config from an explicit Flex token and saved-query id.
     ///
-    /// `token` and `query_id` are stored **verbatim** — they are not trimmed or validated. Leading
-    /// or trailing whitespace will be sent in the `t=`/`q=` query parameters and rejected by IBKR
-    /// with a confusing `1003` "invalid token" at fetch time. Pass already-clean values, or use
-    /// [`from_env`](Self::from_env), which trims and rejects empty values.
-    pub fn new(token: impl Into<String>, query_id: impl Into<String>) -> Self {
-        Self {
-            token: token.into(),
-            query_id: query_id.into(),
-        }
+    /// Both values are **trimmed** of surrounding whitespace and rejected if empty (or empty after
+    /// trimming), so a malformed credential fails here — observably, naming the offending field —
+    /// rather than later as an opaque IBKR `1003` "invalid token" at fetch time. This mirrors the
+    /// validation [`from_env`](Self::from_env) performs, and matches the fallible-`new` shape used
+    /// by the other exchange clients in this crate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IbkrFlexError::InvalidCredential`] if either value is empty after trimming.
+    pub fn new(
+        token: impl Into<String>,
+        query_id: impl Into<String>,
+    ) -> Result<Self, IbkrFlexError> {
+        Ok(Self {
+            token: Self::require_nonempty_trimmed("token", token.into())?,
+            query_id: Self::require_nonempty_trimmed("query_id", query_id.into())?,
+        })
     }
 
     /// Create a config from environment variables.
@@ -200,7 +215,31 @@ impl IbkrFlexConfig {
                 "IBKR_FLEX_QUERY_ID is set but empty".to_owned(),
             ));
         }
-        Ok(Self::new(token, query_id))
+        // Route through `new` so there is a single construction/validation path. The env-var checks
+        // above already produce variable-specific messages (`IBKR_FLEX_TOKEN is set but empty`),
+        // which are more actionable than `new`'s generic field-level error, so they run first; the
+        // re-trim/re-check inside `new` is then a cheap no-op.
+        Self::new(token, query_id)
+    }
+
+    /// Trim `value` and reject it if empty (or empty after trimming), tagging the error with
+    /// `field` so the failure names which credential was malformed. Allocates a new `String` only
+    /// when trimming actually removed characters.
+    fn require_nonempty_trimmed(
+        field: &'static str,
+        value: String,
+    ) -> Result<String, IbkrFlexError> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(IbkrFlexError::InvalidCredential(format!(
+                "{field} is empty after trimming whitespace"
+            )));
+        }
+        if trimmed.len() == value.len() {
+            Ok(value)
+        } else {
+            Ok(trimmed.to_owned())
+        }
     }
 }
 
@@ -706,7 +745,8 @@ mod tests {
 
     #[test]
     fn config_debug_redacts_token() {
-        let config = IbkrFlexConfig::new("super-secret-token", "987654");
+        let config =
+            IbkrFlexConfig::new("super-secret-token", "987654").expect("valid credentials");
         let debug = format!("{config:?}");
         assert!(
             !debug.contains("super-secret-token"),
@@ -717,13 +757,60 @@ mod tests {
 
     #[test]
     fn client_debug_hides_token() {
-        let client = IbkrFlexClient::new(IbkrFlexConfig::new("super-secret-token", "987654"))
-            .expect("HTTP client should build");
+        let client = IbkrFlexClient::new(
+            IbkrFlexConfig::new("super-secret-token", "987654").expect("valid credentials"),
+        )
+        .expect("HTTP client should build");
         let debug = format!("{client:?}");
         assert!(
             !debug.contains("super-secret-token"),
             "token must not leak via Debug"
         );
         assert!(debug.contains("987654"));
+    }
+
+    #[test]
+    fn new_rejects_empty_or_whitespace_token() {
+        for token in ["", "   ", "\t\n"] {
+            match IbkrFlexConfig::new(token, "987654") {
+                Err(IbkrFlexError::InvalidCredential(msg)) => assert!(
+                    msg.contains("token"),
+                    "error should name the `token` field, got: {msg}"
+                ),
+                other => panic!("expected InvalidCredential for token {token:?}, got: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn new_rejects_empty_or_whitespace_query_id() {
+        for query_id in ["", "   ", "\t\n"] {
+            match IbkrFlexConfig::new("valid-token", query_id) {
+                Err(IbkrFlexError::InvalidCredential(msg)) => assert!(
+                    msg.contains("query_id"),
+                    "error should name the `query_id` field, got: {msg}"
+                ),
+                other => {
+                    panic!("expected InvalidCredential for query_id {query_id:?}, got: {other:?}")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn new_trims_surrounding_whitespace() {
+        let config = IbkrFlexConfig::new("  super-secret-token  ", "  987654  ")
+            .expect("padded-but-nonempty credentials are valid");
+        // Debug redacts the token, so `query_id` is the only observable window into the stored
+        // (trimmed) values. Confirm the surrounding whitespace was stripped before storage.
+        let debug = format!("{config:?}");
+        assert!(
+            debug.contains("\"987654\""),
+            "query_id should be trimmed to `987654`, got: {debug}"
+        );
+        assert!(
+            !debug.contains("  987654"),
+            "surrounding whitespace should not survive into the stored query_id, got: {debug}"
+        );
     }
 }

--- a/rustrade-data/src/exchange/ibkr/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/mod.rs
@@ -60,12 +60,21 @@
 //! [`Candle`]: crate::subscription::candle::Candle
 
 pub mod depth;
+// `flex` is private: its public surface is re-exported flat below (matching the `massive`
+// reconciliation module), so callers use a single `ibkr::IbkrFlex*` path rather than the
+// internal submodule layout.
+mod flex;
 pub mod greeks;
 pub mod historical;
 pub mod options;
 pub mod quotes;
 pub mod subscription;
 pub mod trades;
+
+pub use flex::{
+    IbkrFlexClient, IbkrFlexConfig, IbkrFlexCorporateAction, IbkrFlexError, IbkrReorgType,
+    parse_corporate_actions,
+};
 
 use crate::{
     error::DataError,

--- a/rustrade-data/src/exchange/massive/corporate_action.rs
+++ b/rustrade-data/src/exchange/massive/corporate_action.rs
@@ -117,11 +117,11 @@ mod tests {
 
     #[test]
     fn build_split_queries_fans_out_per_symbol() {
-        let filter = CorporateActionFilter {
-            symbols: vec![SmolStr::new("AAPL"), SmolStr::new("NVDA")],
-            start: NaiveDate::from_ymd_opt(2020, 1, 1),
-            end: NaiveDate::from_ymd_opt(2024, 12, 31),
-        };
+        let filter = CorporateActionFilter::new(
+            vec![SmolStr::new("AAPL"), SmolStr::new("NVDA")],
+            NaiveDate::from_ymd_opt(2020, 1, 1),
+            NaiveDate::from_ymd_opt(2024, 12, 31),
+        );
 
         let queries = build_split_queries(&filter);
         assert_eq!(queries.len(), 2);
@@ -134,11 +134,7 @@ mod tests {
 
     #[test]
     fn build_split_queries_empty_symbols_is_one_unfiltered_query() {
-        let filter = CorporateActionFilter {
-            symbols: vec![],
-            start: NaiveDate::from_ymd_opt(2023, 1, 1),
-            end: None,
-        };
+        let filter = CorporateActionFilter::new(vec![], NaiveDate::from_ymd_opt(2023, 1, 1), None);
 
         let queries = build_split_queries(&filter);
         assert_eq!(queries.len(), 1);

--- a/rustrade-data/src/exchange/massive/corporate_action.rs
+++ b/rustrade-data/src/exchange/massive/corporate_action.rs
@@ -1,0 +1,212 @@
+//! [`StockSplitSource`] implementation for the Massive REST client.
+//!
+//! Adapts the lower-level [`MassiveRestClient::fetch_splits`](super::rest::MassiveRestClient)
+//! raw-split stream into the provider-agnostic
+//! [`CorporateAction`] sourcing descriptor, computing the split ratio via the shared
+//! [`CorporateActionKind::stock_split`] helper so Massive derives ratios identically to every other
+//! provider.
+
+use async_stream::try_stream;
+use futures::{Stream, StreamExt};
+use smol_str::SmolStr;
+use tracing::warn;
+
+use rustrade_instrument::corporate_action::{CorporateAction, CorporateActionKind};
+use rustrade_integration::corporate_action::{CorporateActionFilter, StockSplitSource};
+
+use super::error::MassiveError;
+use super::reference::{SplitQuery, StockSplit};
+use super::rest::MassiveRestClient;
+
+impl StockSplitSource for MassiveRestClient {
+    type Error = MassiveError;
+
+    /// Fetch stock splits for `filter`'s symbols and effective-date range, mapped to
+    /// [`CorporateAction<SmolStr>`] descriptors.
+    ///
+    /// `effective_date` provenance: this impl maps it onto Massive's `execution_date` — the split's
+    /// market execution date, satisfying the [`StockSplitSource::fetch_splits`] `effective_date`
+    /// contract. (`StockSplit` exposes no other date field, so there is no ambiguity to resolve.)
+    /// Massive's `/v3/reference/splits` endpoint filters by a **single** ticker, so a multi-symbol filter
+    /// fans out into one query per symbol, concatenated into a single stream in `symbols` order; an
+    /// **empty** `symbols` list issues one unfiltered query (all splits in the date range, subject
+    /// to provider page limits). Splits whose raw `split_to` / `split_from` yield a degenerate ratio
+    /// (zero, negative, or division by zero) are logged and skipped — see
+    /// [`CorporateActionKind::stock_split`].
+    fn fetch_splits(
+        &self,
+        filter: &CorporateActionFilter,
+    ) -> impl Stream<Item = Result<CorporateAction<SmolStr>, Self::Error>> + Send {
+        // Build owned queries eagerly so the returned stream borrows only `self`, not `filter`.
+        let queries = build_split_queries(filter);
+
+        try_stream! {
+            for query in &queries {
+                // Method-call syntax resolves to the *inherent* `MassiveRestClient::fetch_splits`
+                // (which takes `&SplitQuery`); inherent methods shadow trait methods, so this is the
+                // lower-level raw-split stream we adapt — not a recursive call into this impl.
+                let raw = self.fetch_splits(query);
+                futures::pin_mut!(raw);
+                while let Some(split) = raw.next().await {
+                    if let Some(action) = map_split(split?) {
+                        yield action;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Translate a [`CorporateActionFilter`] into one or more Massive [`SplitQuery`]s (one per symbol,
+/// or a single date-only query when no symbols are given).
+fn build_split_queries(filter: &CorporateActionFilter) -> Vec<SplitQuery> {
+    // These queries only ever set the `execution_date_gte`/`lte` range — never the exact
+    // `execution_date` field. `SplitQuery::validate()` (run inside the inner `fetch_splits` stream)
+    // rejects only the exact+range combination, so queries built here can never trip it.
+    let with_dates = |mut query: SplitQuery| {
+        if let Some(start) = filter.start {
+            query = query.execution_date_gte(start);
+        }
+        if let Some(end) = filter.end {
+            query = query.execution_date_lte(end);
+        }
+        query
+    };
+
+    if filter.symbols.is_empty() {
+        vec![with_dates(SplitQuery::new())]
+    } else {
+        filter
+            .symbols
+            .iter()
+            .map(|symbol| with_dates(SplitQuery::new().ticker(symbol.as_str())))
+            .collect()
+    }
+}
+
+/// Map a raw [`StockSplit`] to a [`CorporateAction`] descriptor via the shared ratio helper.
+/// Returns `None` (and logs) for a degenerate ratio so the caller's stream simply omits it.
+fn map_split(split: StockSplit) -> Option<CorporateAction<SmolStr>> {
+    match CorporateActionKind::stock_split(split.split_to, split.split_from) {
+        // `effective_date` maps to Massive's `execution_date` — the split's market execution date,
+        // per the `StockSplitSource::fetch_splits` contract.
+        Some(kind) => Some(CorporateAction::new(
+            SmolStr::from(split.ticker),
+            kind,
+            Some(split.execution_date),
+        )),
+        None => {
+            warn!(
+                ticker = %split.ticker,
+                split_to = %split.split_to,
+                split_from = %split.split_from,
+                "Massive stock split has a degenerate ratio; skipping",
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Tests should panic on unexpected values
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+    use rust_decimal::Decimal;
+
+    #[test]
+    fn build_split_queries_fans_out_per_symbol() {
+        let filter = CorporateActionFilter {
+            symbols: vec![SmolStr::new("AAPL"), SmolStr::new("NVDA")],
+            start: NaiveDate::from_ymd_opt(2020, 1, 1),
+            end: NaiveDate::from_ymd_opt(2024, 12, 31),
+        };
+
+        let queries = build_split_queries(&filter);
+        assert_eq!(queries.len(), 2);
+        assert_eq!(queries[0].ticker.as_deref(), Some("AAPL"));
+        assert_eq!(queries[1].ticker.as_deref(), Some("NVDA"));
+        // Date bounds are applied to every per-symbol query.
+        assert_eq!(queries[0].execution_date_gte, filter.start);
+        assert_eq!(queries[0].execution_date_lte, filter.end);
+    }
+
+    #[test]
+    fn build_split_queries_empty_symbols_is_one_unfiltered_query() {
+        let filter = CorporateActionFilter {
+            symbols: vec![],
+            start: NaiveDate::from_ymd_opt(2023, 1, 1),
+            end: None,
+        };
+
+        let queries = build_split_queries(&filter);
+        assert_eq!(queries.len(), 1);
+        assert_eq!(queries[0].ticker, None);
+        assert_eq!(queries[0].execution_date_gte, filter.start);
+        assert_eq!(queries[0].execution_date_lte, None);
+    }
+
+    #[test]
+    fn map_split_computes_forward_ratio() {
+        let split = StockSplit {
+            ticker: "AAPL".to_string(),
+            execution_date: NaiveDate::from_ymd_opt(2020, 8, 31).unwrap(),
+            split_to: Decimal::from(4),
+            split_from: Decimal::from(1),
+        };
+
+        let action = map_split(split).unwrap();
+        assert_eq!(action.instrument, SmolStr::new("AAPL"));
+        assert_eq!(
+            action.kind,
+            CorporateActionKind::StockSplit {
+                ratio: Decimal::from(4)
+            }
+        );
+        // Pins the provenance: `effective_date` is mapped from the raw split's `execution_date`.
+        assert_eq!(action.effective_date, NaiveDate::from_ymd_opt(2020, 8, 31));
+    }
+
+    #[test]
+    fn map_split_drops_degenerate_ratio() {
+        let split = StockSplit {
+            ticker: "BAD".to_string(),
+            execution_date: NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(),
+            split_to: Decimal::from(1),
+            split_from: Decimal::ZERO,
+        };
+        assert!(map_split(split).is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_splits_via_trait_object_is_stream_of_descriptors() {
+        // A tiny in-test source confirms the trait shape drives end-to-end without a live client.
+        struct OneSplit;
+        impl StockSplitSource for OneSplit {
+            type Error = std::convert::Infallible;
+            fn fetch_splits(
+                &self,
+                _filter: &CorporateActionFilter,
+            ) -> impl Stream<Item = Result<CorporateAction<SmolStr>, Self::Error>> + Send
+            {
+                futures::stream::iter([Ok(CorporateAction::new(
+                    SmolStr::new("TSLA"),
+                    CorporateActionKind::StockSplit {
+                        ratio: Decimal::from(3),
+                    },
+                    NaiveDate::from_ymd_opt(2022, 8, 25),
+                ))])
+            }
+        }
+
+        let actions: Vec<_> = OneSplit
+            .fetch_splits(&CorporateActionFilter::default())
+            .collect()
+            .await;
+        assert_eq!(actions.len(), 1);
+        assert_eq!(
+            actions[0].as_ref().unwrap().instrument,
+            SmolStr::new("TSLA")
+        );
+    }
+}

--- a/rustrade-data/src/exchange/massive/corporate_action.rs
+++ b/rustrade-data/src/exchange/massive/corporate_action.rs
@@ -1,6 +1,6 @@
 //! [`StockSplitSource`] implementation for the Massive REST client.
 //!
-//! Adapts the lower-level [`MassiveRestClient::fetch_splits`](super::rest::MassiveRestClient)
+//! Adapts the lower-level [`MassiveRestClient::fetch_splits_raw`](super::rest::MassiveRestClient)
 //! raw-split stream into the provider-agnostic
 //! [`CorporateAction`] sourcing descriptor, computing the split ratio via the shared
 //! [`CorporateActionKind::stock_split`] helper so Massive derives ratios identically to every other
@@ -42,10 +42,10 @@ impl StockSplitSource for MassiveRestClient {
 
         try_stream! {
             for query in &queries {
-                // Method-call syntax resolves to the *inherent* `MassiveRestClient::fetch_splits`
-                // (which takes `&SplitQuery`); inherent methods shadow trait methods, so this is the
-                // lower-level raw-split stream we adapt — not a recursive call into this impl.
-                let raw = self.fetch_splits(query);
+                // Calls the *inherent* `MassiveRestClient::fetch_splits_raw` (taking `&SplitQuery`),
+                // the lower-level raw-split stream this impl adapts. Its distinct name keeps the
+                // dispatch explicit — no collision with this trait's `fetch_splits`, so no recursion.
+                let raw = self.fetch_splits_raw(query);
                 futures::pin_mut!(raw);
                 while let Some(split) = raw.next().await {
                     if let Some(action) = map_split(split?) {
@@ -61,7 +61,7 @@ impl StockSplitSource for MassiveRestClient {
 /// or a single date-only query when no symbols are given).
 fn build_split_queries(filter: &CorporateActionFilter) -> Vec<SplitQuery> {
     // These queries only ever set the `execution_date_gte`/`lte` range — never the exact
-    // `execution_date` field. `SplitQuery::validate()` (run inside the inner `fetch_splits` stream)
+    // `execution_date` field. `SplitQuery::validate()` (run inside the inner `fetch_splits_raw` stream)
     // rejects only the exact+range combination, so queries built here can never trip it.
     let with_dates = |mut query: SplitQuery| {
         if let Some(start) = filter.start {

--- a/rustrade-data/src/exchange/massive/corporate_action.rs
+++ b/rustrade-data/src/exchange/massive/corporate_action.rs
@@ -113,6 +113,7 @@ mod tests {
     use super::*;
     use chrono::NaiveDate;
     use rust_decimal::Decimal;
+    use rustrade_instrument::corporate_action::SplitRatio;
 
     #[test]
     fn build_split_queries_fans_out_per_symbol() {
@@ -160,7 +161,7 @@ mod tests {
         assert_eq!(
             action.kind,
             CorporateActionKind::StockSplit {
-                ratio: Decimal::from(4)
+                ratio: SplitRatio::new(Decimal::from(4)).unwrap()
             }
         );
         // Pins the provenance: `effective_date` is mapped from the raw split's `execution_date`.
@@ -192,7 +193,7 @@ mod tests {
                 futures::stream::iter([Ok(CorporateAction::new(
                     SmolStr::new("TSLA"),
                     CorporateActionKind::StockSplit {
-                        ratio: Decimal::from(3),
+                        ratio: SplitRatio::new(Decimal::from(3)).unwrap(),
                     },
                     NaiveDate::from_ymd_opt(2022, 8, 25),
                 ))])

--- a/rustrade-data/src/exchange/massive/mod.rs
+++ b/rustrade-data/src/exchange/massive/mod.rs
@@ -76,6 +76,9 @@
 //! let stream = client.start().await?;
 //! ```
 
+// Side-effect-only module: provides `impl StockSplitSource for MassiveRestClient`. It exports no
+// types, so it is private — `use` it nowhere; the impl is in scope wherever the client is.
+mod corporate_action;
 mod error;
 pub(crate) mod live;
 pub(crate) mod options;

--- a/rustrade-data/src/exchange/massive/reference.rs
+++ b/rustrade-data/src/exchange/massive/reference.rs
@@ -1371,12 +1371,12 @@ impl MassiveRestClient {
     ///
     /// ```ignore
     /// let query = SplitQuery::new().ticker("AAPL").limit(100);
-    /// let mut stream = client.fetch_splits(&query);
+    /// let mut stream = client.fetch_splits_raw(&query);
     /// while let Some(split) = stream.next().await {
     ///     println!("{:?}", split?);
     /// }
     /// ```
-    pub fn fetch_splits<'a>(
+    pub fn fetch_splits_raw<'a>(
         &'a self,
         query: &'a SplitQuery,
     ) -> impl Stream<Item = Result<StockSplit, MassiveError>> + 'a {

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -15,6 +15,10 @@
     missing_debug_implementations,
     rust_2018_idioms
 )]
+// Inherited from the barter-rs upstream: the generic, trait-heavy public API legitimately produces
+// complex nested types and many-argument constructors, and `type_alias_bounds` fires on
+// documentation-bearing alias bounds kept intentionally. Denying these adds churn without improving
+// the API.
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
 //! # Barter-Data

--- a/rustrade-data/tests/alpaca_corporate_actions.rs
+++ b/rustrade-data/tests/alpaca_corporate_actions.rs
@@ -37,7 +37,7 @@ use chrono::NaiveDate;
 use futures::StreamExt;
 use rust_decimal::Decimal;
 use rustrade_data::exchange::alpaca::AlpacaRestClient;
-use rustrade_instrument::corporate_action::{CorporateAction, CorporateActionKind};
+use rustrade_instrument::corporate_action::{CorporateAction, CorporateActionKind, SplitRatio};
 use rustrade_integration::corporate_action::{CorporateActionFilter, StockSplitSource};
 use smol_str::SmolStr;
 
@@ -82,7 +82,7 @@ async fn nvda_forward_split_2024_via_source() {
     assert_eq!(
         nvda.kind,
         CorporateActionKind::StockSplit {
-            ratio: Decimal::from(10)
+            ratio: SplitRatio::new(Decimal::from(10)).unwrap()
         }
     );
 }
@@ -103,7 +103,7 @@ async fn atra_reverse_split_2024_via_source() {
     assert_eq!(
         atra.kind,
         CorporateActionKind::StockSplit {
-            ratio: Decimal::new(4, 2)
+            ratio: SplitRatio::new(Decimal::new(4, 2)).unwrap()
         }
     );
 }

--- a/rustrade-data/tests/alpaca_corporate_actions.rs
+++ b/rustrade-data/tests/alpaca_corporate_actions.rs
@@ -1,0 +1,136 @@
+//! Alpaca corporate-actions (stock-split) source integration tests.
+//!
+//! These tests drive the live `StockSplitSource` impl on `AlpacaRestClient` against Alpaca's
+//! `GET /v1beta1/corporate-actions` endpoint. The endpoint is historical reference data and is
+//! available on the **free/Basic (paper) plan** — unlike SIP/OPRA, it is NOT gated behind Algo
+//! Trader Plus.
+//!
+//! # Status
+//!
+//! Marked `#[ignore]` so they never run (or fail) in CI without credentials. The always-run,
+//! hermetic coverage (ratio mapping, the `ex_date`-vs-`payable_date` provenance pin, response /
+//! pagination parsing, degenerate-ratio skip) lives in the `alpaca::reference` and
+//! `alpaca::corporate_action` unit tests.
+//!
+//! # Prerequisites
+//!
+//! 1. Alpaca account (paper is fine; https://app.alpaca.markets).
+//! 2. Environment variables (see `.env.template`):
+//!    - `ALPACA_API_KEY`
+//!    - `ALPACA_SECRET_KEY`
+//!
+//! # Running
+//!
+//! ```bash
+//! source .env
+//! cargo test --test alpaca_corporate_actions --features alpaca -- --ignored
+//! ```
+//!
+//! The fixtures these assert against are real, stable historical splits, so unlike the market-data
+//! streaming tests they do not depend on market hours.
+
+#![cfg(feature = "alpaca")]
+// Test code: unwrap/expect panics are the correct failure mode for test assertions.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use chrono::NaiveDate;
+use futures::StreamExt;
+use rust_decimal::Decimal;
+use rustrade_data::exchange::alpaca::AlpacaRestClient;
+use rustrade_instrument::corporate_action::{CorporateAction, CorporateActionKind};
+use rustrade_integration::corporate_action::{CorporateActionFilter, StockSplitSource};
+use smol_str::SmolStr;
+
+/// Drain a [`StockSplitSource`] stream, panicking on the first per-item error.
+async fn collect<S>(source: &S, filter: &CorporateActionFilter) -> Vec<CorporateAction<SmolStr>>
+where
+    S: StockSplitSource,
+    S::Error: std::fmt::Debug,
+{
+    let stream = source.fetch_splits(filter);
+    futures::pin_mut!(stream);
+
+    let mut out = Vec::new();
+    while let Some(item) = stream.next().await {
+        out.push(item.expect("fetch_splits yielded an error"));
+    }
+    out
+}
+
+fn year_2024(symbol: &str) -> CorporateActionFilter {
+    CorporateActionFilter {
+        symbols: vec![SmolStr::new(symbol)],
+        start: NaiveDate::from_ymd_opt(2024, 1, 1),
+        end: NaiveDate::from_ymd_opt(2024, 12, 31),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires ALPACA_API_KEY/ALPACA_SECRET_KEY + network"]
+async fn nvda_forward_split_2024_via_source() {
+    let client = AlpacaRestClient::from_env().expect("ALPACA credentials must be set");
+
+    let actions = collect(&client, &year_2024("NVDA")).await;
+
+    // NVIDIA's 10-for-1 forward split took effect (ex-date) on 2024-06-10.
+    let nvda = actions
+        .iter()
+        .find(|a| a.effective_date == NaiveDate::from_ymd_opt(2024, 6, 10))
+        .expect("NVDA 2024-06-10 split should be present in the result set");
+
+    assert_eq!(nvda.instrument, SmolStr::new("NVDA"));
+    assert_eq!(
+        nvda.kind,
+        CorporateActionKind::StockSplit {
+            ratio: Decimal::from(10)
+        }
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires ALPACA_API_KEY/ALPACA_SECRET_KEY + network"]
+async fn atra_reverse_split_2024_via_source() {
+    let client = AlpacaRestClient::from_env().expect("ALPACA credentials must be set");
+
+    let actions = collect(&client, &year_2024("ATRA")).await;
+
+    // Atara Biotherapeutics' 1-for-25 reverse split took effect (ex-date) on 2024-06-20 → ratio 0.04.
+    let atra = actions
+        .iter()
+        .find(|a| a.effective_date == NaiveDate::from_ymd_opt(2024, 6, 20))
+        .expect("ATRA 2024-06-20 reverse split should be present in the result set");
+
+    assert_eq!(
+        atra.kind,
+        CorporateActionKind::StockSplit {
+            ratio: Decimal::new(4, 2)
+        }
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires ALPACA_API_KEY/ALPACA_SECRET_KEY + network"]
+async fn raw_inherent_client_returns_nvda_split() {
+    use rustrade_data::exchange::alpaca::CorporateActionsQuery;
+
+    let client = AlpacaRestClient::from_env().expect("ALPACA credentials must be set");
+    let query = CorporateActionsQuery::new()
+        .symbols(["NVDA"])
+        .start(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap())
+        .end(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap());
+
+    let stream = client.fetch_splits_raw(&query);
+    futures::pin_mut!(stream);
+
+    let mut splits = Vec::new();
+    while let Some(item) = stream.next().await {
+        splits.push(item.expect("inherent fetch_splits_raw yielded an error"));
+    }
+
+    let nvda = splits
+        .iter()
+        .find(|s| s.ex_date == NaiveDate::from_ymd_opt(2024, 6, 10).unwrap())
+        .expect("NVDA 2024-06-10 split should be present");
+    assert_eq!(nvda.new_rate, Decimal::from(10));
+    assert_eq!(nvda.old_rate, Decimal::from(1));
+}

--- a/rustrade-data/tests/alpaca_corporate_actions.rs
+++ b/rustrade-data/tests/alpaca_corporate_actions.rs
@@ -58,11 +58,11 @@ where
 }
 
 fn year_2024(symbol: &str) -> CorporateActionFilter {
-    CorporateActionFilter {
-        symbols: vec![SmolStr::new(symbol)],
-        start: NaiveDate::from_ymd_opt(2024, 1, 1),
-        end: NaiveDate::from_ymd_opt(2024, 12, 31),
-    }
+    CorporateActionFilter::new(
+        vec![SmolStr::new(symbol)],
+        NaiveDate::from_ymd_opt(2024, 1, 1),
+        NaiveDate::from_ymd_opt(2024, 12, 31),
+    )
 }
 
 #[tokio::test]

--- a/rustrade-data/tests/fixtures/ibkr_flex/activity_complex_corporate_actions.xml
+++ b/rustrade-data/tests/fixtures/ibkr_flex/activity_complex_corporate_actions.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlexQueryResponse queryName="Activity" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="2025-01-15" toDate="2025-01-15"
+                   period="LastBusinessDay" whenGenerated="2025-01-15;150000">
+      <Trades />
+      <OpenPositions />
+      <CashTransactions />
+
+      <!-- Complex corporate actions -->
+      <CorporateActions>
+        <!-- Choice dividend (stockholder can choose cash or stock) -->
+        <CorporateAction accountId="U1234567"
+                        conid="456789012"
+                        symbol="XYZ"
+                        description="XYZ CORP"
+                        assetCategory="STK"
+                        actionType="CD"
+                        actionDescription="Choice Dividend"
+                        type="CD"
+                        dateTime="2025-01-15"
+                        reportDate="2025-01-15"
+                        quantity="100"
+                        proceeds="0.00"
+                        value="150.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+
+        <!-- Choice dividend delivery (actual receipt) -->
+        <CorporateAction accountId="U1234567"
+                        conid="456789012"
+                        symbol="XYZ"
+                        description="XYZ CORP"
+                        assetCategory="STK"
+                        actionType="CD"
+                        actionDescription="Choice Dividend (Delivery)"
+                        type="CD"
+                        dateTime="2025-01-20"
+                        reportDate="2025-01-20"
+                        quantity="5"
+                        proceeds="0.00"
+                        value="150.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+
+        <!-- Tender offer -->
+        <CorporateAction accountId="U1234567"
+                        conid="567890123"
+                        symbol="ABC"
+                        description="ABC CORP"
+                        assetCategory="STK"
+                        actionType="TO"
+                        actionDescription="Tender"
+                        type="TO"
+                        dateTime="2025-01-15"
+                        reportDate="2025-01-15"
+                        quantity="-50"
+                        proceeds="3500.00"
+                        value="3500.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+
+        <!-- Tender (issue) - receive proceeds -->
+        <CorporateAction accountId="U1234567"
+                        conid="567890123"
+                        symbol="ABC"
+                        description="ABC CORP"
+                        assetCategory="STK"
+                        actionType="TO"
+                        actionDescription="Tender (Issue)"
+                        type="TO"
+                        dateTime="2025-01-20"
+                        reportDate="2025-01-20"
+                        quantity="0"
+                        proceeds="3500.00"
+                        value="3500.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+
+        <!-- Bond conversion -->
+        <CorporateAction accountId="U1234567"
+                        conid="678901234"
+                        symbol="DEF"
+                        description="DEF CORP CONV BOND"
+                        assetCategory="BOND"
+                        actionType="BC"
+                        actionDescription="Bond Conversion"
+                        type="BC"
+                        dateTime="2025-01-15"
+                        reportDate="2025-01-15"
+                        quantity="-10"
+                        proceeds="0.00"
+                        value="10000.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+
+        <!-- Bond conversion (receive stock) -->
+        <CorporateAction accountId="U1234567"
+                        conid="678901235"
+                        symbol="DEF"
+                        description="DEF CORP"
+                        assetCategory="STK"
+                        actionType="BC"
+                        actionDescription="Convertible Issue"
+                        type="BC"
+                        dateTime="2025-01-15"
+                        reportDate="2025-01-15"
+                        quantity="250"
+                        proceeds="0.00"
+                        value="10000.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+
+        <!-- Bond maturity -->
+        <CorporateAction accountId="U1234567"
+                        conid="789012345"
+                        symbol="GHI 5.5 01/15/25"
+                        description="GHI CORP 5.5% BOND"
+                        assetCategory="BOND"
+                        actionType="BM"
+                        actionDescription="Bond Maturity"
+                        type="BM"
+                        dateTime="2025-01-15"
+                        reportDate="2025-01-15"
+                        quantity="-5"
+                        proceeds="5000.00"
+                        value="5000.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+
+        <!-- Coupon payment -->
+        <CorporateAction accountId="U1234567"
+                        conid="789012346"
+                        symbol="JKL 4.0 06/15/30"
+                        description="JKL CORP 4.0% BOND"
+                        assetCategory="BOND"
+                        actionType="CP"
+                        actionDescription="Coupon Payment"
+                        type="CP"
+                        dateTime="2025-01-15"
+                        reportDate="2025-01-15"
+                        quantity="10"
+                        proceeds="200.00"
+                        value="200.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+
+        <!-- Rights issue -->
+        <CorporateAction accountId="U1234567"
+                        conid="890123456"
+                        symbol="MNO"
+                        description="MNO CORP RIGHTS"
+                        assetCategory="STK"
+                        actionType="RI"
+                        actionDescription="Rights Issue"
+                        type="RI"
+                        dateTime="2025-01-15"
+                        reportDate="2025-01-15"
+                        quantity="20"
+                        proceeds="0.00"
+                        value="50.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+
+        <!-- Subscribe rights -->
+        <CorporateAction accountId="U1234567"
+                        conid="890123456"
+                        symbol="MNO"
+                        description="MNO CORP"
+                        assetCategory="STK"
+                        actionType="SR"
+                        actionDescription="Subscribe Rights"
+                        type="SR"
+                        dateTime="2025-01-20"
+                        reportDate="2025-01-20"
+                        quantity="10"
+                        proceeds="-250.00"
+                        value="300.00"
+                        currency="USD"
+                        fxRateToBase="1.0" />
+      </CorporateActions>
+
+      <SecuritiesInfo />
+      <ConversionRates />
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>

--- a/rustrade-data/tests/fixtures/ibkr_flex/activity_corporate_actions.xml
+++ b/rustrade-data/tests/fixtures/ibkr_flex/activity_corporate_actions.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlexQueryResponse queryName="Activity" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="2025-01-15" toDate="2025-01-15"
+                   period="LastBusinessDay" whenGenerated="2025-01-15;150000">
+
+      <!-- Trades - empty for this fixture -->
+      <Trades />
+
+      <!-- Positions - empty for this fixture -->
+      <OpenPositions />
+
+      <!-- Cash Transactions related to corporate actions -->
+      <CashTransactions>
+        <!-- Dividend Payment -->
+        <CashTransaction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="AAPL" description="APPLE INC - Dividend"
+                         conid="265598" securityID="" securityIDType="" cusip="037833100" isin="US0378331005"
+                         underlyingConid="" underlyingSymbol="" issuer="APPLE INC" multiplier=""
+                         strike="" expiry="" putCall="" principalAdjustFactor=""
+                         dateTime="2025-01-15;000000" amount="100.00" type="Dividends"
+                         tradeID="" code="" transactionID="555551" reportDate="2025-01-15"
+                         clientReference="" />
+
+        <!-- Withholding Tax on Dividend -->
+        <CashTransaction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="AAPL" description="APPLE INC - Withholding Tax"
+                         conid="265598" securityID="" securityIDType="" cusip="037833100" isin="US0378331005"
+                         underlyingConid="" underlyingSymbol="" issuer="APPLE INC" multiplier=""
+                         strike="" expiry="" putCall="" principalAdjustFactor=""
+                         dateTime="2025-01-15;000000" amount="-10.00" type="Withholding Tax"
+                         tradeID="" code="" transactionID="555552" reportDate="2025-01-15"
+                         clientReference="" />
+      </CashTransactions>
+
+      <!-- Corporate Actions -->
+      <CorporateActions>
+        <!-- Cash Dividend -->
+        <CorporateAction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="AAPL" description="APPLE INC"
+                         conid="265598" securityID="" securityIDType="" cusip="037833100"
+                         isin="US0378331005" underlyingConid="" underlyingSymbol=""
+                         issuer="APPLE INC" multiplier="" strike="" expiry="" putCall=""
+                         principalAdjustFactor="" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         amount="100.00" proceeds="100.00" value="100" quantity="400"
+                         fifoPnlRealized="0" mtmPnl="0" code="" type="DI" />
+
+        <!-- Stock Split (2-for-1) -->
+        <CorporateAction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="TSLA" description="TESLA INC - 2:1 Split"
+                         conid="76792991" securityID="" securityIDType="" cusip="88160R101"
+                         isin="US88160R1014" underlyingConid="" underlyingSymbol=""
+                         issuer="TESLA INC" multiplier="" strike="" expiry="" putCall=""
+                         principalAdjustFactor="2" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         amount="0" proceeds="0" value="0" quantity="100"
+                         fifoPnlRealized="0" mtmPnl="0" code="" type="FS" />
+
+        <!-- Spinoff -->
+        <CorporateAction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="GOOG" description="ALPHABET INC - Spinoff"
+                         conid="208813719" securityID="" securityIDType="" cusip="02079K305"
+                         isin="US02079K3059" underlyingConid="" underlyingSymbol=""
+                         issuer="ALPHABET INC" multiplier="" strike="" expiry="" putCall=""
+                         principalAdjustFactor="" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         amount="0" proceeds="0" value="1500" quantity="50"
+                         fifoPnlRealized="0" mtmPnl="0" code="" type="SO" />
+
+        <!-- Merger/Acquisition -->
+        <CorporateAction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="ACQUIRED" description="ACQUIRED CORP - Merger"
+                         conid="11111112" securityID="" securityIDType="" cusip="123456789"
+                         isin="US1234567890" underlyingConid="" underlyingSymbol=""
+                         issuer="ACQUIRED CORP" multiplier="" strike="" expiry="" putCall=""
+                         principalAdjustFactor="" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         amount="5000.00" proceeds="5000.00" value="5000" quantity="-100"
+                         fifoPnlRealized="1500.00" mtmPnl="0" code="" type="TC" />
+
+        <!-- Rights Issue -->
+        <CorporateAction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="MSFT" description="MICROSOFT CORP - Rights"
+                         conid="272093" securityID="" securityIDType="" cusip="594918104"
+                         isin="US5949181045" underlyingConid="" underlyingSymbol=""
+                         issuer="MICROSOFT CORP" multiplier="" strike="" expiry="" putCall=""
+                         principalAdjustFactor="" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         amount="0" proceeds="0" value="0" quantity="20"
+                         fifoPnlRealized="0" mtmPnl="0" code="" type="RI" />
+
+        <!-- Stock Dividend -->
+        <CorporateAction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="NVDA" description="NVIDIA CORP - Stock Dividend"
+                         conid="4815747" securityID="" securityIDType="" cusip="67066G104"
+                         isin="US67066G1040" underlyingConid="" underlyingSymbol=""
+                         issuer="NVIDIA CORP" multiplier="" strike="" expiry="" putCall=""
+                         principalAdjustFactor="" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         amount="0" proceeds="0" value="2500" quantity="10"
+                         fifoPnlRealized="0" mtmPnl="0" code="" type="SD" />
+
+        <!-- Reverse Split (1-for-10) -->
+        <CorporateAction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="SPLIT" description="SPLIT CORP - 1:10 Reverse"
+                         conid="22222223" securityID="" securityIDType="" cusip="987654321"
+                         isin="US9876543210" underlyingConid="" underlyingSymbol=""
+                         issuer="SPLIT CORP" multiplier="" strike="" expiry="" putCall=""
+                         principalAdjustFactor="0.1" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         amount="0" proceeds="0" value="0" quantity="-900"
+                         fifoPnlRealized="0" mtmPnl="0" code="" type="RS" />
+
+        <!-- Delisting -->
+        <CorporateAction accountId="U1234567" acctAlias="Test Account" model="" currency="USD"
+                         fxRateToBase="1" assetCategory="STK" symbol="DELIST" description="DELIST CORP - Delisted"
+                         conid="33333334" securityID="" securityIDType="" cusip="555555555"
+                         isin="US5555555555" underlyingConid="" underlyingSymbol=""
+                         issuer="DELIST CORP" multiplier="" strike="" expiry="" putCall=""
+                         principalAdjustFactor="" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         amount="0" proceeds="0" value="0" quantity="-50"
+                         fifoPnlRealized="-500.00" mtmPnl="0" code="" type="DW" />
+      </CorporateActions>
+
+      <!-- Securities Info for Corporate Actions -->
+      <SecuritiesInfo>
+        <SecurityInfo assetCategory="STK" symbol="AAPL" description="APPLE INC"
+                      conid="265598" securityID="" securityIDType="" cusip="037833100"
+                      isin="US0378331005" underlyingConid="" underlyingSymbol="" underlyingSecurityID=""
+                      issuer="APPLE INC" multiplier="" strike="" expiry=""
+                      putCall="" principalAdjustFactor="" maturity="" issueDate=""
+                      underlyingCategory="" subCategory="" code="" />
+
+        <SecurityInfo assetCategory="STK" symbol="TSLA" description="TESLA INC"
+                      conid="76792991" securityID="" securityIDType="" cusip="88160R101"
+                      isin="US88160R1014" underlyingConid="" underlyingSymbol="" underlyingSecurityID=""
+                      issuer="TESLA INC" multiplier="" strike="" expiry=""
+                      putCall="" principalAdjustFactor="2" maturity="" issueDate=""
+                      underlyingCategory="" subCategory="" code="" />
+
+        <SecurityInfo assetCategory="STK" symbol="GOOG" description="ALPHABET INC"
+                      conid="208813719" securityID="" securityIDType="" cusip="02079K305"
+                      isin="US02079K3059" underlyingConid="" underlyingSymbol="" underlyingSecurityID=""
+                      issuer="ALPHABET INC" multiplier="" strike="" expiry=""
+                      putCall="" principalAdjustFactor="" maturity="" issueDate=""
+                      underlyingCategory="" subCategory="" code="" />
+
+        <SecurityInfo assetCategory="STK" symbol="MSFT" description="MICROSOFT CORP"
+                      conid="272093" securityID="" securityIDType="" cusip="594918104"
+                      isin="US5949181045" underlyingConid="" underlyingSymbol="" underlyingSecurityID=""
+                      issuer="MICROSOFT CORP" multiplier="" strike="" expiry=""
+                      putCall="" principalAdjustFactor="" maturity="" issueDate=""
+                      underlyingCategory="" subCategory="" code="" />
+
+        <SecurityInfo assetCategory="STK" symbol="NVDA" description="NVIDIA CORP"
+                      conid="4815747" securityID="" securityIDType="" cusip="67066G104"
+                      isin="US67066G1040" underlyingConid="" underlyingSymbol="" underlyingSecurityID=""
+                      issuer="NVIDIA CORP" multiplier="" strike="" expiry=""
+                      putCall="" principalAdjustFactor="" maturity="" issueDate=""
+                      underlyingCategory="" subCategory="" code="" />
+      </SecuritiesInfo>
+
+      <ConversionRates>
+        <ConversionRate reportDate="2025-01-15" fromCurrency="USD" toCurrency="USD" rate="1" />
+      </ConversionRates>
+
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>

--- a/rustrade-data/tests/fixtures/ibkr_flex/activity_corporate_actions.xml
+++ b/rustrade-data/tests/fixtures/ibkr_flex/activity_corporate_actions.xml
@@ -51,7 +51,7 @@
                          conid="76792991" securityID="" securityIDType="" cusip="88160R101"
                          isin="US88160R1014" underlyingConid="" underlyingSymbol=""
                          issuer="TESLA INC" multiplier="" strike="" expiry="" putCall=""
-                         principalAdjustFactor="2" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         principalAdjustFactor="1.0023" reportDate="2025-01-15" dateTime="2025-01-15;000000"
                          amount="0" proceeds="0" value="0" quantity="100"
                          fifoPnlRealized="0" mtmPnl="0" code="" type="FS" />
 
@@ -101,7 +101,7 @@
                          conid="22222223" securityID="" securityIDType="" cusip="987654321"
                          isin="US9876543210" underlyingConid="" underlyingSymbol=""
                          issuer="SPLIT CORP" multiplier="" strike="" expiry="" putCall=""
-                         principalAdjustFactor="0.1" reportDate="2025-01-15" dateTime="2025-01-15;000000"
+                         principalAdjustFactor="0.9977" reportDate="2025-01-15" dateTime="2025-01-15;000000"
                          amount="0" proceeds="0" value="0" quantity="-900"
                          fifoPnlRealized="0" mtmPnl="0" code="" type="RS" />
 
@@ -129,7 +129,7 @@
                       conid="76792991" securityID="" securityIDType="" cusip="88160R101"
                       isin="US88160R1014" underlyingConid="" underlyingSymbol="" underlyingSecurityID=""
                       issuer="TESLA INC" multiplier="" strike="" expiry=""
-                      putCall="" principalAdjustFactor="2" maturity="" issueDate=""
+                      putCall="" principalAdjustFactor="" maturity="" issueDate=""
                       underlyingCategory="" subCategory="" code="" />
 
         <SecurityInfo assetCategory="STK" symbol="GOOG" description="ALPHABET INC"

--- a/rustrade-data/tests/ibkr_flex_corporate_actions.rs
+++ b/rustrade-data/tests/ibkr_flex_corporate_actions.rs
@@ -1,0 +1,76 @@
+//! IBKR Flex Web Service corporate-action reconciliation integration tests.
+//!
+//! These drive the live [`IbkrFlexClient`] against IBKR's Flex Web Service: SendRequest → poll →
+//! GetStatement → parse the Corporate Actions section. Unlike the Alpaca corporate-actions tests
+//! (which assert against stable, market-wide historical splits), a Flex statement returns whatever
+//! corporate actions *this account* experienced over the saved query's date range — which may be
+//! none. So these tests assert the round-trip succeeds and parses, and log the rows, rather than
+//! asserting specific symbols.
+//!
+//! # Status
+//!
+//! Marked `#[ignore]` so they never run (or fail) in CI without credentials. The always-run,
+//! hermetic coverage (XML parsing, reorg-type mapping, the 2-call flow's response classification /
+//! error paths) lives in the `ibkr::flex` unit tests (`cargo test -p rustrade-data --lib flex
+//! --features ibkr`).
+//!
+//! # Prerequisites
+//!
+//! 1. An IBKR account (paper is fine).
+//! 2. A Flex Web Service token and a saved Activity Flex query that **includes the Corporate
+//!    Actions section** (Account Management → Reports → Flex Queries).
+//! 3. Environment variables (see `.env.template`):
+//!    - `IBKR_FLEX_TOKEN`
+//!    - `IBKR_FLEX_QUERY_ID`
+//!
+//! # Running
+//!
+//! ```bash
+//! source .env
+//! cargo test --test ibkr_flex_corporate_actions --features ibkr -- --ignored
+//! ```
+
+#![cfg(feature = "ibkr")]
+// Test code: unwrap/expect panics are the correct failure mode for test assertions.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rustrade_data::exchange::ibkr::IbkrFlexClient;
+
+#[tokio::test]
+#[ignore = "requires IBKR_FLEX_TOKEN/IBKR_FLEX_QUERY_ID + network"]
+async fn fetch_corporate_actions_live() {
+    let client =
+        IbkrFlexClient::from_env().expect("IBKR_FLEX_TOKEN/IBKR_FLEX_QUERY_ID must be set");
+
+    let actions = client
+        .fetch_corporate_actions()
+        .await
+        .expect("Flex corporate-actions fetch should succeed");
+
+    eprintln!("Fetched {} corporate-action row(s)", actions.len());
+    for action in &actions {
+        eprintln!(
+            "  {:?} {:?} qty_delta={} report_date={:?}",
+            action.action_type, action.symbol, action.quantity_delta, action.report_date,
+        );
+    }
+    // No symbol assertion: the rows are whatever this account experienced (possibly none). The
+    // value here is proving the live SendRequest → poll → GetStatement → parse round-trip works.
+}
+
+#[tokio::test]
+#[ignore = "requires IBKR_FLEX_TOKEN/IBKR_FLEX_QUERY_ID + network"]
+async fn fetch_statement_xml_live_is_a_flex_query_response() {
+    let client =
+        IbkrFlexClient::from_env().expect("IBKR_FLEX_TOKEN/IBKR_FLEX_QUERY_ID must be set");
+
+    let xml = client
+        .fetch_statement_xml()
+        .await
+        .expect("Flex statement fetch should succeed");
+
+    assert!(
+        xml.contains("<FlexQueryResponse"),
+        "the polled statement should be a <FlexQueryResponse> document"
+    );
+}

--- a/rustrade-data/tests/massive_integration.rs
+++ b/rustrade-data/tests/massive_integration.rs
@@ -857,7 +857,7 @@ async fn test_corporate_actions_splits() {
     tracing::info!(%two_years_ago, "Fetching recent stock splits");
 
     let splits: Vec<_> = client
-        .fetch_splits(&query)
+        .fetch_splits_raw(&query)
         .take(10)
         .collect::<Vec<_>>()
         .await;
@@ -899,7 +899,7 @@ async fn test_corporate_actions_splits_specific_ticker() {
     tracing::info!("Fetching NVDA stock splits");
 
     let splits: Vec<_> = client
-        .fetch_splits(&query)
+        .fetch_splits_raw(&query)
         .take(5)
         .collect::<Vec<_>>()
         .await;

--- a/rustrade-data/tests/massive_integration.rs
+++ b/rustrade-data/tests/massive_integration.rs
@@ -920,6 +920,59 @@ async fn test_corporate_actions_splits_specific_ticker() {
     tracing::info!(count = splits.len(), "Fetched NVDA splits");
 }
 
+/// Drive `MassiveRestClient` through the [`StockSplitSource::fetch_splits`] **trait** method
+/// (not the inherent `fetch_splits_raw`), asserting the provider-agnostic `CorporateAction`
+/// mapping end-to-end. Mirrors the Alpaca `nvda_forward_split_2024_via_source` test so both
+/// providers' trait impls have parallel live coverage — the raw tests above exercise only
+/// `fetch_splits_raw`, leaving the `StockSplitSource` adapter untested without this.
+#[tokio::test]
+#[ignore]
+async fn test_corporate_actions_splits_via_source_trait() {
+    use chrono::NaiveDate;
+    use rustrade_instrument::corporate_action::CorporateActionKind;
+    use rustrade_integration::corporate_action::{CorporateActionFilter, StockSplitSource};
+    use smol_str::SmolStr;
+
+    init_logging();
+
+    let client = MassiveRestClient::from_env().expect("Failed to create client");
+
+    // NVIDIA's 10-for-1 forward split executed on 2024-06-10 (a real, stable historical split).
+    let filter = CorporateActionFilter {
+        symbols: vec![SmolStr::new("NVDA")],
+        start: NaiveDate::from_ymd_opt(2024, 1, 1),
+        end: NaiveDate::from_ymd_opt(2024, 12, 31),
+    };
+
+    let actions: Vec<_> = client.fetch_splits(&filter).collect::<Vec<_>>().await;
+
+    // Distinguish "API returned nothing" (bad credentials / wrong date window) from "returned
+    // splits but the target date is missing" — the `find` below conflates both into one panic.
+    assert!(
+        !actions.is_empty(),
+        "fetch_splits returned no actions for NVDA in 2024 — check credentials and date range"
+    );
+
+    let nvda = actions
+        .iter()
+        .map(|result| result.as_ref().expect("fetch_splits yielded an error"))
+        .find(|action| action.effective_date == NaiveDate::from_ymd_opt(2024, 6, 10))
+        .expect("NVDA 2024-06-10 split should be present in the result set");
+
+    assert_eq!(nvda.instrument, "NVDA");
+    assert_eq!(
+        nvda.kind,
+        CorporateActionKind::StockSplit {
+            ratio: Decimal::from(10)
+        }
+    );
+
+    tracing::info!(
+        count = actions.len(),
+        "Fetched NVDA splits via StockSplitSource trait"
+    );
+}
+
 // ============================================================================
 // Options Reference Data Tests
 // ============================================================================

--- a/rustrade-data/tests/massive_integration.rs
+++ b/rustrade-data/tests/massive_integration.rs
@@ -938,11 +938,11 @@ async fn test_corporate_actions_splits_via_source_trait() {
     let client = MassiveRestClient::from_env().expect("Failed to create client");
 
     // NVIDIA's 10-for-1 forward split executed on 2024-06-10 (a real, stable historical split).
-    let filter = CorporateActionFilter {
-        symbols: vec![SmolStr::new("NVDA")],
-        start: NaiveDate::from_ymd_opt(2024, 1, 1),
-        end: NaiveDate::from_ymd_opt(2024, 12, 31),
-    };
+    let filter = CorporateActionFilter::new(
+        vec![SmolStr::new("NVDA")],
+        NaiveDate::from_ymd_opt(2024, 1, 1),
+        NaiveDate::from_ymd_opt(2024, 12, 31),
+    );
 
     let actions: Vec<_> = client.fetch_splits(&filter).collect::<Vec<_>>().await;
 

--- a/rustrade-data/tests/massive_integration.rs
+++ b/rustrade-data/tests/massive_integration.rs
@@ -929,7 +929,7 @@ async fn test_corporate_actions_splits_specific_ticker() {
 #[ignore]
 async fn test_corporate_actions_splits_via_source_trait() {
     use chrono::NaiveDate;
-    use rustrade_instrument::corporate_action::CorporateActionKind;
+    use rustrade_instrument::corporate_action::{CorporateActionKind, SplitRatio};
     use rustrade_integration::corporate_action::{CorporateActionFilter, StockSplitSource};
     use smol_str::SmolStr;
 
@@ -963,7 +963,7 @@ async fn test_corporate_actions_splits_via_source_trait() {
     assert_eq!(
         nvda.kind,
         CorporateActionKind::StockSplit {
-            ratio: Decimal::from(10)
+            ratio: SplitRatio::new(Decimal::from(10)).unwrap()
         }
     );
 

--- a/rustrade-execution/src/lib.rs
+++ b/rustrade-execution/src/lib.rs
@@ -56,6 +56,14 @@ use rustrade_instrument::{
 };
 use rustrade_integration::collection::snapshot::Snapshot;
 use serde::{Deserialize, Serialize};
+// Only `emit_stream_terminated` (and its tests) name `mpsc`, both gated to the venue features —
+// gate the import the same way so the default-empty feature set does not warn it as unused.
+#[cfg(any(
+    feature = "alpaca",
+    feature = "binance",
+    feature = "ibkr",
+    feature = "hyperliquid"
+))]
 use tokio::sync::mpsc;
 
 pub mod balance;
@@ -121,11 +129,24 @@ impl<ExchangeKey, AssetKey, InstrumentKey> AccountEvent<ExchangeKey, AssetKey, I
 /// before a venue's stream task exits so stream death is delivered in-band rather than inferred from
 /// channel EOF.
 ///
-/// Shared by every venue connector (Binance spot/margin, Alpaca, IBKR, Hyperliquid, Mock) so the
-/// single construction/send of the terminal event lives in one place, at the abstraction level where
-/// [`AccountEvent`] is defined rather than inside any one vendor module. The send is best-effort: if
-/// the consumer already dropped the receiver it is a silent no-op — which is the
-/// consumer-initiated-drop case, deliberately *not* signalled (there is no one left to deliver to).
+/// Shared by the channel-based venue connectors (Binance spot/margin, Alpaca, IBKR, Hyperliquid)
+/// so the single send of the terminal event lives in one place, at the abstraction level where
+/// [`AccountEvent`] is defined rather than inside any one vendor module. (The Mock client yields
+/// into a `Stream` rather than an mpsc channel, so it builds the terminal event via
+/// `UnindexedAccountEvent::stream_terminated` directly and does not funnel through this helper.)
+/// The send is best-effort: if the consumer already dropped the receiver it is a silent no-op —
+/// which is the consumer-initiated-drop case, deliberately *not* signalled (there is no one left
+/// to deliver to).
+//
+// Gated to the venues that send terminal events through an mpsc channel from a spawned stream task,
+// so the crate's default-empty feature set does not warn this as unused (mirrors `parse_env_bool`
+// below). The Mock client is always compiled but is excluded by design — see the note above.
+#[cfg(any(
+    feature = "alpaca",
+    feature = "binance",
+    feature = "ibkr",
+    feature = "hyperliquid"
+))]
 pub(crate) fn emit_stream_terminated(
     tx: &mpsc::UnboundedSender<UnindexedAccountEvent>,
     exchange: ExchangeId,
@@ -377,7 +398,17 @@ impl<ExchangeKey, AssetKey, InstrumentKey> AccountSnapshot<ExchangeKey, AssetKey
     }
 }
 
-#[cfg(test)]
+// Both tests exercise the feature-gated `emit_stream_terminated`, so this module compiles under the
+// same venue features — no feature → no function → no test for it.
+#[cfg(all(
+    test,
+    any(
+        feature = "alpaca",
+        feature = "binance",
+        feature = "ibkr",
+        feature = "hyperliquid"
+    )
+))]
 #[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;

--- a/rustrade-execution/src/lib.rs
+++ b/rustrade-execution/src/lib.rs
@@ -15,6 +15,10 @@
     missing_debug_implementations,
     rust_2018_idioms
 )]
+// Inherited from the barter-rs upstream: the generic, trait-heavy public API legitimately produces
+// complex nested types and many-argument constructors, and `type_alias_bounds` fires on
+// documentation-bearing alias bounds kept intentionally. Denying these adds churn without improving
+// the API.
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
 //! # Barter-Execution

--- a/rustrade-instrument/src/corporate_action.rs
+++ b/rustrade-instrument/src/corporate_action.rs
@@ -3,6 +3,106 @@ use derive_more::Constructor;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
+/// A validated stock-split ratio: strictly positive (`> 0`).
+///
+/// `SplitRatio` makes a degenerate ratio **unconstructible**. Every value is `> 0`, so the engine's
+/// split arithmetic (`Position::apply_split` in the `rustrade` crate and the
+/// `EngineEvent::CorporateAction` handler) can never receive a zero or negative ratio *through the
+/// type system* — the failure mode is moved from a runtime panic to a compile-time guarantee.
+///
+/// Construct with [`SplitRatio::new`] (returns `Option`), [`SplitRatio::try_from`] (returns a typed
+/// [`InvalidSplitRatio`] error, for `?`-propagation), or via [`CorporateActionKind::stock_split`]
+/// which builds one from a provider's `split_to` / `split_from` pair. Read the inner value with
+/// [`SplitRatio::get`].
+///
+/// # Serde
+/// Serializes **transparently** as its inner [`Decimal`] (the wire format is a JSON string — the
+/// same format a raw [`Decimal`] field produces — so persisted [`CorporateAction`] / `EngineEvent`
+/// payloads are unchanged). Deserialization is
+/// **validated**: a non-positive ratio on the wire is a hard deserialization error, so a
+/// persisted/replayed event can never reintroduce a degenerate ratio.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct SplitRatio(Decimal);
+
+impl SplitRatio {
+    /// Construct a `SplitRatio`, returning `Some` iff `ratio` is strictly positive (`> 0`).
+    ///
+    /// Returns `None` for zero or negative input — the same degeneracy
+    /// [`CorporateActionKind::stock_split`] rejects, enforced here at the type boundary.
+    #[must_use]
+    pub fn new(ratio: Decimal) -> Option<Self> {
+        (ratio > Decimal::ZERO).then_some(Self(ratio))
+    }
+
+    /// The inner ratio value, always `> 0`.
+    #[must_use]
+    pub const fn get(self) -> Decimal {
+        self.0
+    }
+}
+
+impl From<SplitRatio> for Decimal {
+    /// Infallible downcast: every [`SplitRatio`] is a valid [`Decimal`]. The inverse of the
+    /// validated [`TryFrom<Decimal>`] upcast — prefer `.into()` / `Decimal::from(ratio)` over
+    /// [`SplitRatio::get`] in generic (`impl Into<Decimal>`) contexts.
+    fn from(ratio: SplitRatio) -> Self {
+        ratio.0
+    }
+}
+
+impl std::fmt::Display for SplitRatio {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Error from constructing a [`SplitRatio`] from a non-positive [`Decimal`].
+///
+/// Carries the rejected value so callers (and serde's deserializer) can report it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidSplitRatio(Decimal);
+
+impl InvalidSplitRatio {
+    /// The rejected (non-positive) [`Decimal`] that failed the `> 0` invariant.
+    #[must_use]
+    pub const fn rejected(self) -> Decimal {
+        self.0
+    }
+}
+
+impl std::fmt::Display for InvalidSplitRatio {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "split ratio must be strictly positive, got {}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidSplitRatio {}
+
+impl TryFrom<Decimal> for SplitRatio {
+    type Error = InvalidSplitRatio;
+
+    /// Fallible construction for `?`-propagation. Mirrors [`SplitRatio::new`]'s `> 0` rule but
+    /// returns the rejected value in [`InvalidSplitRatio`] instead of discarding it (`None`).
+    fn try_from(ratio: Decimal) -> Result<Self, Self::Error> {
+        SplitRatio::new(ratio).ok_or(InvalidSplitRatio(ratio))
+    }
+}
+
+// Validated deserialization: read the inner `Decimal`, then enforce the `> 0` invariant via
+// `TryFrom` (the single source of validation logic). A hand-written impl is still required because
+// `#[serde(transparent)]` `Serialize` and `#[serde(try_from)]` `Deserialize` cannot coexist on one
+// derive — this keeps the transparent wire format while reusing `TryFrom`'s check.
+impl<'de> Deserialize<'de> for SplitRatio {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let ratio = <Decimal as Deserialize>::deserialize(deserializer)?;
+        SplitRatio::try_from(ratio).map_err(serde::de::Error::custom)
+    }
+}
+
 /// A corporate-action market fact — *what* happened to an instrument, independent of any
 /// account, broker, or rounding policy.
 ///
@@ -30,8 +130,9 @@ pub enum CorporateActionKind {
     /// - **Reverse** split → `ratio < 1` (e.g. a 1-for-10 reverse split is `0.1`; share count
     ///   scales down, per-share price scales up).
     StockSplit {
-        /// `split_to / split_from`. See the variant docs for the forward/reverse convention.
-        ratio: Decimal,
+        /// `split_to / split_from`, as a validated [`SplitRatio`] (always `> 0`). See the variant
+        /// docs for the forward/reverse convention.
+        ratio: SplitRatio,
     },
 }
 
@@ -44,9 +145,12 @@ impl CorporateActionKind {
     /// shares *before* (`split_from`): a 2-for-1 forward split is `split_to = 2, split_from = 1`
     /// (`ratio = 2`); a 1-for-10 reverse split is `split_to = 1, split_from = 10` (`ratio = 0.1`).
     ///
-    /// Returns `None` for **degenerate** inputs — a `split_from` of zero (division by zero) or any
-    /// non-positive `ratio` (including a `split_to` of zero) — rather than panicking or fabricating
-    /// a nonsensical action. Callers should treat `None` as bad source data and log + skip it, per
+    /// Returns `None` for **degenerate** inputs rather than panicking or fabricating a nonsensical
+    /// action. Both share counts must be strictly positive: a non-positive `split_to` or
+    /// `split_from` (zero or negative) is rejected up front. This also closes the both-negative
+    /// normalization hole, where two negative components would divide to a positive quotient (e.g.
+    /// `-2 / -1 = 2`) and otherwise slip through. The resulting quotient is then re-validated as a
+    /// [`SplitRatio`] (`> 0`). Callers should treat `None` as bad source data and log + skip it, per
     /// the library's "observable failures over silent ones" principle.
     ///
     /// Note: `ratio` is computed at `rust_decimal`'s 28-significant-digit precision, so an inexact
@@ -54,9 +158,13 @@ impl CorporateActionKind {
     /// consumes it.
     #[must_use]
     pub fn stock_split(split_to: Decimal, split_from: Decimal) -> Option<Self> {
+        let positive = |d: Decimal| d > Decimal::ZERO;
+        if !positive(split_to) || !positive(split_from) {
+            return None;
+        }
         split_to
             .checked_div(split_from)
-            .filter(|ratio| ratio.is_sign_positive() && !ratio.is_zero())
+            .and_then(SplitRatio::new)
             .map(|ratio| Self::StockSplit { ratio })
     }
 
@@ -82,7 +190,8 @@ impl CorporateActionKind {
         // `Option` return already expresses "not a split ⇒ no split kind".
         match self {
             Self::StockSplit { ratio } => {
-                Some(if *ratio > Decimal::ONE && ratio.fract().is_zero() {
+                let ratio = ratio.get();
+                Some(if ratio > Decimal::ONE && ratio.fract().is_zero() {
                     SplitAdjustmentKind::Standard
                 } else {
                     SplitAdjustmentKind::NonStandard
@@ -186,28 +295,30 @@ mod tests {
         assert_eq!(instant.to_rfc3339(), "2026-06-22T00:00:00+00:00");
     }
 
+    /// Build a `StockSplit` from a raw ratio for assertions (panics on a non-positive ratio, which
+    /// is fine in test code).
+    fn split_kind_with(ratio: Decimal) -> CorporateActionKind {
+        CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(ratio).unwrap(),
+        }
+    }
+
     #[test]
     fn stock_split_computes_ratio_from_components() {
         // Forward 2-for-1.
         assert_eq!(
             CorporateActionKind::stock_split(Decimal::from(2), Decimal::from(1)),
-            Some(CorporateActionKind::StockSplit {
-                ratio: Decimal::from(2)
-            })
+            Some(split_kind_with(Decimal::from(2)))
         );
         // Reverse 1-for-10 → 0.1.
         assert_eq!(
             CorporateActionKind::stock_split(Decimal::from(1), Decimal::from(10)),
-            Some(CorporateActionKind::StockSplit {
-                ratio: Decimal::new(1, 1)
-            })
+            Some(split_kind_with(Decimal::new(1, 1)))
         );
         // Inexact 3-for-2 → 1.5.
         assert_eq!(
             CorporateActionKind::stock_split(Decimal::from(3), Decimal::from(2)),
-            Some(CorporateActionKind::StockSplit {
-                ratio: Decimal::new(15, 1)
-            })
+            Some(split_kind_with(Decimal::new(15, 1)))
         );
     }
 
@@ -223,17 +334,81 @@ mod tests {
             CorporateActionKind::stock_split(Decimal::ZERO, Decimal::from(5)),
             None
         );
-        // Non-positive ratio (negative component).
+        // Single negative component.
         assert_eq!(
             CorporateActionKind::stock_split(Decimal::from(-2), Decimal::from(1)),
+            None
+        );
+        // Both-negative components: -2 / -1 = 2 is positive and would slip past a quotient-only
+        // check, but the component guard rejects it (no real provider reports negative share counts).
+        assert_eq!(
+            CorporateActionKind::stock_split(Decimal::from(-2), Decimal::from(-1)),
             None
         );
     }
 
     #[test]
+    fn split_ratio_rejects_non_positive() {
+        assert!(SplitRatio::new(Decimal::from(2)).is_some());
+        assert!(SplitRatio::new(Decimal::new(1, 1)).is_some()); // 0.1
+        assert!(SplitRatio::new(Decimal::ZERO).is_none());
+        assert!(SplitRatio::new(Decimal::from(-1)).is_none());
+        assert_eq!(
+            SplitRatio::new(Decimal::from(2)).unwrap().get(),
+            Decimal::from(2)
+        );
+        // `From<SplitRatio> for Decimal` is the infallible inverse of `get()`.
+        assert_eq!(
+            Decimal::from(SplitRatio::new(Decimal::from(2)).unwrap()),
+            Decimal::from(2)
+        );
+    }
+
+    #[test]
+    fn split_ratio_try_from_matches_new_and_carries_rejected_value() {
+        // Same `> 0` rule as `new`, but `?`-friendly and the error carries the rejected value.
+        assert_eq!(
+            SplitRatio::try_from(Decimal::from(2)).unwrap().get(),
+            Decimal::from(2)
+        );
+        assert_eq!(
+            SplitRatio::try_from(Decimal::from(-3)),
+            Err(InvalidSplitRatio(Decimal::from(-3)))
+        );
+        assert_eq!(
+            SplitRatio::try_from(Decimal::ZERO),
+            Err(InvalidSplitRatio(Decimal::ZERO))
+        );
+    }
+
+    #[test]
+    fn split_ratio_serde_roundtrips_and_validates() {
+        // Serializes transparently as a JSON string — the same wire format a raw `Decimal`
+        // produces (wire format unchanged).
+        let ratio = SplitRatio::new(Decimal::from(2)).unwrap();
+        let json = serde_json::to_string(&ratio).unwrap();
+        assert_eq!(json, "\"2\"");
+        assert_eq!(serde_json::from_str::<SplitRatio>(&json).unwrap(), ratio);
+
+        // A fractional positive ratio (e.g. a 1-for-2 reverse split = 0.5) round-trips through the
+        // validating `Deserialize` impl — the `> 0` re-check accepts sub-integer ratios.
+        let frac = SplitRatio::new(Decimal::new(5, 1)).unwrap(); // 0.5
+        let frac_json = serde_json::to_string(&frac).unwrap();
+        assert_eq!(
+            serde_json::from_str::<SplitRatio>(&frac_json).unwrap(),
+            frac
+        );
+
+        // A non-positive ratio on the wire is rejected at deserialization — a persisted/replayed
+        // event can never reintroduce a degenerate ratio.
+        assert!(serde_json::from_str::<SplitRatio>("\"0\"").is_err());
+        assert!(serde_json::from_str::<SplitRatio>("\"-1\"").is_err());
+    }
+
+    #[test]
     fn split_kind_classifies_per_occ_rules() {
         use SplitAdjustmentKind::{NonStandard, Standard};
-        let split = |ratio| CorporateActionKind::StockSplit { ratio };
+        let split = split_kind_with;
 
         // Standard: whole-number forward splits.
         assert_eq!(split(Decimal::from(2)).split_kind(), Some(Standard)); // 2-for-1
@@ -260,9 +435,7 @@ mod tests {
 
     #[test]
     fn corporate_action_descriptor_is_generic_over_the_key() {
-        let kind = CorporateActionKind::StockSplit {
-            ratio: Decimal::from(4),
-        };
+        let kind = split_kind_with(Decimal::from(4));
         let date = NaiveDate::from_ymd_opt(2020, 8, 31);
 
         // Source boundary: keyed by an unresolved provider symbol.

--- a/rustrade-instrument/src/corporate_action.rs
+++ b/rustrade-instrument/src/corporate_action.rs
@@ -1,0 +1,74 @@
+use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// A corporate-action market fact — *what* happened to an instrument, independent of any
+/// account, broker, or rounding policy.
+///
+/// This type carries **market facts only**. It deliberately contains no rounding policy, no
+/// account context, and no resolved timestamp: a data source emitting a split knows the ratio,
+/// not how a particular broker will round fractional shares or when a particular engine should
+/// stamp the adjustment. Those concerns live with the consumer (see the engine-side
+/// `SplitRoundingPolicy` and the `effective_time` resolved via [`split_effective_instant`]).
+///
+/// `#[non_exhaustive]`: further corporate actions (dividends, spin-offs, symbol changes, …) can
+/// be added without breaking downstream exhaustive matches.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[non_exhaustive]
+pub enum CorporateActionKind {
+    /// A forward or reverse stock split, expressed as a single multiplicative `ratio`.
+    ///
+    /// `ratio = split_to / split_from`:
+    /// - **Forward** split → `ratio > 1` (e.g. a 2-for-1 split is `2.0`; share count scales up,
+    ///   per-share price scales down).
+    /// - **Reverse** split → `ratio < 1` (e.g. a 1-for-10 reverse split is `0.1`; share count
+    ///   scales down, per-share price scales up).
+    StockSplit {
+        /// `split_to / split_from`. See the variant docs for the forward/reverse convention.
+        ratio: Decimal,
+    },
+}
+
+/// Resolve a **stock split**'s *effective date* (a calendar `NaiveDate` market fact) to the exact
+/// `DateTime<Utc>` instant at which the adjustment takes effect: **midnight (00:00) UTC** on that
+/// date.
+///
+/// # Why midnight UTC
+///
+/// This is a convenience default tuned for **US equities**, where corporate actions take effect
+/// at the start of the effective session. Midnight UTC falls in the overnight gap after the prior
+/// session's close and before the effective session's open, so when the resulting instant is used
+/// as a merge-sort key against intraday market events, the adjustment lands exactly where a broker
+/// applies it — after the previous day's trading, before the effective day's first print. This
+/// avoids look-ahead (the split is not applied to prior-session events) without skipping into the
+/// effective session's data.
+///
+/// # When to override
+///
+/// Exchanges whose sessions are not naturally bracketed by midnight UTC (non-UTC venues) may need
+/// a different resolution. Callers owning that context should construct the `DateTime<Utc>`
+/// themselves rather than relying on this default.
+///
+/// This instant doubles as the **sort key** when interleaving a corporate-action event into a
+/// time-ordered backtest replay stream.
+pub fn split_effective_instant(date: NaiveDate) -> DateTime<Utc> {
+    date.and_time(NaiveTime::MIN).and_utc()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use chrono::Datelike;
+
+    #[test]
+    fn split_effective_instant_is_midnight_utc_on_the_date() {
+        let date = NaiveDate::from_ymd_opt(2026, 6, 22).unwrap();
+        let instant = split_effective_instant(date);
+
+        assert_eq!(instant.date_naive(), date);
+        assert_eq!(instant.time(), NaiveTime::MIN);
+        assert_eq!(instant.naive_utc().year(), 2026);
+        assert_eq!(instant.to_rfc3339(), "2026-06-22T00:00:00+00:00");
+    }
+}

--- a/rustrade-instrument/src/corporate_action.rs
+++ b/rustrade-instrument/src/corporate_action.rs
@@ -267,6 +267,16 @@ pub fn split_effective_instant(date: NaiveDate) -> DateTime<Utc> {
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Constructor, Deserialize, Serialize,
 )]
+// Public descriptor likely to grow (e.g. an action `id` or `declaration_date`). `#[non_exhaustive]`
+// blocks downstream struct-literal construction and forces `..` in their destructuring patterns, so
+// adding a field stays non-breaking for consumers that only read or match. There is no `Default`, so
+// the derived `CorporateAction::new` is the only constructor; its arity grows with each field, making
+// a new field a breaking change for direct `::new` callers (call it out in the changelog when added).
+// `#[non_exhaustive]` shields only *Rust-code* matching/construction: this struct also derives
+// `Deserialize`, so a new field without `#[serde(default)]` is still a breaking change at the data
+// layer — it fails to deserialize payloads written before the field existed. Give new fields
+// `#[serde(default)]` (or accept the serde break deliberately).
+#[non_exhaustive]
 pub struct CorporateAction<K> {
     /// The instrument the action applies to — a provider symbol at the source boundary, an engine
     /// instrument key after the wrapper's resolution.

--- a/rustrade-instrument/src/corporate_action.rs
+++ b/rustrade-instrument/src/corporate_action.rs
@@ -76,6 +76,10 @@ impl CorporateActionKind {
     /// asserts it, so this is only ever reached with a positive `ratio`.
     #[must_use]
     pub fn split_kind(&self) -> Option<SplitAdjustmentKind> {
+        // No `_` catch-all: `CorporateActionKind` is `#[non_exhaustive]`, so adding a future
+        // non-split variant (dividend, spin-off, …) makes this match fail to compile, forcing an
+        // explicit `None` mapping here rather than silently classifying it as `NonStandard`. The
+        // `Option` return already expresses "not a split ⇒ no split kind".
         match self {
             Self::StockSplit { ratio } => {
                 Some(if *ratio > Decimal::ONE && ratio.fract().is_zero() {
@@ -84,10 +88,6 @@ impl CorporateActionKind {
                     SplitAdjustmentKind::NonStandard
                 })
             }
-            // No `_` catch-all: `CorporateActionKind` is `#[non_exhaustive]`, so adding a future
-            // non-split variant (dividend, spin-off, …) makes this match fail to compile, forcing an
-            // explicit `None` mapping here rather than silently classifying it as `NonStandard`. The
-            // `Option` return already expresses "not a split ⇒ no split kind".
         }
     }
 }

--- a/rustrade-instrument/src/corporate_action.rs
+++ b/rustrade-instrument/src/corporate_action.rs
@@ -59,6 +59,61 @@ impl CorporateActionKind {
             .filter(|ratio| ratio.is_sign_positive() && !ratio.is_zero())
             .map(|ratio| Self::StockSplit { ratio })
     }
+
+    /// Classify how this action affects listed **options** on the underlying, per the OCC
+    /// option-adjustment rules (OCC By-Laws Article VI, §11):
+    /// - `Some(`[`Standard`](SplitAdjustmentKind::Standard)`)` — a whole-number forward split, which
+    ///   the engine adjusts in place;
+    /// - `Some(`[`NonStandard`](SplitAdjustmentKind::NonStandard)`)` — every reverse split, every
+    ///   *fractional* forward split, and the `ratio == 1` no-op, none of which the engine can adjust
+    ///   in place;
+    /// - `None` — this action is **not a split** and so has no split classification (a future
+    ///   dividend, spin-off, …).
+    ///
+    /// A `StockSplit`'s `ratio` is **standard** iff it is a whole number strictly greater than one
+    /// (`ratio > 1 && ratio.fract() == 0`). A non-positive `ratio` cannot occur:
+    /// [`CorporateActionKind::stock_split`] rejects it at construction and `Position::apply_split`
+    /// asserts it, so this is only ever reached with a positive `ratio`.
+    #[must_use]
+    pub fn split_kind(&self) -> Option<SplitAdjustmentKind> {
+        match self {
+            Self::StockSplit { ratio } => {
+                Some(if *ratio > Decimal::ONE && ratio.fract().is_zero() {
+                    SplitAdjustmentKind::Standard
+                } else {
+                    SplitAdjustmentKind::NonStandard
+                })
+            }
+            // No `_` catch-all: `CorporateActionKind` is `#[non_exhaustive]`, so adding a future
+            // non-split variant (dividend, spin-off, …) makes this match fail to compile, forcing an
+            // explicit `None` mapping here rather than silently classifying it as `NonStandard`. The
+            // `Option` return already expresses "not a split ⇒ no split kind".
+        }
+    }
+}
+
+/// How the OCC adjusts listed **options** on an underlying that undergoes a stock split (OCC
+/// By-Laws Article VI, §11) — the classification returned by [`CorporateActionKind::split_kind`].
+///
+/// The two cases demand opposite handling, so the engine branches on them when a split targets an
+/// underlying that has open option positions. A downstream wrapper that PULL-sources corporate
+/// actions can use the same classification to decide how to react *before* injecting the event.
+///
+/// `#[non_exhaustive]`: were the OCC rule ever to gain a further category, it can be added without
+/// breaking downstream exhaustive matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[non_exhaustive]
+pub enum SplitAdjustmentKind {
+    /// A *whole-number forward* split (2-for-1, 3-for-1, …). The option survives with the **same**
+    /// contract identity: strike is divided by `ratio`, contract count is multiplied by `ratio`,
+    /// and the deliverable/multiplier stays 100. A purely mechanical adjustment that keeps the
+    /// existing position valid, so the engine applies it in place.
+    Standard,
+    /// Every *reverse* split (always `ratio < 1`), every *fractional* forward split (e.g. 3-for-2 →
+    /// `1.5`), and the `ratio == 1` no-op. The OCC changes the deliverable and assigns a **new**
+    /// option symbol (e.g. `MSFT` → `MSFT1`), destroying the instrument identity. No mechanical
+    /// in-place adjustment keeps the position valid, so the response is a downstream policy decision.
+    NonStandard,
 }
 
 /// Resolve a **stock split**'s *effective date* (a calendar `NaiveDate` market fact) to the exact
@@ -173,6 +228,34 @@ mod tests {
             CorporateActionKind::stock_split(Decimal::from(-2), Decimal::from(1)),
             None
         );
+    }
+
+    #[test]
+    fn split_kind_classifies_per_occ_rules() {
+        use SplitAdjustmentKind::{NonStandard, Standard};
+        let split = |ratio| CorporateActionKind::StockSplit { ratio };
+
+        // Standard: whole-number forward splits.
+        assert_eq!(split(Decimal::from(2)).split_kind(), Some(Standard)); // 2-for-1
+        assert_eq!(split(Decimal::from(3)).split_kind(), Some(Standard)); // 3-for-1
+        assert_eq!(split(Decimal::from(10)).split_kind(), Some(Standard)); // 10-for-1
+
+        // Standard regardless of internal scale: a whole number carried at non-zero scale (2.0,
+        // 3.00) is still standard. Guards the `fract().is_zero()` classifier against a future
+        // `scale() == 0` regression that would misread these as non-standard.
+        assert_eq!(split(Decimal::new(20, 1)).split_kind(), Some(Standard)); // 2.0
+        assert_eq!(split(Decimal::new(300, 2)).split_kind(), Some(Standard)); // 3.00
+
+        // Non-standard: fractional forward splits.
+        assert_eq!(split(Decimal::new(15, 1)).split_kind(), Some(NonStandard)); // 3-for-2 = 1.5
+        assert_eq!(split(Decimal::new(43, 10)).split_kind(), Some(NonStandard)); // odd fractional
+
+        // Non-standard: every reverse split (ratio < 1).
+        assert_eq!(split(Decimal::new(5, 1)).split_kind(), Some(NonStandard)); // 1-for-2 = 0.5
+        assert_eq!(split(Decimal::new(1, 1)).split_kind(), Some(NonStandard)); // 1-for-10 = 0.1
+
+        // Boundary: a 1-for-1 no-op is not a standard adjustment to apply.
+        assert_eq!(split(Decimal::ONE).split_kind(), Some(NonStandard));
     }
 
     #[test]

--- a/rustrade-instrument/src/corporate_action.rs
+++ b/rustrade-instrument/src/corporate_action.rs
@@ -13,7 +13,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// `#[non_exhaustive]`: further corporate actions (dividends, spin-offs, symbol changes, …) can
 /// be added without breaking downstream exhaustive matches.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+// `Ord`/`PartialOrd`/`Hash` are derived (over and above `Eq`) so this type can be embedded in
+// engine outputs such as `EngineOutput::UnsupportedCorporateAction`, which derive those traits.
+// `rust_decimal::Decimal` implements all three, so the derives are sound for `StockSplit`.
+// MAINTAINER NOTE: every future variant must use field types whose `Ord`/`Hash` stay consistent
+// with `Eq` (e.g. no `f32`/`f64`, which lack `Ord`); otherwise these derives must be dropped.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 #[non_exhaustive]
 pub enum CorporateActionKind {
     /// A forward or reverse stock split, expressed as a single multiplicative `ratio`.

--- a/rustrade-instrument/src/corporate_action.rs
+++ b/rustrade-instrument/src/corporate_action.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
+use derive_more::Constructor;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
@@ -34,6 +35,32 @@ pub enum CorporateActionKind {
     },
 }
 
+impl CorporateActionKind {
+    /// Construct a [`StockSplit`](CorporateActionKind::StockSplit) from a provider's raw
+    /// `split_to` / `split_from` pair, computing `ratio = split_to / split_from` **once, in one
+    /// place**, so every data source derives the ratio identically (no per-provider arithmetic).
+    ///
+    /// Providers report a split as two share counts — shares *after* the split (`split_to`) over
+    /// shares *before* (`split_from`): a 2-for-1 forward split is `split_to = 2, split_from = 1`
+    /// (`ratio = 2`); a 1-for-10 reverse split is `split_to = 1, split_from = 10` (`ratio = 0.1`).
+    ///
+    /// Returns `None` for **degenerate** inputs — a `split_from` of zero (division by zero) or any
+    /// non-positive `ratio` (including a `split_to` of zero) — rather than panicking or fabricating
+    /// a nonsensical action. Callers should treat `None` as bad source data and log + skip it, per
+    /// the library's "observable failures over silent ones" principle.
+    ///
+    /// Note: `ratio` is computed at `rust_decimal`'s 28-significant-digit precision, so an inexact
+    /// quotient (e.g. 1-for-3) is rounded there — identical to how the engine's `apply_split`
+    /// consumes it.
+    #[must_use]
+    pub fn stock_split(split_to: Decimal, split_from: Decimal) -> Option<Self> {
+        split_to
+            .checked_div(split_from)
+            .filter(|ratio| ratio.is_sign_positive() && !ratio.is_zero())
+            .map(|ratio| Self::StockSplit { ratio })
+    }
+}
+
 /// Resolve a **stock split**'s *effective date* (a calendar `NaiveDate` market fact) to the exact
 /// `DateTime<Utc>` instant at which the adjustment takes effect: **midnight (00:00) UTC** on that
 /// date.
@@ -60,6 +87,33 @@ pub fn split_effective_instant(date: NaiveDate) -> DateTime<Utc> {
     date.and_time(NaiveTime::MIN).and_utc()
 }
 
+/// A corporate-action market fact **bound to a specific instrument**, as yielded by a PULL
+/// reference-data source (see `StockSplitSource` in `rustrade-integration`).
+///
+/// Generic over the instrument key `K` so the *same* descriptor serves both ends of the sourcing
+/// pipeline: a **source** yields `CorporateAction<Symbol>` carrying an unresolved provider ticker
+/// (e.g. `CorporateAction<SmolStr>`), and a **wrapper** resolves that symbol to the engine's
+/// instrument key, producing `CorporateAction<InstrumentKey>` before constructing the engine event.
+///
+/// This is a *fact*, not an engine event: it carries **no rounding policy** (the source does not
+/// know the account/broker) and **no resolved `effective_time` instant**. `effective_date` is the
+/// calendar date the action takes effect (the market fact; `None` if the source omits it);
+/// resolving it to the `DateTime<Utc>` the engine stamps is the caller's job via
+/// [`split_effective_instant`].
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Constructor, Deserialize, Serialize,
+)]
+pub struct CorporateAction<K> {
+    /// The instrument the action applies to — a provider symbol at the source boundary, an engine
+    /// instrument key after the wrapper's resolution.
+    pub instrument: K,
+    /// The corporate-action market fact (e.g. a stock-split ratio).
+    pub kind: CorporateActionKind,
+    /// The calendar date the action takes effect, if the source supplies one. Resolve it to the
+    /// engine's stamping instant with [`split_effective_instant`].
+    pub effective_date: Option<NaiveDate>,
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
@@ -75,5 +129,67 @@ mod tests {
         assert_eq!(instant.time(), NaiveTime::MIN);
         assert_eq!(instant.naive_utc().year(), 2026);
         assert_eq!(instant.to_rfc3339(), "2026-06-22T00:00:00+00:00");
+    }
+
+    #[test]
+    fn stock_split_computes_ratio_from_components() {
+        // Forward 2-for-1.
+        assert_eq!(
+            CorporateActionKind::stock_split(Decimal::from(2), Decimal::from(1)),
+            Some(CorporateActionKind::StockSplit {
+                ratio: Decimal::from(2)
+            })
+        );
+        // Reverse 1-for-10 → 0.1.
+        assert_eq!(
+            CorporateActionKind::stock_split(Decimal::from(1), Decimal::from(10)),
+            Some(CorporateActionKind::StockSplit {
+                ratio: Decimal::new(1, 1)
+            })
+        );
+        // Inexact 3-for-2 → 1.5.
+        assert_eq!(
+            CorporateActionKind::stock_split(Decimal::from(3), Decimal::from(2)),
+            Some(CorporateActionKind::StockSplit {
+                ratio: Decimal::new(15, 1)
+            })
+        );
+    }
+
+    #[test]
+    fn stock_split_rejects_degenerate_components() {
+        // Division by zero (split_from == 0).
+        assert_eq!(
+            CorporateActionKind::stock_split(Decimal::from(1), Decimal::ZERO),
+            None
+        );
+        // Zero ratio (split_to == 0).
+        assert_eq!(
+            CorporateActionKind::stock_split(Decimal::ZERO, Decimal::from(5)),
+            None
+        );
+        // Non-positive ratio (negative component).
+        assert_eq!(
+            CorporateActionKind::stock_split(Decimal::from(-2), Decimal::from(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn corporate_action_descriptor_is_generic_over_the_key() {
+        let kind = CorporateActionKind::StockSplit {
+            ratio: Decimal::from(4),
+        };
+        let date = NaiveDate::from_ymd_opt(2020, 8, 31);
+
+        // Source boundary: keyed by an unresolved provider symbol.
+        let sourced = CorporateAction::new("AAPL", kind.clone(), date);
+        assert_eq!(sourced.instrument, "AAPL");
+        assert_eq!(sourced.effective_date, date);
+
+        // Wrapper re-keys the same fact to an engine-style index.
+        let resolved = CorporateAction::new(0_usize, sourced.kind.clone(), sourced.effective_date);
+        assert_eq!(resolved.instrument, 0_usize);
+        assert_eq!(resolved.kind, kind);
     }
 }

--- a/rustrade-instrument/src/corporate_action.rs
+++ b/rustrade-instrument/src/corporate_action.rs
@@ -344,9 +344,15 @@ mod tests {
             CorporateActionKind::stock_split(Decimal::ZERO, Decimal::from(5)),
             None
         );
-        // Single negative component.
+        // Single negative component — `split_to` negative alone.
         assert_eq!(
             CorporateActionKind::stock_split(Decimal::from(-2), Decimal::from(1)),
+            None
+        );
+        // Single negative component — `split_from` negative alone (the symmetric case: a positive
+        // `split_to` over a negative `split_from` yields a negative quotient the guard also rejects).
+        assert_eq!(
+            CorporateActionKind::stock_split(Decimal::from(2), Decimal::from(-1)),
             None
         );
         // Both-negative components: -2 / -1 = 2 is positive and would slip past a quotient-only

--- a/rustrade-instrument/src/corporate_action.rs
+++ b/rustrade-instrument/src/corporate_action.rs
@@ -156,12 +156,35 @@ impl CorporateActionKind {
     /// Note: `ratio` is computed at `rust_decimal`'s 28-significant-digit precision, so an inexact
     /// quotient (e.g. 1-for-3) is rounded there — identical to how the engine's `apply_split`
     /// consumes it.
+    ///
+    /// # Argument order
+    /// The order is **`split_to` then `split_from`** — a 2-for-1 forward split is
+    /// `stock_split(2, 1)`, *not* `stock_split(1, 2)`. Both parameters are [`Decimal`], so the
+    /// compiler cannot catch a swap, and there is no runtime signal either: passing them reversed
+    /// silently yields the reciprocal ratio — turning a forward split into a reverse split (or vice
+    /// versa) — which is still a valid [`SplitRatio`]. The call site is the only place this
+    /// convention is enforced, so keep the arguments in `to, from` order.
+    ///
+    /// ```
+    /// use rustrade_instrument::corporate_action::{CorporateActionKind, SplitAdjustmentKind};
+    /// use rust_decimal::Decimal;
+    ///
+    /// // 2-for-1 forward split: split_to = 2, split_from = 1 → ratio 2 (shares scale up).
+    /// let forward = CorporateActionKind::stock_split(Decimal::from(2), Decimal::from(1)).unwrap();
+    /// assert_eq!(forward.split_kind(), Some(SplitAdjustmentKind::Standard));
+    ///
+    /// // Arguments swapped: ratio 0.5 — a *reverse* split, accepted silently. Order matters.
+    /// let swapped = CorporateActionKind::stock_split(Decimal::from(1), Decimal::from(2)).unwrap();
+    /// assert_eq!(swapped.split_kind(), Some(SplitAdjustmentKind::NonStandard));
+    /// ```
     #[must_use]
     pub fn stock_split(split_to: Decimal, split_from: Decimal) -> Option<Self> {
         let positive = |d: Decimal| d > Decimal::ZERO;
         if !positive(split_to) || !positive(split_from) {
             return None;
         }
+        // `checked_div` can only return `None` via overflow here: the zero divisor is already
+        // excluded by the `positive()` guard above, so division-by-zero never reaches this point.
         split_to
             .checked_div(split_from)
             .and_then(SplitRatio::new)
@@ -179,9 +202,11 @@ impl CorporateActionKind {
     ///   dividend, spin-off, …).
     ///
     /// A `StockSplit`'s `ratio` is **standard** iff it is a whole number strictly greater than one
-    /// (`ratio > 1 && ratio.fract() == 0`). A non-positive `ratio` cannot occur:
-    /// [`CorporateActionKind::stock_split`] rejects it at construction and `Position::apply_split`
-    /// asserts it, so this is only ever reached with a positive `ratio`.
+    /// (`ratio > 1 && ratio.fract() == 0`). A non-positive `ratio` cannot occur: the field is a
+    /// [`SplitRatio`], whose own type invariant is `> 0` (enforced at construction and on
+    /// deserialization), so this classifier is only ever reached with a positive `ratio` — no local
+    /// runtime check is needed. Downstream consumers of the same `ratio` (including
+    /// `Position::apply_split`) likewise rely on this type-level guarantee rather than re-checking it.
     #[must_use]
     pub fn split_kind(&self) -> Option<SplitAdjustmentKind> {
         // No `_` catch-all: `CorporateActionKind` is `#[non_exhaustive]`, so adding a future

--- a/rustrade-instrument/src/lib.rs
+++ b/rustrade-instrument/src/lib.rs
@@ -15,6 +15,10 @@
     missing_debug_implementations,
     rust_2018_idioms
 )]
+// Inherited from the barter-rs upstream: the generic, trait-heavy public API legitimately produces
+// complex nested types and many-argument constructors, and `type_alias_bounds` fires on
+// documentation-bearing alias bounds kept intentionally. Denying these adds churn without improving
+// the API.
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
 //! # Barter-Instrument

--- a/rustrade-instrument/src/lib.rs
+++ b/rustrade-instrument/src/lib.rs
@@ -44,6 +44,11 @@ pub mod instrument;
 /// indexing non-indexed collections.
 pub mod index;
 
+/// Corporate-action market facts (e.g. stock splits) and date-resolution helpers.
+///
+/// eg/ `CorporateActionKind`, `split_effective_instant`, etc.
+pub mod corporate_action;
+
 /// Interactive Brokers support types (behind `ibkr` feature).
 #[cfg(feature = "ibkr")]
 pub mod ibkr;

--- a/rustrade-integration/Cargo.toml
+++ b/rustrade-integration/Cargo.toml
@@ -12,9 +12,12 @@ readme = "README.md"
 description = "Low-level framework for composing flexible web integrations, especially with financial exchanges"
 
 [features]
-default = ["collection", "error", "protocol", "serde", "subscription", "socket", "stream"]
-full = ["collection", "channel", "error", "metric", "protocol", "serde", "subscription", "socket", "stream"]
+default = ["collection", "error", "protocol", "serde", "subscription", "socket", "stream", "corporate-action"]
+full = ["collection", "channel", "error", "metric", "protocol", "serde", "subscription", "socket", "stream", "corporate-action"]
 collection = ["dep:indexmap", "dep:fnv", "dep:itertools", "dep:derive_more"]
+# PULL corporate-action sourcing trait + filter. Needs `stream` (rustrade-instrument descriptor +
+# chrono + futures) and `subscription` (smol_str symbol key); pulls no new dependencies of its own.
+corporate-action = ["stream", "subscription"]
 channel = ["dep:tokio", "dep:tokio-stream", "dep:derive_more", "dep:tracing"]
 error = ["dep:url", "dep:serde_qs", "dep:serde_urlencoded", "dep:thiserror"]
 metric = []

--- a/rustrade-integration/Cargo.toml
+++ b/rustrade-integration/Cargo.toml
@@ -16,8 +16,10 @@ default = ["collection", "error", "protocol", "serde", "subscription", "socket",
 full = ["collection", "channel", "error", "metric", "protocol", "serde", "subscription", "socket", "stream", "corporate-action"]
 collection = ["dep:indexmap", "dep:fnv", "dep:itertools", "dep:derive_more"]
 # PULL corporate-action sourcing trait + filter. Needs `stream` (rustrade-instrument descriptor +
-# chrono + futures) and `subscription` (smol_str symbol key); pulls no new dependencies of its own.
-corporate-action = ["stream", "subscription"]
+# chrono + futures), `subscription` (smol_str symbol key), and `derive_more` for the `Constructor`
+# derive on `CorporateActionFilter`. `derive_more` also arrives transitively via `stream`, but is
+# listed explicitly so this module's requirement is self-described and survives a `stream` refactor.
+corporate-action = ["stream", "subscription", "dep:derive_more"]
 channel = ["dep:tokio", "dep:tokio-stream", "dep:derive_more", "dep:tracing"]
 error = ["dep:url", "dep:serde_qs", "dep:serde_urlencoded", "dep:thiserror"]
 metric = []

--- a/rustrade-integration/src/corporate_action.rs
+++ b/rustrade-integration/src/corporate_action.rs
@@ -1,0 +1,104 @@
+//! PULL-based corporate-action **sourcing** abstractions.
+//!
+//! This module models the *global-PULL reference-data* shape shared by providers such as
+//! Massive/Polygon and Alpaca: query a provider by symbol + effective-date range and receive a
+//! stream of corporate-action facts. The yielded fact is the
+//! [`CorporateAction`](rustrade_instrument::corporate_action::CorporateAction) descriptor
+//! (re-exported here), keyed by an unresolved provider symbol ([`SmolStr`]); a wrapper resolves the
+//! symbol to its engine instrument key and supplies the rounding policy + stamping instant before
+//! injecting an engine event.
+//!
+//! # The kind lives in the trait name, not a filter
+//!
+//! There is deliberately **no unified `CorporateActionSource` with a `kinds` filter**. Reference
+//! providers expose a *separate endpoint per action type* (splits vs dividends), so the action kind
+//! is encoded in the trait itself: [`StockSplitSource`] fetches splits. A `DividendSource` sibling
+//! trait is the natural future addition when dividends are needed — each fully typed, with no
+//! discriminant enum to keep in lockstep with
+//! [`CorporateActionKind`](rustrade_instrument::corporate_action::CorporateActionKind).
+//!
+//! # What is intentionally out of scope
+//!
+//! Account-scoped or push-based sources (e.g. Interactive Brokers' WSH / Flex Query feeds) do not
+//! fit the global-by-symbol PULL model and are **intentionally not** expressed through this trait.
+//! Such a source maps its data onto the same [`CorporateAction`] descriptor via its own adapter.
+
+use chrono::NaiveDate;
+use futures::Stream;
+use smol_str::SmolStr;
+
+#[doc(inline)]
+pub use rustrade_instrument::corporate_action::{CorporateAction, CorporateActionKind};
+
+/// Filter for a PULL corporate-action reference-data query.
+///
+/// All fields are optional restrictions; the default (empty `symbols`, no date bounds) requests
+/// every action a source knows about, subject to provider limits. Date bounds are inclusive and
+/// expressed against the action's **effective date**.
+///
+/// # Symbols
+///
+/// `symbols` holds **provider** ticker strings (e.g. `"AAPL"`), not resolved engine keys. An empty
+/// `symbols` list means "no symbol restriction". How a source maps multiple symbols onto its
+/// transport (one request per symbol vs a single batched request) is an implementation detail.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CorporateActionFilter {
+    /// Provider ticker symbols to fetch; empty means no symbol restriction.
+    pub symbols: Vec<SmolStr>,
+    /// Inclusive lower bound on the action's effective date, if any.
+    pub start: Option<NaiveDate>,
+    /// Inclusive upper bound on the action's effective date, if any.
+    pub end: Option<NaiveDate>,
+}
+
+/// A source of **stock-split** corporate actions, fetched by symbol + effective-date range.
+///
+/// Implementors wrap a provider's splits endpoint (e.g. Massive's `/v3/reference/splits`) and yield
+/// [`CorporateAction<SmolStr>`] descriptors — the split ratio computed via the shared
+/// [`CorporateActionKind::stock_split`] helper, keyed by the provider symbol. The consumer resolves
+/// the symbol to an engine instrument key and constructs the engine event.
+///
+/// The returned stream is lazy: items are produced as it is polled, and the stream is `Send` so it
+/// can be driven from any async runtime/task.
+///
+/// # Object safety
+///
+/// This trait is **not object-safe**: `fetch_splits` returns `impl Stream + Send` (return-position
+/// `impl Trait` in a trait method), which the compiler cannot erase to `dyn`. So
+/// `Box<dyn StockSplitSource>` and `Vec<Box<dyn StockSplitSource>>` (e.g. a multi-provider routing
+/// table) cannot be formed directly. To hold heterogeneous sources, dispatch over an enum of the
+/// concrete types, or write a thin wrapper whose method calls `.boxed()` on the stream and erases to
+/// `BoxStream<'_, Result<CorporateAction<SmolStr>, E>>`.
+pub trait StockSplitSource {
+    /// Error yielded as a stream item when a fetch fails (e.g. a transport or deserialisation
+    /// error). Per-item so a partial result set is still observable up to the failure point.
+    ///
+    /// No bound is imposed here; consumers add whatever their use-case requires at the call site
+    /// (e.g. `S::Error: Display` for logging, or `S::Error: std::error::Error` for `?` propagation).
+    type Error;
+
+    /// Fetch the stock splits matching `filter`, as a stream of [`CorporateAction<SmolStr>`]
+    /// descriptors (or per-item errors).
+    ///
+    /// # `effective_date` contract
+    ///
+    /// Every implementation MUST populate each descriptor's
+    /// [`effective_date`](rustrade_instrument::corporate_action::CorporateAction::effective_date)
+    /// with the **market execution date** — the
+    /// calendar date on which the split takes effect on-exchange (shares outstanding adjust, the
+    /// price re-bases). It is **not** the declaration date, ex-date, or record date: those can
+    /// precede execution by days to weeks, and stamping the engine adjustment to one of them applies
+    /// the split early and silently corrupts backtest results.
+    ///
+    /// Providers expose this date under different field names (e.g. Massive's `execution_date`), and
+    /// some surface several candidate dates per split. Which provider field satisfies the
+    /// execution-date semantic is a **static, per-implementation decision** — it is the same field
+    /// for every event a given source yields, so it is a property of the implementation, not of the
+    /// individual fact. Each implementation MUST therefore document, in its own `fetch_splits`
+    /// rustdoc, which provider field it maps onto `effective_date`, and SHOULD pin that mapping with
+    /// a unit test against a known fixture so a later refactor cannot change it unnoticed.
+    fn fetch_splits(
+        &self,
+        filter: &CorporateActionFilter,
+    ) -> impl Stream<Item = Result<CorporateAction<SmolStr>, Self::Error>> + Send;
+}

--- a/rustrade-integration/src/corporate_action.rs
+++ b/rustrade-integration/src/corporate_action.rs
@@ -24,6 +24,7 @@
 //! Such a source maps its data onto the same [`CorporateAction`] descriptor via its own adapter.
 
 use chrono::NaiveDate;
+use derive_more::Constructor;
 use futures::Stream;
 use smol_str::SmolStr;
 
@@ -41,7 +42,12 @@ pub use rustrade_instrument::corporate_action::{CorporateAction, CorporateAction
 /// `symbols` holds **provider** ticker strings (e.g. `"AAPL"`), not resolved engine keys. An empty
 /// `symbols` list means "no symbol restriction". How a source maps multiple symbols onto its
 /// transport (one request per symbol vs a single batched request) is an implementation detail.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+// Public filter likely to grow (e.g. pagination cursor/limit). `#[non_exhaustive]` keeps adding
+// fields non-breaking for downstream users; construct via `CorporateActionFilter::new(..)`, or
+// `Default::default()` followed by per-field assignment when forward-compatibility matters
+// (struct-update syntax is unavailable to downstream crates on a `#[non_exhaustive]` struct).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Constructor)]
+#[non_exhaustive]
 pub struct CorporateActionFilter {
     /// Provider ticker symbols to fetch; empty means no symbol restriction.
     pub symbols: Vec<SmolStr>,

--- a/rustrade-integration/src/corporate_action.rs
+++ b/rustrade-integration/src/corporate_action.rs
@@ -90,11 +90,20 @@ pub trait StockSplitSource {
     ///
     /// Every implementation MUST populate each descriptor's
     /// [`effective_date`](rustrade_instrument::corporate_action::CorporateAction::effective_date)
-    /// with the **market execution date** — the
-    /// calendar date on which the split takes effect on-exchange (shares outstanding adjust, the
-    /// price re-bases). It is **not** the declaration date, ex-date, or record date: those can
-    /// precede execution by days to weeks, and stamping the engine adjustment to one of them applies
-    /// the split early and silently corrupts backtest results.
+    /// with the **market execution date** — the calendar date on which the split takes effect
+    /// on-exchange: shares outstanding adjust and the price re-bases to the split-adjusted basis.
+    /// The field must be the date the adjustment actually *executes*, not merely when it was
+    /// announced or booked; stamping the engine adjustment to any *earlier* date applies the split
+    /// ahead of the market and silently corrupts backtest results.
+    ///
+    /// For a **stock split** that execution date is the **ex-split date**. Unlike a cash dividend —
+    /// whose ex-date deliberately *precedes* payment — a split's ex-date and execution date coincide:
+    /// on the ex-date the shares already trade on the new, split-adjusted basis. So mapping a
+    /// provider's ex-date onto `effective_date` is correct *for splits* (Alpaca's adapter does
+    /// exactly this, documenting the choice and pinning it with a fixture test). What the field must
+    /// **not** be is a *declaration*/announcement date, a *record* date, or a *payable*/settlement
+    /// date: those can fall days to weeks off the ex-date and would apply the split at the wrong
+    /// instant.
     ///
     /// Providers expose this date under different field names (e.g. Massive's `execution_date`), and
     /// some surface several candidate dates per split. Which provider field satisfies the

--- a/rustrade-integration/src/lib.rs
+++ b/rustrade-integration/src/lib.rs
@@ -78,6 +78,12 @@ pub mod stream;
 #[cfg(feature = "socket")]
 pub mod socket;
 
+/// PULL-based corporate-action sourcing: the [`StockSplitSource`](corporate_action::StockSplitSource)
+/// trait + [`CorporateActionFilter`](corporate_action::CorporateActionFilter), re-exporting the
+/// `CorporateAction` descriptor from `rustrade-instrument`.
+#[cfg(feature = "corporate-action")]
+pub mod corporate_action;
+
 /// [`Validator`]s are capable of determining if their internal state is satisfactory to fulfill
 /// some use case defined by the implementor.
 pub trait Validator {

--- a/rustrade-integration/src/lib.rs
+++ b/rustrade-integration/src/lib.rs
@@ -15,6 +15,10 @@
     missing_debug_implementations,
     rust_2018_idioms
 )]
+// Inherited from the barter-rs upstream: the generic, trait-heavy public API legitimately produces
+// complex nested types and many-argument constructors, and `type_alias_bounds` fires on
+// documentation-bearing alias bounds kept intentionally. Denying these adds churn without improving
+// the API.
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
 //! # Barter-Integration

--- a/rustrade/Cargo.toml
+++ b/rustrade/Cargo.toml
@@ -12,21 +12,16 @@ readme = "README.md"
 description = "Framework for building high-performance live-trading, paper-trading and back-testing systems"
 
 [features]
-# Forwards the Massive market-data feature so the corporate-action *sourcing* example can drive the
-# `StockSplitSource` impl on `MassiveRestClient`. Kept off by default — the engine itself needs no
-# provider.
+# Forward provider market-data features so the corporate-action *sourcing* example can drive a real
+# `StockSplitSource` impl (Massive's `MassiveRestClient` / Alpaca's `AlpacaRestClient`). Both off by
+# default — the engine itself needs no provider; the example falls back to a canned offline source.
 massive = ["rustrade-data/massive"]
+alpaca = ["rustrade-data/alpaca"]
 
 [[bench]]
 name = "backtest"
 path = "benches/backtest/mod.rs"
 harness = false
-
-# The corporate-action sourcing example uses the Massive REST client. Without `required-features`,
-# `cargo check --all-targets` (default features) would fail to compile it.
-[[example]]
-name = "corporate_action_sourcing"
-required-features = ["massive"]
 
 [dev-dependencies]
 rust_decimal_macros = { workspace = true }

--- a/rustrade/Cargo.toml
+++ b/rustrade/Cargo.toml
@@ -11,10 +11,22 @@ documentation = "https://docs.rs/rustrade"
 readme = "README.md"
 description = "Framework for building high-performance live-trading, paper-trading and back-testing systems"
 
+[features]
+# Forwards the Massive market-data feature so the corporate-action *sourcing* example can drive the
+# `StockSplitSource` impl on `MassiveRestClient`. Kept off by default — the engine itself needs no
+# provider.
+massive = ["rustrade-data/massive"]
+
 [[bench]]
 name = "backtest"
 path = "benches/backtest/mod.rs"
 harness = false
+
+# The corporate-action sourcing example uses the Massive REST client. Without `required-features`,
+# `cargo check --all-targets` (default features) would fail to compile it.
+[[example]]
+name = "corporate_action_sourcing"
+required-features = ["massive"]
 
 [dev-dependencies]
 rust_decimal_macros = { workspace = true }

--- a/rustrade/benches/backtest/mod.rs
+++ b/rustrade/benches/backtest/mod.rs
@@ -5,7 +5,10 @@ use criterion::{Criterion, Throughput};
 use rust_decimal::Decimal;
 use rustrade::{
     backtest,
-    backtest::{BacktestArgsConstant, BacktestArgsDynamic, market_data::MarketDataInMemory},
+    backtest::{
+        BacktestArgsConstant, BacktestArgsDynamic, aux_events::NoAuxEvents,
+        market_data::MarketDataInMemory,
+    },
     engine::{
         Engine, Processor,
         clock::HistoricalClock,
@@ -472,6 +475,7 @@ fn args_constant(
         market_data,
         summary_interval: Daily,
         engine_state,
+        aux_events: NoAuxEvents,
     })
 }
 

--- a/rustrade/examples/backtests_concurrent.rs
+++ b/rustrade/examples/backtests_concurrent.rs
@@ -4,6 +4,7 @@ use rust_decimal::Decimal;
 use rustrade::{
     backtest::{
         BacktestArgsConstant, BacktestArgsDynamic,
+        aux_events::NoAuxEvents,
         market_data::{BacktestMarketData, MarketDataInMemory},
         run_backtests,
     },
@@ -73,6 +74,7 @@ async fn main() {
         market_data,
         summary_interval: Daily,
         engine_state,
+        aux_events: NoAuxEvents,
     });
 
     // Define dummy dynamic backtest arguments

--- a/rustrade/examples/corporate_action_injection.rs
+++ b/rustrade/examples/corporate_action_injection.rs
@@ -43,7 +43,6 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, NaiveDate, Utc};
-use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use rustrade::{
     EngineEvent, SplitRoundingPolicy, Timed,
@@ -73,7 +72,7 @@ use rustrade_data::{
     subscription::trade::PublicTrade,
 };
 use rustrade_instrument::{
-    corporate_action::{CorporateActionKind, split_effective_instant},
+    corporate_action::{CorporateActionKind, SplitRatio, split_effective_instant},
     exchange::ExchangeId,
     index::IndexedInstruments,
     instrument::InstrumentIndex,
@@ -137,8 +136,11 @@ async fn main() {
             //    second event with a *different* id (a reversal followed by the corrected split).
             id: "EXAMPLE-2025-03-24-split".into(),
             instrument: split_instrument,
-            // A 2-for-1 forward split: `ratio = split_to / split_from = 2`.
-            kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+            // A 2-for-1 forward split: `ratio = split_to / split_from = 2`. `SplitRatio` validates
+            // the ratio is strictly positive (it is also derivable via `stock_split(2, 1)`).
+            kind: CorporateActionKind::StockSplit {
+                ratio: SplitRatio::new(dec!(2)).expect("2 is a valid (positive) split ratio"),
+            },
             // 3: rounding policy matching the broker. `Floor` = whole-share broker (disposes the
             //    fractional sliver as cash-in-lieu, reported via `SplitRemainder`); `Fractional` =
             //    fractional-share broker (no remainder).
@@ -197,7 +199,7 @@ async fn main() {
 fn live_injection_sketch(
     feed_tx: &UnboundedTx<EngineEvent>,
     instrument: InstrumentIndex,
-    ratio: Decimal,
+    ratio: SplitRatio,
     effective_date: NaiveDate,
 ) {
     let event = EngineEvent::CorporateAction {
@@ -246,7 +248,9 @@ fn standard_option_split_sketch(equity: InstrumentIndex, effective_date: NaiveDa
         instrument: equity,
         // A whole-number forward split ⇒ `split_kind()` is `Some(Standard)` ⇒ options on the
         // underlying are adjusted in place rather than flagged for an identity change.
-        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).expect("2 is a valid (positive) split ratio"),
+        },
         policy: SplitRoundingPolicy::Fractional,
         effective_time: split_effective_instant(effective_date),
     }
@@ -293,7 +297,10 @@ fn non_standard_option_split_wrapper_sketch(
             EngineEvent::CorporateAction {
                 id: format!("MSFT-{effective_date}-reverse-split").into(),
                 instrument: equity,
-                kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+                kind: CorporateActionKind::StockSplit {
+                    ratio: SplitRatio::new(dec!(0.5))
+                        .expect("0.5 is a valid (positive) split ratio"),
+                },
                 policy: SplitRoundingPolicy::Fractional,
                 effective_time,
             },

--- a/rustrade/examples/corporate_action_injection.rs
+++ b/rustrade/examples/corporate_action_injection.rs
@@ -1,0 +1,239 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
+//! Inject an `EngineEvent::CorporateAction` (a stock split) into the engine — backtest and live.
+//!
+//! The engine never sources corporate actions itself: positions are fill-derived, so even in live
+//! trading a broker applying a split overnight does **not** fix the engine's internal
+//! `quantity`/`price_entry_average`/`pnl_unrealised`. A wrapper detects the action and injects an
+//! `EngineEvent::CorporateAction`; the engine adjusts every open position on the target instrument
+//! and emits observables (`SplitRemainder`, `OpenOrdersAtSplit`, `OptionPositionsUnadjustedForSplit`,
+//! `UnsupportedCorporateAction`).
+//!
+//! This example shows **how to construct and inject the event**, on both paths:
+//! - **Backtest** (`main`, runnable): the split is supplied via an [`AuxEventsInMemory`] aux source,
+//!   merged with the market stream in simulated-time order, and the backtest runs to completion.
+//! - **Live** ([`live_injection_sketch`], shown but not executed — it needs a running broker
+//!   connection): the same event is sent directly through the public `System.feed_tx` channel.
+//!
+//! It is deliberately **not** an auto-injecting driver and does **no sourcing** (resolving tickers,
+//! fetching split ratios, deciding rounding policy, and choosing *when* to inject all remain wrapper
+//! concerns). The four caller obligations the event's rustdoc spells out are demonstrated here:
+//!   1. assign a **unique `id`** per action (the sole idempotency key);
+//!   2. resolve the ticker to the engine's `InstrumentKey`;
+//!   3. supply the rounding [`SplitRoundingPolicy`] matching the broker (whole-share vs fractional);
+//!   4. resolve the effective date to an `effective_time` instant via [`split_effective_instant`].
+//!
+//! The focus is the injection mechanics, not the position adjustment: this backtest opens no
+//! position before the split (the default strategy trades nothing), so the split is a structural
+//! no-op on positions here and emits no `SplitRemainder`. To *observe* the adjustment and emitted
+//! outputs you must (a) have an open position on the instrument and (b) consume the audit stream —
+//! which `backtest` disables (`AuditMode::Disabled`). See
+//! `examples/engine_sync_with_audit_replica_engine_state.rs` for audit consumption, and the
+//! `test_engine_process_engine_event_with_audit` integration tests for the split adjustment and
+//! outputs asserted directly against an open position.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use rustrade::{
+    EngineEvent, SplitRoundingPolicy, Timed,
+    backtest::{
+        BacktestArgsConstant, BacktestArgsDynamic, aux_events::AuxEventsInMemory, backtest,
+        market_data::MarketDataInMemory,
+    },
+    engine::state::{
+        EngineState, builder::EngineStateBuilder, global::DefaultGlobalData,
+        instrument::data::DefaultInstrumentMarketData, trading::TradingState,
+    },
+    logging::init_logging,
+    risk::DefaultRiskManager,
+    statistic::time::Daily,
+    strategy::DefaultStrategy,
+    system::config::SystemConfig,
+};
+use rustrade_data::{
+    event::{DataKind, MarketEvent},
+    streams::consumer::MarketStreamEvent,
+    subscription::trade::PublicTrade,
+};
+use rustrade_instrument::{
+    corporate_action::{CorporateActionKind, split_effective_instant},
+    exchange::ExchangeId,
+    index::IndexedInstruments,
+    instrument::InstrumentIndex,
+};
+use rustrade_integration::channel::{Tx, UnboundedTx};
+use serde::Deserialize;
+
+const CONFIG_PATH: &str = "rustrade/examples/config/backtest_config.json";
+
+#[derive(Deserialize)]
+struct Config {
+    // `risk_free_return` is also present in the JSON but unused here; serde ignores it.
+    system: SystemConfig,
+}
+
+#[tokio::main]
+async fn main() {
+    init_logging();
+
+    let Config {
+        system: SystemConfig {
+            instruments,
+            executions,
+        },
+    } = load_config();
+
+    // Obligation 2: the wrapper resolves the ticker to the engine's `InstrumentKey`. Here the first
+    // configured instrument (index 0) plays the part of the splitting equity.
+    let instruments = IndexedInstruments::new(instruments);
+    let split_instrument = InstrumentIndex::new(0);
+
+    // Self-contained market data: four trades spanning 22:00–23:00 on the effective date. A real
+    // backtest loads these from disk — see `examples/backtests_concurrent.rs`.
+    let market_data = MarketDataInMemory::new(Arc::new(synthetic_trades(split_instrument)));
+    // Seeds only `EngineState` metadata (the trading-summary start). The backtest's
+    // `HistoricalClock` is seeded independently from `min(first market event, first aux event)` —
+    // here midnight UTC (the split instant), *before* this 22:00 value.
+    let time_engine_start = ts("2025-03-24T22:00:00Z");
+
+    let engine_state = EngineStateBuilder::new(&instruments, DefaultGlobalData, |_| {
+        DefaultInstrumentMarketData::default()
+    })
+    .time_engine_start(time_engine_start)
+    .trading_state(TradingState::Enabled)
+    .build();
+
+    // Construct the corporate-action event. Obligations 1, 3, 4 are all visible here.
+    let effective_date = NaiveDate::from_ymd_opt(2025, 3, 24).unwrap();
+    // 4: resolve the effective *date* to the effective *instant*. Midnight UTC lands the adjustment
+    //    in the overnight gap, after the prior session and before the effective one — where a broker
+    //    applies it. The clock advances to this instant in backtest. Computed once: it is both the
+    //    event's `effective_time` and the merge-sort key (the same instant, so the split interleaves
+    //    at the right point).
+    let effective_time = split_effective_instant(effective_date);
+    let split = Timed::new(
+        EngineEvent::CorporateAction {
+            // 1: a unique action id (the sole idempotency key). A same-day correction would be a
+            //    second event with a *different* id (a reversal followed by the corrected split).
+            id: "EXAMPLE-2025-03-24-split".into(),
+            instrument: split_instrument,
+            // A 2-for-1 forward split: `ratio = split_to / split_from = 2`.
+            kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+            // 3: rounding policy matching the broker. `Floor` = whole-share broker (disposes the
+            //    fractional sliver as cash-in-lieu, reported via `SplitRemainder`); `Fractional` =
+            //    fractional-share broker (no remainder).
+            policy: SplitRoundingPolicy::Floor,
+            effective_time,
+        },
+        effective_time,
+    );
+
+    // Supply the split via the aux source. `AuxEventsInMemory::new` asserts ascending-by-time order;
+    // a single event is trivially sorted. `NoAuxEvents` (the default) would inject nothing.
+    let aux_events = AuxEventsInMemory::new(Arc::new(vec![split]));
+
+    let args_constant = Arc::new(BacktestArgsConstant {
+        instruments,
+        executions,
+        market_data,
+        summary_interval: Daily,
+        engine_state,
+        aux_events,
+    });
+
+    let args_dynamic = BacktestArgsDynamic {
+        id: "corporate-action-injection".into(),
+        risk_free_return: dec!(0.05),
+        strategy: DefaultStrategy::<EngineState<DefaultGlobalData, DefaultInstrumentMarketData>>::default(),
+        risk: DefaultRiskManager::<EngineState<DefaultGlobalData, DefaultInstrumentMarketData>>::default(),
+    };
+
+    let summary = backtest(args_constant, args_dynamic)
+        .await
+        .expect("backtest with an injected corporate action must complete");
+
+    println!(
+        "Backtest '{}' completed with an injected 2:1 split.",
+        summary.id
+    );
+    summary.trading_summary.print_summary();
+}
+
+/// Live-injection sketch — **not executed** by `main` (it needs a running broker/market connection),
+/// shown to document the live path.
+///
+/// In a live `System` (built via `SystemBuilder`, e.g.
+/// `examples/engine_sync_with_live_market_data_and_mock_execution_and_audit.rs`), `system.feed_tx`
+/// is a public [`UnboundedTx`] of `EngineEvent`. Once the wrapper has confirmed the broker applied a
+/// split, it constructs the *same* event as above and sends it directly. There is no `From`
+/// shortcut — the variant is `#[from(skip)]` precisely so every field (`id`, `policy`,
+/// `effective_time`) is supplied consciously.
+///
+/// Inject **once**, after the broker has applied the action and before processing new fills on the
+/// post-split scale.
+// Defined for documentation; never called (a live System cannot be constructed in this offline
+// example), so it would otherwise trip `dead_code`.
+#[allow(dead_code)]
+fn live_injection_sketch(
+    feed_tx: &UnboundedTx<EngineEvent>,
+    instrument: InstrumentIndex,
+    ratio: Decimal,
+    effective_date: NaiveDate,
+) {
+    let event = EngineEvent::CorporateAction {
+        id: format!("AAPL-{effective_date}-split").into(),
+        instrument,
+        kind: CorporateActionKind::StockSplit { ratio },
+        policy: SplitRoundingPolicy::Fractional,
+        effective_time: split_effective_instant(effective_date),
+    };
+
+    // `Tx::send` accepts anything `Into<EngineEvent>`; the fully-constructed event qualifies
+    // reflexively. The engine must be alive to receive it.
+    feed_tx
+        .send(event)
+        .expect("engine feed receiver must be alive");
+}
+
+/// Four trades for `instrument` spanning 22:00–23:00; the midnight-UTC split sorts before all of
+/// them on the effective date, so the adjustment is applied before the day's first fill.
+fn synthetic_trades(
+    instrument: InstrumentIndex,
+) -> Vec<MarketStreamEvent<InstrumentIndex, DataKind>> {
+    [
+        ("2025-03-24T22:00:00Z", dec!(60_000)),
+        ("2025-03-24T22:15:00Z", dec!(60_100)),
+        ("2025-03-24T22:45:00Z", dec!(60_200)),
+        ("2025-03-24T23:00:00Z", dec!(60_300)),
+    ]
+    .into_iter()
+    .map(|(time, price)| {
+        let time = ts(time);
+        MarketStreamEvent::Item(MarketEvent {
+            time_exchange: time,
+            time_received: time,
+            exchange: ExchangeId::BinanceSpot,
+            instrument,
+            kind: DataKind::Trade(PublicTrade {
+                id: "trade".into(),
+                price,
+                amount: dec!(0.01),
+                side: None,
+            }),
+        })
+    })
+    .collect()
+}
+
+fn ts(raw: &str) -> DateTime<Utc> {
+    raw.parse().unwrap()
+}
+
+fn load_config() -> Config {
+    let file = std::fs::File::open(CONFIG_PATH).expect("backtest_config.json must exist");
+    serde_json::from_reader(std::io::BufReader::new(file))
+        .expect("backtest_config.json must deserialize")
+}

--- a/rustrade/examples/corporate_action_injection.rs
+++ b/rustrade/examples/corporate_action_injection.rs
@@ -6,14 +6,22 @@
 //! trading a broker applying a split overnight does **not** fix the engine's internal
 //! `quantity`/`price_entry_average`/`pnl_unrealised`. A wrapper detects the action and injects an
 //! `EngineEvent::CorporateAction`; the engine adjusts every open position on the target instrument
-//! and emits observables (`SplitRemainder`, `OpenOrdersAtSplit`, `OptionPositionsUnadjustedForSplit`,
-//! `UnsupportedCorporateAction`).
+//! and emits observables (`SplitRemainder`, `OpenOrdersAtSplit`, `OptionPositionAdjustedForSplit`,
+//! `OptionPositionsRequireIdentityChange`, `UnsupportedCorporateAction`).
 //!
-//! This example shows **how to construct and inject the event**, on both paths:
+//! This example shows **how to construct and inject the event**, on four paths:
 //! - **Backtest** (`main`, runnable): the split is supplied via an [`AuxEventsInMemory`] aux source,
 //!   merged with the market stream in simulated-time order, and the backtest runs to completion.
 //! - **Live** ([`live_injection_sketch`], shown but not executed — it needs a running broker
 //!   connection): the same event is sent directly through the public `System.feed_tx` channel.
+//! - **Standard option adjustment** ([`standard_option_split_sketch`]): a whole-number forward split
+//!   on the *underlying equity* also adjusts every option position on that underlying **in place**
+//!   (strike ÷ ratio, contracts × ratio, multiplier unchanged), emitting `OptionPositionAdjustedForSplit`
+//!   plus an `OpenOrdersAtSplit` for each adjusted option's own resting orders.
+//! - **Non-standard option identity change** ([`non_standard_option_split_wrapper_sketch`]): a reverse
+//!   or fractional-forward split needs a new contract identity the engine never re-registers; the
+//!   wrapper pre-declares both identities and drives close-old + trade-new through the aux seam (the
+//!   backtest pattern), the engine only signals `OptionPositionsRequireIdentityChange`.
 //!
 //! It is deliberately **not** an auto-injecting driver and does **no sourcing** (resolving tickers,
 //! fetching split ratios, deciding rounding policy, and choosing *when* to inject all remain wrapper
@@ -43,9 +51,15 @@ use rustrade::{
         BacktestArgsConstant, BacktestArgsDynamic, aux_events::AuxEventsInMemory, backtest,
         market_data::MarketDataInMemory,
     },
-    engine::state::{
-        EngineState, builder::EngineStateBuilder, global::DefaultGlobalData,
-        instrument::data::DefaultInstrumentMarketData, trading::TradingState,
+    engine::{
+        command::Command,
+        state::{
+            EngineState,
+            builder::EngineStateBuilder,
+            global::DefaultGlobalData,
+            instrument::{data::DefaultInstrumentMarketData, filter::InstrumentFilter},
+            trading::TradingState,
+        },
     },
     logging::init_logging,
     risk::DefaultRiskManager,
@@ -64,7 +78,10 @@ use rustrade_instrument::{
     index::IndexedInstruments,
     instrument::InstrumentIndex,
 };
-use rustrade_integration::channel::{Tx, UnboundedTx};
+use rustrade_integration::{
+    channel::{Tx, UnboundedTx},
+    collection::one_or_many::OneOrMany,
+};
 use serde::Deserialize;
 
 const CONFIG_PATH: &str = "rustrade/examples/config/backtest_config.json";
@@ -196,6 +213,101 @@ fn live_injection_sketch(
     feed_tx
         .send(event)
         .expect("engine feed receiver must be alive");
+}
+
+/// Standard option-adjust sketch — **not executed**; documents the *option* side of a standard split.
+///
+/// A `CorporateAction` always targets the **underlying equity** (a `Spot` instrument) — never an
+/// option key directly (a split on an option key is rejected as `UnsupportedCorporateAction`). When
+/// the ratio is **standard** — a whole-number forward split, i.e. `kind.split_kind()` is
+/// `Some(SplitAdjustmentKind::Standard)` (2-for-1, 3-for-1, …) — the engine, after splitting the
+/// equity, additionally adjusts **every open option position on that underlying in place**, with no
+/// instrument re-registration:
+///   - strike ÷ `ratio` (a 50,000 call becomes a 25,000 call on a 2:1);
+///   - contract count × `ratio` (via `Position::apply_split`);
+///   - deliverable/multiplier (`contract_size`) **unchanged** — the OCC standard rule keeps the same
+///     contract identity, so the engine's ledger stays valid.
+///
+/// For each adjusted option position it emits one `OptionPositionAdjustedForSplit`, and — exactly as
+/// for the equity — an `OpenOrdersAtSplit` listing that option's own resting orders: a real broker
+/// price-adjusts those resting orders, so the engine cancels nothing, but a backtest wrapper must
+/// cancel them itself or the mock exchange fills the now-stale-premium order against the post-split
+/// print.
+///
+/// The event is constructed **identically** to the equity-only case — only the ratio's standard-ness
+/// and the presence of option positions on the underlying change what the engine emits. (The emitted
+/// observables are only visible on the audit-stream path; see the
+/// `test_engine_process_engine_event_with_audit` integration tests.)
+// Defined for documentation; never called, so it would otherwise trip `dead_code`.
+#[allow(dead_code)]
+fn standard_option_split_sketch(equity: InstrumentIndex, effective_date: NaiveDate) -> EngineEvent {
+    EngineEvent::CorporateAction {
+        id: format!("MSFT-{effective_date}-2for1-split").into(),
+        instrument: equity,
+        // A whole-number forward split ⇒ `split_kind()` is `Some(Standard)` ⇒ options on the
+        // underlying are adjusted in place rather than flagged for an identity change.
+        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        policy: SplitRoundingPolicy::Fractional,
+        effective_time: split_effective_instant(effective_date),
+    }
+}
+
+/// Non-standard option-split wrapper sketch — **not executed**; documents the wrapper protocol for a
+/// non-standard split (every reverse split, every fractional forward split), **including the backtest
+/// path**, and builds the aux-event vec that drives it.
+///
+/// On a non-standard split the OCC assigns affected options a **new contract identity** (new
+/// deliverable, new symbol e.g. `MSFT` → `MSFT1`). The library **never re-registers instruments at
+/// runtime** (the instrument set is fixed at construction), so it applies the equity split, records
+/// its `id`, emits `OptionPositionsRequireIdentityChange`, and leaves the options at pre-split terms.
+/// Because the equity split *was* applied and its `id` recorded, this is **not** retryable — the
+/// signal is a directive, not a failure. **Continuing exposure through the change is a wrapper
+/// decision:** close the old option via the normal `Command` path, and (if desired) trade a
+/// **pre-declared** new-identity instrument as an ordinary instrument.
+///
+/// This is fully backtestable through the same aux-event seam used for the split itself, because a
+/// backtest replays *known* history: pre-declare **both** identities at construction (each gets its
+/// own data series — the new identity naturally has prints only post-split), then inject BOTH the
+/// `CorporateAction` and a flatten `Command::ClosePositions` for the old identity at the split
+/// boundary. This function returns exactly that vec, ready for `AuxEventsInMemory::new` (its entries
+/// are ascending by `Timed::time`, as that constructor requires).
+///
+/// **Caveat (identical to the `OpenOrdersAtSplit` backtest pattern):** in backtest the close trigger
+/// is *pre-planned* (the split date is known ahead), not *reactive-from-the-observable* — `backtest()`
+/// disables the audit stream, so `OptionPositionsRequireIdentityChange` is invisible there; the
+/// reactive decision code runs live and is unit-tested separately. The economic simulation (fills,
+/// timing, P&L) stays faithful because the aux merge respects each event's `Timed::time`.
+// Defined for documentation; never called, so it would otherwise trip `dead_code`.
+#[allow(dead_code)]
+fn non_standard_option_split_wrapper_sketch(
+    equity: InstrumentIndex,
+    old_option: InstrumentIndex,
+    effective_date: NaiveDate,
+) -> Vec<Timed<EngineEvent>> {
+    let effective_time = split_effective_instant(effective_date);
+    vec![
+        // 1: the non-standard split (a 1-for-2 reverse ⇒ `ratio = 0.5`, never standard). Targets the
+        //    *equity*; the engine applies the equity split, records the `id`, and emits
+        //    `OptionPositionsRequireIdentityChange` for the held option — it does not adjust it.
+        Timed::new(
+            EngineEvent::CorporateAction {
+                id: format!("MSFT-{effective_date}-reverse-split").into(),
+                instrument: equity,
+                kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+                policy: SplitRoundingPolicy::Fractional,
+                effective_time,
+            },
+            effective_time,
+        ),
+        // 2: the wrapper's reaction — flatten the old option identity. Injected just after the split
+        //    (a later `Timed::time`, so the merge orders it after the split on the engine stream).
+        Timed::new(
+            EngineEvent::Command(Command::ClosePositions(InstrumentFilter::Instruments(
+                OneOrMany::One(old_option),
+            ))),
+            effective_time + chrono::TimeDelta::seconds(60),
+        ),
+    ]
 }
 
 /// Four trades for `instrument` spanning 22:00–23:00; the midnight-UTC split sorts before all of

--- a/rustrade/examples/corporate_action_injection.rs
+++ b/rustrade/examples/corporate_action_injection.rs
@@ -45,7 +45,7 @@ use std::sync::Arc;
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal_macros::dec;
 use rustrade::{
-    EngineEvent, SplitRoundingPolicy, Timed,
+    CorporateActionKind, EngineEvent, SplitRatio, SplitRoundingPolicy, Timed,
     backtest::{
         BacktestArgsConstant, BacktestArgsDynamic, aux_events::AuxEventsInMemory, backtest,
         market_data::MarketDataInMemory,
@@ -62,6 +62,7 @@ use rustrade::{
     },
     logging::init_logging,
     risk::DefaultRiskManager,
+    split_effective_instant,
     statistic::time::Daily,
     strategy::DefaultStrategy,
     system::config::SystemConfig,
@@ -71,11 +72,11 @@ use rustrade_data::{
     streams::consumer::MarketStreamEvent,
     subscription::trade::PublicTrade,
 };
+// `InstrumentIndex`/`ExchangeId`/`IndexedInstruments` are not re-exported at the crate root, so
+// this dependency remains for the index-building types; the corporate-action types now come from
+// the `rustrade` crate root (see the re-exports there).
 use rustrade_instrument::{
-    corporate_action::{CorporateActionKind, SplitRatio, split_effective_instant},
-    exchange::ExchangeId,
-    index::IndexedInstruments,
-    instrument::InstrumentIndex,
+    exchange::ExchangeId, index::IndexedInstruments, instrument::InstrumentIndex,
 };
 use rustrade_integration::{
     channel::{Tx, UnboundedTx},

--- a/rustrade/examples/corporate_action_sourcing.rs
+++ b/rustrade/examples/corporate_action_sourcing.rs
@@ -43,11 +43,11 @@ use smol_str::SmolStr;
 #[tokio::main]
 async fn main() {
     // A reference-data query: these symbols, splits effective on/after 2020-01-01.
-    let filter = CorporateActionFilter {
-        symbols: vec![SmolStr::new("AAPL"), SmolStr::new("NVDA")],
-        start: NaiveDate::from_ymd_opt(2020, 1, 1),
-        end: None,
-    };
+    let filter = CorporateActionFilter::new(
+        vec![SmolStr::new("AAPL"), SmolStr::new("NVDA")],
+        NaiveDate::from_ymd_opt(2020, 1, 1),
+        None,
+    );
 
     // Source the splits from the first available provider (feature-gated + credentialed), falling
     // back to a canned offline source. Every provider goes through the same generic `collect_splits`.

--- a/rustrade/examples/corporate_action_sourcing.rs
+++ b/rustrade/examples/corporate_action_sourcing.rs
@@ -1,0 +1,166 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
+//! Source stock splits via [`StockSplitSource`] and turn each into an injectable engine event.
+//!
+//! This is the **sourcing** half of corporate-action handling — the complement to
+//! `examples/corporate_action_injection.rs` (which shows construction + injection given a known
+//! split). Here a PULL reference-data source supplies the splits; the example then performs the
+//! wrapper's job of mapping each sourced fact into an [`EngineEvent::CorporateAction`].
+//!
+//! The flow, end to end:
+//!   1. build a [`CorporateActionFilter`] (symbols + optional effective-date range);
+//!   2. fetch a stream of [`CorporateAction<SmolStr>`] facts from a [`StockSplitSource`];
+//!   3. for each fact, perform the four wrapper obligations and construct the engine event:
+//!      (a) assign a **unique `id`**, (b) resolve the **ticker → `InstrumentKey`**, (c) supply the
+//!      broker **rounding policy**, (d) resolve the **effective date → `effective_time`** via
+//!      [`split_effective_instant`];
+//!   4. inject it (live → `System.feed_tx`; backtest → the aux-event source) — shown but not
+//!      executed; *when/whether* to inject stays a wrapper decision, so this is **not** an
+//!      auto-injecting driver.
+//!
+//! Run it with the real Massive source (needs `MASSIVE_API_KEY`):
+//! ```bash
+//! cargo run -p rustrade --features massive --example corporate_action_sourcing
+//! ```
+//! Without the key it falls back to a small in-example [`DemoSplitSource`] so the mechanics still
+//! run offline. Both paths flow through the same trait-generic [`collect_splits`].
+
+use chrono::NaiveDate;
+use futures::{Stream, StreamExt};
+use rust_decimal_macros::dec;
+use rustrade::{EngineEvent, SplitRoundingPolicy};
+use rustrade_data::exchange::massive::MassiveRestClient;
+use rustrade_instrument::{
+    corporate_action::{CorporateAction, CorporateActionKind, split_effective_instant},
+    instrument::InstrumentIndex,
+};
+use rustrade_integration::corporate_action::{CorporateActionFilter, StockSplitSource};
+use smol_str::SmolStr;
+
+#[tokio::main]
+async fn main() {
+    // A reference-data query: these symbols, splits effective on/after 2020-01-01.
+    let filter = CorporateActionFilter {
+        symbols: vec![SmolStr::new("AAPL"), SmolStr::new("NVDA")],
+        start: NaiveDate::from_ymd_opt(2020, 1, 1),
+        end: None,
+    };
+
+    // Source the splits. With MASSIVE_API_KEY set, this drives the real `StockSplitSource` impl on
+    // `MassiveRestClient` against the live `/v3/reference/splits` endpoint; without it, a canned
+    // in-example source keeps the example runnable. Both go through the same generic `collect_splits`.
+    let actions = match MassiveRestClient::from_env() {
+        Ok(client) => {
+            println!("Sourcing splits from Massive…");
+            collect_splits(&client, &filter).await
+        }
+        Err(_) => {
+            println!("MASSIVE_API_KEY not set — using canned demo splits.");
+            collect_splits(&DemoSplitSource, &filter).await
+        }
+    };
+
+    // For each sourced fact, do the wrapper's job and build the injectable engine event.
+    for action in &actions {
+        match build_event(action) {
+            Some(event) => {
+                println!("Built injectable event: {event:?}");
+                // Inject: live → `system.feed_tx.send(event)`; backtest → add to an
+                // `AuxEventsInMemory` source (see `examples/corporate_action_injection.rs`).
+                // Sourcing never injects on its own.
+            }
+            None => println!(
+                "Skipping {} (ticker did not resolve, or no effective date).",
+                action.instrument
+            ),
+        }
+    }
+
+    println!("Sourced {} split action(s).", actions.len());
+}
+
+/// Drain a [`StockSplitSource`] into a `Vec`, demonstrating trait-generic consumption — the same
+/// code drives the Massive client or any other implementor.
+async fn collect_splits<S>(
+    source: &S,
+    filter: &CorporateActionFilter,
+) -> Vec<CorporateAction<SmolStr>>
+where
+    S: StockSplitSource,
+    S::Error: std::fmt::Display,
+{
+    let stream = source.fetch_splits(filter);
+    futures::pin_mut!(stream);
+
+    let mut actions = Vec::new();
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(action) => actions.push(action),
+            // Per-item error: report and keep going — a partial result set is still useful.
+            Err(error) => eprintln!("corporate-action source error: {error}"),
+        }
+    }
+    actions
+}
+
+/// Turn a sourced [`CorporateAction<SmolStr>`] into an injectable [`EngineEvent::CorporateAction`],
+/// performing the four wrapper obligations. Returns `None` if the ticker does not resolve to an
+/// engine key or the action carries no effective date.
+fn build_event(action: &CorporateAction<SmolStr>) -> Option<EngineEvent> {
+    // (b) resolve the provider ticker to the engine's instrument key.
+    let instrument = resolve_ticker(action.instrument.as_str())?;
+    // (d) the effective date is required to stamp the event. A compliant `StockSplitSource` always
+    //     populates `effective_date` (per the trait contract), so `None` here means the source
+    //     misbehaved — this `?` is a defensive guard, not a routine branch.
+    let effective_date = action.effective_date?;
+
+    Some(EngineEvent::CorporateAction {
+        // (a) a unique, source-stable id — the sole idempotency key. A same-day correction would be
+        //     a second event with a *different* id (a reversal followed by the corrected split).
+        id: format!("{}-{}-split", action.instrument, effective_date).into(),
+        instrument,
+        // The market fact carries straight through, ratio and all.
+        kind: action.kind.clone(),
+        // (c) the broker rounding policy — a fractional-share broker here.
+        policy: SplitRoundingPolicy::Fractional,
+        // (d) effective *date* → effective *instant* (midnight UTC; also the backtest merge key).
+        effective_time: split_effective_instant(effective_date),
+    })
+}
+
+/// Stand-in for the wrapper's ticker → `InstrumentKey` registry. A real wrapper looks this up in its
+/// indexed instruments; here two symbols map to fixed indices and everything else is unknown.
+fn resolve_ticker(ticker: &str) -> Option<InstrumentIndex> {
+    match ticker {
+        "AAPL" => Some(InstrumentIndex::new(0)),
+        "NVDA" => Some(InstrumentIndex::new(1)),
+        _ => None,
+    }
+}
+
+/// A canned, offline [`StockSplitSource`] so the example runs without Massive credentials.
+struct DemoSplitSource;
+
+impl StockSplitSource for DemoSplitSource {
+    type Error = std::convert::Infallible;
+
+    fn fetch_splits(
+        &self,
+        _filter: &CorporateActionFilter,
+    ) -> impl Stream<Item = Result<CorporateAction<SmolStr>, Self::Error>> + Send {
+        futures::stream::iter([
+            // Apple 4-for-1, 2020-08-31.
+            Ok(CorporateAction::new(
+                SmolStr::new("AAPL"),
+                CorporateActionKind::StockSplit { ratio: dec!(4) },
+                NaiveDate::from_ymd_opt(2020, 8, 31),
+            )),
+            // NVIDIA 10-for-1, 2024-06-10.
+            Ok(CorporateAction::new(
+                SmolStr::new("NVDA"),
+                CorporateActionKind::StockSplit { ratio: dec!(10) },
+                NaiveDate::from_ymd_opt(2024, 6, 10),
+            )),
+        ])
+    }
+}

--- a/rustrade/examples/corporate_action_sourcing.rs
+++ b/rustrade/examples/corporate_action_sourcing.rs
@@ -18,18 +18,21 @@
 //!      executed; *when/whether* to inject stays a wrapper decision, so this is **not** an
 //!      auto-injecting driver.
 //!
-//! Run it with the real Massive source (needs `MASSIVE_API_KEY`):
+//! Run it against a real provider (each behind its own feature + credentials):
 //! ```bash
+//! # Alpaca corporate-actions endpoint (needs ALPACA_API_KEY / ALPACA_SECRET_KEY; free/paper tier):
+//! cargo run -p rustrade --features alpaca --example corporate_action_sourcing
+//! # Massive /v3/reference/splits (needs MASSIVE_API_KEY):
 //! cargo run -p rustrade --features massive --example corporate_action_sourcing
 //! ```
-//! Without the key it falls back to a small in-example [`DemoSplitSource`] so the mechanics still
-//! run offline. Both paths flow through the same trait-generic [`collect_splits`].
+//! Without any provider feature/credentials it falls back to a small in-example [`DemoSplitSource`]
+//! so the mechanics still run offline. Every path flows through the same trait-generic
+//! [`collect_splits`].
 
 use chrono::NaiveDate;
 use futures::{Stream, StreamExt};
 use rust_decimal_macros::dec;
 use rustrade::{EngineEvent, SplitRoundingPolicy};
-use rustrade_data::exchange::massive::MassiveRestClient;
 use rustrade_instrument::{
     corporate_action::{CorporateAction, CorporateActionKind, split_effective_instant},
     instrument::InstrumentIndex,
@@ -46,19 +49,9 @@ async fn main() {
         end: None,
     };
 
-    // Source the splits. With MASSIVE_API_KEY set, this drives the real `StockSplitSource` impl on
-    // `MassiveRestClient` against the live `/v3/reference/splits` endpoint; without it, a canned
-    // in-example source keeps the example runnable. Both go through the same generic `collect_splits`.
-    let actions = match MassiveRestClient::from_env() {
-        Ok(client) => {
-            println!("Sourcing splits from Massive…");
-            collect_splits(&client, &filter).await
-        }
-        Err(_) => {
-            println!("MASSIVE_API_KEY not set — using canned demo splits.");
-            collect_splits(&DemoSplitSource, &filter).await
-        }
-    };
+    // Source the splits from the first available provider (feature-gated + credentialed), falling
+    // back to a canned offline source. Every provider goes through the same generic `collect_splits`.
+    let actions = source_actions(&filter).await;
 
     // For each sourced fact, do the wrapper's job and build the injectable engine event.
     for action in &actions {
@@ -79,8 +72,35 @@ async fn main() {
     println!("Sourced {} split action(s).", actions.len());
 }
 
+/// Pick a [`StockSplitSource`] and drain it. Each real provider is feature-gated and used only when
+/// its credentials are present; otherwise the canned [`DemoSplitSource`] keeps the example runnable.
+async fn source_actions(filter: &CorporateActionFilter) -> Vec<CorporateAction<SmolStr>> {
+    #[cfg(feature = "alpaca")]
+    {
+        use rustrade_data::exchange::alpaca::AlpacaRestClient;
+        if let Ok(client) = AlpacaRestClient::from_env() {
+            println!("Sourcing splits from Alpaca…");
+            return collect_splits(&client, filter).await;
+        }
+        println!("ALPACA_API_KEY/ALPACA_SECRET_KEY not set — trying the next source.");
+    }
+
+    #[cfg(feature = "massive")]
+    {
+        use rustrade_data::exchange::massive::MassiveRestClient;
+        if let Ok(client) = MassiveRestClient::from_env() {
+            println!("Sourcing splits from Massive…");
+            return collect_splits(&client, filter).await;
+        }
+        println!("MASSIVE_API_KEY not set — trying the next source.");
+    }
+
+    println!("No provider source available — using canned demo splits.");
+    collect_splits(&DemoSplitSource, filter).await
+}
+
 /// Drain a [`StockSplitSource`] into a `Vec`, demonstrating trait-generic consumption — the same
-/// code drives the Massive client or any other implementor.
+/// code drives the Alpaca/Massive client or any other implementor.
 async fn collect_splits<S>(
     source: &S,
     filter: &CorporateActionFilter,
@@ -138,7 +158,7 @@ fn resolve_ticker(ticker: &str) -> Option<InstrumentIndex> {
     }
 }
 
-/// A canned, offline [`StockSplitSource`] so the example runs without Massive credentials.
+/// A canned, offline [`StockSplitSource`] so the example runs without provider credentials.
 struct DemoSplitSource;
 
 impl StockSplitSource for DemoSplitSource {

--- a/rustrade/examples/corporate_action_sourcing.rs
+++ b/rustrade/examples/corporate_action_sourcing.rs
@@ -169,16 +169,19 @@ impl StockSplitSource for DemoSplitSource {
         _filter: &CorporateActionFilter,
     ) -> impl Stream<Item = Result<CorporateAction<SmolStr>, Self::Error>> + Send {
         futures::stream::iter([
-            // Apple 4-for-1, 2020-08-31.
+            // Apple 4-for-1, 2020-08-31. A real source feeds the provider's `split_to`/`split_from`
+            // straight into `stock_split`, which derives the validated ratio in one place.
             Ok(CorporateAction::new(
                 SmolStr::new("AAPL"),
-                CorporateActionKind::StockSplit { ratio: dec!(4) },
+                CorporateActionKind::stock_split(dec!(4), dec!(1))
+                    .expect("4-for-1 is a valid split"),
                 NaiveDate::from_ymd_opt(2020, 8, 31),
             )),
             // NVIDIA 10-for-1, 2024-06-10.
             Ok(CorporateAction::new(
                 SmolStr::new("NVDA"),
-                CorporateActionKind::StockSplit { ratio: dec!(10) },
+                CorporateActionKind::stock_split(dec!(10), dec!(1))
+                    .expect("10-for-1 is a valid split"),
                 NaiveDate::from_ymd_opt(2024, 6, 10),
             )),
         ])

--- a/rustrade/examples/corporate_action_sourcing.rs
+++ b/rustrade/examples/corporate_action_sourcing.rs
@@ -32,11 +32,11 @@
 use chrono::NaiveDate;
 use futures::{Stream, StreamExt};
 use rust_decimal_macros::dec;
-use rustrade::{EngineEvent, SplitRoundingPolicy};
-use rustrade_instrument::{
-    corporate_action::{CorporateAction, CorporateActionKind, split_effective_instant},
-    instrument::InstrumentIndex,
-};
+use rustrade::{CorporateActionKind, EngineEvent, SplitRoundingPolicy, split_effective_instant};
+// `CorporateAction` (the reference-data record) and `InstrumentIndex` are not re-exported at the
+// crate root, so this dependency remains for them; `CorporateActionKind`/`split_effective_instant`
+// now come from the `rustrade` crate root.
+use rustrade_instrument::{corporate_action::CorporateAction, instrument::InstrumentIndex};
 use rustrade_integration::corporate_action::{CorporateActionFilter, StockSplitSource};
 use smol_str::SmolStr;
 

--- a/rustrade/examples/engine_backtest_with_candle_market_data.rs
+++ b/rustrade/examples/engine_backtest_with_candle_market_data.rs
@@ -23,7 +23,9 @@ use chrono::{DateTime, Duration, Utc};
 use rust_decimal::Decimal;
 use rustrade::{
     backtest::{
-        BacktestArgsConstant, BacktestArgsDynamic, backtest,
+        BacktestArgsConstant, BacktestArgsDynamic,
+        aux_events::NoAuxEvents,
+        backtest,
         market_data::{BacktestMarketData, MarketDataInMemory},
     },
     engine::{
@@ -100,6 +102,7 @@ async fn main() {
         market_data,
         summary_interval: Daily,
         engine_state,
+        aux_events: NoAuxEvents,
     });
 
     // DefaultStrategy/DefaultRiskManager are no-ops — this example demonstrates the

--- a/rustrade/src/backtest/aux_events.rs
+++ b/rustrade/src/backtest/aux_events.rs
@@ -1,0 +1,111 @@
+use crate::{EngineEvent, Timed};
+use rustrade_data::event::DataKind;
+use rustrade_instrument::{
+    asset::AssetIndex, exchange::ExchangeIndex, instrument::InstrumentIndex,
+};
+use std::sync::Arc;
+
+/// Source of auxiliary (non-market) [`EngineEvent`]s to interleave with the market-event replay
+/// during a backtest, in simulated-time order.
+///
+/// The backtest harness pre-merges these events with the market stream into a single
+/// time-ordered [`Stream`](futures::Stream) **before** the engine channel, so an injected
+/// [`EngineEvent::CorporateAction`] (or [`EngineEvent::ContractExpiry`]) is processed at exactly
+/// the right point in the timeline. Live trading injects the same events directly via
+/// `System.feed_tx`; this trait is the backtest equivalent.
+///
+/// The default implementation, [`NoAuxEvents`], yields nothing — existing backtests opt out at
+/// zero cost.
+///
+/// # Caller obligation
+/// [`aux_events`](Self::aux_events) MUST yield events sorted ascending by [`Timed::time`]. The
+/// merge with the market stream is a two-way merge that relies on both inputs already being
+/// sorted; out-of-order aux events produce an out-of-order engine feed (and, in backtest, a
+/// non-monotonic [`HistoricalClock`](crate::engine::clock::HistoricalClock)).
+pub trait AuxEventSource<
+    MarketKind = DataKind,
+    ExchangeKey = ExchangeIndex,
+    AssetKey = AssetIndex,
+    InstrumentKey = InstrumentIndex,
+>
+{
+    /// Return the auxiliary events to interleave, sorted ascending by [`Timed::time`].
+    fn aux_events(
+        &self,
+    ) -> impl Iterator<Item = Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>;
+}
+
+/// Zero-size [`AuxEventSource`] that yields no events.
+///
+/// The default `AuxEvents` type for [`BacktestArgsConstant`](super::BacktestArgsConstant), so a
+/// backtest that injects no corporate actions or expiries pays nothing — the two-way merge sees an
+/// empty aux side and reduces to the market stream unchanged.
+#[derive(Debug, Clone, Default)]
+pub struct NoAuxEvents;
+
+impl<MarketKind, ExchangeKey, AssetKey, InstrumentKey>
+    AuxEventSource<MarketKind, ExchangeKey, AssetKey, InstrumentKey> for NoAuxEvents
+{
+    fn aux_events(
+        &self,
+    ) -> impl Iterator<Item = Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>
+    {
+        std::iter::empty()
+    }
+}
+
+/// In-memory [`AuxEventSource`] backed by an [`Arc`]'d, pre-sorted `Vec`.
+///
+/// Mirrors [`MarketDataInMemory`](super::market_data::MarketDataInMemory): cloning is O(1) (an
+/// `Arc` clone), so the same source can be shared across a concurrent
+/// [`run_backtests`](super::run_backtests) sweep without re-allocating per backtest.
+#[derive(Debug, Clone)]
+pub struct AuxEventsInMemory<
+    MarketKind = DataKind,
+    ExchangeKey = ExchangeIndex,
+    AssetKey = AssetIndex,
+    InstrumentKey = InstrumentIndex,
+> {
+    events: Arc<Vec<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>>,
+}
+
+impl<MarketKind, ExchangeKey, AssetKey, InstrumentKey>
+    AuxEventsInMemory<MarketKind, ExchangeKey, AssetKey, InstrumentKey>
+{
+    /// Create a new in-memory aux source from a pre-sorted `Vec` of [`Timed`] events.
+    ///
+    /// # Panics
+    /// Panics if `events` is not sorted ascending by [`Timed::time`] (the [`AuxEventSource`] caller
+    /// obligation). This is a hard assert in all builds: out-of-order aux events would silently
+    /// produce a non-monotonic [`HistoricalClock`](crate::engine::clock::HistoricalClock) and wrong
+    /// simulation results in release. Observable failure > silent corruption.
+    pub fn new(
+        events: Arc<Vec<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>>,
+    ) -> Self {
+        // Hard assert (not `debug_assert!`): `events` ordering is a caller-supplied external
+        // invariant, and a violation would silently corrupt the simulated timeline in release
+        // rather than panic. The O(N) scan is negligible against the caller's own O(N log N) sort.
+        assert!(
+            events.windows(2).all(|w| w[0].time <= w[1].time),
+            "AuxEventsInMemory events must be sorted ascending by Timed::time"
+        );
+        Self { events }
+    }
+}
+
+impl<MarketKind, ExchangeKey, AssetKey, InstrumentKey>
+    AuxEventSource<MarketKind, ExchangeKey, AssetKey, InstrumentKey>
+    for AuxEventsInMemory<MarketKind, ExchangeKey, AssetKey, InstrumentKey>
+where
+    MarketKind: Clone,
+    ExchangeKey: Clone,
+    AssetKey: Clone,
+    InstrumentKey: Clone,
+{
+    fn aux_events(
+        &self,
+    ) -> impl Iterator<Item = Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>
+    {
+        self.events.iter().cloned()
+    }
+}

--- a/rustrade/src/backtest/aux_events.rs
+++ b/rustrade/src/backtest/aux_events.rs
@@ -22,6 +22,16 @@ use std::sync::Arc;
 /// merge with the market stream is a two-way merge that relies on both inputs already being
 /// sorted; out-of-order aux events produce an out-of-order engine feed (and, in backtest, a
 /// non-monotonic [`HistoricalClock`](crate::engine::clock::HistoricalClock)).
+///
+/// # Limitation — `ContractExpiry` does not advance the backtest clock
+/// [`EngineEvent::ContractExpiry`](crate::EngineEvent::ContractExpiry) carries no timestamp (unlike
+/// [`EngineEvent::CorporateAction`](crate::EngineEvent::CorporateAction), which carries
+/// `effective_time`). An injected expiry is therefore **ordered** correctly within the merged
+/// stream but does **not** advance the
+/// [`HistoricalClock`](crate::engine::clock::HistoricalClock): its synthetic settlement fill is
+/// stamped at the prior market tick, not the expiry instant. `CorporateAction` is unaffected (it
+/// advances the clock to its `effective_time`). If exact expiry-instant stamping matters, drive a
+/// market event at the expiry time alongside the injected `ContractExpiry`.
 pub trait AuxEventSource<
     MarketKind = DataKind,
     ExchangeKey = ExchangeIndex,

--- a/rustrade/src/backtest/aux_events.rs
+++ b/rustrade/src/backtest/aux_events.rs
@@ -71,6 +71,35 @@ impl<MarketKind, ExchangeKey, AssetKey, InstrumentKey>
     }
 }
 
+/// Panic if `events` are not sorted ascending by [`Timed::time`] (the [`AuxEventSource`] caller
+/// obligation).
+///
+/// Shared by [`AuxEventsInMemory::new`] (early detection at construction, before any backtest runs)
+/// and the backtest harness's pre-merge step (the load-bearing check for *any* [`AuxEventSource`]
+/// impl — a custom source backed by a DB or file never goes through `AuxEventsInMemory`, so this is
+/// the only guard on its events). A hard panic in all builds — not `debug_assert!` — because a
+/// violation silently feeds the engine a non-monotonic timeline (and
+/// [`HistoricalClock`](crate::engine::clock::HistoricalClock)) in release rather than failing. The
+/// O(N) scan is negligible against the caller's own O(N log N) sort, and the message names the
+/// offending pair so a failing custom source is debuggable without a rebuild.
+pub(crate) fn assert_aux_events_sorted<MarketKind, ExchangeKey, AssetKey, InstrumentKey>(
+    events: &[Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>],
+) {
+    if let Some((i, w)) = events
+        .windows(2)
+        .enumerate()
+        .find(|(_, w)| w[0].time > w[1].time)
+    {
+        panic!(
+            "AuxEventSource events must be sorted ascending by Timed::time; \
+             events[{i}].time={:?} > events[{}].time={:?}",
+            w[0].time,
+            i + 1,
+            w[1].time,
+        );
+    }
+}
+
 /// In-memory [`AuxEventSource`] backed by an [`Arc`]'d, pre-sorted `Vec`.
 ///
 /// Mirrors [`MarketDataInMemory`](super::market_data::MarketDataInMemory): cloning is O(1) (an
@@ -99,13 +128,9 @@ impl<MarketKind, ExchangeKey, AssetKey, InstrumentKey>
     pub fn new(
         events: Arc<Vec<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>>,
     ) -> Self {
-        // Hard assert (not `debug_assert!`): `events` ordering is a caller-supplied external
-        // invariant, and a violation would silently corrupt the simulated timeline in release
-        // rather than panic. The O(N) scan is negligible against the caller's own O(N log N) sort.
-        assert!(
-            events.windows(2).all(|w| w[0].time <= w[1].time),
-            "AuxEventsInMemory events must be sorted ascending by Timed::time"
-        );
+        // Enforce the caller's ascending-`Timed::time` obligation at construction, shared with the
+        // backtest harness's pre-merge check. See [`assert_aux_events_sorted`].
+        assert_aux_events_sorted(&events);
         Self { events }
     }
 }
@@ -124,5 +149,48 @@ where
     ) -> impl Iterator<Item = Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>
     {
         self.events.iter().cloned()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)] // Test code: panics on bad fixture input are acceptable
+mod tests {
+    use super::*;
+    use crate::shutdown::Shutdown;
+    use chrono::DateTime;
+
+    fn at(secs: i64) -> Timed<EngineEvent> {
+        Timed::new(
+            EngineEvent::Shutdown(Shutdown),
+            DateTime::from_timestamp(secs, 0).expect("valid timestamp"),
+        )
+    }
+
+    #[test]
+    fn assert_aux_events_sorted_accepts_ascending_and_equal_timestamps() {
+        // Ascending and *equal* adjacent timestamps both satisfy the contract (the check is `<=`).
+        assert_aux_events_sorted::<DataKind, ExchangeIndex, AssetIndex, InstrumentIndex>(&[
+            at(1_000),
+            at(1_000),
+            at(2_000),
+        ]);
+    }
+
+    #[test]
+    #[should_panic(expected = "events[1].time")]
+    fn assert_aux_events_sorted_panics_on_unsorted_pair() {
+        // The second pair (index 1) is out of order; the message must name that pair.
+        assert_aux_events_sorted::<DataKind, ExchangeIndex, AssetIndex, InstrumentIndex>(&[
+            at(1_000),
+            at(3_000),
+            at(2_000),
+        ]);
+    }
+
+    #[test]
+    #[should_panic(expected = "sorted ascending by Timed::time")]
+    fn aux_events_in_memory_new_rejects_unsorted() {
+        // `AuxEventsInMemory::new` must delegate to the shared check rather than accept unsorted input.
+        let _ = AuxEventsInMemory::<DataKind>::new(Arc::new(vec![at(2_000), at(1_000)]));
     }
 }

--- a/rustrade/src/backtest/aux_events.rs
+++ b/rustrade/src/backtest/aux_events.rs
@@ -17,11 +17,18 @@ use std::sync::Arc;
 /// The default implementation, [`NoAuxEvents`], yields nothing — existing backtests opt out at
 /// zero cost.
 ///
-/// # Caller obligation
-/// [`aux_events`](Self::aux_events) MUST yield events sorted ascending by [`Timed::time`]. The
-/// merge with the market stream is a two-way merge that relies on both inputs already being
-/// sorted; out-of-order aux events produce an out-of-order engine feed (and, in backtest, a
-/// non-monotonic [`HistoricalClock`](crate::engine::clock::HistoricalClock)).
+/// # Caller obligations
+/// - [`aux_events`](Self::aux_events) MUST yield events sorted ascending by [`Timed::time`]. The
+///   merge with the market stream is a two-way merge that relies on both inputs already being
+///   sorted; out-of-order aux events produce an out-of-order engine feed (and, in backtest, a
+///   non-monotonic [`HistoricalClock`](crate::engine::clock::HistoricalClock)).
+/// - For an [`EngineEvent::CorporateAction`](crate::EngineEvent::CorporateAction), the wrapping
+///   [`Timed::time`] MUST equal the action's `effective_time`. These are two independent knobs: the
+///   merge **positions** the event in the stream by `Timed::time`, while the handler advances the
+///   [`HistoricalClock`](crate::engine::clock::HistoricalClock) to `effective_time` and stamps the
+///   adjustment there. A mismatch is silently honored — the action would be *ordered* at one instant
+///   but *take effect* at another — so the adjustment fires at the wrong simulated time. This is not
+///   enforced (the handler cannot see the wrapping `Timed`); keep them equal.
 ///
 /// # Limitation — `ContractExpiry` does not advance the backtest clock
 /// [`EngineEvent::ContractExpiry`](crate::EngineEvent::ContractExpiry) carries no timestamp (unlike

--- a/rustrade/src/backtest/aux_events.rs
+++ b/rustrade/src/backtest/aux_events.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 /// `System.feed_tx`; this trait is the backtest equivalent.
 ///
 /// The default implementation, [`NoAuxEvents`], yields nothing — existing backtests opt out at
-/// zero cost.
+/// negligible per-event overhead.
 ///
 /// # Caller obligations
 /// - [`aux_events`](Self::aux_events) MUST yield events sorted ascending by [`Timed::time`]. The
@@ -26,9 +26,10 @@ use std::sync::Arc;
 ///   [`Timed::time`] MUST equal the action's `effective_time`. These are two independent knobs: the
 ///   merge **positions** the event in the stream by `Timed::time`, while the handler advances the
 ///   [`HistoricalClock`](crate::engine::clock::HistoricalClock) to `effective_time` and stamps the
-///   adjustment there. A mismatch is silently honored — the action would be *ordered* at one instant
-///   but *take effect* at another — so the adjustment fires at the wrong simulated time. This is not
-///   enforced (the handler cannot see the wrapping `Timed`); keep them equal.
+///   adjustment there. A mismatch would *order* the action at one instant but make it *take effect*
+///   at another. The backtest harness **enforces** this pre-merge via
+///   [`assert_aux_corporate_action_effective_times`] (a hard panic naming the offending event) — the
+///   handler itself cannot see the wrapping `Timed`, so keep the two equal to pass the check.
 ///
 /// # Limitation — `ContractExpiry` does not advance the backtest clock
 /// [`EngineEvent::ContractExpiry`](crate::EngineEvent::ContractExpiry) carries no timestamp (unlike
@@ -55,8 +56,8 @@ pub trait AuxEventSource<
 /// Zero-size [`AuxEventSource`] that yields no events.
 ///
 /// The default `AuxEvents` type for [`BacktestArgsConstant`](super::BacktestArgsConstant), so a
-/// backtest that injects no corporate actions or expiries pays nothing — the two-way merge sees an
-/// empty aux side and reduces to the market stream unchanged.
+/// backtest that injects no corporate actions or expiries adds only negligible per-event overhead —
+/// the two-way merge sees an empty aux side and forwards the market stream.
 #[derive(Debug, Clone, Default)]
 pub struct NoAuxEvents;
 
@@ -97,6 +98,42 @@ pub(crate) fn assert_aux_events_sorted<MarketKind, ExchangeKey, AssetKey, Instru
             i + 1,
             w[1].time,
         );
+    }
+}
+
+/// Panic if any injected [`EngineEvent::CorporateAction`] carries an `effective_time` that differs
+/// from its wrapping [`Timed::time`] (the second [`AuxEventSource`] caller obligation).
+///
+/// The merge **positions** a corporate action in the stream by `Timed::time`, while the handler
+/// advances the [`HistoricalClock`](crate::engine::clock::HistoricalClock) to `effective_time` and
+/// stamps the adjustment there. If the two disagree the action is *ordered* at one instant but
+/// *takes effect* at another — a silent look-ahead / stale-stamp bug with no failure point in a
+/// release build. This enforces them equal at the same pre-merge site as
+/// [`assert_aux_events_sorted`] (a hard panic in all builds — the handler itself cannot see the
+/// wrapping `Timed`, so the harness is the only place this can be checked). The O(N) scan is
+/// negligible over the handful-sized aux set, and the message names the offending event so a failing
+/// source is debuggable without a rebuild.
+pub(crate) fn assert_aux_corporate_action_effective_times<
+    MarketKind,
+    ExchangeKey,
+    AssetKey,
+    InstrumentKey,
+>(
+    events: &[Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>],
+) {
+    for (i, event) in events.iter().enumerate() {
+        if let EngineEvent::CorporateAction {
+            id, effective_time, ..
+        } = &event.value
+            && *effective_time != event.time
+        {
+            panic!(
+                "AuxEventSource CorporateAction (id={id}) at events[{i}] must carry \
+                 effective_time == Timed::time; effective_time={effective_time:?} != \
+                 Timed::time={:?}",
+                event.time,
+            );
+        }
     }
 }
 
@@ -156,13 +193,34 @@ where
 #[allow(clippy::expect_used)] // Test code: panics on bad fixture input are acceptable
 mod tests {
     use super::*;
+    use crate::SplitRoundingPolicy;
     use crate::shutdown::Shutdown;
     use chrono::DateTime;
+    use rust_decimal::Decimal;
+    use rustrade_instrument::corporate_action::{CorporateActionKind, SplitRatio};
 
     fn at(secs: i64) -> Timed<EngineEvent> {
         Timed::new(
             EngineEvent::Shutdown(Shutdown),
             DateTime::from_timestamp(secs, 0).expect("valid timestamp"),
+        )
+    }
+
+    /// Build a `CorporateAction` whose `effective_time` and wrapping `Timed::time` can differ, to
+    /// exercise `assert_aux_corporate_action_effective_times`.
+    fn corp_action(effective_secs: i64, time_secs: i64) -> Timed<EngineEvent> {
+        Timed::new(
+            EngineEvent::CorporateAction {
+                id: "test-split".into(),
+                instrument: InstrumentIndex::new(0),
+                kind: CorporateActionKind::StockSplit {
+                    ratio: SplitRatio::new(Decimal::from(2)).expect("valid ratio"),
+                },
+                policy: SplitRoundingPolicy::Fractional,
+                effective_time: DateTime::from_timestamp(effective_secs, 0)
+                    .expect("valid timestamp"),
+            },
+            DateTime::from_timestamp(time_secs, 0).expect("valid timestamp"),
         )
     }
 
@@ -192,5 +250,30 @@ mod tests {
     fn aux_events_in_memory_new_rejects_unsorted() {
         // `AuxEventsInMemory::new` must delegate to the shared check rather than accept unsorted input.
         let _ = AuxEventsInMemory::<DataKind>::new(Arc::new(vec![at(2_000), at(1_000)]));
+    }
+
+    #[test]
+    fn assert_aux_corporate_action_effective_times_accepts_matching_times() {
+        // effective_time == Timed::time satisfies the contract; non-CorporateAction events (the
+        // trailing Shutdown) are ignored by the check. No panic.
+        assert_aux_corporate_action_effective_times::<
+            DataKind,
+            ExchangeIndex,
+            AssetIndex,
+            InstrumentIndex,
+        >(&[corp_action(1_000, 1_000), at(2_000)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "effective_time == Timed::time")]
+    fn assert_aux_corporate_action_effective_times_panics_on_mismatch() {
+        // A CorporateAction ordered at Timed::time=2000 but taking effect at 1000 is a silent
+        // look-ahead; the hard assert (all builds) must panic naming the offending event.
+        assert_aux_corporate_action_effective_times::<
+            DataKind,
+            ExchangeIndex,
+            AssetIndex,
+            InstrumentIndex,
+        >(&[corp_action(1_000, 2_000)]);
     }
 }

--- a/rustrade/src/backtest/market_data.rs
+++ b/rustrade/src/backtest/market_data.rs
@@ -22,9 +22,10 @@ use std::sync::Arc;
 ///   an implementation backed by a single-pass cursor must not let one consume events the other
 ///   needs.
 ///
-/// # Limitation
-/// The harness currently `collect`s the entire `stream` into memory to perform the time-merge, so
-/// lazy streaming is not preserved — sources too large to fit in memory are not yet supported.
+/// # Memory model
+/// The time-merge consumes this stream **lazily** (it is polled on demand, never collected), so the
+/// harness's memory overhead is O(1) in the dataset size — a source streamed item-by-item stays
+/// streamed end to end.
 pub trait BacktestMarketData {
     /// The type of market events provided by this data source.
     type Kind;

--- a/rustrade/src/backtest/market_data.rs
+++ b/rustrade/src/backtest/market_data.rs
@@ -7,14 +7,36 @@ use std::sync::Arc;
 
 /// Interface that provides the backtest MarketStream and associated
 /// [`HistoricalClock`](crate::engine::clock::HistoricalClock).
+///
+/// # Caller obligations
+/// The backtest harness time-merges this market data with any
+/// [`AuxEventSource`](super::aux_events::AuxEventSource) events into a single ordered engine feed,
+/// so an implementation MUST uphold:
+/// - [`stream`](Self::stream) yields events sorted ascending by `time_exchange`. The merge is a
+///   two-way merge that assumes both inputs are already sorted; an unsorted stream produces an
+///   out-of-order engine feed and a non-monotonic
+///   [`HistoricalClock`](crate::engine::clock::HistoricalClock).
+/// - [`time_first_event`](Self::time_first_event) and [`stream`](Self::stream) are *coherent*: they
+///   describe the same dataset, and `time_first_event` equals the `time_exchange` of the first
+///   [`MarketStreamEvent::Item`] that `stream` will yield. The harness calls them independently, so
+///   an implementation backed by a single-pass cursor must not let one consume events the other
+///   needs.
+///
+/// # Limitation
+/// The harness currently `collect`s the entire `stream` into memory to perform the time-merge, so
+/// lazy streaming is not preserved — sources too large to fit in memory are not yet supported.
 pub trait BacktestMarketData {
     /// The type of market events provided by this data source.
     type Kind;
 
     /// Return the `DateTime<Utc>` of the first event in the market data `Stream`.
+    ///
+    /// Must be coherent with [`stream`](Self::stream) — see the trait-level caller obligations.
     fn time_first_event(&self) -> impl Future<Output = Result<DateTime<Utc>, BarterError>>;
 
-    /// Return a `Stream` of `MarketStreamEvent`s.
+    /// Return a `Stream` of `MarketStreamEvent`s, sorted ascending by `time_exchange`.
+    ///
+    /// See the trait-level caller obligations for the sort and coherence requirements.
     fn stream(
         &self,
     ) -> impl Future<
@@ -59,10 +81,12 @@ where
 }
 
 impl<Kind> MarketDataInMemory<Kind> {
-    /// Create a new in-memory market data source from a vector of market events.
+    /// Create a new in-memory market data source from a pre-sorted vector of market events.
     ///
     /// # Panics
-    /// Panics if `events` contains no `MarketStreamEvent::Item` variant.
+    /// - Panics if `events` contains no [`MarketStreamEvent::Item`] variant.
+    /// - Panics if the [`Item`](MarketStreamEvent::Item) timestamps are not sorted ascending by
+    ///   `time_exchange` (the [`BacktestMarketData`] caller obligation).
     #[allow(clippy::expect_used)] // Caller contract: events must contain at least one MarketStreamEvent::Item variant
     pub fn new(events: Arc<Vec<MarketStreamEvent<InstrumentIndex, Kind>>>) -> Self {
         let time_first_event = events
@@ -72,6 +96,22 @@ impl<Kind> MarketDataInMemory<Kind> {
                 _ => None,
             })
             .expect("cannot construct MarketDataInMemory using an empty Vec<MarketStreamEvent>");
+
+        // Hard assert (not `debug_assert!`): event ordering is a caller-supplied external invariant
+        // that the harness's time-merge with `AuxEventSource` events relies on; an unsorted stream
+        // would silently produce a non-monotonic clock and wrong simulation results in release.
+        // Mirrors `AuxEventsInMemory::new`. `Reconnecting` events carry no timestamp (the harness
+        // carries the prior time forward), so only `Item` timestamps are checked.
+        assert!(
+            events
+                .iter()
+                .filter_map(|event| match event {
+                    MarketStreamEvent::Item(event) => Some(event.time_exchange),
+                    _ => None,
+                })
+                .is_sorted(),
+            "MarketDataInMemory events must be sorted ascending by MarketEvent::time_exchange"
+        );
 
         Self {
             time_first_event,

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     system::builder::{AuditMode, SystemBuild},
 };
 use chrono::{DateTime, Utc};
-use futures::{StreamExt, future::try_join_all, stream};
+use futures::{Stream, StreamExt, future::try_join_all};
 use rust_decimal::Decimal;
 use rustrade_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
 use rustrade_execution::AccountEvent;
@@ -39,7 +39,12 @@ use rustrade_instrument::{
     instrument::InstrumentIndex,
 };
 use smol_str::SmolStr;
-use std::{fmt::Debug, sync::Arc};
+use std::{
+    fmt::Debug,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 /// Defines the [`AuxEventSource`](aux_events::AuxEventSource) interface for interleaving non-market
 /// `EngineEvent`s (e.g. corporate actions, contract expiries) into a backtest in simulated-time
@@ -256,20 +261,17 @@ where
         + Send
         + Sync,
 {
-    // Collect the market stream and pre-merge it with the auxiliary (non-market) events into a
-    // single time-ordered stream BEFORE the engine channel, so an injected event (e.g. a corporate
-    // action) is processed at the correct point in simulated time. Merging into one stream — rather
-    // than forwarding market and aux as two producers into the engine feed — is what preserves the
-    // time order (two `forward_to` tasks would interleave non-deterministically). See
-    // [`AuxEventSource`].
+    // Lazily merge the market stream with the auxiliary (non-market) events into a single
+    // time-ordered stream BEFORE the engine channel, so an injected event (e.g. a corporate action)
+    // is processed at the correct point in simulated time. The market side stays lazy — it is never
+    // collected — so peak memory is O(1) in the dataset size, and the common no-aux case streams
+    // exactly as a pre-corporate-action backtest did. Merging into one stream — rather than
+    // forwarding market and aux as two producers into the engine feed — is what preserves the time
+    // order (two `forward_to` tasks would interleave non-deterministically). See [`AuxEventSource`].
     let market_first = args_constant.market_data.time_first_event().await?;
-    let raw_market = args_constant
-        .market_data
-        .stream()
-        .await?
-        .collect::<Vec<_>>()
-        .await;
-    let market = market_events_to_timed(raw_market, market_first);
+    let raw_market = args_constant.market_data.stream().await?;
+    // The aux side is tiny (corporate actions / expiries number in the handful), so collecting it is
+    // cheap and lets the merge peek it synchronously.
     let aux = args_constant.aux_events.aux_events().collect::<Vec<_>>();
 
     // Seed the clock from the earliest of the first market event and the first aux event, so an aux
@@ -304,11 +306,11 @@ where
         args_dynamic.risk,
     );
 
-    // Drive the engine from the single pre-merged time-ordered stream. Its item is `EngineEvent`,
+    // Drive the engine from the single lazily-merged time-ordered stream. Its item is `EngineEvent`,
     // which the engine's feed accepts directly (`Event: From<MarketStream::Item>` is satisfied
     // reflexively), so it flows through `SystemBuild`'s existing single market-forwarding task and
     // `shutdown_after_backtest` needs no change.
-    let market_stream = stream::iter(merge_timed(market, aux));
+    let market_stream = merge_market_with_aux(raw_market, market_first, aux);
 
     let system = SystemBuild::new(
         engine,
@@ -334,71 +336,127 @@ where
     })
 }
 
-/// Map time-sorted market events to `Timed<EngineEvent>`, preserving order.
+/// A lazy, time-ordered two-way merge of a backtest market stream and pre-collected auxiliary
+/// (non-market) events.
 ///
-/// A [`MarketStreamEvent::Reconnecting`] carries no timestamp; its position is preserved by
-/// carrying the previous event's `time_exchange` forward (`seed` is used only if the very first
-/// event is a `Reconnecting`). For an in-memory backtest no `Reconnecting` events occur, so the
-/// carry-forward is purely defensive.
-fn market_events_to_timed<MarketKind, ExchangeKey, AssetKey, InstrumentKey>(
-    events: Vec<MarketStreamEvent<InstrumentKey, MarketKind>>,
-    seed: DateTime<Utc>,
-) -> Vec<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>
+/// The market side stays **lazy** — it is polled on demand and never collected, so peak memory is
+/// O(1) in the dataset size and the common no-aux case streams exactly as a pre-corporate-action
+/// backtest did. The aux side is tiny (corporate actions / expiries number in the handful), so it is
+/// held as a `Peekable` iterator and peeked synchronously to decide ordering.
+///
+/// # Ordering contract
+/// - `aux` MUST be sorted ascending by [`Timed::time`] (the [`AuxEventSource`] obligation); the
+///   market stream is assumed time-sorted by `time_exchange`.
+/// - Aux events win ties (`aux.time <= market.time`), so an injected event at the same instant as a
+///   market event is processed first — e.g. a stock split adjusts positions before any fill stamped
+///   at that instant.
+/// - A [`MarketStreamEvent::Reconnecting`] carries no timestamp; its ordering inherits the prior
+///   market event's `time_exchange` (`last_market_time`), falling back to the seed only if it leads.
+///   For an in-memory backtest no `Reconnecting` events occur, so the carry-forward is purely
+///   defensive.
+///
+/// The yielded item is a bare [`EngineEvent`]; the engine reads simulated time itself (via the
+/// market event's exchange timestamp), so the ordering time is internal to this merge.
+#[pin_project::pin_project]
+struct TimedMergeStream<St, MarketKind, ExchangeKey, AssetKey, InstrumentKey>
+where
+    St: Stream<Item = MarketStreamEvent<InstrumentKey, MarketKind>>,
+{
+    #[pin]
+    market: futures::stream::Peekable<St>,
+    aux: std::iter::Peekable<
+        std::vec::IntoIter<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>,
+    >,
+    last_market_time: DateTime<Utc>,
+}
+
+impl<St, MarketKind, ExchangeKey, AssetKey, InstrumentKey> Stream
+    for TimedMergeStream<St, MarketKind, ExchangeKey, AssetKey, InstrumentKey>
+where
+    St: Stream<Item = MarketStreamEvent<InstrumentKey, MarketKind>>,
+    EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>:
+        From<MarketStreamEvent<InstrumentKey, MarketKind>>,
+{
+    type Item = EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        // No aux remaining: forward the market side verbatim (the O(1)-memory fast path).
+        let Some(aux_time) = this.aux.peek().map(|timed| timed.time) else {
+            return this
+                .market
+                .as_mut()
+                .poll_next(cx)
+                .map(|opt| opt.map(|event| convert_market(event, this.last_market_time)));
+        };
+
+        // Aux has an event: peek the market's next event to order them.
+        match this.market.as_mut().poll_peek(cx) {
+            // Can't decide ordering until the market's next event (or its end) is known.
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(market_next)) => {
+                // Copy the Copy `DateTime` out so the peek borrow of `this.market` ends here,
+                // freeing `this.market` to be re-polled in the `else` arm below.
+                let market_time = match market_next {
+                    MarketStreamEvent::Item(market_event) => market_event.time_exchange,
+                    MarketStreamEvent::Reconnecting(_) => *this.last_market_time,
+                };
+                if aux_time <= market_time {
+                    // Aux leads or ties — emit it. `aux.peek()` was `Some`, so `next()` is `Some`.
+                    Poll::Ready(this.aux.next().map(|timed| timed.value))
+                } else {
+                    this.market
+                        .as_mut()
+                        .poll_next(cx)
+                        .map(|opt| opt.map(|event| convert_market(event, this.last_market_time)))
+                }
+            }
+            // Market exhausted — drain the remaining aux events in order.
+            Poll::Ready(None) => Poll::Ready(this.aux.next().map(|timed| timed.value)),
+        }
+    }
+}
+
+/// Convert a market event to an [`EngineEvent`], advancing `last_market_time` on an `Item` so a later
+/// [`MarketStreamEvent::Reconnecting`] (which has no timestamp) can inherit the prior time for
+/// ordering.
+fn convert_market<MarketKind, ExchangeKey, AssetKey, InstrumentKey>(
+    event: MarketStreamEvent<InstrumentKey, MarketKind>,
+    last_market_time: &mut DateTime<Utc>,
+) -> EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>
 where
     EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>:
         From<MarketStreamEvent<InstrumentKey, MarketKind>>,
 {
-    let mut last_time = seed;
-    events
-        .into_iter()
-        .map(|event| {
-            let time = match &event {
-                MarketStreamEvent::Item(market_event) => {
-                    last_time = market_event.time_exchange;
-                    market_event.time_exchange
-                }
-                MarketStreamEvent::Reconnecting(_) => last_time,
-            };
-            Timed::new(EngineEvent::from(event), time)
-        })
-        .collect()
+    if let MarketStreamEvent::Item(market_event) = &event {
+        *last_market_time = market_event.time_exchange;
+    }
+    EngineEvent::from(event)
 }
 
-/// Two-way merge of two `time`-sorted `Vec<Timed<EngineEvent>>` into one time-ordered
-/// `Vec<EngineEvent>`.
-///
-/// Both inputs are assumed sorted ascending by [`Timed::time`] (an O(N+M) merge). Aux events win
-/// ties (`aux.time <= market.time`), so an injected event at the same instant as a market event is
-/// processed first — e.g. a stock split adjusts positions before any fill stamped at that instant.
-fn merge_timed<MarketKind, ExchangeKey, AssetKey, InstrumentKey>(
-    market: Vec<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>,
+/// Build a [`TimedMergeStream`]. `seed` is the fallback ordering time for a leading
+/// [`MarketStreamEvent::Reconnecting`]; `aux` MUST be sorted ascending by [`Timed::time`].
+fn merge_market_with_aux<St, MarketKind, ExchangeKey, AssetKey, InstrumentKey>(
+    market: St,
+    seed: DateTime<Utc>,
     aux: Vec<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>,
-) -> Vec<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>> {
-    let mut merged = Vec::with_capacity(market.len() + aux.len());
-    let mut market = market.into_iter().peekable();
-    let mut aux = aux.into_iter().peekable();
-    loop {
-        // Take from aux when it leads or ties (aux wins ties); otherwise from market. Each branch
-        // is only reached after the corresponding `peek()` returned `Some`, so `next()` is
-        // guaranteed `Some` — the `if let` is a total match, never a silent drop.
-        let next = match (aux.peek(), market.peek()) {
-            (Some(a), Some(m)) if a.time <= m.time => aux.next(),
-            (Some(_), Some(_)) => market.next(),
-            (Some(_), None) => aux.next(),
-            (None, Some(_)) => market.next(),
-            (None, None) => break,
-        };
-        if let Some(timed) = next {
-            merged.push(timed.value);
-        }
+) -> TimedMergeStream<St, MarketKind, ExchangeKey, AssetKey, InstrumentKey>
+where
+    St: Stream<Item = MarketStreamEvent<InstrumentKey, MarketKind>>,
+{
+    TimedMergeStream {
+        market: market.peekable(),
+        aux: aux.into_iter().peekable(),
+        last_market_time: seed,
     }
-    merged
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)] // Test code: panicking on a bad fixture is acceptable
 mod tests {
     use super::*;
+    use futures::stream;
     use rustrade_data::{event::DataKind, subscription::trade::PublicTrade};
     use rustrade_instrument::exchange::ExchangeId;
 
@@ -406,7 +464,7 @@ mod tests {
         DateTime::from_timestamp(secs, 0).unwrap()
     }
 
-    /// A `Timed` marker whose `ContractExpiry` instrument id identifies it in assertions.
+    /// A `Timed` aux marker whose `ContractExpiry` instrument id identifies it in assertions.
     fn marker(id: usize, secs: i64) -> Timed<EngineEvent<DataKind>> {
         Timed::new(expiry(id), at(secs))
     }
@@ -415,12 +473,14 @@ mod tests {
         EngineEvent::ContractExpiry(InstrumentIndex::new(id))
     }
 
-    fn trade_event(secs: i64) -> MarketStreamEvent<InstrumentIndex, DataKind> {
+    /// A market `Item` at `secs`; its `instrument` id identifies it in assertions (it becomes a
+    /// `MarketEvent` engine event after the merge, distinct from the `ContractExpiry` aux markers).
+    fn trade_event(id: usize, secs: i64) -> MarketStreamEvent<InstrumentIndex, DataKind> {
         MarketStreamEvent::Item(MarketEvent {
             time_exchange: at(secs),
             time_received: at(secs),
             exchange: ExchangeId::BinanceSpot,
-            instrument: InstrumentIndex::new(0),
+            instrument: InstrumentIndex::new(id),
             kind: DataKind::Trade(PublicTrade {
                 id: "t".into(),
                 price: Decimal::ONE,
@@ -430,55 +490,121 @@ mod tests {
         })
     }
 
-    #[test]
-    fn merge_interleaves_by_time_with_aux_first_on_ties() {
-        let market = vec![marker(0, 10), marker(1, 30)];
+    /// The `instrument` id of a `MarketEvent` engine event, or `None` for any other variant.
+    fn market_id(event: &EngineEvent<DataKind>) -> Option<usize> {
+        match event {
+            EngineEvent::Market(MarketStreamEvent::Item(market_event)) => {
+                Some(market_event.instrument.index())
+            }
+            _ => None,
+        }
+    }
+
+    /// The instrument id of a `ContractExpiry` aux marker, or `None` for any other variant.
+    fn expiry_id(event: &EngineEvent<DataKind>) -> Option<usize> {
+        match event {
+            EngineEvent::ContractExpiry(instrument) => Some(instrument.index()),
+            _ => None,
+        }
+    }
+
+    async fn merge(
+        market: Vec<MarketStreamEvent<InstrumentIndex, DataKind>>,
+        seed: DateTime<Utc>,
+        aux: Vec<Timed<EngineEvent<DataKind>>>,
+    ) -> Vec<EngineEvent<DataKind>> {
+        merge_market_with_aux(stream::iter(market), seed, aux)
+            .collect::<Vec<_>>()
+            .await
+    }
+
+    #[tokio::test]
+    async fn merge_interleaves_by_time_with_aux_first_on_ties() {
+        // Market items at t=10 (id 0) and t=30 (id 1); aux markers at t=20 (id 100) and t=30 (id 101).
+        let market = vec![trade_event(0, 10), trade_event(1, 30)];
         let aux = vec![marker(100, 20), marker(101, 30)];
-        // aux (101) at t=30 must precede market (1) at the same t=30.
+        let merged = merge(market, at(0), aux).await;
+        // aux (101) at t=30 must precede market (1) at the same t=30 (aux wins ties).
         assert_eq!(
-            merge_timed(market, aux),
-            vec![expiry(0), expiry(100), expiry(101), expiry(1)]
+            merged.iter().map(market_id).collect::<Vec<_>>(),
+            vec![Some(0), None, None, Some(1)]
+        );
+        assert_eq!(
+            merged.iter().map(expiry_id).collect::<Vec<_>>(),
+            vec![None, Some(100), Some(101), None]
         );
     }
 
-    #[test]
-    fn merge_empty_aux_is_market_identity() {
-        let market = vec![marker(0, 10), marker(1, 20)];
-        assert_eq!(merge_timed(market, Vec::new()), vec![expiry(0), expiry(1)]);
+    #[tokio::test]
+    async fn merge_empty_aux_is_market_identity() {
+        // The O(1)-memory fast path: market is forwarded verbatim.
+        let market = vec![trade_event(0, 10), trade_event(1, 20)];
+        let merged = merge(market, at(0), Vec::new()).await;
+        assert_eq!(
+            merged.iter().map(market_id).collect::<Vec<_>>(),
+            vec![Some(0), Some(1)]
+        );
     }
 
-    #[test]
-    fn merge_empty_market_yields_aux_in_order() {
+    #[tokio::test]
+    async fn merge_empty_market_yields_aux_in_order() {
         let aux = vec![marker(100, 5), marker(101, 6)];
-        assert_eq!(merge_timed(Vec::new(), aux), vec![expiry(100), expiry(101)]);
+        let merged = merge(Vec::new(), at(0), aux).await;
+        assert_eq!(
+            merged.iter().map(expiry_id).collect::<Vec<_>>(),
+            vec![Some(100), Some(101)]
+        );
     }
 
-    #[test]
-    fn merge_both_empty_is_empty() {
-        let merged: Vec<EngineEvent<DataKind>> = merge_timed(Vec::new(), Vec::new());
+    #[tokio::test]
+    async fn merge_both_empty_is_empty() {
+        let merged = merge(Vec::new(), at(0), Vec::new()).await;
         assert!(merged.is_empty());
     }
 
-    #[test]
-    fn market_events_to_timed_stamps_time_exchange_and_carries_forward_reconnecting() {
-        let events = vec![
-            trade_event(10),
+    #[tokio::test]
+    async fn merge_reconnecting_carries_prior_time_forward() {
+        // Market: Item @10, Reconnecting (no timestamp, inherits 10), Item @30.
+        let market = vec![
+            trade_event(0, 10),
             MarketStreamEvent::Reconnecting(ExchangeId::BinanceSpot),
-            trade_event(30),
+            trade_event(1, 30),
         ];
-        let timed: Vec<Timed<EngineEvent<DataKind>>> = market_events_to_timed(events, at(1));
-        let times: Vec<i64> = timed.iter().map(|timed| timed.time.timestamp()).collect();
-        // Item @10, Reconnecting carries the prior 10 forward, Item @30.
-        assert_eq!(times, vec![10, 10, 30]);
+        // An aux marker at t=20 must order AFTER the Reconnecting (carried time 10 <= 20) and BEFORE
+        // the t=30 item; this reveals the carried-forward time.
+        let aux = vec![marker(100, 20)];
+        let merged = merge(market, at(0), aux).await;
+        let order: Vec<_> = merged
+            .iter()
+            .map(|event| match event {
+                EngineEvent::Market(MarketStreamEvent::Item(m)) => {
+                    format!("item{}", m.instrument.index())
+                }
+                EngineEvent::Market(MarketStreamEvent::Reconnecting(_)) => {
+                    "reconnecting".to_string()
+                }
+                EngineEvent::ContractExpiry(instrument) => format!("aux{}", instrument.index()),
+                _ => "other".to_string(),
+            })
+            .collect();
+        assert_eq!(order, vec!["item0", "reconnecting", "aux100", "item1"]);
     }
 
-    #[test]
-    fn market_events_to_timed_uses_seed_for_leading_reconnecting() {
-        let timed = market_events_to_timed::<DataKind, ExchangeIndex, AssetIndex, InstrumentIndex>(
-            vec![MarketStreamEvent::Reconnecting(ExchangeId::BinanceSpot)],
-            at(7),
-        );
-        assert_eq!(timed.len(), 1);
-        assert_eq!(timed[0].time, at(7));
+    #[tokio::test]
+    async fn merge_leading_reconnecting_uses_seed() {
+        // A leading Reconnecting has no prior market time, so it inherits the seed. With the seed at
+        // t=7 and an aux marker at t=5, the aux (5 <= 7) must lead the Reconnecting.
+        let market = vec![MarketStreamEvent::Reconnecting(ExchangeId::BinanceSpot)];
+        let aux = vec![marker(100, 5)];
+        let merged = merge(market, at(7), aux).await;
+        let order: Vec<_> = merged
+            .iter()
+            .map(|event| match event {
+                EngineEvent::Market(MarketStreamEvent::Reconnecting(_)) => "reconnecting",
+                EngineEvent::ContractExpiry(_) => "aux",
+                _ => "other",
+            })
+            .collect();
+        assert_eq!(order, vec!["aux", "reconnecting"]);
     }
 }

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -5,7 +5,7 @@ use crate::{EngineEvent, Timed};
 /// using market data, and analyzing the performance of these simulations.
 use crate::{
     backtest::{
-        aux_events::{AuxEventSource, NoAuxEvents},
+        aux_events::{AuxEventSource, NoAuxEvents, assert_aux_events_sorted},
         market_data::BacktestMarketData,
         summary::{BacktestSummary, MultiBacktestSummary},
     },
@@ -264,8 +264,8 @@ where
     // Lazily merge the market stream with the auxiliary (non-market) events into a single
     // time-ordered stream BEFORE the engine channel, so an injected event (e.g. a corporate action)
     // is processed at the correct point in simulated time. The market side stays lazy — it is never
-    // collected — so peak memory is O(1) in the dataset size, and the common no-aux case streams
-    // exactly as a pre-corporate-action backtest did. Merging into one stream — rather than
+    // collected — so peak memory is O(1) in the dataset size, and the common no-aux case adds only
+    // negligible per-event overhead vs a pre-corporate-action backtest. Merging into one stream — rather than
     // forwarding market and aux as two producers into the engine feed — is what preserves the time
     // order (two `forward_to` tasks would interleave non-deterministically). See [`AuxEventSource`].
     let market_first = args_constant.market_data.time_first_event().await?;
@@ -273,6 +273,12 @@ where
     // The aux side is tiny (corporate actions / expiries number in the handful), so collecting it is
     // cheap and lets the merge peek it synchronously.
     let aux = args_constant.aux_events.aux_events().collect::<Vec<_>>();
+    // Enforce the `AuxEventSource` contract before the merge below, which relies on `aux` being sorted
+    // ascending by `Timed::time`. A custom source yielding unsorted events would otherwise silently feed
+    // the engine a non-monotonic timeline in release builds — wrong results with no failure point. Hard
+    // panic shared with `AuxEventsInMemory::new`; the aux set is handful-sized, so the O(n) scan is
+    // immeasurable. See [`assert_aux_events_sorted`].
+    assert_aux_events_sorted(&aux);
 
     // Seed the clock from the earliest of the first market event and the first aux event, so an aux
     // event scheduled before the first market tick still orders and stamps correctly.
@@ -340,8 +346,8 @@ where
 /// (non-market) events.
 ///
 /// The market side stays **lazy** — it is polled on demand and never collected, so peak memory is
-/// O(1) in the dataset size and the common no-aux case streams exactly as a pre-corporate-action
-/// backtest did. The aux side is tiny (corporate actions / expiries number in the handful), so it is
+/// O(1) in the dataset size and the common no-aux case adds only negligible per-event overhead
+/// versus a pre-corporate-action backtest. The aux side is tiny (corporate actions / expiries number in the handful), so it is
 /// held as a `Peekable` iterator and peeked synchronously to decide ordering.
 ///
 /// # Ordering contract

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -175,6 +175,26 @@ where
 /// Run a single backtest with the given parameters.
 ///
 /// Simulates a trading strategy using historical market data and generates performance metrics.
+///
+/// # Auxiliary (non-market) event injection
+/// Events from [`BacktestArgsConstant::aux_events`] (corporate actions, contract expiries, commands)
+/// are **pre-merged** with the market stream into one time-ordered stream before the engine, so each
+/// is processed at the correct point in simulated time. An aux event sharing a timestamp with a
+/// market event is ordered **first** (so e.g. a split applies before same-instant fills), and the
+/// engine clock is seeded from `min(first_market_event, first_aux_event)` — an aux event scheduled
+/// before the first market tick still orders and stamps correctly. The merge/tie-break/seed logic is
+/// unit-tested in `backtest::tests`.
+///
+/// # What the returned summary does and does not contain
+/// This function returns only a [`BacktestSummary`] whose `trading_summary` aggregates statistics
+/// derived from **closed** positions (PnL, returns, drawdown per `TearSheet`). It does **not** expose
+/// final engine/position state: a position left **open** at the end of the run — e.g. one that took a
+/// stock split but no subsequent closing fill — contributes nothing to `trading_summary`, and a
+/// notional-preserving split moves no aggregate metric on its own. Callers needing to inspect
+/// post-run positions (or assert that a corporate action mutated a position) must drive their own
+/// engine harness; the split *economics* are asserted at the `Engine::process_with_audit` seam (see
+/// the `test_corporate_action_*` tests), which this path cannot reach because it hardcodes
+/// [`AuditMode::Disabled`] — the per-event `EngineOutput` stream is therefore not observable here.
 pub async fn backtest<
     MarketData,
     SummaryInterval,

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -1,9 +1,11 @@
+use crate::{EngineEvent, Timed};
 /// Backtesting utilities for algorithmic trading strategies.
 ///
 /// This module provides tools for running historical simulations of trading strategies
 /// using market data, and analyzing the performance of these simulations.
 use crate::{
     backtest::{
+        aux_events::{AuxEventSource, NoAuxEvents},
         market_data::BacktestMarketData,
         summary::{BacktestSummary, MultiBacktestSummary},
     },
@@ -27,13 +29,22 @@ use crate::{
     execution::builder::{ExecutionBuild, ExecutionBuilder},
     system::builder::{AuditMode, SystemBuild},
 };
-use futures::future::try_join_all;
+use chrono::{DateTime, Utc};
+use futures::{StreamExt, future::try_join_all, stream};
 use rust_decimal::Decimal;
-use rustrade_data::event::MarketEvent;
+use rustrade_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
 use rustrade_execution::AccountEvent;
-use rustrade_instrument::{index::IndexedInstruments, instrument::InstrumentIndex};
+use rustrade_instrument::{
+    asset::AssetIndex, exchange::ExchangeIndex, index::IndexedInstruments,
+    instrument::InstrumentIndex,
+};
 use smol_str::SmolStr;
 use std::{fmt::Debug, sync::Arc};
+
+/// Defines the [`AuxEventSource`](aux_events::AuxEventSource) interface for interleaving non-market
+/// `EngineEvent`s (e.g. corporate actions, contract expiries) into a backtest in simulated-time
+/// order.
+pub mod aux_events;
 
 /// Defines the interface and implementations for different types of market data sources
 /// that can be used in backtests.
@@ -47,7 +58,7 @@ pub mod summary;
 /// Contains shared inputs like instruments, execution configurations,
 /// market data, and summary time intervals.
 #[derive(Debug, Clone)]
-pub struct BacktestArgsConstant<MarketData, SummaryInterval, State> {
+pub struct BacktestArgsConstant<MarketData, SummaryInterval, State, AuxEvents = NoAuxEvents> {
     /// Set of trading instruments indexed by unique identifiers.
     pub instruments: IndexedInstruments,
     /// Exchange execution configurations.
@@ -58,6 +69,13 @@ pub struct BacktestArgsConstant<MarketData, SummaryInterval, State> {
     pub summary_interval: SummaryInterval,
     /// EngineState.
     pub engine_state: State,
+    /// Source of auxiliary (non-market) `EngineEvent`s to interleave with the market data in
+    /// simulated-time order (e.g. corporate actions, contract expiries).
+    ///
+    /// Defaults to [`NoAuxEvents`] (yields nothing), so existing backtests opt out at zero cost.
+    /// Corporate actions are market facts shared across an entire strategy sweep, so they live on
+    /// this shared constant and thread through [`run_backtests`] for free.
+    pub aux_events: AuxEvents,
 }
 
 /// Configuration for variables that can change between individual backtests.
@@ -85,9 +103,15 @@ pub async fn run_backtests<
     Risk,
     GlobalData,
     InstrumentData,
+    Aux,
 >(
     args_constant: Arc<
-        BacktestArgsConstant<MarketData, SummaryInterval, EngineState<GlobalData, InstrumentData>>,
+        BacktestArgsConstant<
+            MarketData,
+            SummaryInterval,
+            EngineState<GlobalData, InstrumentData>,
+            Aux,
+        >,
     >,
     args_dynamic_iter: impl IntoIterator<Item = BacktestArgsDynamic<Strategy, Risk>>,
 ) -> Result<MultiBacktestSummary<SummaryInterval>, BarterError>
@@ -129,6 +153,9 @@ where
         + Send
         + 'static,
     InstrumentData: InstrumentDataState + Default + Send + 'static,
+    Aux: AuxEventSource<InstrumentData::MarketEventKind, ExchangeIndex, AssetIndex, InstrumentIndex>
+        + Send
+        + Sync,
 {
     let time_start = std::time::Instant::now();
 
@@ -148,9 +175,22 @@ where
 /// Run a single backtest with the given parameters.
 ///
 /// Simulates a trading strategy using historical market data and generates performance metrics.
-pub async fn backtest<MarketData, SummaryInterval, Strategy, Risk, GlobalData, InstrumentData>(
+pub async fn backtest<
+    MarketData,
+    SummaryInterval,
+    Strategy,
+    Risk,
+    GlobalData,
+    InstrumentData,
+    Aux,
+>(
     args_constant: Arc<
-        BacktestArgsConstant<MarketData, SummaryInterval, EngineState<GlobalData, InstrumentData>>,
+        BacktestArgsConstant<
+            MarketData,
+            SummaryInterval,
+            EngineState<GlobalData, InstrumentData>,
+            Aux,
+        >,
     >,
     args_dynamic: BacktestArgsDynamic<Strategy, Risk>,
 ) -> Result<BacktestSummary<SummaryInterval>, BarterError>
@@ -192,13 +232,32 @@ where
         + Send
         + 'static,
     InstrumentData: InstrumentDataState + Send + 'static,
+    Aux: AuxEventSource<InstrumentData::MarketEventKind, ExchangeIndex, AssetIndex, InstrumentIndex>
+        + Send
+        + Sync,
 {
-    let clock = args_constant
+    // Collect the market stream and pre-merge it with the auxiliary (non-market) events into a
+    // single time-ordered stream BEFORE the engine channel, so an injected event (e.g. a corporate
+    // action) is processed at the correct point in simulated time. Merging into one stream — rather
+    // than forwarding market and aux as two producers into the engine feed — is what preserves the
+    // time order (two `forward_to` tasks would interleave non-deterministically). See
+    // [`AuxEventSource`].
+    let market_first = args_constant.market_data.time_first_event().await?;
+    let raw_market = args_constant
         .market_data
-        .time_first_event()
-        .await
-        .map(HistoricalClock::new)?;
-    let market_stream = args_constant.market_data.stream().await?;
+        .stream()
+        .await?
+        .collect::<Vec<_>>()
+        .await;
+    let market = market_events_to_timed(raw_market, market_first);
+    let aux = args_constant.aux_events.aux_events().collect::<Vec<_>>();
+
+    // Seed the clock from the earliest of the first market event and the first aux event, so an aux
+    // event scheduled before the first market tick still orders and stamps correctly.
+    let clock_start = aux
+        .first()
+        .map_or(market_first, |first| market_first.min(first.time));
+    let clock = HistoricalClock::new(clock_start);
 
     // Build Execution infrastructure
     let ExecutionBuild {
@@ -225,6 +284,12 @@ where
         args_dynamic.risk,
     );
 
+    // Drive the engine from the single pre-merged time-ordered stream. Its item is `EngineEvent`,
+    // which the engine's feed accepts directly (`Event: From<MarketStream::Item>` is satisfied
+    // reflexively), so it flows through `SystemBuild`'s existing single market-forwarding task and
+    // `shutdown_after_backtest` needs no change.
+    let market_stream = stream::iter(merge_timed(market, aux));
+
     let system = SystemBuild::new(
         engine,
         EngineFeedMode::Stream,
@@ -247,4 +312,153 @@ where
         risk_free_return: args_dynamic.risk_free_return,
         trading_summary,
     })
+}
+
+/// Map time-sorted market events to `Timed<EngineEvent>`, preserving order.
+///
+/// A [`MarketStreamEvent::Reconnecting`] carries no timestamp; its position is preserved by
+/// carrying the previous event's `time_exchange` forward (`seed` is used only if the very first
+/// event is a `Reconnecting`). For an in-memory backtest no `Reconnecting` events occur, so the
+/// carry-forward is purely defensive.
+fn market_events_to_timed<MarketKind, ExchangeKey, AssetKey, InstrumentKey>(
+    events: Vec<MarketStreamEvent<InstrumentKey, MarketKind>>,
+    seed: DateTime<Utc>,
+) -> Vec<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>
+where
+    EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>:
+        From<MarketStreamEvent<InstrumentKey, MarketKind>>,
+{
+    let mut last_time = seed;
+    events
+        .into_iter()
+        .map(|event| {
+            let time = match &event {
+                MarketStreamEvent::Item(market_event) => {
+                    last_time = market_event.time_exchange;
+                    market_event.time_exchange
+                }
+                MarketStreamEvent::Reconnecting(_) => last_time,
+            };
+            Timed::new(EngineEvent::from(event), time)
+        })
+        .collect()
+}
+
+/// Two-way merge of two `time`-sorted `Vec<Timed<EngineEvent>>` into one time-ordered
+/// `Vec<EngineEvent>`.
+///
+/// Both inputs are assumed sorted ascending by [`Timed::time`] (an O(N+M) merge). Aux events win
+/// ties (`aux.time <= market.time`), so an injected event at the same instant as a market event is
+/// processed first — e.g. a stock split adjusts positions before any fill stamped at that instant.
+fn merge_timed<MarketKind, ExchangeKey, AssetKey, InstrumentKey>(
+    market: Vec<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>,
+    aux: Vec<Timed<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>>>,
+) -> Vec<EngineEvent<MarketKind, ExchangeKey, AssetKey, InstrumentKey>> {
+    let mut merged = Vec::with_capacity(market.len() + aux.len());
+    let mut market = market.into_iter().peekable();
+    let mut aux = aux.into_iter().peekable();
+    loop {
+        // Take from aux when it leads or ties (aux wins ties); otherwise from market. Each branch
+        // is only reached after the corresponding `peek()` returned `Some`, so `next()` is
+        // guaranteed `Some` — the `if let` is a total match, never a silent drop.
+        let next = match (aux.peek(), market.peek()) {
+            (Some(a), Some(m)) if a.time <= m.time => aux.next(),
+            (Some(_), Some(_)) => market.next(),
+            (Some(_), None) => aux.next(),
+            (None, Some(_)) => market.next(),
+            (None, None) => break,
+        };
+        if let Some(timed) = next {
+            merged.push(timed.value);
+        }
+    }
+    merged
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panicking on a bad fixture is acceptable
+mod tests {
+    use super::*;
+    use rustrade_data::{event::DataKind, subscription::trade::PublicTrade};
+    use rustrade_instrument::exchange::ExchangeId;
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(secs, 0).unwrap()
+    }
+
+    /// A `Timed` marker whose `ContractExpiry` instrument id identifies it in assertions.
+    fn marker(id: usize, secs: i64) -> Timed<EngineEvent<DataKind>> {
+        Timed::new(expiry(id), at(secs))
+    }
+
+    fn expiry(id: usize) -> EngineEvent<DataKind> {
+        EngineEvent::ContractExpiry(InstrumentIndex::new(id))
+    }
+
+    fn trade_event(secs: i64) -> MarketStreamEvent<InstrumentIndex, DataKind> {
+        MarketStreamEvent::Item(MarketEvent {
+            time_exchange: at(secs),
+            time_received: at(secs),
+            exchange: ExchangeId::BinanceSpot,
+            instrument: InstrumentIndex::new(0),
+            kind: DataKind::Trade(PublicTrade {
+                id: "t".into(),
+                price: Decimal::ONE,
+                amount: Decimal::ONE,
+                side: None,
+            }),
+        })
+    }
+
+    #[test]
+    fn merge_interleaves_by_time_with_aux_first_on_ties() {
+        let market = vec![marker(0, 10), marker(1, 30)];
+        let aux = vec![marker(100, 20), marker(101, 30)];
+        // aux (101) at t=30 must precede market (1) at the same t=30.
+        assert_eq!(
+            merge_timed(market, aux),
+            vec![expiry(0), expiry(100), expiry(101), expiry(1)]
+        );
+    }
+
+    #[test]
+    fn merge_empty_aux_is_market_identity() {
+        let market = vec![marker(0, 10), marker(1, 20)];
+        assert_eq!(merge_timed(market, Vec::new()), vec![expiry(0), expiry(1)]);
+    }
+
+    #[test]
+    fn merge_empty_market_yields_aux_in_order() {
+        let aux = vec![marker(100, 5), marker(101, 6)];
+        assert_eq!(merge_timed(Vec::new(), aux), vec![expiry(100), expiry(101)]);
+    }
+
+    #[test]
+    fn merge_both_empty_is_empty() {
+        let merged: Vec<EngineEvent<DataKind>> = merge_timed(Vec::new(), Vec::new());
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn market_events_to_timed_stamps_time_exchange_and_carries_forward_reconnecting() {
+        let events = vec![
+            trade_event(10),
+            MarketStreamEvent::Reconnecting(ExchangeId::BinanceSpot),
+            trade_event(30),
+        ];
+        let timed: Vec<Timed<EngineEvent<DataKind>>> = market_events_to_timed(events, at(1));
+        let times: Vec<i64> = timed.iter().map(|timed| timed.time.timestamp()).collect();
+        // Item @10, Reconnecting carries the prior 10 forward, Item @30.
+        assert_eq!(times, vec![10, 10, 30]);
+    }
+
+    #[test]
+    fn market_events_to_timed_uses_seed_for_leading_reconnecting() {
+        let timed = market_events_to_timed::<DataKind, ExchangeIndex, AssetIndex, InstrumentIndex>(
+            vec![MarketStreamEvent::Reconnecting(ExchangeId::BinanceSpot)],
+            at(7),
+        );
+        assert_eq!(timed.len(), 1);
+        assert_eq!(timed[0].time, at(7));
+    }
 }

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -5,7 +5,10 @@ use crate::{EngineEvent, Timed};
 /// using market data, and analyzing the performance of these simulations.
 use crate::{
     backtest::{
-        aux_events::{AuxEventSource, NoAuxEvents, assert_aux_events_sorted},
+        aux_events::{
+            AuxEventSource, NoAuxEvents, assert_aux_corporate_action_effective_times,
+            assert_aux_events_sorted,
+        },
         market_data::BacktestMarketData,
         summary::{BacktestSummary, MultiBacktestSummary},
     },
@@ -77,7 +80,8 @@ pub struct BacktestArgsConstant<MarketData, SummaryInterval, State, AuxEvents = 
     /// Source of auxiliary (non-market) `EngineEvent`s to interleave with the market data in
     /// simulated-time order (e.g. corporate actions, contract expiries).
     ///
-    /// Defaults to [`NoAuxEvents`] (yields nothing), so existing backtests opt out at zero cost.
+    /// Defaults to [`NoAuxEvents`] (yields nothing), so existing backtests opt out at negligible
+    /// per-event overhead.
     /// Corporate actions are market facts shared across an entire strategy sweep, so they live on
     /// this shared constant and thread through [`run_backtests`] for free.
     pub aux_events: AuxEvents,
@@ -279,6 +283,12 @@ where
     // panic shared with `AuxEventsInMemory::new`; the aux set is handful-sized, so the O(n) scan is
     // immeasurable. See [`assert_aux_events_sorted`].
     assert_aux_events_sorted(&aux);
+    // Enforce the second `AuxEventSource` obligation: every injected `CorporateAction`'s
+    // `effective_time` must equal its wrapping `Timed::time`. A mismatch would order the action at
+    // one instant but apply it at another (a silent look-ahead / stale-stamp bug); the handler
+    // cannot see the wrapping `Timed`, so this pre-merge site is the only place to catch it. Hard
+    // panic, handful-sized scan. See [`assert_aux_corporate_action_effective_times`].
+    assert_aux_corporate_action_effective_times(&aux);
 
     // Seed the clock from the earliest of the first market event and the first aux event, so an aux
     // event scheduled before the first market tick still orders and stamps correctly.

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -366,6 +366,10 @@ where
 /// - Aux events win ties (`aux.time <= market.time`), so an injected event at the same instant as a
 ///   market event is processed first — e.g. a stock split adjusts positions before any fill stamped
 ///   at that instant.
+/// - Between two **aux** events at the same instant, ordering follows their original
+///   [`AuxEventSource`] order: the aux side is consumed as a stable, in-order iterator and the merge
+///   never reorders equal-time aux events. Inject aux events already in the order you want ties
+///   broken.
 /// - A [`MarketStreamEvent::Reconnecting`] carries no timestamp; its ordering inherits the prior
 ///   market event's `time_exchange` (`last_market_time`), falling back to the seed only if it leads.
 ///   For an in-memory backtest no `Reconnecting` events occur, so the carry-forward is purely

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -395,6 +395,17 @@ where
                         for pos_id in opt_position_ids {
                             if let Some(position) = option_state.position.positions.get_mut(&pos_id)
                             {
+                                // Mirror the live handler's input invariant (see
+                                // `process_corporate_action`): option contract counts are whole, so a
+                                // non-integer count is corruption that must fail observably — not be
+                                // silently floored/carried. Keeps live and replica behaviour identical
+                                // (a live panic here must be a replica panic, or audit parity drifts).
+                                assert!(
+                                    position.quantity_abs.fract().is_zero(),
+                                    "replica: option position {pos_id:?} holds a non-integer contract \
+                                     count {} before a standard split — data corruption",
+                                    position.quantity_abs,
+                                );
                                 position.apply_split(ratio, policy, option_last_price);
                             }
                         }

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -229,6 +229,11 @@ where
                     instrument_state.expiration_processed = true;
                 }
             }
+            EngineEvent::CorporateAction { .. } => {
+                // TODO: event-replay the position adjustment here to keep the replica in
+                // parity once the live handler is wired. No-op until then; mirrors the
+                // live engine's current transitional no-op.
+            }
         }
     }
 

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -3,7 +3,7 @@ use crate::{
     engine::{
         EngineMeta, EngineOutput, Processor,
         audit::{AuditTick, EngineAudit, ProcessAudit, context::EngineContext},
-        state::{EngineState, instrument::data::InstrumentDataState},
+        state::{EngineState, instrument::data::InstrumentDataState, position::PositionId},
     },
     execution::AccountStreamEvent,
 };
@@ -11,7 +11,10 @@ use rustrade_integration::collection::none_one_or_many::NoneOneOrMany;
 // (used by `update_from_event` to inspect the live engine's outputs)
 use rustrade_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
 use rustrade_execution::AccountEvent;
-use rustrade_instrument::instrument::InstrumentIndex;
+use rustrade_instrument::{
+    corporate_action::CorporateActionKind,
+    instrument::{InstrumentIndex, kind::InstrumentKind},
+};
 use rustrade_integration::Terminal;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -136,6 +139,17 @@ where
     ///   replica cannot independently determine which branch the live engine took, so it
     ///   mirrors the decision by inspecting `PositionExit` outputs.
     ///
+    /// - **`CorporateAction`**: a *hybrid*. `Position::apply_split` is deterministic, so the
+    ///   adjustment (quantity / basis / unrealised PnL) is **event-replayed** for every position
+    ///   from the payload — after re-running the same guards (idempotency / non-`Spot` /
+    ///   unsupported-kind, all of which skip without mutating). The Floor-to-zero **close** is
+    ///   **output-mirrored** (like `ContractExpiry`): the live handler stamps the closing
+    ///   `PositionExit.time_exit` with `self.time()`, which is wall-clock-derived on
+    ///   `HistoricalClock` and therefore cannot be reproduced from the payload, so the replica
+    ///   removes the slot and folds the *live* `PositionExit` into the tear sheet. Parity (incl.
+    ///   tear sheets) is asserted by the replica-parity integration test, which guards against the
+    ///   live handler and this arm drifting apart.
+    ///
     /// Adding a new event type: choose event replay (deterministic transition) or output
     /// mirroring (conditional/non-deterministic) based on whether the replica can reproduce
     /// the live engine's branching from the event alone.
@@ -229,10 +243,101 @@ where
                     instrument_state.expiration_processed = true;
                 }
             }
-            EngineEvent::CorporateAction { .. } => {
-                // TODO: event-replay the position adjustment here to keep the replica in
-                // parity once the live handler is wired. No-op until then; mirrors the
-                // live engine's current transitional no-op.
+            EngineEvent::CorporateAction {
+                id,
+                instrument,
+                kind,
+                policy,
+                effective_time: _,
+            } => {
+                // Hybrid replay (mirrors the live `process_corporate_action`):
+                //  - `apply_split` is deterministic ⇒ event-replay it for every position to
+                //    reproduce the quantity / basis / unrealised-PnL adjustment exactly.
+                //  - the Floor-to-zero close is OUTPUT-MIRRORED (like the `ContractExpiry` arm),
+                //    because the live handler stamps the closing `PositionExit.time_exit` with
+                //    `self.time()`, which is wall-clock-derived on `HistoricalClock` and cannot be
+                //    reproduced from the payload. Folding the *live* exit keeps tear-sheet parity
+                //    exact. Keep this branch structurally symmetric with the live handler — the
+                //    replica-parity test fails if they drift. Warnings are intentionally omitted
+                //    (the live engine already logged them for this event).
+
+                // Guards — each skips WITHOUT mutating or recording `id`, exactly as the live
+                // handler does, so the replica never applies an action the live engine rejected.
+                {
+                    let instrument_state = self
+                        .replica_engine_state_mut()
+                        .instruments
+                        .instrument_index_mut(&instrument);
+                    // Idempotency: already applied (the set mirrors the live engine's).
+                    if instrument_state.corporate_actions_processed.contains(&id) {
+                        return;
+                    }
+                    // Unsupported instrument kind (checked first, like the live handler): equity
+                    // splits only apply to `Spot`. `id` not recorded ⇒ retryable.
+                    if !matches!(instrument_state.instrument.kind, InstrumentKind::Spot) {
+                        return;
+                    }
+                }
+                // Unsupported action kind — the compiler-mandated arm for the `#[non_exhaustive]`
+                // `CorporateActionKind` (runtime-unreachable in this phase). `id` not recorded.
+                let CorporateActionKind::StockSplit { ratio } = kind else {
+                    return;
+                };
+
+                // Last price for the eager `pnl_unrealised` recompute — same source the live
+                // handler reads. Identical here because the replica replayed the same market data.
+                let last_price = self
+                    .replica_engine_state()
+                    .instruments
+                    .instrument_index(&instrument)
+                    .data
+                    .price();
+
+                // Event-replay `apply_split` on ALL positions (N in Hedging). Collect ids first to
+                // avoid a borrow conflict with the per-position re-borrow, like the live handler.
+                let position_ids: Vec<PositionId> = self
+                    .replica_engine_state()
+                    .instruments
+                    .instrument_index(&instrument)
+                    .position
+                    .positions
+                    .keys()
+                    .cloned()
+                    .collect();
+                for pos_id in position_ids {
+                    let instrument_state = self
+                        .replica_engine_state_mut()
+                        .instruments
+                        .instrument_index_mut(&instrument);
+                    if let Some(position) = instrument_state.position.positions.get_mut(&pos_id) {
+                        position.apply_split(ratio, policy, last_price);
+                    }
+                }
+
+                // Mirror Floor-to-zero closes from the live `PositionExit` outputs: remove the slot
+                // and fold the live exit into the tear sheet (carrying the live `time_exit`).
+                for output in outputs.iter() {
+                    if let EngineOutput::PositionExit(exit) = output
+                        && exit.instrument == instrument
+                    {
+                        let instrument_state = self
+                            .replica_engine_state_mut()
+                            .instruments
+                            .instrument_index_mut(&instrument);
+                        instrument_state
+                            .position
+                            .positions
+                            .shift_remove(&exit.position_id);
+                        instrument_state.tear_sheet.update_from_position(exit);
+                    }
+                }
+
+                // Record `id` — the action has now been applied (mirrors the live handler).
+                self.replica_engine_state_mut()
+                    .instruments
+                    .instrument_index_mut(&instrument)
+                    .corporate_actions_processed
+                    .insert(id);
             }
         }
     }

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -283,6 +283,11 @@ where
                 let CorporateActionKind::StockSplit { ratio } = kind else {
                     return;
                 };
+                // Unwrap the validated `SplitRatio` to its inner `Decimal` for the arithmetic
+                // below. Unlike the live handler — which keeps the typed `SplitRatio` (as `ratio`)
+                // to carry into its output records and names the inner value `ratio_decimal` — the
+                // replica emits no outputs, so it shadows `ratio` directly with the `Decimal`.
+                let ratio = ratio.get();
 
                 // Last price for the eager `pnl_unrealised` recompute — same source the live
                 // handler reads. Identical here because the replica replayed the same market data.
@@ -329,6 +334,15 @@ where
                             .positions
                             .shift_remove(&exit.position_id);
                         instrument_state.tear_sheet.update_from_position(exit);
+                        // Mirror the live handler's Hedging fill-routing prune on floor-to-zero
+                        // (engine/mod.rs): drop the now-dangling `cid → removed_pos_id` mapping by
+                        // VALUE. Without this, the replica retains a stale routing entry the live
+                        // engine has already pruned, so the full-state `assert_eq!` over
+                        // `InstrumentState` (which includes `position_ids`) diverges for any
+                        // `OmsMode::Hedging` position floored to zero by a reverse split.
+                        instrument_state
+                            .position_ids
+                            .retain(|_, mapped| *mapped != exit.position_id);
                     }
                 }
 
@@ -362,13 +376,17 @@ where
                             equity.instrument.exchange,
                         )
                     };
-                    let affected_options: Vec<InstrumentIndex> = self
+                    // Scan ALL options on the underlying (held OR unheld), mirroring the live
+                    // handler: a standard split divides the strike of every registered option so
+                    // the registry stays consistent for positions opened later. Unheld options get
+                    // the strike fix only; held options additionally event-replay `apply_split`.
+                    let options_on_underlying: Vec<InstrumentIndex> = self
                         .replica_engine_state()
                         .instruments
                         .0
                         .values()
                         .filter(|state| {
-                            state.is_affected_option_on_underlying(
+                            state.is_option_on_underlying(
                                 &equity_base,
                                 &equity_quote,
                                 &equity_exchange,
@@ -376,38 +394,54 @@ where
                         })
                         .map(|state| state.key)
                         .collect();
-                    for opt_key in affected_options {
+                    for opt_key in options_on_underlying {
                         let option_state = self
                             .replica_engine_state_mut()
                             .instruments
                             .instrument_index_mut(&opt_key);
-                        let option_last_price = option_state.data.price();
-                        // Mirror the live handler's `else { continue; }`: the scan only matched
-                        // Option instruments, so this is defensive (unreachable) — skip the whole
-                        // iteration rather than apply_split without adjusting the strike if it hits.
+                        // Mirror the live handler's loud unreachable: the scan only matched Option
+                        // instruments, so a non-Option here is corruption — fail observably rather
+                        // than apply_split without adjusting the strike.
                         let InstrumentKind::Option(ref mut contract) = option_state.instrument.kind
                         else {
-                            continue;
+                            unreachable!(
+                                "replica: is_option_on_underlying matched a non-Option instrument \
+                                 {opt_key:?}"
+                            );
                         };
                         contract.strike /= ratio;
+
+                        // Unheld option: strike correction is the whole job (silent registry fix),
+                        // mirroring the live handler.
+                        if option_state.position.positions.is_empty() {
+                            continue;
+                        }
+                        let option_last_price = option_state.data.price();
                         let opt_position_ids: Vec<PositionId> =
                             option_state.position.positions.keys().cloned().collect();
                         for pos_id in opt_position_ids {
-                            if let Some(position) = option_state.position.positions.get_mut(&pos_id)
-                            {
-                                // Mirror the live handler's input invariant (see
-                                // `process_corporate_action`): option contract counts are whole, so a
-                                // non-integer count is corruption that must fail observably — not be
-                                // silently floored/carried. Keeps live and replica behaviour identical
-                                // (a live panic here must be a replica panic, or audit parity drifts).
-                                assert!(
-                                    position.quantity_abs.fract().is_zero(),
-                                    "replica: option position {pos_id:?} holds a non-integer contract \
-                                     count {} before a standard split — data corruption",
-                                    position.quantity_abs,
+                            // `pos_id` was just collected from this map; fail loudly (matching the
+                            // strike-adjust `unreachable!` above) if that ever changes, mirroring the
+                            // live handler.
+                            let Some(position) = option_state.position.positions.get_mut(&pos_id)
+                            else {
+                                unreachable!(
+                                    "replica: position id {pos_id:?} collected from this option's \
+                                     positions map"
                                 );
-                                position.apply_split(ratio, policy, option_last_price);
-                            }
+                            };
+                            // Mirror the live handler's input invariant (see
+                            // `process_corporate_action`): option contract counts are whole, so a
+                            // non-integer count is corruption that must fail observably — not be
+                            // silently floored/carried. Keeps live and replica behaviour identical
+                            // (a live panic here must be a replica panic, or audit parity drifts).
+                            assert!(
+                                position.quantity_abs.fract().is_zero(),
+                                "replica: option position {pos_id:?} holds a non-integer contract \
+                                 count {} before a standard split — data corruption",
+                                position.quantity_abs,
+                            );
+                            position.apply_split(ratio, policy, option_last_price);
                         }
                     }
                 }

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -12,7 +12,7 @@ use rustrade_integration::collection::none_one_or_many::NoneOneOrMany;
 use rustrade_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
 use rustrade_execution::AccountEvent;
 use rustrade_instrument::{
-    corporate_action::CorporateActionKind,
+    corporate_action::{CorporateActionKind, SplitAdjustmentKind},
     instrument::{InstrumentIndex, kind::InstrumentKind},
 };
 use rustrade_integration::Terminal;
@@ -329,6 +329,75 @@ where
                             .positions
                             .shift_remove(&exit.position_id);
                         instrument_state.tear_sheet.update_from_position(exit);
+                    }
+                }
+
+                // Standard option adjustment (mirrors the live handler's option-handling step).
+                // For a STANDARD (whole-number forward) split, the engine adjusts each option on
+                // this underlying IN PLACE: strike ÷ ratio + apply_split per option position. This
+                // is fully deterministic (strike division + apply_split reading the option's own
+                // replayed price), so it is PURE event-replay — options never floor-to-zero on a
+                // forward split, so no output-mirror is needed (unlike the equity Floor-to-zero
+                // close above). NON-standard splits leave options untouched (the live handler only
+                // emits a signal and mutates no option state), so this whole block is skipped.
+                //
+                // Classify via a `match` (not the old `if matches!`) to stay structurally symmetric
+                // with the live handler. `SplitAdjustmentKind` is `#[non_exhaustive]` (another
+                // crate) and cannot be matched exhaustively here; only a Standard split mutates
+                // option state in the replica — NonStandard, any future variant, and the unreachable
+                // None deliberately skip (the live handler emits only a signal output for them, which
+                // the replica, mirroring state not outputs, has nothing to apply). Warnings are
+                // intentionally omitted (see the block comment above).
+                let adjust_options_in_place =
+                    matches!(kind.split_kind(), Some(SplitAdjustmentKind::Standard));
+                if adjust_options_in_place {
+                    let (equity_base, equity_quote, equity_exchange) = {
+                        let equity = self
+                            .replica_engine_state()
+                            .instruments
+                            .instrument_index(&instrument);
+                        (
+                            equity.instrument.underlying.base,
+                            equity.instrument.underlying.quote,
+                            equity.instrument.exchange,
+                        )
+                    };
+                    let affected_options: Vec<InstrumentIndex> = self
+                        .replica_engine_state()
+                        .instruments
+                        .0
+                        .values()
+                        .filter(|state| {
+                            state.is_affected_option_on_underlying(
+                                &equity_base,
+                                &equity_quote,
+                                &equity_exchange,
+                            )
+                        })
+                        .map(|state| state.key)
+                        .collect();
+                    for opt_key in affected_options {
+                        let option_state = self
+                            .replica_engine_state_mut()
+                            .instruments
+                            .instrument_index_mut(&opt_key);
+                        let option_last_price = option_state.data.price();
+                        // Mirror the live handler's `else { continue; }`: the scan only matched
+                        // Option instruments, so this is defensive (unreachable) — skip the whole
+                        // iteration rather than apply_split without adjusting the strike if it hits.
+                        let InstrumentKind::Option(ref mut contract) = option_state.instrument.kind
+                        else {
+                            continue;
+                        };
+                        contract.strike /= ratio;
+                        let opt_position_ids: Vec<PositionId> =
+                            option_state.position.positions.keys().cloned().collect();
+                        for pos_id in opt_position_ids {
+                            if let Some(position) = option_state.position.positions.get_mut(&pos_id)
+                            {
+                                position.apply_split(ratio, policy, option_last_price);
+                            }
+                        }
                     }
                 }
 

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -3,7 +3,11 @@ use crate::{
     engine::{
         EngineMeta, EngineOutput, Processor,
         audit::{AuditTick, EngineAudit, ProcessAudit, context::EngineContext},
-        state::{EngineState, instrument::data::InstrumentDataState, position::PositionId},
+        state::{
+            EngineState,
+            instrument::data::InstrumentDataState,
+            position::{PositionId, SplitRoundingPolicy},
+        },
     },
     execution::AccountStreamEvent,
 };
@@ -441,7 +445,17 @@ where
                                  count {} before a standard split — data corruption",
                                 position.quantity_abs,
                             );
-                            position.apply_split(ratio, policy, option_last_price);
+                            // Pass `Fractional` explicitly, NOT the equity `policy`, mirroring the
+                            // live handler (`process_corporate_action`): the assert above guarantees
+                            // an integer contract count so the policy is a no-op here, and the
+                            // equity's whole-share-lot policy does not govern option legs. Hard-coding
+                            // it keeps live and replica byte-identical even if a future
+                            // `SplitRoundingPolicy` variant were to differ on already-integer inputs.
+                            position.apply_split(
+                                ratio,
+                                SplitRoundingPolicy::Fractional,
+                                option_last_price,
+                            );
                         }
                     }
                 }

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -287,11 +287,43 @@ where
                 let CorporateActionKind::StockSplit { ratio } = kind else {
                     return;
                 };
-                // Unwrap the validated `SplitRatio` to its inner `Decimal` for the arithmetic
-                // below. Unlike the live handler — which keeps the typed `SplitRatio` (as `ratio`)
-                // to carry into its output records and names the inner value `ratio_decimal` — the
-                // replica emits no outputs, so it shadows `ratio` directly with the `Decimal`.
-                let ratio = ratio.get();
+                // Keep the typed `SplitRatio` (`ratio`) for `apply_split` and derive its inner
+                // `Decimal` (`ratio_decimal`) for the option strike division — mirroring the live
+                // handler's split of the two. (The live handler additionally carries the typed
+                // `SplitRatio` into output records; the replica emits none, so it needs the typed
+                // value only for `apply_split`.)
+                let ratio_decimal = ratio.get();
+
+                // Classify for option handling ONCE, up front (mirrors the live handler's Step 2c).
+                // `SplitAdjustmentKind` is `#[non_exhaustive]` (another crate) and cannot be matched
+                // exhaustively here; only a Standard split mutates option state in the replica —
+                // NonStandard, any future variant, and the unreachable None deliberately skip (the
+                // live handler emits only a signal output for them, which the replica — mirroring
+                // state, not outputs — has nothing to apply). Hoisted above the mutation so
+                // pre-validation and application share one classification and cannot drift.
+                let adjust_options_in_place =
+                    matches!(kind.split_kind(), Some(SplitAdjustmentKind::Standard));
+
+                // Pre-validate the whole action BEFORE mutating anything, mirroring the live
+                // handler's Step 2c: if the live engine rejected it (Decimal overflow or a corrupted
+                // option contract count) it recorded no `id` and mutated nothing, so the replica
+                // must do the same or state parity drifts. Single-sourced via the same
+                // `validate_corporate_action_split` the live handler calls, so both reach the
+                // identical accept/reject decision. No output emitted — the replica mirrors state,
+                // and the live engine already logged the rejection.
+                if self
+                    .replica_engine_state()
+                    .instruments
+                    .validate_corporate_action_split(
+                        &instrument,
+                        ratio,
+                        policy,
+                        adjust_options_in_place,
+                    )
+                    .is_err()
+                {
+                    return;
+                }
 
                 // Last price for the eager `pnl_unrealised` recompute — same source the live
                 // handler reads. Identical here because the replica replayed the same market data.
@@ -319,7 +351,15 @@ where
                         .instruments
                         .instrument_index_mut(&instrument);
                     if let Some(position) = instrument_state.position.positions.get_mut(&pos_id) {
-                        position.apply_split(ratio, policy, last_price);
+                        // Pre-validated above ⇒ `Err` is unreachable; `unreachable!` mirrors the live
+                        // handler (a live panic here must be a replica panic too, or audit parity
+                        // drifts). The replica discards the `Ok` value, so `if let Err` suffices.
+                        if let Err(error) = position.apply_split(ratio, policy, last_price) {
+                            unreachable!(
+                                "replica: equity apply_split failed after pre-validation for \
+                                 {pos_id:?}: {error}"
+                            );
+                        }
                     }
                 }
 
@@ -358,16 +398,7 @@ where
                 // forward split, so no output-mirror is needed (unlike the equity Floor-to-zero
                 // close above). NON-standard splits leave options untouched (the live handler only
                 // emits a signal and mutates no option state), so this whole block is skipped.
-                //
-                // Classify via a `match` (not the old `if matches!`) to stay structurally symmetric
-                // with the live handler. `SplitAdjustmentKind` is `#[non_exhaustive]` (another
-                // crate) and cannot be matched exhaustively here; only a Standard split mutates
-                // option state in the replica — NonStandard, any future variant, and the unreachable
-                // None deliberately skip (the live handler emits only a signal output for them, which
-                // the replica, mirroring state not outputs, has nothing to apply). Warnings are
-                // intentionally omitted (see the block comment above).
-                let adjust_options_in_place =
-                    matches!(kind.split_kind(), Some(SplitAdjustmentKind::Standard));
+                // Branches on `adjust_options_in_place` computed up front (see the hoist above).
                 if adjust_options_in_place {
                     let (equity_base, equity_quote, equity_exchange) = {
                         let equity = self
@@ -413,7 +444,7 @@ where
                                  {opt_key:?}"
                             );
                         };
-                        contract.strike /= ratio;
+                        contract.strike /= ratio_decimal;
 
                         // Unheld option: strike correction is the whole job (silent registry fix),
                         // mirroring the live handler.
@@ -434,28 +465,24 @@ where
                                      positions map"
                                 );
                             };
-                            // Mirror the live handler's input invariant (see
-                            // `process_corporate_action`): option contract counts are whole, so a
-                            // non-integer count is corruption that must fail observably — not be
-                            // silently floored/carried. Keeps live and replica behaviour identical
-                            // (a live panic here must be a replica panic, or audit parity drifts).
-                            assert!(
-                                position.quantity_abs.fract().is_zero(),
-                                "replica: option position {pos_id:?} holds a non-integer contract \
-                                 count {} before a standard split — data corruption",
-                                position.quantity_abs,
-                            );
                             // Pass `Fractional` explicitly, NOT the equity `policy`, mirroring the
-                            // live handler (`process_corporate_action`): the assert above guarantees
-                            // an integer contract count so the policy is a no-op here, and the
-                            // equity's whole-share-lot policy does not govern option legs. Hard-coding
-                            // it keeps live and replica byte-identical even if a future
-                            // `SplitRoundingPolicy` variant were to differ on already-integer inputs.
-                            position.apply_split(
+                            // live handler (`process_corporate_action`): pre-validation already
+                            // rejected any non-integer contract count (as `PositionStateInvalid`), so
+                            // the policy is a no-op here and the equity's whole-share-lot policy does
+                            // not govern option legs. Pre-validated ⇒ `Err` is unreachable;
+                            // `unreachable!` mirrors the live handler (a live panic here must be a
+                            // replica panic too, or audit parity drifts). The replica discards the
+                            // `Ok` value, so `if let Err` suffices.
+                            if let Err(error) = position.apply_split(
                                 ratio,
                                 SplitRoundingPolicy::Fractional,
                                 option_last_price,
-                            );
+                            ) {
+                                unreachable!(
+                                    "replica: option apply_split failed after pre-validation for \
+                                     {pos_id:?}: {error}"
+                                );
+                            }
                         }
                     }
                 }

--- a/rustrade/src/engine/clock.rs
+++ b/rustrade/src/engine/clock.rs
@@ -174,6 +174,10 @@ impl<MarketEventKind: Debug> TimeExchange for EngineEvent<MarketEventKind> {
                 AccountEventKind::Trade(trade) => Some(trade.time_exchange),
                 _ => None,
             },
+            // The corporate action carries its own resolved effective instant, so the
+            // `HistoricalClock` advances to it — the adjustment is ordered and stamped exactly
+            // (no look-ahead onto the prior session's market events).
+            Self::CorporateAction { effective_time, .. } => Some(*effective_time),
             _ => None,
         }
     }
@@ -183,9 +187,13 @@ impl<MarketEventKind: Debug> TimeExchange for EngineEvent<MarketEventKind> {
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
+    use crate::engine::state::position::SplitRoundingPolicy;
     use chrono::TimeDelta;
+    use rust_decimal::Decimal;
     use rustrade_data::event::MarketEvent;
-    use rustrade_instrument::{exchange::ExchangeId, instrument::InstrumentIndex};
+    use rustrade_instrument::{
+        corporate_action::CorporateActionKind, exchange::ExchangeId, instrument::InstrumentIndex,
+    };
 
     fn market_event(time_exchange: DateTime<Utc>) -> EngineEvent<()> {
         EngineEvent::Market(MarketStreamEvent::Item(MarketEvent {
@@ -341,6 +349,58 @@ mod tests {
         assert!(
             (95..=105).contains(&delta_ms),
             "Historical clock time delta outside expected range"
+        );
+    }
+
+    fn corporate_action_event(effective_time: DateTime<Utc>) -> EngineEvent<()> {
+        EngineEvent::CorporateAction {
+            id: "test-split".into(),
+            instrument: InstrumentIndex::new(0),
+            kind: CorporateActionKind::StockSplit {
+                ratio: Decimal::new(2, 0),
+            },
+            policy: SplitRoundingPolicy::Fractional,
+            effective_time,
+        }
+    }
+
+    #[test]
+    fn test_corporate_action_advances_clock_to_effective_time() {
+        use chrono::{NaiveDate, NaiveTime};
+
+        // Midnight UTC of the effective date, plus two intraday market events on that date.
+        let effective = NaiveDate::from_ymd_opt(2026, 6, 22)
+            .unwrap()
+            .and_time(NaiveTime::MIN)
+            .and_utc();
+        let intraday_open = effective + TimeDelta::hours(13) + TimeDelta::minutes(30);
+        let intraday_later = intraday_open + TimeDelta::hours(2);
+
+        // The event reports its `effective_time` as its exchange time.
+        assert_eq!(
+            corporate_action_event(effective).time_exchange(),
+            Some(effective),
+            "CorporateAction must report effective_time as its exchange time"
+        );
+
+        // In-order: the midnight split precedes that day's intraday events — the clock
+        // advances to the split, then monotonically through the intraday prints.
+        let mut clock = HistoricalClock::new(effective - TimeDelta::days(1));
+        clock.process(&corporate_action_event(effective));
+        assert_eq!(clock.inner.read().time_exchange_last, effective);
+        clock.process(&market_event(intraday_open));
+        assert_eq!(clock.inner.read().time_exchange_last, intraday_open);
+        clock.process(&market_event(intraday_later));
+        assert_eq!(clock.inner.read().time_exchange_last, intraday_later);
+
+        // Out-of-order safety: a midnight split arriving after that day's intraday events
+        // must not regress the clock (same monotonic guard as any other event).
+        let mut clock = HistoricalClock::new(intraday_later);
+        clock.process(&corporate_action_event(effective));
+        assert_eq!(
+            clock.inner.read().time_exchange_last,
+            intraday_later,
+            "an earlier midnight split must not regress time_exchange_last"
         );
     }
 }

--- a/rustrade/src/engine/clock.rs
+++ b/rustrade/src/engine/clock.rs
@@ -192,7 +192,9 @@ mod tests {
     use rust_decimal::Decimal;
     use rustrade_data::event::MarketEvent;
     use rustrade_instrument::{
-        corporate_action::CorporateActionKind, exchange::ExchangeId, instrument::InstrumentIndex,
+        corporate_action::{CorporateActionKind, SplitRatio},
+        exchange::ExchangeId,
+        instrument::InstrumentIndex,
     };
 
     fn market_event(time_exchange: DateTime<Utc>) -> EngineEvent<()> {
@@ -357,7 +359,7 @@ mod tests {
             id: "test-split".into(),
             instrument: InstrumentIndex::new(0),
             kind: CorporateActionKind::StockSplit {
-                ratio: Decimal::new(2, 0),
+                ratio: SplitRatio::new(Decimal::new(2, 0)).unwrap(),
             },
             policy: SplitRoundingPolicy::Fractional,
             effective_time,

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -937,19 +937,26 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                         // record asserts the position WAS adjusted, so never emit it for a position
                         // the re-borrow could not find.
                         if let Some(position) = option_state.position.positions.get_mut(&pos_id) {
-                            // `_`-prefixed: used only by the debug_assert, which compiles out in
-                            // release. A standard split is a whole-number ratio and option contract
-                            // counts are integers, so the disposal is provably zero — assert it so a
-                            // future apply_split/contract-count regression is caught in test, not
-                            // silently dropped (no SplitRemainder is emitted on this path).
-                            let _split_result =
-                                position.apply_split(ratio, policy, option_last_price);
-                            debug_assert!(
-                                _split_result.remainder.is_zero(),
-                                "standard option split (whole-number ratio × integer contract \
-                                 count) left a non-zero remainder {} — invariant violated",
-                                _split_result.remainder,
+                            // Option contract counts are whole, and a standard split is a
+                            // whole-number ratio, so `integer × integer` stays integer with no
+                            // fractional remainder — the equity's `SplitRoundingPolicy` (a
+                            // whole-share-lot concept) does not govern option legs. Enforce that
+                            // invariant on the INPUT with a hard `assert!` (NOT `debug_assert!`,
+                            // which compiles out in release): a non-integer contract count is state
+                            // corruption that must fail observably, never be silently floored (under
+                            // `Floor`) or silently carried (under `Fractional`). Asserting the input
+                            // — rather than the post-split `remainder` — is the meaningful check:
+                            // under `Fractional` the remainder is always zero by construction, so a
+                            // remainder assert would be vacuous. With the invariant upheld the
+                            // disposal is provably zero, so no SplitRemainder/CIL or floor-to-zero
+                            // close is possible here.
+                            assert!(
+                                position.quantity_abs.fract().is_zero(),
+                                "option position {pos_id:?} holds a non-integer contract count {} \
+                                 before a standard split — data corruption",
+                                position.quantity_abs,
                             );
+                            position.apply_split(ratio, policy, option_last_price);
                             outputs.push(EngineOutput::OptionPositionAdjustedForSplit {
                                 option_instrument: opt_key,
                                 ratio,
@@ -1098,6 +1105,14 @@ pub enum EngineOutput<
     ///
     /// `quantity_fractional_disposed × price_entry_average_post_split` is the cost basis of the
     /// disposed sliver; both fields share the post-split era (Decimal arithmetic, no ratio).
+    ///
+    /// # Relationship to [`PositionExit`](Self::PositionExit)
+    /// A reverse split under `Floor` can round a position's quantity to zero. When that happens the
+    /// handler emits **both** a `SplitRemainder` **and** a [`PositionExit`](Self::PositionExit) for
+    /// the same `instrument` + `position_id` — there is no value double-count: the `PositionExit`
+    /// closes the now-zero-quantity slot and books its realised PnL, while this `SplitRemainder`
+    /// records the disposed fractional sliver as cash-in-lieu. So when both share a `position_id`,
+    /// this `SplitRemainder` is the position's **entire** remaining disposal.
     SplitRemainder {
         /// Instrument whose position was split.
         instrument: InstrumentKey,

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -16,7 +16,7 @@ use crate::{
             EngineState,
             instrument::data::InstrumentDataState,
             order::{in_flight_recorder::InFlightRequestRecorder, manager::OrderManager},
-            position::{PositionExited, PositionId},
+            position::{PositionExited, PositionId, SplitRoundingPolicy},
             trading::TradingState,
         },
     },
@@ -30,21 +30,27 @@ use crate::{
     },
 };
 use chrono::{DateTime, Utc};
+use derive_more::Constructor;
 use rust_decimal::Decimal;
 use rustrade_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
 use rustrade_execution::{
     AccountEvent,
-    order::Order,
+    order::{Order, id::ClientOrderId},
     trade::{AssetFees, Trade, TradeId},
 };
 use rustrade_instrument::{
     Side,
     asset::AssetIndex,
+    corporate_action::CorporateActionKind,
     exchange::ExchangeIndex,
-    instrument::{InstrumentIndex, kind::option::OptionKind},
+    instrument::{
+        InstrumentIndex,
+        kind::{InstrumentKind, option::OptionKind},
+    },
 };
 use rustrade_integration::channel::Tx;
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 use std::fmt::Debug;
 use tracing::{info, warn};
 
@@ -190,15 +196,23 @@ where
                 // trigger algo order generation — return early before that check.
                 return EngineAudit::from(audit);
             }
-            EngineEvent::CorporateAction { .. } => {
-                // TODO: position-adjustment handler not yet wired. Surface loudly so an
-                // early-injected event is not silently dropped, and return before algo
-                // order generation (the adjustment is engine-driven, like ContractExpiry).
-                warn!(
-                    ?event,
-                    "CorporateAction received but its handler is not yet implemented; no-op"
-                );
-                return EngineAudit::process(event);
+            EngineEvent::CorporateAction {
+                id,
+                instrument,
+                kind,
+                policy,
+                effective_time: _,
+            } => {
+                let outputs = self.process_corporate_action(id, instrument, kind, *policy);
+                // Fold each observable output (SplitRemainder / OpenOrdersAtSplit /
+                // OptionPositionsUnadjustedForSplit / PositionExit / UnsupportedCorporateAction)
+                // into the audit. Like ContractExpiry, a corporate action is engine-driven and
+                // settles regardless of TradingState — return early before algo generation.
+                let mut audit = ProcessAudit::with_event(event);
+                for output in outputs {
+                    audit = audit.add_output(output);
+                }
+                return EngineAudit::from(audit);
             }
         };
 
@@ -436,7 +450,6 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
         // For options, ITM/OTM determination requires the *underlying's* price, not the
         // option's own market price (which includes premium and would give wrong results).
         // We find the underlying spot instrument by matching the option's underlying.base.
-        use rustrade_instrument::instrument::kind::InstrumentKind;
         // Capture both the underlying base key and the exchange so we can filter
         // the spot scan to the same exchange. Without the exchange filter, a
         // multi-exchange setup (e.g. BTC/USD on both Binance and Alpaca) would
@@ -625,6 +638,249 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
 
         exited
     }
+
+    /// Processes a `CorporateAction` (stock split / reverse split) for the given instrument,
+    /// adjusting **every** open position and returning the observable outputs to fold into the
+    /// audit.
+    ///
+    /// Unlike `process_contract_expiry`, this **does not** cancel resting orders (a real broker
+    /// price-adjusts them, so an engine-side cancel would diverge) and **does not** require a
+    /// market price (the split is applied regardless; see below).
+    ///
+    /// # Algorithm
+    /// 1. Idempotency guard on `id` (per-instrument `corporate_actions_processed` set). A
+    ///    duplicate `id` is skipped with a warning.
+    /// 2. **Unsupported guards (no silent no-op, `id` not recorded ⇒ retryable).** The
+    ///    instrument-kind check runs **first** so a split on an option is attributed to the
+    ///    instrument, not the (supported) kind:
+    ///    - target instrument is not `Spot` ⇒ [`UnsupportedCorporateActionReason::InstrumentKindNotSupported`];
+    ///    - action kind is not a stock split ⇒ [`UnsupportedCorporateActionReason::ActionKindNotSupported`]
+    ///      (the compiler-mandated arm for the `#[non_exhaustive]` [`CorporateActionKind`]).
+    /// 3. Snapshot resting orders into [`EngineOutput::OpenOrdersAtSplit`] (no cancellation).
+    /// 4. Apply the split to every open position via [`Position::apply_split`]; emit one
+    ///    [`EngineOutput::SplitRemainder`] per position that disposed a fractional sliver. A
+    ///    position floored to zero quantity is removed and folded as an
+    ///    [`EngineOutput::PositionExit`].
+    /// 5. Scan for option positions on the same underlying and emit
+    ///    [`EngineOutput::OptionPositionsUnadjustedForSplit`] if any (options are unadjusted in
+    ///    this phase).
+    /// 6. Record `id` in `corporate_actions_processed`.
+    ///
+    /// # Missing last price
+    /// If the instrument's last price is unavailable the split is **still applied** and the `id`
+    /// **recorded** (the quantity/basis arithmetic needs no price); `pnl_unrealised` is set to
+    /// zero with a warning and corrected on the next market tick. This is **not** retryable —
+    /// contrast `process_contract_expiry`, which bails and is retryable.
+    pub fn process_corporate_action<OnTradingDisabled, OnDisconnect>(
+        &mut self,
+        id: &SmolStr,
+        key: &InstrumentIndex,
+        kind: &CorporateActionKind,
+        policy: SplitRoundingPolicy,
+    ) -> Vec<EngineOutput<OnTradingDisabled, OnDisconnect>>
+    where
+        Clock: EngineClock,
+        InstrumentData: InstrumentDataState,
+    {
+        let mut outputs = Vec::new();
+        // Engine clock time for deterministic stamping (the clock was already advanced to the
+        // event's `effective_time` before this handler runs).
+        let engine_time = self.time();
+
+        let instrument_state = self.state.instruments.instrument_index_mut(key);
+
+        // Step 1: idempotency guard (keyed on `id` alone). Warn on suppression — a wrapper-reused
+        // `id` would otherwise silently drop a real action.
+        if instrument_state.corporate_actions_processed.contains(id) {
+            warn!(
+                %id,
+                instrument = ?key,
+                effective_time = ?engine_time,
+                "CorporateAction id already processed — skipping (idempotent). Ensure each \
+                 action (incl. same-day corrections) carries a unique id."
+            );
+            return outputs;
+        }
+
+        // Step 2a: reject non-Spot targets (checked BEFORE the action kind so a split on an
+        // option is attributed to the instrument, not the supported kind). Do NOT record `id`.
+        if !matches!(instrument_state.instrument.kind, InstrumentKind::Spot) {
+            warn!(
+                %id,
+                instrument = ?key,
+                kind = ?instrument_state.instrument.kind,
+                "CorporateAction targets a non-Spot instrument — unsupported (equity splits \
+                 only). Emitting UnsupportedCorporateAction; id NOT recorded (retryable)."
+            );
+            outputs.push(EngineOutput::UnsupportedCorporateAction {
+                instrument: *key,
+                kind: kind.clone(),
+                reason: UnsupportedCorporateActionReason::InstrumentKindNotSupported,
+            });
+            return outputs;
+        }
+
+        // Step 2b: extract the split ratio. `CorporateActionKind` is `#[non_exhaustive]` and
+        // defined in another crate, so the compiler mandates this `else` arm even though
+        // `StockSplit` is currently the only variant. It is runtime-unreachable until a second
+        // kind exists, then becomes the "action kind not supported" rejection. Do NOT record `id`.
+        let CorporateActionKind::StockSplit { ratio } = kind else {
+            warn!(
+                %id,
+                instrument = ?key,
+                kind = ?kind,
+                "CorporateAction kind not supported (stock splits only). Emitting \
+                 UnsupportedCorporateAction; id NOT recorded (retryable once supported)."
+            );
+            outputs.push(EngineOutput::UnsupportedCorporateAction {
+                instrument: *key,
+                kind: kind.clone(),
+                reason: UnsupportedCorporateActionReason::ActionKindNotSupported,
+            });
+            return outputs;
+        };
+        let ratio = *ratio;
+
+        // Step 3: snapshot resting orders as an observable — do NOT cancel (a broker price-adjusts
+        // them, so an engine-side cancel would diverge from the broker).
+        let resting_orders: Vec<OpenOrderAtSplit> = instrument_state
+            .orders
+            .orders()
+            .map(|order| OpenOrderAtSplit {
+                cid: order.key.cid.clone(),
+                price_pre_split: order.price,
+                quantity_pre_split: order.quantity,
+            })
+            .collect();
+
+        // Last price for the eager `pnl_unrealised` recompute. None ⇒ 0 (+ warn); the split is
+        // still applied and the `id` recorded (NOT retryable).
+        let last_price = instrument_state.data.price();
+        if last_price.is_none() {
+            warn!(
+                %id,
+                instrument = ?key,
+                "CorporateAction: instrument last price unavailable — pnl_unrealised set to 0, \
+                 corrected on the next market tick. The split is still applied (not retryable)."
+            );
+        }
+
+        // Step 4: apply to ALL open positions (N in Hedging mode). Collect ids first to avoid a
+        // borrow conflict with the per-position re-borrow, mirroring process_contract_expiry.
+        let position_ids: Vec<PositionId> = instrument_state
+            .position
+            .positions
+            .keys()
+            .cloned()
+            .collect();
+        // Pre-size: up to a SplitRemainder + a PositionExit per position, plus the
+        // OpenOrdersAtSplit and OptionPositionsUnadjustedForSplit observables.
+        outputs.reserve(position_ids.len() * 2 + 2);
+
+        for pos_id in position_ids {
+            let instrument_state = self.state.instruments.instrument_index_mut(key);
+            let Some(position) = instrument_state.position.positions.get_mut(&pos_id) else {
+                continue;
+            };
+
+            let side = position.side;
+            let result = position.apply_split(ratio, policy, last_price);
+            // Read the post-split basis AFTER apply_split overwrote it (Convention A): quantity
+            // and price then share the post-split era, valuing the disposed sliver with one
+            // multiply and no ratio knowledge.
+            let price_entry_average_post_split = position.price_entry_average;
+            let quantity_abs_after = position.quantity_abs;
+
+            if result.remainder > Decimal::ZERO {
+                outputs.push(EngineOutput::SplitRemainder {
+                    instrument: *key,
+                    position_id: pos_id.clone(),
+                    side,
+                    quantity_fractional_disposed: result.remainder,
+                    price_entry_average_post_split,
+                });
+            }
+
+            // Floor whole-position disposal: a reverse split under `Floor` can round the quantity
+            // to zero. Remove the slot and fold a PositionExit so no zero-qty zombie strands its
+            // pnl_realised (which would later leak into a fresh post-split buy via VWAP-from-zero).
+            if quantity_abs_after.is_zero() {
+                let instrument_state = self.state.instruments.instrument_index_mut(key);
+                if let Some(closed) = instrument_state.position.positions.shift_remove(&pos_id) {
+                    let mut exit = PositionExited::from(closed);
+                    exit.position_id = pos_id.clone();
+                    exit.time_exit = engine_time;
+                    instrument_state.tear_sheet.update_from_position(&exit);
+                    outputs.push(EngineOutput::PositionExit(exit));
+                }
+            }
+        }
+
+        // Emit the observable resting-orders snapshot if any rest.
+        if !resting_orders.is_empty() {
+            outputs.push(EngineOutput::OpenOrdersAtSplit {
+                instrument: *key,
+                orders: resting_orders,
+            });
+        }
+
+        // Step 5: options-on-underlying guard. A split targets the underlying equity; option
+        // positions on that underlying are left unadjusted in this phase. Mirror of the
+        // spot-given-option scan in process_contract_expiry: find Option instruments whose
+        // underlying matches this equity's, on the same exchange, that hold positions.
+        //
+        // Both `base` AND `quote` are matched: `Underlying` is a full pair identity, and a
+        // `CorporateAction` targets a single `InstrumentIndex` (only that instrument's positions
+        // are split). Without the quote filter, a BTC/USDT split would also flag BTC/USDC option
+        // positions that the engine itself never adjusted — false-positive noise. Mirrors the
+        // base+quote filter in process_contract_expiry's underlying-spot scan.
+        let (equity_base, equity_quote, equity_exchange) = {
+            let equity = self.state.instruments.instrument_index(key);
+            (
+                equity.instrument.underlying.base,
+                equity.instrument.underlying.quote,
+                equity.instrument.exchange,
+            )
+        };
+        let affected_options: Vec<InstrumentIndex> = self
+            .state
+            .instruments
+            .0
+            .values()
+            .filter(|state| {
+                matches!(&state.instrument.kind, InstrumentKind::Option(_))
+                    && state.instrument.underlying.base == equity_base
+                    && state.instrument.underlying.quote == equity_quote
+                    && state.instrument.exchange == equity_exchange
+                    && !state.position.positions.is_empty()
+            })
+            .map(|state| state.key)
+            .collect();
+        if !affected_options.is_empty() {
+            warn!(
+                %id,
+                instrument = ?key,
+                count = affected_options.len(),
+                "CorporateAction: option positions on the splitting underlying are left \
+                 UNADJUSTED (option corporate-action handling is deferred). Emitting \
+                 OptionPositionsUnadjustedForSplit."
+            );
+            outputs.push(EngineOutput::OptionPositionsUnadjustedForSplit {
+                split_instrument: *key,
+                ratio,
+                affected_options,
+            });
+        }
+
+        // Step 6: record the `id` — the action has now been applied.
+        self.state
+            .instruments
+            .instrument_index_mut(key)
+            .corporate_actions_processed
+            .insert(id.clone());
+
+        outputs
+    }
 }
 
 impl<Clock, State, ExecutionTxs, Strategy, Risk> Engine<Clock, State, ExecutionTxs, Strategy, Risk>
@@ -667,7 +923,11 @@ where
 }
 
 /// Output produced by [`Engine`] operations, used to construct an `Engine` [`EngineAudit`].
+///
+/// `#[non_exhaustive]`: engine-driven outputs (e.g. corporate-action observables) can be added
+/// without breaking downstream exhaustive matches. External matchers must carry a wildcard arm.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+#[non_exhaustive]
 pub enum EngineOutput<
     OnTradingDisabled,
     OnDisconnect,
@@ -680,6 +940,91 @@ pub enum EngineOutput<
     PositionExit(PositionExited<AssetIndex, InstrumentKey>),
     MarketDisconnect(OnDisconnect),
     AlgoOrders(GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>),
+
+    /// Cash-in-lieu observable: a corporate-action split disposed a fractional share quantity
+    /// (under [`SplitRoundingPolicy::Floor`]) from one open position. Emitted **per position**
+    /// (`position_id` attributes it in hedging mode). The library writes no balances — the
+    /// wrapper reconciles this against the broker's CIL payment.
+    ///
+    /// `quantity_fractional_disposed × price_entry_average_post_split` is the cost basis of the
+    /// disposed sliver; both fields share the post-split era (Decimal arithmetic, no ratio).
+    SplitRemainder {
+        /// Instrument whose position was split.
+        instrument: InstrumentKey,
+        /// Position the remainder was disposed from.
+        position_id: PositionId,
+        /// Direction of the position (sign of the disposed sliver).
+        side: Side,
+        /// Post-split fractional shares disposed by `Floor` rounding (always `< 1`, `> 0`).
+        quantity_fractional_disposed: Decimal,
+        /// The position's split-adjusted per-share basis (`= old_avg / ratio`), read **after**
+        /// the split is applied.
+        price_entry_average_post_split: Decimal,
+    },
+
+    /// Observable snapshot of the resting orders an instrument had at the moment a split was
+    /// applied. The handler **does not** cancel or re-price them — a real broker price-adjusts
+    /// resting orders, so an engine-side cancel would diverge. The wrapper decides cancel-vs-keep
+    /// (and **must** cancel in backtest, or the mock exchange fills stale-priced orders).
+    OpenOrdersAtSplit {
+        /// Instrument whose resting orders are listed.
+        instrument: InstrumentKey,
+        /// The resting orders, captured at pre-split prices/quantities.
+        orders: Vec<OpenOrderAtSplit>,
+    },
+
+    /// Observable signal that option positions on a splitting underlying were left **unadjusted**
+    /// (option corporate-action handling is deferred). The wrapper decides what to do.
+    OptionPositionsUnadjustedForSplit {
+        /// The underlying equity instrument that was split.
+        split_instrument: InstrumentKey,
+        /// The split ratio that was applied to the underlying.
+        ratio: Decimal,
+        /// Option instruments (holding positions) on that underlying, left unadjusted.
+        affected_options: Vec<InstrumentKey>,
+    },
+
+    /// Observable signal that a [`CorporateAction`](crate::EngineEvent::CorporateAction) could
+    /// **not** be processed. The action was **not** applied and its `id` was **not** recorded, so
+    /// it remains retryable once support is added (e.g. a corrected instrument key, or a future
+    /// library version). See [`UnsupportedCorporateActionReason`].
+    UnsupportedCorporateAction {
+        /// The instrument the rejected action targeted.
+        instrument: InstrumentKey,
+        /// The action's market-fact kind (carried verbatim for the consumer).
+        kind: CorporateActionKind,
+        /// Why the action could not be processed.
+        reason: UnsupportedCorporateActionReason,
+    },
+}
+
+/// A single resting order captured in an [`EngineOutput::OpenOrdersAtSplit`] observable.
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
+)]
+pub struct OpenOrderAtSplit {
+    /// Client order id of the resting order.
+    pub cid: ClientOrderId,
+    /// Limit price before the split (`None` for market/stop orders).
+    pub price_pre_split: Option<Decimal>,
+    /// Order quantity before the split.
+    pub quantity_pre_split: Decimal,
+}
+
+/// Reason a [`CorporateAction`](crate::EngineEvent::CorporateAction) could not be processed,
+/// carried by [`EngineOutput::UnsupportedCorporateAction`].
+///
+/// `#[non_exhaustive]`: further rejection causes (e.g. a non-standard option split requiring a
+/// symbol-identity change) can be added without breaking downstream exhaustive matches.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+#[non_exhaustive]
+pub enum UnsupportedCorporateActionReason {
+    /// The target instrument is not a `Spot` equity (e.g. an option, perpetual, or future).
+    /// Equity-split arithmetic is invalid for these; option splits are handled separately.
+    InstrumentKindNotSupported,
+    /// The corporate-action kind is not handled by this engine version (only stock splits are
+    /// supported). Reachable once non-split kinds (dividends, spin-offs, …) are delivered.
+    ActionKindNotSupported,
 }
 
 /// Output produced by the [`Engine`] updating from an [`TradingState`], used to construct

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -41,7 +41,7 @@ use rustrade_execution::{
 use rustrade_instrument::{
     Side,
     asset::AssetIndex,
-    corporate_action::{CorporateActionKind, SplitAdjustmentKind},
+    corporate_action::{CorporateActionKind, SplitAdjustmentKind, SplitRatio},
     exchange::ExchangeIndex,
     instrument::{
         InstrumentIndex,
@@ -765,7 +765,13 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             });
             return outputs;
         };
-        let ratio = *ratio;
+        // `ratio` is a validated `SplitRatio` (always `> 0`, enforced at construction and on
+        // deserialization), so the engine's split arithmetic can never receive a degenerate ratio
+        // through the event path. Copy the `SplitRatio` out (it is `Copy`) to carry the type-level
+        // invariant unbroken into the output records, and extract the inner `Decimal` for the
+        // arithmetic below.
+        let ratio: SplitRatio = *ratio;
+        let ratio_decimal = ratio.get();
 
         // Step 3: snapshot resting orders as an observable — do NOT cancel (a broker price-adjusts
         // them, so an engine-side cancel would diverge from the broker).
@@ -810,7 +816,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             };
 
             let side = position.side;
-            let result = position.apply_split(ratio, policy, last_price);
+            let result = position.apply_split(ratio_decimal, policy, last_price);
             // Read the post-split basis AFTER apply_split overwrote it (Convention A): quantity
             // and price then share the post-split era, valuing the disposed sliver with one
             // multiply and no ratio knowledge.
@@ -838,6 +844,18 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                     exit.time_exit = engine_time;
                     instrument_state.tear_sheet.update_from_position(&exit);
                     outputs.push(EngineOutput::PositionExit(exit));
+
+                    // Prune the hedging fill-routing map for the removed position. This must prune
+                    // by VALUE (the removed `PositionId`), NOT via `cleanup_routing_tables` (which
+                    // retains by `ClientOrderId` still present in `self.orders`): the split
+                    // deliberately leaves the position's resting order in place (a broker
+                    // price-adjusts it), so its CID is still in `orders` and `cleanup_routing_tables`
+                    // would keep the now-dangling `cid → removed_pos_id` mapping. Left stale, an
+                    // `OmsMode::Hedging` late fill on that order would resolve the dead id and
+                    // silently reopen a floored-out position.
+                    instrument_state
+                        .position_ids
+                        .retain(|_, mapped| *mapped != pos_id);
                 }
             }
         }
@@ -850,17 +868,16 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             });
         }
 
-        // Step 5: options-on-underlying handling. A split targets the underlying equity; option
-        // positions on that underlying must also be adjusted (standard split) or flagged for a
-        // wrapper-side identity change (non-standard split). Mirror of the spot-given-option scan
-        // in process_contract_expiry: find Option instruments whose underlying matches this
-        // equity's, on the same exchange, that hold positions.
+        // Step 5: options-on-underlying handling. A split targets the underlying equity; listed
+        // options on that underlying must also be adjusted (standard split) or flagged for a
+        // wrapper-side identity change (non-standard split). The scan mirrors the spot-given-option
+        // scan in process_contract_expiry, inverted: find Option instruments whose underlying
+        // matches this equity's, on the same exchange.
         //
         // Both `base` AND `quote` are matched: `Underlying` is a full pair identity, and a
-        // `CorporateAction` targets a single `InstrumentIndex` (only that instrument's positions
-        // are split). Without the quote filter, a BTC/USDT split would also flag BTC/USDC option
-        // positions that the engine itself never adjusted — false-positive noise. Mirrors the
-        // base+quote filter in process_contract_expiry's underlying-spot scan.
+        // `CorporateAction` targets a single `InstrumentIndex`. Without the quote filter, a
+        // BTC/USDT split would also touch BTC/USDC options the engine never adjusted — wrong.
+        // Mirrors the base+quote filter in process_contract_expiry's underlying-spot scan.
         let (equity_base, equity_quote, equity_exchange) = {
             let equity = self.state.instruments.instrument_index(key);
             (
@@ -869,126 +886,155 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                 equity.instrument.exchange,
             )
         };
-        let affected_options: Vec<InstrumentIndex> = self
-            .state
-            .instruments
-            .0
-            .values()
-            .filter(|state| {
-                state.is_affected_option_on_underlying(
-                    &equity_base,
-                    &equity_quote,
-                    &equity_exchange,
-                )
-            })
-            .map(|state| state.key)
-            .collect();
-        if !affected_options.is_empty() {
-            // Classify the split for OPTION handling (extracted to keep this handler's branching
-            // flat). `true` ⇒ adjust the options in place (standard split); `false` ⇒ signal a
-            // downstream identity change. A future `#[non_exhaustive]` `SplitAdjustmentKind` variant
-            // is handled conservatively as non-standard and `warn!`-surfaced (observable beats
-            // silent) — see [`option_split_adjust_in_place`].
-            if option_split_adjust_in_place(id, key, kind) {
-                // STANDARD (whole-number forward split, OCC Art. VI §11): the option keeps its
-                // contract identity. Adjust each affected option IN PLACE — strike ÷ ratio,
-                // contracts × ratio (via apply_split), multiplier (contract_size) unchanged.
-                for opt_key in affected_options {
-                    let option_state = self.state.instruments.instrument_index_mut(&opt_key);
 
-                    // Snapshot the option's resting orders as an observable BEFORE adjusting — a
-                    // broker price-adjusts them, so the engine cancels nothing, but
-                    // the wrapper must know (and a backtest MockExchange would otherwise fill a
-                    // now-stale-premium resting order against the post-split print).
-                    let option_orders: Vec<OpenOrderAtSplit> = option_state
-                        .orders
-                        .orders()
-                        .map(|order| OpenOrderAtSplit {
-                            cid: order.key.cid.clone(),
-                            price_pre_split: order.price,
-                            quantity_pre_split: order.quantity,
-                        })
-                        .collect();
+        // Classify the split for OPTION handling up front (cheap; only `warn!`s on an unexpected
+        // classification). `true` ⇒ adjust the options in place (standard split); `false` ⇒ signal
+        // a downstream identity change. A future `#[non_exhaustive]` `SplitAdjustmentKind` variant
+        // is handled conservatively as non-standard and `warn!`-surfaced (observable beats silent)
+        // — see [`option_split_adjust_in_place`].
+        if option_split_adjust_in_place(id, key, kind) {
+            // STANDARD (whole-number forward split, OCC Art. VI §11): the option keeps its contract
+            // identity, so the adjustment is purely mechanical (strike ÷ ratio; contracts × ratio
+            // for held positions; multiplier/contract_size unchanged). Adjust the strike of EVERY
+            // registered option on the underlying — held OR unheld. The instrument set is fixed at
+            // construction, so an option that is unheld at split time can have a position opened
+            // later and then settle at expiry against its strike; leaving it on the pre-split strike
+            // would mis-settle that future position. Unheld options get the strike correction
+            // SILENTLY (a registry fix, no position event); held options additionally get
+            // per-position `apply_split` + observables.
+            let options_on_underlying: Vec<InstrumentIndex> = self
+                .state
+                .instruments
+                .0
+                .values()
+                .filter(|state| {
+                    state.is_option_on_underlying(&equity_base, &equity_quote, &equity_exchange)
+                })
+                .map(|state| state.key)
+                .collect();
 
-                    // The OPTION's own last price (premium) for the eager pnl_unrealised recompute
-                    // — not the underlying equity's. None ⇒ 0 (+ warn), mirroring the equity path:
-                    // the split is still applied, corrected on the next market tick.
-                    let option_last_price = option_state.data.price();
-                    if option_last_price.is_none() {
-                        warn!(
-                            %id,
-                            instrument = ?opt_key,
-                            "CorporateAction: option last price unavailable — pnl_unrealised set to \
-                             0 after the standard-split adjustment, corrected on the next market \
-                             tick. The split is still applied (not retryable)."
-                        );
-                    }
+            for opt_key in options_on_underlying {
+                let option_state = self.state.instruments.instrument_index_mut(&opt_key);
 
-                    // Adjust the strike in place. The scan only matched Option instruments, so the
-                    // `else` is defensive (unreachable); skip rather than misadjust if it ever hits.
-                    let InstrumentKind::Option(ref mut contract) = option_state.instrument.kind
-                    else {
-                        continue;
-                    };
-                    let strike_pre_split = contract.strike;
-                    contract.strike /= ratio;
-                    let strike_post_split = contract.strike;
+                // Adjust the strike in place. The scan only matched Option instruments, so the
+                // `else` arm is unreachable; fail loudly rather than silently misadjust if that
+                // invariant is ever broken (a re-borrow on a freshly-collected key cannot miss).
+                let InstrumentKind::Option(ref mut contract) = option_state.instrument.kind else {
+                    unreachable!(
+                        "is_option_on_underlying matched a non-Option instrument {opt_key:?}"
+                    );
+                };
+                let strike_pre_split = contract.strike;
+                contract.strike /= ratio_decimal;
+                let strike_post_split = contract.strike;
 
-                    // Apply the split to EACH of the option's positions (N in Hedging) and emit one
-                    // per-position record. A whole-number ratio × an integer contract count leaves a
-                    // whole contract count ⇒ no fractional remainder, no CIL, no floor-to-zero,
-                    // regardless of `policy`.
-                    let opt_position_ids: Vec<PositionId> =
-                        option_state.position.positions.keys().cloned().collect();
-                    for pos_id in opt_position_ids {
-                        // Gate the observable on the mutation actually happening, mirroring the
-                        // equity loop's `else { continue; }`: an OptionPositionAdjustedForSplit
-                        // record asserts the position WAS adjusted, so never emit it for a position
-                        // the re-borrow could not find.
-                        if let Some(position) = option_state.position.positions.get_mut(&pos_id) {
-                            // Option contract counts are whole, and a standard split is a
-                            // whole-number ratio, so `integer × integer` stays integer with no
-                            // fractional remainder — the equity's `SplitRoundingPolicy` (a
-                            // whole-share-lot concept) does not govern option legs. Enforce that
-                            // invariant on the INPUT with a hard `assert!` (NOT `debug_assert!`,
-                            // which compiles out in release): a non-integer contract count is state
-                            // corruption that must fail observably, never be silently floored (under
-                            // `Floor`) or silently carried (under `Fractional`). Asserting the input
-                            // — rather than the post-split `remainder` — is the meaningful check:
-                            // under `Fractional` the remainder is always zero by construction, so a
-                            // remainder assert would be vacuous. With the invariant upheld the
-                            // disposal is provably zero, so no SplitRemainder/CIL or floor-to-zero
-                            // close is possible here.
-                            assert!(
-                                position.quantity_abs.fract().is_zero(),
-                                "option position {pos_id:?} holds a non-integer contract count {} \
-                                 before a standard split — data corruption",
-                                position.quantity_abs,
-                            );
-                            position.apply_split(ratio, policy, option_last_price);
-                            outputs.push(EngineOutput::OptionPositionAdjustedForSplit {
-                                option_instrument: opt_key,
-                                ratio,
-                                strike_pre_split,
-                                strike_post_split,
-                                position_id: pos_id,
-                            });
-                        }
-                    }
-
-                    if !option_orders.is_empty() {
-                        outputs.push(EngineOutput::OpenOrdersAtSplit {
-                            instrument: opt_key,
-                            orders: option_orders,
-                        });
-                    }
+                // Unheld option: the strike correction above is the whole job — no positions to
+                // split, no observable (a silent registry fix; the user-chosen behaviour).
+                if option_state.position.positions.is_empty() {
+                    continue;
                 }
-            } else {
-                // NON-STANDARD (every reverse split, every fractional forward split): the OCC
-                // assigns a new contract identity (new deliverable / symbol e.g. MSFT → MSFT1),
-                // which the engine cannot represent (fixed-at-construction instrument set). Leave
-                // the options at pre-split terms and signal the wrapper. The equity split itself is
-                // still applied and the `id` recorded below.
+
+                // Snapshot the held option's resting orders as an observable BEFORE adjusting its
+                // positions — a broker price-adjusts them, so the engine cancels nothing, but the
+                // wrapper must know (and a backtest MockExchange would otherwise fill a
+                // now-stale-premium resting order against the post-split print).
+                let option_orders: Vec<OpenOrderAtSplit> = option_state
+                    .orders
+                    .orders()
+                    .map(|order| OpenOrderAtSplit {
+                        cid: order.key.cid.clone(),
+                        price_pre_split: order.price,
+                        quantity_pre_split: order.quantity,
+                    })
+                    .collect();
+
+                // The OPTION's own last price (premium) for the eager pnl_unrealised recompute —
+                // not the underlying equity's. None ⇒ 0 (+ warn), mirroring the equity path: the
+                // split is still applied, corrected on the next market tick.
+                let option_last_price = option_state.data.price();
+                if option_last_price.is_none() {
+                    warn!(
+                        %id,
+                        instrument = ?opt_key,
+                        "CorporateAction: option last price unavailable — pnl_unrealised set to 0 \
+                         after the standard-split adjustment, corrected on the next market tick. \
+                         The split is still applied (not retryable)."
+                    );
+                }
+
+                // Apply the split to EACH of the option's positions (N in Hedging) and emit one
+                // per-position record. A whole-number ratio × an integer contract count leaves a
+                // whole contract count ⇒ no fractional remainder, no CIL, no floor-to-zero,
+                // regardless of `policy`.
+                let opt_position_ids: Vec<PositionId> =
+                    option_state.position.positions.keys().cloned().collect();
+                for pos_id in opt_position_ids {
+                    // `pos_id` was just collected from this same positions map in a single-threaded
+                    // engine, so the re-borrow cannot miss; fail loudly (matching the strike-adjust
+                    // `unreachable!` above) if that ever changes, rather than silently skipping an
+                    // OptionPositionAdjustedForSplit whose contract asserts the position WAS adjusted.
+                    let Some(position) = option_state.position.positions.get_mut(&pos_id) else {
+                        unreachable!(
+                            "position id {pos_id:?} collected from this option's positions map"
+                        );
+                    };
+
+                    // Option contract counts are whole, and a standard split is a whole-number
+                    // ratio, so `integer × integer` stays integer with no fractional remainder —
+                    // the equity's `SplitRoundingPolicy` (a whole-share-lot concept) does not govern
+                    // option legs. Enforce that invariant on the INPUT with a hard `assert!` (NOT
+                    // `debug_assert!`, which compiles out in release): a non-integer contract count
+                    // is state corruption that must fail observably, never be silently floored
+                    // (under `Floor`) or silently carried (under `Fractional`). Asserting the input
+                    // — rather than the post-split `remainder` — is the meaningful check: under
+                    // `Fractional` the remainder is always zero by construction, so a remainder
+                    // assert would be vacuous. With the invariant upheld the disposal is provably
+                    // zero, so no SplitRemainder/CIL or floor-to-zero close is possible here.
+                    assert!(
+                        position.quantity_abs.fract().is_zero(),
+                        "option position {pos_id:?} holds a non-integer contract count {} before a \
+                         standard split — data corruption",
+                        position.quantity_abs,
+                    );
+                    position.apply_split(ratio_decimal, policy, option_last_price);
+                    outputs.push(EngineOutput::OptionPositionAdjustedForSplit {
+                        option_instrument: opt_key,
+                        ratio,
+                        strike_pre_split,
+                        strike_post_split,
+                        position_id: pos_id,
+                    });
+                }
+
+                if !option_orders.is_empty() {
+                    outputs.push(EngineOutput::OpenOrdersAtSplit {
+                        instrument: opt_key,
+                        orders: option_orders,
+                    });
+                }
+            }
+        } else {
+            // NON-STANDARD (every reverse split, every fractional forward split): the OCC assigns a
+            // new contract identity (new deliverable / symbol e.g. MSFT → MSFT1), which the engine
+            // cannot represent (fixed-at-construction instrument set) — and there is no correct
+            // in-place strike fix, since the deliverable itself changes. Touch NO option strikes;
+            // only signal the wrapper about HELD option positions that need an identity change. The
+            // equity split itself is still applied and the `id` recorded below.
+            let affected_options: Vec<InstrumentIndex> = self
+                .state
+                .instruments
+                .0
+                .values()
+                .filter(|state| {
+                    state.is_affected_option_on_underlying(
+                        &equity_base,
+                        &equity_quote,
+                        &equity_exchange,
+                    )
+                })
+                .map(|state| state.key)
+                .collect();
+            if !affected_options.is_empty() {
                 warn!(
                     %id,
                     instrument = ?key,
@@ -1171,8 +1217,9 @@ pub enum EngineOutput<
     OptionPositionAdjustedForSplit {
         /// The option instrument whose strike and position were adjusted.
         option_instrument: InstrumentKey,
-        /// The (whole-number, `> 1`) forward split ratio that was applied.
-        ratio: Decimal,
+        /// The forward split ratio that was applied, as a validated [`SplitRatio`] (always `> 0`;
+        /// in practice a whole number `> 1`, since this variant is emitted only for standard splits).
+        ratio: SplitRatio,
         /// The option strike before the split was applied.
         strike_pre_split: Decimal,
         /// The option strike after the split (`= strike_pre_split / ratio`).
@@ -1208,8 +1255,9 @@ pub enum EngineOutput<
     OptionPositionsRequireIdentityChange {
         /// The underlying equity instrument that was split.
         split_instrument: InstrumentKey,
-        /// The split ratio that was applied to the underlying.
-        ratio: Decimal,
+        /// The split ratio that was applied to the underlying, as a validated [`SplitRatio`]
+        /// (always `> 0`).
+        ratio: SplitRatio,
         /// Option instruments (holding positions) on that underlying that require a wrapper-side
         /// identity change; left at pre-split terms by the engine.
         affected_options: Vec<InstrumentKey>,

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -653,9 +653,17 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     /// dispatch; the engine's event loop does this automatically via the clock's time-exchange
     /// handling, so a direct caller (e.g. a test) must advance the clock first.
     ///
+    /// Note this is clock-kind dependent: under `HistoricalClock` (backtest) the clock is advanced
+    /// to `effective_time`, so outputs carry it; under `LiveClock` the clock is **not** advanceable
+    /// and outputs are stamped at `Utc::now()`, not `effective_time` (correct for live — the
+    /// adjustment happens now — but worth noting if you compare live and replayed stamps).
+    ///
     /// # Algorithm
     /// 1. Idempotency guard on `id` (per-instrument `corporate_actions_processed` set). A
-    ///    duplicate `id` is skipped with a warning.
+    ///    duplicate `id` is skipped with a warning. This holds within a live session but does **not**
+    ///    survive a snapshot taken before the set existed; see the `corporate_actions_processed`
+    ///    field on [`InstrumentState`](crate::engine::state::instrument::InstrumentState) for the
+    ///    migration caveat.
     /// 2. **Unsupported guards (no silent no-op, `id` not recorded ⇒ retryable).** The
     ///    instrument-kind check runs **first** so a split on an option is attributed to the
     ///    instrument, not the (supported) kind:
@@ -996,7 +1004,15 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                          standard split — data corruption",
                         position.quantity_abs,
                     );
-                    position.apply_split(ratio_decimal, policy, option_last_price);
+                    // Pass `Fractional` explicitly, NOT the equity's `policy`: the assert above
+                    // guarantees an integer contract count so no remainder can arise (the policy is
+                    // a no-op here), and threading the equity's whole-share-lot policy into the
+                    // option path would falsely imply it governs option legs. It does not.
+                    position.apply_split(
+                        ratio_decimal,
+                        SplitRoundingPolicy::Fractional,
+                        option_last_price,
+                    );
                     outputs.push(EngineOutput::OptionPositionAdjustedForSplit {
                         option_instrument: opt_key,
                         ratio,
@@ -1168,6 +1184,10 @@ pub enum EngineOutput<
     /// closes the now-zero-quantity slot and books its realised PnL, while this `SplitRemainder`
     /// records the disposed fractional sliver as cash-in-lieu. So when both share a `position_id`,
     /// this `SplitRemainder` is the position's **entire** remaining disposal.
+    ///
+    /// **Ordering contract:** within the handler's output `Vec` the `SplitRemainder` is always
+    /// emitted **before** its paired `PositionExit`, so a consumer that books cash-in-lieu before
+    /// finalising the close can rely on encountering them in that order.
     SplitRemainder {
         /// Instrument whose position was split.
         instrument: InstrumentKey,

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -190,6 +190,16 @@ where
                 // trigger algo order generation — return early before that check.
                 return EngineAudit::from(audit);
             }
+            EngineEvent::CorporateAction { .. } => {
+                // TODO: position-adjustment handler not yet wired. Surface loudly so an
+                // early-injected event is not silently dropped, and return before algo
+                // order generation (the adjustment is engine-driven, like ContractExpiry).
+                warn!(
+                    ?event,
+                    "CorporateAction received but its handler is not yet implemented; no-op"
+                );
+                return EngineAudit::process(event);
+            }
         };
 
         if let TradingState::Enabled = self.state.trading {

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -41,7 +41,7 @@ use rustrade_execution::{
 use rustrade_instrument::{
     Side,
     asset::AssetIndex,
-    corporate_action::CorporateActionKind,
+    corporate_action::{CorporateActionKind, SplitAdjustmentKind},
     exchange::ExchangeIndex,
     instrument::{
         InstrumentIndex,
@@ -205,8 +205,9 @@ where
             } => {
                 let outputs = self.process_corporate_action(id, instrument, kind, *policy);
                 // Fold each observable output (SplitRemainder / OpenOrdersAtSplit /
-                // OptionPositionsUnadjustedForSplit / PositionExit / UnsupportedCorporateAction)
-                // into the audit. Like ContractExpiry, a corporate action is engine-driven and
+                // OptionPositionAdjustedForSplit / OptionPositionsRequireIdentityChange /
+                // PositionExit / UnsupportedCorporateAction) into the audit. Like ContractExpiry, a
+                // corporate action is engine-driven and
                 // settles regardless of TradingState — return early before algo generation.
                 let mut audit = ProcessAudit::with_event(event);
                 for output in outputs {
@@ -647,6 +648,11 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     /// price-adjusts them, so an engine-side cancel would diverge) and **does not** require a
     /// market price (the split is applied regardless; see below).
     ///
+    /// All outputs (and any folded `PositionExit`) are stamped at the engine clock's current time.
+    /// The caller is expected to have advanced the clock to the event's `effective_time` before
+    /// dispatch; the engine's event loop does this automatically via the clock's time-exchange
+    /// handling, so a direct caller (e.g. a test) must advance the clock first.
+    ///
     /// # Algorithm
     /// 1. Idempotency guard on `id` (per-instrument `corporate_actions_processed` set). A
     ///    duplicate `id` is skipped with a warning.
@@ -661,9 +667,20 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     ///    [`EngineOutput::SplitRemainder`] per position that disposed a fractional sliver. A
     ///    position floored to zero quantity is removed and folded as an
     ///    [`EngineOutput::PositionExit`].
-    /// 5. Scan for option positions on the same underlying and emit
-    ///    [`EngineOutput::OptionPositionsUnadjustedForSplit`] if any (options are unadjusted in
-    ///    this phase).
+    /// 5. Scan for option positions on the same underlying and handle them per the OCC
+    ///    standard/non-standard rule ([`CorporateActionKind::split_kind`]):
+    ///    - **standard** (whole-number forward split) ⇒ adjust each option **in place**
+    ///      (strike ÷ `ratio`, contracts × `ratio` via [`Position::apply_split`], multiplier
+    ///      unchanged), emitting one [`EngineOutput::OptionPositionAdjustedForSplit`] per position
+    ///      plus — if the option has resting orders — an [`EngineOutput::OpenOrdersAtSplit`] for them
+    ///      (a real broker price-adjusts them; the engine cancels nothing). Because option positions
+    ///      are held in **whole contracts**, a whole-number ratio applied to them disposes no
+    ///      fractional sliver, so — unlike the equity path above, where a fractional remainder can
+    ///      arise — **no** [`EngineOutput::SplitRemainder`] is emitted on this path;
+    ///    - **non-standard** (every reverse split, every fractional forward split) ⇒ the engine
+    ///      **cannot** adjust them (the OCC assigns a new contract identity), so it emits
+    ///      [`EngineOutput::OptionPositionsRequireIdentityChange`] and leaves them at pre-split
+    ///      terms. The equity split is applied and the `id` recorded **regardless**.
     /// 6. Record `id` in `corporate_actions_processed`.
     ///
     /// # Missing last price
@@ -773,8 +790,8 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             .keys()
             .cloned()
             .collect();
-        // Pre-size: up to a SplitRemainder + a PositionExit per position, plus the
-        // OpenOrdersAtSplit and OptionPositionsUnadjustedForSplit observables.
+        // Pre-size: up to a SplitRemainder + a PositionExit per position, plus the equity
+        // OpenOrdersAtSplit and the option-handling observable(s).
         outputs.reserve(position_ids.len() * 2 + 2);
 
         for pos_id in position_ids {
@@ -824,10 +841,11 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             });
         }
 
-        // Step 5: options-on-underlying guard. A split targets the underlying equity; option
-        // positions on that underlying are left unadjusted in this phase. Mirror of the
-        // spot-given-option scan in process_contract_expiry: find Option instruments whose
-        // underlying matches this equity's, on the same exchange, that hold positions.
+        // Step 5: options-on-underlying handling. A split targets the underlying equity; option
+        // positions on that underlying must also be adjusted (standard split) or flagged for a
+        // wrapper-side identity change (non-standard split). Mirror of the spot-given-option scan
+        // in process_contract_expiry: find Option instruments whose underlying matches this
+        // equity's, on the same exchange, that hold positions.
         //
         // Both `base` AND `quote` are matched: `Underlying` is a full pair identity, and a
         // `CorporateAction` targets a single `InstrumentIndex` (only that instrument's positions
@@ -848,28 +866,128 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             .0
             .values()
             .filter(|state| {
-                matches!(&state.instrument.kind, InstrumentKind::Option(_))
-                    && state.instrument.underlying.base == equity_base
-                    && state.instrument.underlying.quote == equity_quote
-                    && state.instrument.exchange == equity_exchange
-                    && !state.position.positions.is_empty()
+                state.is_affected_option_on_underlying(
+                    &equity_base,
+                    &equity_quote,
+                    &equity_exchange,
+                )
             })
             .map(|state| state.key)
             .collect();
         if !affected_options.is_empty() {
-            warn!(
-                %id,
-                instrument = ?key,
-                count = affected_options.len(),
-                "CorporateAction: option positions on the splitting underlying are left \
-                 UNADJUSTED (option corporate-action handling is deferred). Emitting \
-                 OptionPositionsUnadjustedForSplit."
-            );
-            outputs.push(EngineOutput::OptionPositionsUnadjustedForSplit {
-                split_instrument: *key,
-                ratio,
-                affected_options,
-            });
+            // Classify the split for OPTION handling (extracted to keep this handler's branching
+            // flat). `true` ⇒ adjust the options in place (standard split); `false` ⇒ signal a
+            // downstream identity change. A future `#[non_exhaustive]` `SplitAdjustmentKind` variant
+            // is handled conservatively as non-standard and `warn!`-surfaced (observable beats
+            // silent) — see [`option_split_adjust_in_place`].
+            if option_split_adjust_in_place(id, key, kind) {
+                // STANDARD (whole-number forward split, OCC Art. VI §11): the option keeps its
+                // contract identity. Adjust each affected option IN PLACE — strike ÷ ratio,
+                // contracts × ratio (via apply_split), multiplier (contract_size) unchanged.
+                for opt_key in affected_options {
+                    let option_state = self.state.instruments.instrument_index_mut(&opt_key);
+
+                    // Snapshot the option's resting orders as an observable BEFORE adjusting — a
+                    // broker price-adjusts them, so the engine cancels nothing, but
+                    // the wrapper must know (and a backtest MockExchange would otherwise fill a
+                    // now-stale-premium resting order against the post-split print).
+                    let option_orders: Vec<OpenOrderAtSplit> = option_state
+                        .orders
+                        .orders()
+                        .map(|order| OpenOrderAtSplit {
+                            cid: order.key.cid.clone(),
+                            price_pre_split: order.price,
+                            quantity_pre_split: order.quantity,
+                        })
+                        .collect();
+
+                    // The OPTION's own last price (premium) for the eager pnl_unrealised recompute
+                    // — not the underlying equity's. None ⇒ 0 (+ warn), mirroring the equity path:
+                    // the split is still applied, corrected on the next market tick.
+                    let option_last_price = option_state.data.price();
+                    if option_last_price.is_none() {
+                        warn!(
+                            %id,
+                            instrument = ?opt_key,
+                            "CorporateAction: option last price unavailable — pnl_unrealised set to \
+                             0 after the standard-split adjustment, corrected on the next market \
+                             tick. The split is still applied (not retryable)."
+                        );
+                    }
+
+                    // Adjust the strike in place. The scan only matched Option instruments, so the
+                    // `else` is defensive (unreachable); skip rather than misadjust if it ever hits.
+                    let InstrumentKind::Option(ref mut contract) = option_state.instrument.kind
+                    else {
+                        continue;
+                    };
+                    let strike_pre_split = contract.strike;
+                    contract.strike /= ratio;
+                    let strike_post_split = contract.strike;
+
+                    // Apply the split to EACH of the option's positions (N in Hedging) and emit one
+                    // per-position record. A whole-number ratio × an integer contract count leaves a
+                    // whole contract count ⇒ no fractional remainder, no CIL, no floor-to-zero,
+                    // regardless of `policy`.
+                    let opt_position_ids: Vec<PositionId> =
+                        option_state.position.positions.keys().cloned().collect();
+                    for pos_id in opt_position_ids {
+                        // Gate the observable on the mutation actually happening, mirroring the
+                        // equity loop's `else { continue; }`: an OptionPositionAdjustedForSplit
+                        // record asserts the position WAS adjusted, so never emit it for a position
+                        // the re-borrow could not find.
+                        if let Some(position) = option_state.position.positions.get_mut(&pos_id) {
+                            // `_`-prefixed: used only by the debug_assert, which compiles out in
+                            // release. A standard split is a whole-number ratio and option contract
+                            // counts are integers, so the disposal is provably zero — assert it so a
+                            // future apply_split/contract-count regression is caught in test, not
+                            // silently dropped (no SplitRemainder is emitted on this path).
+                            let _split_result =
+                                position.apply_split(ratio, policy, option_last_price);
+                            debug_assert!(
+                                _split_result.remainder.is_zero(),
+                                "standard option split (whole-number ratio × integer contract \
+                                 count) left a non-zero remainder {} — invariant violated",
+                                _split_result.remainder,
+                            );
+                            outputs.push(EngineOutput::OptionPositionAdjustedForSplit {
+                                option_instrument: opt_key,
+                                ratio,
+                                strike_pre_split,
+                                strike_post_split,
+                                position_id: pos_id,
+                            });
+                        }
+                    }
+
+                    if !option_orders.is_empty() {
+                        outputs.push(EngineOutput::OpenOrdersAtSplit {
+                            instrument: opt_key,
+                            orders: option_orders,
+                        });
+                    }
+                }
+            } else {
+                // NON-STANDARD (every reverse split, every fractional forward split): the OCC
+                // assigns a new contract identity (new deliverable / symbol e.g. MSFT → MSFT1),
+                // which the engine cannot represent (fixed-at-construction instrument set). Leave
+                // the options at pre-split terms and signal the wrapper. The equity split itself is
+                // still applied and the `id` recorded below.
+                warn!(
+                    %id,
+                    instrument = ?key,
+                    count = affected_options.len(),
+                    %ratio,
+                    "CorporateAction: non-standard split — option positions on the splitting \
+                     underlying require a new contract identity the engine cannot apply. Emitting \
+                     OptionPositionsRequireIdentityChange; options left at pre-split terms."
+                );
+                outputs.push(EngineOutput::OptionPositionsRequireIdentityChange {
+                    split_instrument: *key,
+                    ratio,
+                    affected_options,
+                });
+            }
         }
 
         // Step 6: record the `id` — the action has now been applied.
@@ -880,6 +998,38 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             .insert(id.clone());
 
         outputs
+    }
+}
+
+/// Classify a stock split for **option** handling: `true` ⇒ the engine can adjust the affected
+/// options **in place** (a standard whole-number forward split, OCC Art. VI §11); `false` ⇒ it must
+/// leave them at pre-split terms and signal a downstream identity change (every reverse split, every
+/// fractional forward split, and the `ratio == 1` no-op).
+///
+/// [`SplitAdjustmentKind`] is `#[non_exhaustive]` and defined in another crate, so it cannot be
+/// matched exhaustively here — a future variant will **not** raise a compile error. Rather than let
+/// one silently take the non-standard path, this names the known classifications and routes anything
+/// unexpected through the conservative non-standard path with a `warn!` (observable over silent). The
+/// `None` arm (kind is not a split) is unreachable at the call site — the `StockSplit` is destructured
+/// before this runs — but is folded into the same conservative branch.
+fn option_split_adjust_in_place(
+    id: &SmolStr,
+    key: &InstrumentIndex,
+    kind: &CorporateActionKind,
+) -> bool {
+    match kind.split_kind() {
+        Some(SplitAdjustmentKind::Standard) => true,
+        Some(SplitAdjustmentKind::NonStandard) => false,
+        other => {
+            warn!(
+                %id,
+                instrument = ?key,
+                classification = ?other,
+                "CorporateAction: unexpected option split classification — handling conservatively \
+                 as non-standard (engine cannot adjust options in place)."
+            );
+            false
+        }
     }
 }
 
@@ -973,14 +1123,71 @@ pub enum EngineOutput<
         orders: Vec<OpenOrderAtSplit>,
     },
 
-    /// Observable signal that option positions on a splitting underlying were left **unadjusted**
-    /// (option corporate-action handling is deferred). The wrapper decides what to do.
-    OptionPositionsUnadjustedForSplit {
+    /// Observable record that a **standard** (OCC even / whole-number-forward) split on an
+    /// underlying equity was applied to one option position on that underlying **in place**: the
+    /// option's strike was divided by `ratio`, its contract count multiplied by `ratio` (via
+    /// [`Position::apply_split`](crate::engine::state::position::Position::apply_split)), and its
+    /// cost basis divided by `ratio`. The deliverable/multiplier (`contract_size`) is **unchanged**
+    /// — the OCC standard rule keeps the same contract identity, so the engine's ledger stays valid
+    /// without any instrument re-registration.
+    ///
+    /// Emitted **per position** (`position_id` attributes the adjusted slot in hedging mode, where
+    /// one option instrument can hold N independent positions) — the same granularity as
+    /// [`EngineOutput::SplitRemainder`], because this is an audit record of a completed per-slot
+    /// mutation rather than a directive. The strike change is an instrument-level fact repeated in
+    /// each per-position record: `strike_pre_split`/`strike_post_split` are identical across all
+    /// records for the same `option_instrument` (only `position_id` differs), so a consumer needing
+    /// just the strike adjustment can read the first record and ignore the rest.
+    ///
+    /// The same standard adjustment **also** emits an [`EngineOutput::OpenOrdersAtSplit`] for the
+    /// adjusted option's own resting orders, if it has any (their premium is now stale-priced) —
+    /// observable, never cancelled, exactly as on the equity path. No [`EngineOutput::SplitRemainder`]
+    /// accompanies it: a whole-number ratio applied to an integer contract count disposes no
+    /// fractional sliver.
+    OptionPositionAdjustedForSplit {
+        /// The option instrument whose strike and position were adjusted.
+        option_instrument: InstrumentKey,
+        /// The (whole-number, `> 1`) forward split ratio that was applied.
+        ratio: Decimal,
+        /// The option strike before the split was applied.
+        strike_pre_split: Decimal,
+        /// The option strike after the split (`= strike_pre_split / ratio`).
+        strike_post_split: Decimal,
+        /// The specific position slot that was adjusted (attribution in hedging mode).
+        position_id: PositionId,
+    },
+
+    /// Observable signal that a **non-standard** split (every reverse split, and every fractional
+    /// forward split) on an underlying equity affected option positions the engine **cannot**
+    /// adjust in place. The OCC assigns such options a new contract identity (new deliverable, new
+    /// symbol e.g. `MSFT` → `MSFT1`), which would require runtime instrument re-registration — a
+    /// wrapper concern, not a library one.
+    ///
+    /// Unlike [`EngineOutput::UnsupportedCorporateAction`], the underlying equity split **was**
+    /// applied and its `id` **was** recorded (the `Spot` target always splits); only the listed
+    /// option positions are left at their pre-split terms. This is therefore **not** retryable —
+    /// the wrapper must close the listed options (and/or open positions under a pre-declared new
+    /// identity), it must not re-inject the same action.
+    ///
+    /// # Backtest pattern
+    /// This is fully backtestable through the same aux-event seam used for the split itself, because
+    /// a backtest replays *known* history: pre-declare **both** identities at construction (each with
+    /// its own data series — the new identity naturally has prints only post-split), then inject BOTH
+    /// the [`CorporateAction`](crate::EngineEvent::CorporateAction) and a flatten
+    /// [`Command::ClosePositions`](crate::engine::command::Command::ClosePositions) for the old
+    /// identity at the split boundary. **Caveat** (identical to the
+    /// [`EngineOutput::OpenOrdersAtSplit`] backtest caveat): in backtest the close trigger is
+    /// *pre-planned* (the split date is known ahead), not *reactive* from this observable — the
+    /// backtest harness disables the audit stream, so this output is invisible there; the reactive
+    /// decision code runs live. Fill timing and P&L stay faithful (the aux merge respects each
+    /// event's time).
+    OptionPositionsRequireIdentityChange {
         /// The underlying equity instrument that was split.
         split_instrument: InstrumentKey,
         /// The split ratio that was applied to the underlying.
         ratio: Decimal,
-        /// Option instruments (holding positions) on that underlying, left unadjusted.
+        /// Option instruments (holding positions) on that underlying that require a wrapper-side
+        /// identity change; left at pre-split terms by the engine.
         affected_options: Vec<InstrumentKey>,
     },
 

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -663,14 +663,16 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     ///    - action kind is not a stock split ⇒ [`UnsupportedCorporateActionReason::ActionKindNotSupported`]
     ///      (the compiler-mandated arm for the `#[non_exhaustive]` [`CorporateActionKind`]).
     /// 3. Snapshot resting orders into [`EngineOutput::OpenOrdersAtSplit`] (no cancellation).
-    /// 4. Apply the split to every open position via [`Position::apply_split`]; emit one
+    /// 4. Apply the split to every open position via
+    ///    [`Position::apply_split`](crate::engine::state::position::Position::apply_split); emit one
     ///    [`EngineOutput::SplitRemainder`] per position that disposed a fractional sliver. A
     ///    position floored to zero quantity is removed and folded as an
     ///    [`EngineOutput::PositionExit`].
     /// 5. Scan for option positions on the same underlying and handle them per the OCC
     ///    standard/non-standard rule ([`CorporateActionKind::split_kind`]):
     ///    - **standard** (whole-number forward split) ⇒ adjust each option **in place**
-    ///      (strike ÷ `ratio`, contracts × `ratio` via [`Position::apply_split`], multiplier
+    ///      (strike ÷ `ratio`, contracts × `ratio` via
+    ///      [`Position::apply_split`](crate::engine::state::position::Position::apply_split), multiplier
     ///      unchanged), emitting one [`EngineOutput::OptionPositionAdjustedForSplit`] per position
     ///      plus — if the option has resting orders — an [`EngineOutput::OpenOrdersAtSplit`] for them
     ///      (a real broker price-adjusts them; the engine cancels nothing). Because option positions
@@ -688,6 +690,13 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     /// **recorded** (the quantity/basis arithmetic needs no price); `pnl_unrealised` is set to
     /// zero with a warning and corrected on the next market tick. This is **not** retryable —
     /// contrast `process_contract_expiry`, which bails and is retryable.
+    ///
+    /// # Approximate `pnl_unrealised` immediately after the split
+    /// Even *with* a last price, the eagerly recomputed `pnl_unrealised` is approximate until the
+    /// next market tick: in live the split arrives before the first post-split print, so a pre-split
+    /// price is valued against the post-split basis (overstated for forward splits, understated for
+    /// reverse). Do not drive hard risk checks off the immediate post-split snapshot — see
+    /// [`Position::apply_split`](crate::engine::state::position::Position::apply_split).
     pub fn process_corporate_action<OnTradingDisabled, OnDisconnect>(
         &mut self,
         id: &SmolStr,

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -418,8 +418,15 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     {
         let instrument_state = self.state.instruments.instrument_index_mut(key);
 
-        // Guard: idempotent — ignore duplicates after first processing.
+        // Guard: idempotent — ignore duplicates after first processing. Warn so the skip is
+        // observable in logs (this settlement path returns PositionExits, not EngineOutputs, so it
+        // has no audit-stream signal to emit — unlike process_corporate_action's duplicate-id path).
         if instrument_state.expiration_processed {
+            warn!(
+                instrument = ?key,
+                "ContractExpiry already processed — skipping (idempotent). Re-injecting the same \
+                 expiry is a no-op."
+            );
             return vec![];
         }
 
@@ -733,6 +740,15 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                 "CorporateAction id already processed — skipping (idempotent). Ensure each \
                  action (incl. same-day corrections) carries a unique id."
             );
+            // Surface the idempotent skip on the output/audit stream (distinct from the
+            // rejection paths' UnsupportedCorporateAction — this is a non-mutating no-op, not a
+            // retryable rejection), so a consumer watching only the stream can tell it apart from a
+            // successful split that had nothing to adjust.
+            outputs.push(EngineOutput::CorporateActionAlreadyProcessed {
+                instrument: *key,
+                kind: kind.clone(),
+                id: id.clone(),
+            });
             return outputs;
         }
 
@@ -984,17 +1000,27 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                 contract.strike /= ratio_decimal;
                 let strike_post_split = contract.strike;
 
-                // Unheld option: the strike correction above is the whole job — no positions to
-                // split, no observable (a silent registry fix; the user-chosen behaviour).
+                // Snapshot the option's resting orders as an observable BEFORE the unheld early-out
+                // and before adjusting any positions — a broker price-adjusts them, so the engine
+                // cancels nothing, but the wrapper must know (and a backtest MockExchange would
+                // otherwise fill a now-stale-premium resting order against the post-split print).
+                // Mirrors the equity leg, which snapshots regardless of position state: an UNHELD
+                // option can still carry a resting order to *open* a position, whose premium is now
+                // stale against the post-split strike, so it must be surfaced just the same.
+                let option_orders = snapshot_open_orders_at_split(&option_state.orders);
+
+                // Unheld option: the strike correction + resting-order snapshot above are the whole
+                // job — no positions to split. Still surface any resting orders (equity-leg parity),
+                // then move on; no per-position observable applies.
                 if option_state.position.positions.is_empty() {
+                    if !option_orders.is_empty() {
+                        outputs.push(EngineOutput::OpenOrdersAtSplit {
+                            instrument: opt_key,
+                            orders: option_orders,
+                        });
+                    }
                     continue;
                 }
-
-                // Snapshot the held option's resting orders as an observable BEFORE adjusting its
-                // positions — a broker price-adjusts them, so the engine cancels nothing, but the
-                // wrapper must know (and a backtest MockExchange would otherwise fill a
-                // now-stale-premium resting order against the post-split print).
-                let option_orders = snapshot_open_orders_at_split(&option_state.orders);
 
                 // The OPTION's own last price (premium) for the eager pnl_unrealised recompute —
                 // not the underlying equity's. None ⇒ 0 (+ warn), mirroring the equity path: the
@@ -1363,6 +1389,36 @@ pub enum EngineOutput<
         kind: CorporateActionKind,
         /// Why the action could not be processed.
         reason: UnsupportedCorporateActionReason,
+    },
+
+    /// Observable, **non-mutating** signal that a
+    /// [`CorporateAction`](crate::EngineEvent::CorporateAction) was skipped because its `id` had
+    /// already been processed (the handler's idempotency guard fired).
+    ///
+    /// This is deliberately a **distinct** variant from
+    /// [`EngineOutput::UnsupportedCorporateAction`], not a new reason under it: an idempotent skip
+    /// is the *opposite* of a rejection on both axes. The `id` **was** recorded — by a **prior,
+    /// successful** application — and the action is **not** retryable (re-submitting the same `id`
+    /// will always hit this same guard). Reporting it as `UnsupportedCorporateAction` would falsely
+    /// tell a consumer the action was not applied and remains retryable.
+    ///
+    /// Emitted so a consumer watching only the output/audit stream can distinguish "duplicate `id`,
+    /// correctly ignored" from "a successful split on an instrument with nothing to adjust" — both
+    /// otherwise produce no mutation observables.
+    ///
+    /// **No state was mutated** and no other observable accompanies this one. A consumer that folds
+    /// [`SplitRemainder`](Self::SplitRemainder) / [`PositionExit`](Self::PositionExit) /
+    /// [`OptionPositionAdjustedForSplit`](Self::OptionPositionAdjustedForSplit) into a mutation
+    /// tally must **not** count this variant.
+    CorporateActionAlreadyProcessed {
+        /// The instrument the duplicate action targeted.
+        instrument: InstrumentKey,
+        /// The re-submitted action's market-fact kind (carried verbatim for the consumer). This is
+        /// the kind of the duplicate event, which — should a caller violate the idempotency contract
+        /// by reusing an `id` with a different `kind` — is not necessarily the originally-applied one.
+        kind: CorporateActionKind,
+        /// The already-processed action `id` that was skipped.
+        id: SmolStr,
     },
 }
 

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         state::{
             EngineState,
             instrument::data::InstrumentDataState,
-            order::{in_flight_recorder::InFlightRequestRecorder, manager::OrderManager},
+            order::{Orders, in_flight_recorder::InFlightRequestRecorder, manager::OrderManager},
             position::{PositionExited, PositionId, SplitRoundingPolicy},
             trading::TradingState,
         },
@@ -781,17 +781,46 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
         let ratio: SplitRatio = *ratio;
         let ratio_decimal = ratio.get();
 
+        // Classify the split for OPTION handling ONCE, up front: `true` ⇒ adjust the options in
+        // place (standard whole-number forward split); `false` ⇒ signal a downstream identity
+        // change. Computed here so pre-validation (Step 2c) and application (Step 5) share the
+        // identical classification and can never drift.
+        let adjust_options_in_place = option_split_adjust_in_place(id, key, kind);
+
+        // Step 2c: PRE-VALIDATE the split against EVERY position it would mutate, WITHOUT mutating
+        // anything, BEFORE Step 3's output push and Step 4's mutation. A feed that would overflow
+        // `Decimal`, or a corrupted (non-integer) option contract count, rejects the action
+        // ATOMICALLY here — no position is partially rescaled and the `id` is NOT recorded
+        // (retryable once the blocking condition is resolved). Single-sourced with the audit replica
+        // via `InstrumentStates::validate_corporate_action_split`, so both reach the identical
+        // accept/reject decision by construction rather than by hand-mirrored vigilance.
+        if let Err(reason) = self.state.instruments.validate_corporate_action_split(
+            key,
+            ratio,
+            policy,
+            adjust_options_in_place,
+        ) {
+            warn!(
+                %id,
+                instrument = ?key,
+                ?reason,
+                "CorporateAction: split failed pre-validation (applying it would mutate positions \
+                 non-atomically) — emitting UnsupportedCorporateAction; id NOT recorded (retryable \
+                 once the blocking condition is resolved)."
+            );
+            outputs.push(EngineOutput::UnsupportedCorporateAction {
+                instrument: *key,
+                kind: kind.clone(),
+                reason,
+            });
+            return outputs;
+        }
+
         // Step 3: snapshot resting orders as an observable — do NOT cancel (a broker price-adjusts
-        // them, so an engine-side cancel would diverge from the broker).
-        let resting_orders: Vec<OpenOrderAtSplit> = instrument_state
-            .orders
-            .orders()
-            .map(|order| OpenOrderAtSplit {
-                cid: order.key.cid.clone(),
-                price_pre_split: order.price,
-                quantity_pre_split: order.quantity,
-            })
-            .collect();
+        // them, so an engine-side cancel would diverge from the broker). Re-borrow the instrument
+        // state: pre-validation above released the earlier borrow.
+        let instrument_state = self.state.instruments.instrument_index(key);
+        let resting_orders = snapshot_open_orders_at_split(&instrument_state.orders);
 
         // Last price for the eager `pnl_unrealised` recompute. None ⇒ 0 (+ warn); the split is
         // still applied and the `id` recorded (NOT retryable).
@@ -824,7 +853,27 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             };
 
             let side = position.side;
-            let result = position.apply_split(ratio_decimal, policy, last_price);
+            let result = match position.apply_split(ratio, policy, last_price) {
+                Ok(result) => result,
+                // Step 2c pre-validation already proved every equity position rescales without
+                // `Decimal` overflow, so an `Err` here is genuinely unreachable unless that
+                // invariant is broken; fail loudly rather than silently skip the split. (An
+                // extreme `last_price` does NOT reach this arm — the derived `pnl_unrealised`
+                // recompute degrades to 0 and is flagged on the `Ok` result, see below.)
+                Err(error) => {
+                    unreachable!("apply_split failed after pre-validation for {pos_id:?}: {error}")
+                }
+            };
+            if result.pnl_unrealised_overflowed {
+                warn!(
+                    %id,
+                    instrument = ?key,
+                    position_id = ?pos_id,
+                    "CorporateAction: post-split pnl_unrealised recompute overflowed Decimal \
+                     (extreme last price) — set to 0, corrected on the next market tick. The split \
+                     (quantity/basis) was still applied atomically."
+                );
+            }
             // Read the post-split basis AFTER apply_split overwrote it: quantity
             // and price then share the post-split era, valuing the disposed sliver with one
             // multiply and no ratio knowledge.
@@ -895,12 +944,11 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             )
         };
 
-        // Classify the split for OPTION handling up front (cheap; only `warn!`s on an unexpected
-        // classification). `true` ⇒ adjust the options in place (standard split); `false` ⇒ signal
-        // a downstream identity change. A future `#[non_exhaustive]` `SplitAdjustmentKind` variant
-        // is handled conservatively as non-standard and `warn!`-surfaced (observable beats silent)
-        // — see [`option_split_adjust_in_place`].
-        if option_split_adjust_in_place(id, key, kind) {
+        // Step 5 branches on the option classification computed up front in Step 2c — reused here
+        // (rather than recomputed) so application can never diverge from what pre-validation
+        // checked. `true` ⇒ adjust the options in place (standard split); `false` ⇒ signal a
+        // downstream identity change (see [`option_split_adjust_in_place`]).
+        if adjust_options_in_place {
             // STANDARD (whole-number forward split, OCC Art. VI §11): the option keeps its contract
             // identity, so the adjustment is purely mechanical (strike ÷ ratio; contracts × ratio
             // for held positions; multiplier/contract_size unchanged). Adjust the strike of EVERY
@@ -946,15 +994,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                 // positions — a broker price-adjusts them, so the engine cancels nothing, but the
                 // wrapper must know (and a backtest MockExchange would otherwise fill a
                 // now-stale-premium resting order against the post-split print).
-                let option_orders: Vec<OpenOrderAtSplit> = option_state
-                    .orders
-                    .orders()
-                    .map(|order| OpenOrderAtSplit {
-                        cid: order.key.cid.clone(),
-                        price_pre_split: order.price,
-                        quantity_pre_split: order.quantity,
-                    })
-                    .collect();
+                let option_orders = snapshot_open_orders_at_split(&option_state.orders);
 
                 // The OPTION's own last price (premium) for the eager pnl_unrealised recompute —
                 // not the underlying equity's. None ⇒ 0 (+ warn), mirroring the equity path: the
@@ -987,32 +1027,35 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                         );
                     };
 
-                    // Option contract counts are whole, and a standard split is a whole-number
-                    // ratio, so `integer × integer` stays integer with no fractional remainder —
-                    // the equity's `SplitRoundingPolicy` (a whole-share-lot concept) does not govern
-                    // option legs. Enforce that invariant on the INPUT with a hard `assert!` (NOT
-                    // `debug_assert!`, which compiles out in release): a non-integer contract count
-                    // is state corruption that must fail observably, never be silently floored
-                    // (under `Floor`) or silently carried (under `Fractional`). Asserting the input
-                    // — rather than the post-split `remainder` — is the meaningful check: under
-                    // `Fractional` the remainder is always zero by construction, so a remainder
-                    // assert would be vacuous. With the invariant upheld the disposal is provably
-                    // zero, so no SplitRemainder/CIL or floor-to-zero close is possible here.
-                    assert!(
-                        position.quantity_abs.fract().is_zero(),
-                        "option position {pos_id:?} holds a non-integer contract count {} before a \
-                         standard split — data corruption",
-                        position.quantity_abs,
-                    );
-                    // Pass `Fractional` explicitly, NOT the equity's `policy`: the assert above
-                    // guarantees an integer contract count so no remainder can arise (the policy is
-                    // a no-op here), and threading the equity's whole-share-lot policy into the
-                    // option path would falsely imply it governs option legs. It does not.
-                    position.apply_split(
-                        ratio_decimal,
+                    // Option contract counts are whole and a standard split is a whole-number ratio,
+                    // so `integer × integer` stays integer with no fractional remainder — the
+                    // equity's `SplitRoundingPolicy` (a whole-share-lot concept) does not govern
+                    // option legs, so pass `Fractional` explicitly (threading the equity policy here
+                    // would falsely imply it governs option legs). Step 2c pre-validation already
+                    // rejected any non-integer contract count (as `PositionStateInvalid`) and proved
+                    // this rescale cannot overflow, so no remainder or floor-to-zero can arise and
+                    // the `Err` arm is genuinely unreachable.
+                    let opt_result = match position.apply_split(
+                        ratio,
                         SplitRoundingPolicy::Fractional,
                         option_last_price,
-                    );
+                    ) {
+                        Ok(result) => result,
+                        Err(error) => unreachable!(
+                            "option apply_split failed after pre-validation for {pos_id:?}: {error}"
+                        ),
+                    };
+                    if opt_result.pnl_unrealised_overflowed {
+                        warn!(
+                            %id,
+                            instrument = ?opt_key,
+                            position_id = ?pos_id,
+                            "CorporateAction: post-split option pnl_unrealised recompute overflowed \
+                             Decimal (extreme premium) — set to 0, corrected on the next market \
+                             tick. The option adjustment (contract count/basis) was still applied \
+                             atomically."
+                        );
+                    }
                     outputs.push(EngineOutput::OptionPositionAdjustedForSplit {
                         option_instrument: opt_key,
                         ratio,
@@ -1109,6 +1152,23 @@ fn option_split_adjust_in_place(
             false
         }
     }
+}
+
+/// Snapshot every resting order in `orders` into the [`OpenOrderAtSplit`] records carried by an
+/// [`EngineOutput::OpenOrdersAtSplit`] observable. Shared by the equity and held-option snapshot
+/// sites in `process_corporate_action` so both capture exactly the same fields — a split cancels
+/// nothing (a broker price-adjusts resting orders), it only reports them.
+fn snapshot_open_orders_at_split(
+    orders: &Orders<ExchangeIndex, InstrumentIndex>,
+) -> Vec<OpenOrderAtSplit> {
+    orders
+        .orders()
+        .map(|order| OpenOrderAtSplit {
+            cid: order.key.cid.clone(),
+            price_pre_split: order.price,
+            quantity_pre_split: order.quantity,
+        })
+        .collect()
 }
 
 impl<Clock, State, ExecutionTxs, Strategy, Risk> Engine<Clock, State, ExecutionTxs, Strategy, Risk>
@@ -1292,8 +1352,10 @@ pub enum EngineOutput<
 
     /// Observable signal that a [`CorporateAction`](crate::EngineEvent::CorporateAction) could
     /// **not** be processed. The action was **not** applied and its `id` was **not** recorded, so
-    /// it remains retryable once support is added (e.g. a corrected instrument key, or a future
-    /// library version). See [`UnsupportedCorporateActionReason`].
+    /// it remains retryable once the blocking condition is resolved — a corrected instrument key, a
+    /// future library version, or a reconciled position. Note some reasons are only retryable after
+    /// upstream state is fixed (not automatically on the next identical event); see the per-variant
+    /// notes on [`UnsupportedCorporateActionReason`].
     UnsupportedCorporateAction {
         /// The instrument the rejected action targeted.
         instrument: InstrumentKey,
@@ -1331,6 +1393,18 @@ pub enum UnsupportedCorporateActionReason {
     /// The corporate-action kind is not handled by this engine version (only stock splits are
     /// supported). Reachable once non-split kinds (dividends, spin-offs, …) are delivered.
     ActionKindNotSupported,
+    /// A position the split would mutate is in an invalid state that pre-validation rejected
+    /// **before any mutation** — specifically a **held option position with a non-integer contract
+    /// count** facing a standard (whole-number) split. Option contracts are whole; a fractional
+    /// count is state corruption, so the action is rejected atomically rather than silently floored
+    /// (under `Floor`) or carried (under `Fractional`). **Not** self-healing on retry: the
+    /// corrupted position must be reconciled before the action can succeed.
+    PositionStateInvalid,
+    /// The split arithmetic would overflow `Decimal` for at least one affected position — an
+    /// extreme ratio or quantity driving a rescaled field past `Decimal::MAX`. Detected by the
+    /// read-only pre-validation pass, so **no** position was mutated. Indicates a corrupt or
+    /// adversarial feed rather than a transient condition.
+    ArithmeticOverflow,
 }
 
 /// Output produced by the [`Engine`] updating from an [`TradingState`], used to construct

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -858,8 +858,10 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             .keys()
             .cloned()
             .collect();
-        // Pre-size: up to a SplitRemainder + a PositionExit per position, plus the equity
-        // OpenOrdersAtSplit and the option-handling observable(s).
+        // Pre-size for the equity leg: up to a SplitRemainder + a PositionExit per position, plus the
+        // equity OpenOrdersAtSplit and one option-handling observable. This is a lower-bound hint, not
+        // an exact count — the standard-option path may push further OptionPositionAdjustedForSplit /
+        // per-option OpenOrdersAtSplit outputs, which the `Vec` accommodates by growing as needed.
         outputs.reserve(position_ids.len() * 2 + 2);
 
         for pos_id in position_ids {

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -825,7 +825,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
 
             let side = position.side;
             let result = position.apply_split(ratio_decimal, policy, last_price);
-            // Read the post-split basis AFTER apply_split overwrote it (Convention A): quantity
+            // Read the post-split basis AFTER apply_split overwrote it: quantity
             // and price then share the post-split era, valuing the disposed sliver with one
             // multiply and no ratio knowledge.
             let price_entry_average_post_split = position.price_entry_average;
@@ -1259,6 +1259,13 @@ pub enum EngineOutput<
     /// option positions are left at their pre-split terms. This is therefore **not** retryable —
     /// the wrapper must close the listed options (and/or open positions under a pre-declared new
     /// identity), it must not re-inject the same action.
+    ///
+    /// **Resting option orders are the caller's responsibility here.** Unlike the standard-split
+    /// path (and the equity path), this non-standard branch emits **no**
+    /// [`EngineOutput::OpenOrdersAtSplit`] for the affected options — the engine touches no option
+    /// state on a non-standard split. Any resting orders on the old option identity are therefore
+    /// **not** surfaced through this observable; the wrapper must cancel them as part of the
+    /// identity change, since they reference a contract identity that no longer trades post-split.
     ///
     /// # Backtest pattern
     /// This is fully backtestable through the same aux-event seam used for the split itself, because

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -27,6 +27,7 @@ use rustrade_instrument::{
     index::IndexedInstruments,
     instrument::{
         Instrument, InstrumentIndex,
+        kind::InstrumentKind,
         name::{InstrumentNameExchange, InstrumentNameInternal},
     },
 };
@@ -355,6 +356,30 @@ pub struct InstrumentState<
 impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
     InstrumentState<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
 {
+    /// `true` if this is an **option** written on the underlying `(base, quote)` traded on
+    /// `exchange` that currently holds at least one open position — i.e. exactly the options a
+    /// corporate action on the underlying spot must also adjust.
+    ///
+    /// Single-sources the affected-option scan shared by the live engine handler
+    /// (`process_corporate_action`) and the audit replica, so the predicate cannot drift between
+    /// them (the replica-parity test guards observable behaviour; this guards the predicate itself).
+    pub(crate) fn is_affected_option_on_underlying(
+        &self,
+        base: &AssetKey,
+        quote: &AssetKey,
+        exchange: &ExchangeKey,
+    ) -> bool
+    where
+        AssetKey: PartialEq,
+        ExchangeKey: PartialEq,
+    {
+        matches!(&self.instrument.kind, InstrumentKind::Option(_))
+            && self.instrument.underlying.base == *base
+            && self.instrument.underlying.quote == *quote
+            && self.instrument.exchange == *exchange
+            && !self.position.positions.is_empty()
+    }
+
     /// Updates the instrument state using an account snapshot from the exchange.
     ///
     /// This updates active orders for the instrument, using timestamps where relevant to ensure

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     statistic::summary::instrument::TearSheetGenerator,
 };
 use chrono::{DateTime, Utc};
-use fnv::FnvHashMap;
+use fnv::{FnvHashMap, FnvHashSet};
 use itertools::Either;
 use rustrade_data::event::MarketEvent;
 use rustrade_execution::{
@@ -31,7 +31,7 @@ use rustrade_instrument::{
         name::{InstrumentNameExchange, InstrumentNameInternal},
     },
 };
-use rustrade_integration::collection::{FnvIndexMap, FnvIndexSet, snapshot::Snapshot};
+use rustrade_integration::collection::{FnvIndexMap, snapshot::Snapshot};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::fmt::Debug;
@@ -306,8 +306,11 @@ pub struct InstrumentState<
     ///
     /// Rejected actions (unsupported instrument/action kind) are deliberately **not** recorded,
     /// so they remain retryable once support is added.
+    ///
+    /// A hash set (insertion order is never read — only `contains`/`insert`), consistent with the
+    /// sibling `FnvHashMap` routing fields below.
     #[serde(default)]
-    pub corporate_actions_processed: FnvIndexSet<SmolStr>,
+    pub corporate_actions_processed: FnvHashSet<SmolStr>,
 
     /// Maps `ClientOrderId` → `PositionId` for hedging-mode fill routing.
     ///
@@ -917,7 +920,7 @@ where
                         data: instrument_data_init(instrument),
                         fee_model: FeeModelConfig::default(),
                         expiration_processed: false,
-                        corporate_actions_processed: FnvIndexSet::default(),
+                        corporate_actions_processed: FnvHashSet::default(),
                         position_ids: FnvHashMap::default(),
                         pending_fills: Vec::new(),
                         exchange_id_to_cid: FnvHashMap::default(),

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -309,6 +309,15 @@ pub struct InstrumentState<
     ///
     /// A hash set (insertion order is never read — only `contains`/`insert`), consistent with the
     /// sibling `FnvHashMap` routing fields below.
+    ///
+    /// # Schema migration
+    ///
+    /// `#[serde(default)]` lets snapshots taken before this field existed deserialize with an empty
+    /// set. Consequence: a consumer that snapshots an `InstrumentState` **after** applying a
+    /// corporate action, then reloads it and re-injects the **same** action `id`, finds the set
+    /// empty and applies the action twice (quantity doubled again, basis halved again). Idempotency
+    /// holds within a live session; deduping replay across a pre-field snapshot is the consumer's
+    /// responsibility (e.g. pre-populate this set with already-applied ids on upgrade).
     #[serde(default)]
     pub corporate_actions_processed: FnvHashSet<SmolStr>,
 

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -360,13 +360,16 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
     InstrumentState<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
 {
     /// `true` if this is an **option** written on the underlying `(base, quote)` traded on
-    /// `exchange` that currently holds at least one open position — i.e. exactly the options a
-    /// corporate action on the underlying spot must also adjust.
+    /// `exchange` — held or not. A standard (whole-number forward) split must divide the strike of
+    /// **every** such registered option, not only those currently holding a position: the
+    /// instrument set is fixed at construction, so an option that is unheld at split time can still
+    /// have a position opened later and then settle at expiry against its strike. Leaving an unheld
+    /// option on its pre-split strike would mis-settle that future position.
     ///
-    /// Single-sources the affected-option scan shared by the live engine handler
+    /// Single-sources the option scan shared by the live engine handler
     /// (`process_corporate_action`) and the audit replica, so the predicate cannot drift between
-    /// them (the replica-parity test guards observable behaviour; this guards the predicate itself).
-    pub(crate) fn is_affected_option_on_underlying(
+    /// them. [`Self::is_affected_option_on_underlying`] layers the holds-a-position gate on top.
+    pub(crate) fn is_option_on_underlying(
         &self,
         base: &AssetKey,
         quote: &AssetKey,
@@ -380,7 +383,28 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
             && self.instrument.underlying.base == *base
             && self.instrument.underlying.quote == *quote
             && self.instrument.exchange == *exchange
-            && !self.position.positions.is_empty()
+    }
+
+    /// `true` if this is an **option** on the underlying `(base, quote)` traded on `exchange` that
+    /// currently **holds at least one open position** — i.e. the options whose held positions a
+    /// corporate action must event-adjust (per-position `apply_split` + observables) or, on a
+    /// non-standard split, flag for a wrapper-side identity change.
+    ///
+    /// This is [`Self::is_option_on_underlying`] plus the non-empty-position gate. The strike
+    /// correction on a standard split uses the broader [`Self::is_option_on_underlying`] (it must
+    /// also reach unheld options); this narrower predicate selects the options that carry a
+    /// position event.
+    pub(crate) fn is_affected_option_on_underlying(
+        &self,
+        base: &AssetKey,
+        quote: &AssetKey,
+        exchange: &ExchangeKey,
+    ) -> bool
+    where
+        AssetKey: PartialEq,
+        ExchangeKey: PartialEq,
+    {
+        self.is_option_on_underlying(base, quote, exchange) && !self.position.positions.is_empty()
     }
 
     /// Updates the instrument state using an account snapshot from the exchange.

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -30,8 +30,9 @@ use rustrade_instrument::{
         name::{InstrumentNameExchange, InstrumentNameInternal},
     },
 };
-use rustrade_integration::collection::{FnvIndexMap, snapshot::Snapshot};
+use rustrade_integration::collection::{FnvIndexMap, FnvIndexSet, snapshot::Snapshot};
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 use std::fmt::Debug;
 use tracing::{debug, warn};
 
@@ -292,6 +293,20 @@ pub struct InstrumentState<
     /// set when appropriate.
     #[serde(default)]
     pub expiration_processed: bool,
+
+    /// Set of corporate-action `id`s already applied to this instrument (idempotency key).
+    ///
+    /// A `CorporateAction` event carries a caller-assigned unique `id`; the handler records it
+    /// here once applied and skips (with a warning) any `id` already present. Scope is
+    /// per-instrument — naturally bounded by the number of corporate actions an instrument sees,
+    /// so no global store / LRU is required. This per-instrument-set keyed on `id` alone is
+    /// intentional and sufficient for stock splits (a split event targets a single instrument);
+    /// revisit for future multi-instrument actions (e.g. spin-offs).
+    ///
+    /// Rejected actions (unsupported instrument/action kind) are deliberately **not** recorded,
+    /// so they remain retryable once support is added.
+    #[serde(default)]
+    pub corporate_actions_processed: FnvIndexSet<SmolStr>,
 
     /// Maps `ClientOrderId` → `PositionId` for hedging-mode fill routing.
     ///
@@ -799,6 +814,7 @@ where
         data: _,
         fee_model: _,
         expiration_processed: _,
+        corporate_actions_processed: _,
         position_ids: _,
         pending_fills: _,
         exchange_id_to_cid: _,
@@ -876,6 +892,7 @@ where
                         data: instrument_data_init(instrument),
                         fee_model: FeeModelConfig::default(),
                         expiration_processed: false,
+                        corporate_actions_processed: FnvIndexSet::default(),
                         position_ids: FnvHashMap::default(),
                         pending_fills: Vec::new(),
                         exchange_id_to_cid: FnvHashMap::default(),

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -1,8 +1,11 @@
 use crate::{
-    engine::state::{
-        instrument::{data::InstrumentDataState, filter::InstrumentFilter},
-        order::{Orders, manager::OrderManager},
-        position::{OmsMode, PositionExited, PositionManager},
+    engine::{
+        UnsupportedCorporateActionReason,
+        state::{
+            instrument::{data::InstrumentDataState, filter::InstrumentFilter},
+            order::{Orders, manager::OrderManager},
+            position::{OmsMode, PositionExited, PositionManager, SplitRoundingPolicy},
+        },
     },
     statistic::summary::instrument::TearSheetGenerator,
 };
@@ -23,6 +26,7 @@ use rustrade_execution::{
 use rustrade_instrument::{
     Keyed,
     asset::{AssetIndex, name::AssetNameExchange},
+    corporate_action::SplitRatio,
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
     instrument::{
@@ -105,6 +109,72 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
         self.0
             .get_mut(key)
             .unwrap_or_else(|| panic!("InstrumentStates does not contain: {key}"))
+    }
+
+    /// Pre-validate a stock split against **every** position it would mutate, **without mutating
+    /// anything**, so `process_corporate_action` (and its audit replica) can reject an
+    /// un-applicable action *atomically* — no partial rescaling on an overflowing feed or a
+    /// corrupted option contract count.
+    ///
+    /// Single-sourced so the live handler and the audit replica reach the identical decision by
+    /// construction (not by hand-mirrored vigilance). Checks, in the same order the handler mutates:
+    /// - every open position on the splitting `equity` can be rescaled without `Decimal` overflow
+    ///   (equity quantities may legitimately be fractional, so there is no integer check here);
+    /// - iff `adjust_options_in_place` (a standard, whole-number forward split), every **held**
+    ///   option position on the same underlying holds an **integer** contract count (a non-integer
+    ///   count is state corruption) and can be rescaled without overflow.
+    ///
+    /// Returns the [`UnsupportedCorporateActionReason`] the caller should surface on the first
+    /// failure, or `Ok(())` when the whole action can be applied. Non-standard splits touch no
+    /// option state, so only the equity positions are validated for them.
+    pub(crate) fn validate_corporate_action_split(
+        &self,
+        equity: &InstrumentIndex,
+        ratio: SplitRatio,
+        policy: SplitRoundingPolicy,
+        adjust_options_in_place: bool,
+    ) -> Result<(), UnsupportedCorporateActionReason> {
+        // Equity positions: overflow only. A fractional equity quantity is legitimate (fractional-
+        // share brokers), so there is no integer invariant to check here — unlike option contracts.
+        let equity_state = self.instrument_index(equity);
+        for position in equity_state.position.positions.values() {
+            position
+                .validate_split(ratio, policy)
+                .map_err(|_overflow| UnsupportedCorporateActionReason::ArithmeticOverflow)?;
+        }
+
+        // Non-standard splits leave all option state untouched (the handler only emits a signal),
+        // so there is nothing further to validate.
+        if !adjust_options_in_place {
+            return Ok(());
+        }
+
+        // Standard split: mirror the handler's held-option scan (base + quote + exchange identity)
+        // and enforce the integer-contract invariant + overflow-safety on every held option
+        // position BEFORE the handler mutates any of them.
+        let base = equity_state.instrument.underlying.base;
+        let quote = equity_state.instrument.underlying.quote;
+        let exchange = equity_state.instrument.exchange;
+        for option_state in self
+            .0
+            .values()
+            .filter(|state| state.is_option_on_underlying(&base, &quote, &exchange))
+        {
+            for position in option_state.position.positions.values() {
+                // Option contract counts are whole; a non-integer count is corruption the handler
+                // must not silently floor/carry. Surfaced as an observable rejection, not a panic.
+                if !position.quantity_abs.fract().is_zero() {
+                    return Err(UnsupportedCorporateActionReason::PositionStateInvalid);
+                }
+                // Held option legs are rescaled with `Fractional` (the integer invariant above makes
+                // the equity `policy` a no-op), matching the handler's per-option `apply_split`.
+                position
+                    .validate_split(ratio, SplitRoundingPolicy::Fractional)
+                    .map_err(|_overflow| UnsupportedCorporateActionReason::ArithmeticOverflow)?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Return an `Iterator` of references to `InstrumentState`s being tracked, optionally filtered

--- a/rustrade/src/engine/state/position.rs
+++ b/rustrade/src/engine/state/position.rs
@@ -26,6 +26,47 @@ pub enum OmsMode {
     Hedging,
 }
 
+/// Rounding policy applied to a [`Position`]'s share quantity when a stock split or reverse
+/// split produces a fractional resulting share count.
+///
+/// This is **broker policy, not arithmetic** — different brokers round differently — so there
+/// is intentionally **no `Default`**. The caller must choose explicitly.
+///
+/// `#[non_exhaustive]`: a future broker rounding mode (e.g. net-then-round across lots) can be
+/// added without breaking downstream exhaustive matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[non_exhaustive]
+pub enum SplitRoundingPolicy {
+    /// Whole-share brokers: floor `quantity_abs` to an integer share count. The disposed
+    /// fraction becomes cash-in-lieu, reported via [`SplitResult::remainder`] for the caller
+    /// to reconcile against the broker's CIL payment.
+    Floor,
+    /// Fractional-share brokers (e.g. Alpaca): keep the exact fractional share count. No
+    /// cash-in-lieu — [`SplitResult::remainder`] is always `0`.
+    Fractional,
+}
+
+/// Outcome of [`Position::apply_split`].
+///
+/// A `struct` (rather than a bare `Decimal`) so the contract can grow without a breaking
+/// signature change. `#[non_exhaustive]` enforces that promise — adding a field stays
+/// non-breaking because downstream callers cannot construct or exhaustively destructure it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct SplitResult {
+    /// Post-split fractional shares disposed by `Floor` rounding.
+    ///
+    /// Defined as `(quantity_abs × ratio) − floor(quantity_abs × ratio)`, i.e. the fractional
+    /// part of the scaled share count, expressed in **post-split share units**. Always `< 1`.
+    /// It is `0` under [`SplitRoundingPolicy::Fractional`] and for any split that leaves a whole
+    /// share count (including all forward splits applied to a whole-share position).
+    ///
+    /// Value it at the **post-split** `price_entry_average` (`= old_avg / ratio`, the position's
+    /// `price_entry_average` *after* [`Position::apply_split`] returns) to obtain the cost basis
+    /// of the disposed sliver.
+    pub remainder: Decimal,
+}
+
 /// Manages open positions for a single instrument.
 ///
 /// Supports two OMS modes (configurable at construction):
@@ -556,6 +597,110 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
             closed_fee,
             self.contract_size,
         );
+    }
+
+    /// Apply a stock split / reverse split to this [`Position`] in place, returning the
+    /// fractional share quantity disposed by rounding (cash-in-lieu).
+    ///
+    /// `ratio = split_to / split_from`: `> 1` for a forward split (2:1 ⇒ `2.0`), `< 1` for a
+    /// reverse split (1:10 ⇒ `0.1`). The library is sign-agnostic — shorts use identical
+    /// arithmetic, with direction carried by [`Position::side`].
+    ///
+    /// # What is rescaled
+    /// - `quantity_abs ×= ratio`, then floored under [`SplitRoundingPolicy::Floor`] only.
+    /// - `price_entry_average = old_avg / ratio` — the true split-adjusted per-share basis.
+    ///   This is **notional-preserving** (`new_qty_unfloored × new_avg == old_qty × old_avg`)
+    ///   and is deliberately **not** `notional / floored_qty`, which would spread the disposed
+    ///   fraction's value back into the surviving shares and inflate cost basis.
+    /// - `quantity_abs_max ×= ratio`, **unfloored even under `Floor`**. It is the high-water
+    ///   mark used solely as the denominator of the exit-fee proportion
+    ///   (`quantity_abs / quantity_abs_max`) and the return denominator
+    ///   (`price_entry_average × quantity_abs_max`); flooring it would drift those ratios for
+    ///   inexact splits. A non-integer max is correct here — it is a proportion reference, not
+    ///   a tradeable share lot.
+    ///
+    /// # `last_price` — eager unrealised-PnL recompute
+    /// Pass the instrument's most recent price (the same source the caller uses elsewhere,
+    /// e.g. `InstrumentState::data.price()`). After rescaling, `pnl_unrealised` is recomputed
+    /// from it. If `None` (no market data yet) `pnl_unrealised` is set to `0` and the caller
+    /// should emit a warning; it is corrected on the next market tick. This closes the window
+    /// in which a risk check between the split and the next tick would read a stale pre-split
+    /// value. `pnl_unrealised` is **never** scaled by `ratio` (that would assume the price moved
+    /// exactly as the split predicted).
+    ///
+    /// # What is left untouched
+    /// `pnl_realised`, `fees_enter`, `fees_exit` (all `$`-denominated and already realised),
+    /// `side`, `instrument`, `trades`, `contract_size`.
+    ///
+    /// # Return value & caller obligations
+    /// Returns [`SplitResult`] whose `remainder` is the post-split fractional shares disposed
+    /// (`0` under `Fractional` / forward splits). The caller (handler) should emit it as an
+    /// observable cash-in-lieu output; **this method writes no balances** (crediting CIL from
+    /// inside the engine would double-count in live and bypass the mock exchange in backtest).
+    ///
+    /// **Floor whole-position disposal:** under `Floor` a reverse split can round `quantity_abs`
+    /// to `0` (e.g. 1 share, 1:10). When that happens this method still only rescales `self` and
+    /// returns the `SplitResult` (with `remainder` == the full scaled fraction); it does **not**
+    /// remove the position. The caller **must** detect `quantity_abs == 0` after the call, remove
+    /// the position slot, and emit a closing `PositionExit` — otherwise a zero-quantity zombie
+    /// position strands its `pnl_realised` (which would later leak into a fresh post-split buy via
+    /// VWAP-from-zero) and pollutes snapshots.
+    ///
+    /// **Reads of the post-split basis:** this method **overwrites** `price_entry_average`. A
+    /// caller needing the post-split per-share basis (e.g. to value `remainder`) should read
+    /// `price_entry_average` *after* this call returns.
+    ///
+    /// # Known limitation — Floor reverse-split ledger gap
+    /// Under `Floor` the disposed fraction leaves the position with no `pnl_realised` entry (CIL
+    /// is the wrapper's responsibility via the balance path). So `quantity_abs × price_entry_average
+    /// + pnl_realised` is not a faithful internal ledger across a `Floor` reverse split — only the
+    /// wrapper, reconciling `remainder` against broker cash, closes that gap.
+    ///
+    /// # Panics
+    /// Panics if `ratio` is not strictly positive (zero or negative). `ratio = split_to / split_from`,
+    /// both positive by definition. A zero ratio would panic in `Decimal` division regardless, but a
+    /// negative ratio divides silently and would corrupt `price_entry_average` / `quantity_abs_max`
+    /// (negative basis / high-water mark), so it is rejected eagerly here — in release builds too.
+    pub fn apply_split(
+        &mut self,
+        ratio: Decimal,
+        policy: SplitRoundingPolicy,
+        last_price: Option<Decimal>,
+    ) -> SplitResult {
+        // Hard assert (not `debug_assert!`): `ratio` is caller-supplied external data, and a negative
+        // value would silently corrupt state in release rather than panic. Observable failure > silent.
+        assert!(
+            ratio > Decimal::ZERO,
+            "split ratio must be strictly positive (split_to / split_from), got {ratio}"
+        );
+
+        // Scaled (unfloored) quantity on the new share scale.
+        let scaled_quantity = self.quantity_abs * ratio;
+        let new_quantity = match policy {
+            SplitRoundingPolicy::Floor => scaled_quantity.floor(),
+            SplitRoundingPolicy::Fractional => scaled_quantity,
+        };
+
+        // Post-split fractional shares disposed (Convention A). Zero under `Fractional`, and for
+        // any split leaving a whole share count (all forward splits from a whole-share base).
+        let remainder = scaled_quantity - new_quantity;
+
+        // Notional-preserving per-share basis: old_avg / ratio (≡ old_notional ÷ the *unfloored*
+        // scaled quantity), independent of rounding.
+        self.price_entry_average /= ratio;
+        self.quantity_abs = new_quantity;
+        // High-water mark scales UNFLOORED even under Floor — it is a proportion denominator
+        // (exit fees, returns), not a share lot.
+        self.quantity_abs_max *= ratio;
+
+        // Eagerly recompute unrealised PnL from the supplied price so a risk check between the
+        // split and the next market tick never reads a stale pre-split value. None ⇒ 0.
+        match last_price {
+            Some(price) => self.update_pnl_unrealised(price),
+            None => self.pnl_unrealised = Decimal::ZERO,
+        }
+
+        SplitResult { remainder }
     }
 }
 
@@ -1552,5 +1697,349 @@ mod tests {
 
             assert_eq!(actual, test.expected, "TC{} failed", index);
         }
+    }
+
+    /// Build a `Position` with explicit core fields and sentinel values for the rest, so
+    /// `apply_split` tests can assert exactly which fields move and which are left untouched.
+    fn split_position(
+        side: Side,
+        price_entry_average: Decimal,
+        quantity_abs: Decimal,
+        quantity_abs_max: Decimal,
+        fees_enter: Decimal,
+    ) -> Position<QuoteAsset, InstrumentNameInternal> {
+        Position {
+            instrument: InstrumentNameInternal::new("instrument"),
+            side,
+            price_entry_average,
+            quantity_abs,
+            quantity_abs_max,
+            pnl_unrealised: dec!(999.0), // sentinel: apply_split must overwrite this
+            pnl_realised: dec!(-12.5),   // sentinel: apply_split must NOT touch this
+            fees_enter: AssetFees {
+                asset: QuoteAsset,
+                fees: fees_enter,
+                fees_quote: Some(fees_enter),
+            },
+            fees_exit: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(3.0),
+                fees_quote: Some(dec!(3.0)),
+            },
+            time_enter: DateTime::<Utc>::MIN_UTC,
+            time_exchange_update: DateTime::<Utc>::MIN_UTC,
+            trades: vec![TradeId::new("t")],
+            contract_size: Decimal::ONE,
+        }
+    }
+
+    #[test]
+    fn test_apply_split() {
+        use SplitRoundingPolicy::{Floor, Fractional};
+
+        struct TestCase {
+            name: &'static str,
+            side: Side,
+            avg: Decimal,
+            qty: Decimal,
+            qty_max: Decimal,
+            fees_enter: Decimal,
+            ratio: Decimal,
+            policy: SplitRoundingPolicy,
+            last_price: Decimal,
+            expected_qty: Decimal,
+            expected_qty_max: Decimal,
+            expected_avg: Decimal,
+            expected_remainder: Decimal,
+        }
+
+        // forward (2:1) & reverse (1:10) & an inexact ratio (3:2) × long & short × Floor & Fractional,
+        // including a partially-closed position (quantity_abs < quantity_abs_max).
+        let cases = vec![
+            // Forward 2:1, long, Floor — q*r=20 is integer ⇒ floor no-op, remainder 0.
+            TestCase {
+                name: "fwd 2:1 long floor",
+                side: Side::Buy,
+                avg: dec!(100),
+                qty: dec!(10),
+                qty_max: dec!(10),
+                fees_enter: dec!(8),
+                ratio: dec!(2),
+                policy: Floor,
+                last_price: dec!(120),
+                expected_qty: dec!(20),
+                expected_qty_max: dec!(20),
+                expected_avg: dec!(50),
+                expected_remainder: dec!(0),
+            },
+            // Forward 2:1, short, Fractional.
+            TestCase {
+                name: "fwd 2:1 short frac",
+                side: Side::Sell,
+                avg: dec!(100),
+                qty: dec!(10),
+                qty_max: dec!(10),
+                fees_enter: dec!(8),
+                ratio: dec!(2),
+                policy: Fractional,
+                last_price: dec!(90),
+                expected_qty: dec!(20),
+                expected_qty_max: dec!(20),
+                expected_avg: dec!(50),
+                expected_remainder: dec!(0),
+            },
+            // Reverse 1:10, long, Floor — 101 → 10.1 floor 10, remainder 0.1, qty_max unfloored 10.1.
+            TestCase {
+                name: "rev 1:10 long floor",
+                side: Side::Buy,
+                avg: dec!(10),
+                qty: dec!(101),
+                qty_max: dec!(101),
+                fees_enter: dec!(20),
+                ratio: dec!(0.1),
+                policy: Floor,
+                last_price: dec!(110),
+                expected_qty: dec!(10),
+                expected_qty_max: dec!(10.1),
+                expected_avg: dec!(100),
+                expected_remainder: dec!(0.1),
+            },
+            // Reverse 1:10, short, Fractional — 101 → 10.1, remainder 0.
+            TestCase {
+                name: "rev 1:10 short frac",
+                side: Side::Sell,
+                avg: dec!(10),
+                qty: dec!(101),
+                qty_max: dec!(101),
+                fees_enter: dec!(20),
+                ratio: dec!(0.1),
+                policy: Fractional,
+                last_price: dec!(90),
+                expected_qty: dec!(10.1),
+                expected_qty_max: dec!(10.1),
+                expected_avg: dec!(100),
+                expected_remainder: dec!(0),
+            },
+            // Inexact 3:2 (1.5), short, Floor, partially closed (qty 5 < max 7) — 5 → 7.5 floor 7, remainder 0.5.
+            TestCase {
+                name: "3:2 short floor partial",
+                side: Side::Sell,
+                avg: dec!(90),
+                qty: dec!(5),
+                qty_max: dec!(7),
+                fees_enter: dec!(14),
+                ratio: dec!(1.5),
+                policy: Floor,
+                last_price: dec!(60),
+                expected_qty: dec!(7),
+                expected_qty_max: dec!(10.5),
+                expected_avg: dec!(60),
+                expected_remainder: dec!(0.5),
+            },
+            // Inexact 3:2 (1.5), long, Fractional, partially closed — 5 → 7.5, remainder 0.
+            TestCase {
+                name: "3:2 long frac partial",
+                side: Side::Buy,
+                avg: dec!(90),
+                qty: dec!(5),
+                qty_max: dec!(7),
+                fees_enter: dec!(14),
+                ratio: dec!(1.5),
+                policy: Fractional,
+                last_price: dec!(120),
+                expected_qty: dec!(7.5),
+                expected_qty_max: dec!(10.5),
+                expected_avg: dec!(60),
+                expected_remainder: dec!(0),
+            },
+        ];
+
+        for tc in cases {
+            let mut p = split_position(tc.side, tc.avg, tc.qty, tc.qty_max, tc.fees_enter);
+            let pnl_realised_before = p.pnl_realised;
+            let fees_enter_before = p.fees_enter.clone();
+            let fees_exit_before = p.fees_exit.clone();
+            let time_update_before = p.time_exchange_update;
+
+            let result = p.apply_split(tc.ratio, tc.policy, Some(tc.last_price));
+
+            assert_eq!(p.quantity_abs, tc.expected_qty, "{}: quantity_abs", tc.name);
+            assert_eq!(
+                p.quantity_abs_max, tc.expected_qty_max,
+                "{}: quantity_abs_max (unfloored)",
+                tc.name
+            );
+            assert_eq!(
+                p.price_entry_average, tc.expected_avg,
+                "{}: price_entry_average",
+                tc.name
+            );
+            assert_eq!(
+                result.remainder, tc.expected_remainder,
+                "{}: remainder",
+                tc.name
+            );
+
+            // pnl_unrealised eagerly recomputed from last_price using the POST-split fields.
+            let expected_pnl = calculate_pnl_unrealised(
+                tc.side,
+                tc.expected_avg,
+                tc.expected_qty,
+                tc.expected_qty_max,
+                tc.fees_enter,
+                tc.last_price,
+                Decimal::ONE,
+            );
+            assert_eq!(
+                p.pnl_unrealised, expected_pnl,
+                "{}: pnl_unrealised",
+                tc.name
+            );
+            assert_ne!(
+                p.pnl_unrealised,
+                dec!(999.0),
+                "{}: sentinel overwritten",
+                tc.name
+            );
+
+            // Untouched fields.
+            assert_eq!(
+                p.pnl_realised, pnl_realised_before,
+                "{}: pnl_realised untouched",
+                tc.name
+            );
+            assert_eq!(
+                p.fees_enter, fees_enter_before,
+                "{}: fees_enter untouched",
+                tc.name
+            );
+            assert_eq!(
+                p.fees_exit, fees_exit_before,
+                "{}: fees_exit untouched",
+                tc.name
+            );
+            assert_eq!(p.side, tc.side, "{}: side untouched", tc.name);
+            assert_eq!(
+                p.contract_size,
+                Decimal::ONE,
+                "{}: contract_size untouched",
+                tc.name
+            );
+            assert_eq!(
+                p.time_exchange_update, time_update_before,
+                "{}: time_exchange_update untouched (primitive carries no time)",
+                tc.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_apply_split_floor_to_zero() {
+        // 1 share, reverse 1:10, Floor: floors to 0. remainder is the full scaled fraction 0.1
+        // (post-split units, Convention A) — NOT 1.0. apply_split only rescales self; the slot
+        // removal + PositionExit is the handler's job (asserted at the handler/replica level).
+        let mut p = split_position(Side::Buy, dec!(50), dec!(1), dec!(1), dec!(2));
+        let result = p.apply_split(dec!(0.1), SplitRoundingPolicy::Floor, Some(dec!(500)));
+
+        assert_eq!(p.quantity_abs, dec!(0), "position floors to zero");
+        assert_eq!(
+            result.remainder,
+            dec!(0.1),
+            "remainder is post-split fractional shares (Convention A), not pre-split 1.0"
+        );
+        assert_eq!(
+            p.price_entry_average,
+            dec!(500),
+            "post-split avg = old_avg / ratio"
+        );
+        // CIL value = remainder valued at the post-split avg = original notional (1 × 50).
+        assert_eq!(
+            result.remainder * p.price_entry_average,
+            dec!(50),
+            "disposed sliver value equals original notional"
+        );
+    }
+
+    #[test]
+    fn test_apply_split_invariants() {
+        // --- Notional preservation under Fractional: new_qty × new_avg ≈ old_qty × old_avg
+        //     within a bounded tolerance (rust_decimal rounds non-terminating quotients at 28
+        //     digits — 100/1.5 does not terminate), NOT bit-exact. ---
+        let mut p = split_position(Side::Buy, dec!(100), dec!(7), dec!(7), dec!(5));
+        let old_notional = dec!(7) * dec!(100);
+        p.apply_split(dec!(1.5), SplitRoundingPolicy::Fractional, None);
+        let new_notional = p.quantity_abs * p.price_entry_average;
+        let tolerance = Decimal::new(1, 20); // 1e-20
+        assert!(
+            (new_notional - old_notional).abs() < tolerance,
+            "Fractional notional preserved within tolerance: {new_notional} vs {old_notional}"
+        );
+
+        // --- Notional reconstruction under Floor: floored_qty×adj_avg + remainder×adj_avg ==
+        //     old_notional, exactly (avg/ratio terminates: 10/0.5 = 20). ---
+        let mut p = split_position(Side::Buy, dec!(10), dec!(101), dec!(101), dec!(5));
+        let old_notional = dec!(101) * dec!(10);
+        let result = p.apply_split(dec!(0.5), SplitRoundingPolicy::Floor, None);
+        let reconstructed =
+            p.quantity_abs * p.price_entry_average + result.remainder * p.price_entry_average;
+        assert_eq!(
+            reconstructed, old_notional,
+            "Floor notional fully reconstructed including the disposed remainder"
+        );
+
+        // --- Fee-ratio invariant: quantity_abs / quantity_abs_max preserved EXACTLY for a
+        //     partially-closed position because quantity_abs_max is unfloored. Constructed so
+        //     the quantity floor is a no-op (4×1.5 = 6, integer) while qmax×1.5 = 7.5 is
+        //     non-integer — flooring qmax (the regression) would drift the ratio. ---
+        let mut p = split_position(Side::Buy, dec!(90), dec!(4), dec!(5), dec!(10));
+        let fee_ratio_before = p.quantity_abs / p.quantity_abs_max; // 4/5 = 0.8
+        let exit_fees_before =
+            approximate_remaining_exit_fees(p.quantity_abs, p.quantity_abs_max, p.fees_enter.fees);
+        p.apply_split(dec!(1.5), SplitRoundingPolicy::Floor, None);
+        assert_eq!(
+            p.quantity_abs,
+            dec!(6),
+            "quantity floor is a no-op (4×1.5 = 6)"
+        );
+        assert_eq!(
+            p.quantity_abs_max,
+            dec!(7.5),
+            "quantity_abs_max stays unfloored"
+        );
+        assert_eq!(
+            p.quantity_abs / p.quantity_abs_max,
+            fee_ratio_before,
+            "fee-ratio preserved exactly (would drift to 6/7 if qmax were floored)"
+        );
+        let exit_fees_after =
+            approximate_remaining_exit_fees(p.quantity_abs, p.quantity_abs_max, p.fees_enter.fees);
+        assert_eq!(
+            exit_fees_after, exit_fees_before,
+            "approximate_remaining_exit_fees survives the split"
+        );
+
+        // --- Return-denominator invariance: price_entry_average × quantity_abs_max preserved
+        //     (avg ÷ r cancels max × r), so tear-sheet returns survive the split unchanged. ---
+        let mut p = split_position(Side::Buy, dec!(90), dec!(4), dec!(5), dec!(10));
+        let denom_before = p.price_entry_average * p.quantity_abs_max; // 90 × 5 = 450
+        p.apply_split(dec!(1.5), SplitRoundingPolicy::Floor, None);
+        let denom_after = p.price_entry_average * p.quantity_abs_max; // 60 × 7.5 = 450
+        assert_eq!(
+            denom_after, denom_before,
+            "calculate_pnl_return denominator preserved"
+        );
+    }
+
+    #[test]
+    fn test_apply_split_none_price_zeroes_pnl_unrealised() {
+        // None last_price ⇒ pnl_unrealised = 0 (corrected on the next market tick); NOT scaled.
+        let mut p = split_position(Side::Buy, dec!(100), dec!(10), dec!(10), dec!(5));
+        p.pnl_unrealised = dec!(123.45);
+        let _ = p.apply_split(dec!(2), SplitRoundingPolicy::Floor, None);
+        assert_eq!(
+            p.pnl_unrealised,
+            Decimal::ZERO,
+            "None last_price ⇒ pnl_unrealised = 0"
+        );
     }
 }

--- a/rustrade/src/engine/state/position.rs
+++ b/rustrade/src/engine/state/position.rs
@@ -641,7 +641,10 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     ///
     /// # What is left untouched
     /// `pnl_realised`, `fees_enter`, `fees_exit` (all `$`-denominated and already realised),
-    /// `side`, `instrument`, `trades`, `contract_size`.
+    /// `side`, `instrument`, `trades`, `contract_size`. Also `time_exchange_update`: a split is a
+    /// corporate-action fact, not a market print, so it deliberately does not bump the
+    /// last-market-update timestamp — that field can therefore read months stale after a reverse
+    /// split until the next real tick arrives.
     ///
     /// # Return value & caller obligations
     /// Returns [`SplitResult`] whose `remainder` is the post-split fractional shares disposed

--- a/rustrade/src/engine/state/position.rs
+++ b/rustrade/src/engine/state/position.rs
@@ -628,6 +628,17 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// value. `pnl_unrealised` is **never** scaled by `ratio` (that would assume the price moved
     /// exactly as the split predicted).
     ///
+    /// ## The immediate post-split `pnl_unrealised` is approximate — do not use it for risk checks
+    /// The recompute pairs `last_price` with the **post-split** basis. In live trading a split is
+    /// typically injected at split-open *before* the first post-split print, so `last_price` is
+    /// still a **pre-split** price valued against a post-split basis — transiently **overstating**
+    /// `pnl_unrealised` for a forward split (and understating it for a reverse split) by roughly the
+    /// split ratio. It self-corrects on the next market tick. The arithmetic is correct given its
+    /// inputs; it is the price/basis era mismatch that makes the value unreliable. Treat the
+    /// post-split snapshot's `pnl_unrealised` as approximate and **do not** drive hard risk decisions
+    /// off it until a post-split price has arrived. (In backtests this window does not arise: the
+    /// split is injected at its own simulated timestamp, ordered before same-instant prints.)
+    ///
     /// # What is left untouched
     /// `pnl_realised`, `fees_enter`, `fees_exit` (all `$`-denominated and already realised),
     /// `side`, `instrument`, `trades`, `contract_size`.

--- a/rustrade/src/engine/state/position.rs
+++ b/rustrade/src/engine/state/position.rs
@@ -4,9 +4,12 @@ use indexmap::IndexMap;
 use rust_decimal::Decimal;
 pub use rustrade_execution::order::id::PositionId;
 use rustrade_execution::trade::{AssetFees, Trade, TradeId};
-use rustrade_instrument::{Side, asset::AssetIndex, instrument::InstrumentIndex};
+use rustrade_instrument::{
+    Side, asset::AssetIndex, corporate_action::SplitRatio, instrument::InstrumentIndex,
+};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use thiserror::Error;
 use tracing::error;
 
 /// Order Management System mode governing how positions are tracked.
@@ -65,6 +68,50 @@ pub struct SplitResult {
     /// `price_entry_average` *after* [`Position::apply_split`] returns) to obtain the cost basis
     /// of the disposed sliver.
     pub remainder: Decimal,
+
+    /// `true` iff the eager post-split `pnl_unrealised` recompute overflowed `Decimal` and was
+    /// set to `0` instead of panicking.
+    ///
+    /// The split itself (`quantity_abs` / `price_entry_average` / `quantity_abs_max`) is **always**
+    /// applied — this flags only that the derived, already-approximate `pnl_unrealised` snapshot
+    /// (see [`Position::apply_split`]'s `last_price` docs) could not be represented from an extreme
+    /// `last_price` and was zeroed, exactly as when no `last_price` is available. It self-corrects
+    /// on the next market tick. The caller (handler) should emit a `warn!`; it is **never** a reason
+    /// to reject or retry the split. `#[serde(default)]` keeps this forward-compatible for any
+    /// downstream consumer that persists a `SplitResult` directly (the engine itself does not
+    /// persist it); default `false` = no overflow.
+    #[serde(default)]
+    pub pnl_unrealised_overflowed: bool,
+}
+
+/// Error from [`Position::apply_split`] / [`Position::validate_split`].
+///
+/// The ratio is a [`SplitRatio`] (always `> 0`), so a degenerate ratio is unconstructible — the
+/// only remaining failure is `Decimal` **overflow** when an extreme ratio or quantity drives a
+/// rescaled value past `Decimal::MAX`. [`Position::apply_split`] computes every rescaled field
+/// *before* committing any, so an `Err` leaves the [`Position`] **unmutated** (all-or-nothing).
+///
+/// `#[non_exhaustive]`: further split-failure causes can be added without breaking downstream
+/// exhaustive matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum SplitError {
+    /// The split arithmetic overflowed `Decimal` — one of `quantity_abs × ratio`,
+    /// `price_entry_average ÷ ratio`, or `quantity_abs_max × ratio` exceeded `Decimal::MAX`. The
+    /// [`Position`] is left unmutated; the caller should surface this as an observable failure
+    /// (the feed produced an unrepresentable ratio/quantity) rather than proceed.
+    #[error("split arithmetic overflowed Decimal (ratio or quantity too large to represent)")]
+    Overflow,
+}
+
+/// The rescaled field values a split produces, computed by [`Position::compute_split`] without
+/// mutating the position — committed by [`Position::apply_split`], discarded by
+/// [`Position::validate_split`].
+struct SplitComputed {
+    quantity_abs: Decimal,
+    price_entry_average: Decimal,
+    quantity_abs_max: Decimal,
+    remainder: Decimal,
 }
 
 /// Manages open positions for a single instrument.
@@ -581,6 +628,25 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
         );
     }
 
+    /// Checked, non-mutating twin of [`update_pnl_unrealised`](Self::update_pnl_unrealised):
+    /// computes the unrealised PnL at `price`, returning `None` if the `Decimal` arithmetic
+    /// overflows instead of panicking.
+    ///
+    /// Used by [`apply_split`](Self::apply_split) to degrade the eager post-split `pnl_unrealised`
+    /// recompute to `0` on an extreme `last_price` rather than panic mid-way through an atomic
+    /// multi-position corporate-action adjustment. See [`checked_calculate_pnl_unrealised`].
+    fn checked_pnl_unrealised(&self, price: Decimal) -> Option<Decimal> {
+        checked_calculate_pnl_unrealised(
+            self.side,
+            self.price_entry_average,
+            self.quantity_abs,
+            self.quantity_abs_max,
+            self.fees_enter.fees,
+            price,
+            self.contract_size,
+        )
+    }
+
     /// Updates the [`Position`] `pnl_realised` from a closed portion of the [`Position`] quantity.
     pub fn update_pnl_realised(
         &mut self,
@@ -609,8 +675,10 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// # What is rescaled
     /// - `quantity_abs ×= ratio`, then floored under [`SplitRoundingPolicy::Floor`] only.
     /// - `price_entry_average = old_avg / ratio` — the true split-adjusted per-share basis.
-    ///   This is **notional-preserving** (`new_qty_unfloored × new_avg == old_qty × old_avg`)
-    ///   and is deliberately **not** `notional / floored_qty`, which would spread the disposed
+    ///   This is **notional-preserving** (`new_qty_unfloored × new_avg ≈ old_qty × old_avg`, exact
+    ///   up to `Decimal`'s 28-significant-digit precision — bit-exact for terminating quotients,
+    ///   within rounding for non-terminating ones such as any 1-for-3 or 1-for-7 reverse split) and
+    ///   is deliberately **not** `notional / floored_qty`, which would spread the disposed
     ///   fraction's value back into the surviving shares and inflate cost basis.
     /// - `quantity_abs_max ×= ratio`, **unfloored even under `Floor`**. It is the high-water
     ///   mark used solely as the denominator of the exit-fee proportion
@@ -627,6 +695,14 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// in which a risk check between the split and the next tick would read a stale pre-split
     /// value. `pnl_unrealised` is **never** scaled by `ratio` (that would assume the price moved
     /// exactly as the split predicted).
+    ///
+    /// An extreme `last_price` whose recompute would overflow `Decimal` is treated the **same** as
+    /// `None`: `pnl_unrealised` is set to `0`, [`SplitResult::pnl_unrealised_overflowed`] is set,
+    /// and the split still applies atomically. It is **never** turned into an `Err` or a panic — the
+    /// quantity/basis rescale is already committed and must stay whole (a panic here would defeat
+    /// the whole-action atomicity the engine's pre-validation guarantees; a caught panic on retry
+    /// could double-apply a partially-split hedging book). Only the ratio-driven fields can fail the
+    /// call (see `# Errors`); the derived `pnl_unrealised` degrades gracefully.
     ///
     /// ## The immediate post-split `pnl_unrealised` is approximate — do not use it for risk checks
     /// The recompute pairs `last_price` with the **post-split** basis. In live trading a split is
@@ -647,10 +723,14 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// split until the next real tick arrives.
     ///
     /// # Return value & caller obligations
-    /// Returns [`SplitResult`] whose `remainder` is the post-split fractional shares disposed
-    /// (`0` under `Fractional` / forward splits). The caller (handler) should emit it as an
-    /// observable cash-in-lieu output; **this method writes no balances** (crediting CIL from
-    /// inside the engine would double-count in live and bypass the mock exchange in backtest).
+    /// Returns `Ok(`[`SplitResult`]`)` whose `remainder` is the post-split fractional shares
+    /// disposed — `0` under [`Fractional`](SplitRoundingPolicy::Fractional), and for any split that
+    /// leaves a whole share count (e.g. every forward split applied to a *whole-share* position). It
+    /// can be **non-zero** for a forward split under [`Floor`](SplitRoundingPolicy::Floor) when the
+    /// starting `quantity_abs` is itself fractional (e.g. 10.3 shares, 2-for-1 → 20.6, floored to
+    /// 20, remainder 0.6). The caller (handler) should emit it as an observable cash-in-lieu output;
+    /// **this method writes no balances** (crediting CIL from inside the engine would double-count
+    /// in live and bypass the mock exchange in backtest).
     ///
     /// **Floor whole-position disposal:** under `Floor` a reverse split can round `quantity_abs`
     /// to `0` (e.g. 1 share, 1:10). When that happens this method still only rescales `self` and
@@ -670,52 +750,123 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// + pnl_realised` is not a faithful internal ledger across a `Floor` reverse split — only the
     /// wrapper, reconciling `remainder` against broker cash, closes that gap.
     ///
-    /// # Panics
-    /// Panics if `ratio` is not strictly positive (zero or negative). `ratio = split_to / split_from`,
-    /// both positive by definition. A zero ratio would panic in `Decimal` division regardless, but a
-    /// negative ratio divides silently and would corrupt `price_entry_average` / `quantity_abs_max`
-    /// (negative basis / high-water mark), so it is rejected eagerly here — in release builds too.
+    /// # Ratio validity — a type-level guarantee, not a runtime check
+    /// `ratio` is a [`SplitRatio`], so it is strictly positive (`> 0`) *by construction* — the
+    /// degenerate-ratio failure mode is eliminated through the type system, not re-checked here.
+    /// (A validated `SplitRatio` is what `CorporateActionKind::stock_split` and the
+    /// `EngineEvent::CorporateAction` handler already thread through, so callers always hold one.)
+    ///
+    /// # Errors
+    /// Returns [`SplitError::Overflow`] if the split arithmetic overflows `Decimal` — an extreme
+    /// ratio or quantity driving `quantity_abs × ratio`, `price_entry_average ÷ ratio`, or
+    /// `quantity_abs_max × ratio` past `Decimal::MAX`. All three are computed **before** any field
+    /// is written, so on `Err` the [`Position`] is left **unmutated** and the caller can reject the
+    /// action atomically (see [`Position::validate_split`] to pre-validate a batch of positions).
     pub fn apply_split(
         &mut self,
-        ratio: Decimal,
+        ratio: SplitRatio,
         policy: SplitRoundingPolicy,
         last_price: Option<Decimal>,
-    ) -> SplitResult {
-        // Hard assert (not `debug_assert!`): `ratio` is caller-supplied external data, and a negative
-        // value would silently corrupt state in release rather than panic. Observable failure > silent.
-        assert!(
-            ratio > Decimal::ZERO,
-            "split ratio must be strictly positive (split_to / split_from), got {ratio}"
-        );
+    ) -> Result<SplitResult, SplitError> {
+        // `ratio` is a `SplitRatio` (`> 0` by construction), so no runtime sign check is needed.
+        // Compute the rescaled fields first; an overflow returns `Err` with `self` untouched.
+        let computed = self.compute_split(ratio.get(), policy)?;
 
+        // All arithmetic succeeded — commit atomically.
+        self.price_entry_average = computed.price_entry_average;
+        self.quantity_abs = computed.quantity_abs;
+        // High-water mark scales UNFLOORED even under Floor (see `compute_split`).
+        self.quantity_abs_max = computed.quantity_abs_max;
+
+        // Eagerly recompute unrealised PnL from the supplied price so a risk check between the
+        // split and the next market tick never reads a stale pre-split value. `None` (no market
+        // data yet) ⇒ 0. An extreme `last_price` whose recompute overflows `Decimal` ALSO ⇒ 0
+        // (flagged on the result) rather than a panic: the split (quantity/basis) is already
+        // committed and must stay atomic, and `pnl_unrealised` is a derived, self-correcting
+        // display value — panicking here would defeat the whole-action atomicity the engine's
+        // pre-validation guarantees (a mid-loop panic could leave a hedging book half-split and
+        // double-apply on retry). It self-corrects on the next market tick.
+        let pnl_unrealised_overflowed = match last_price {
+            Some(price) => match self.checked_pnl_unrealised(price) {
+                Some(pnl) => {
+                    self.pnl_unrealised = pnl;
+                    false
+                }
+                None => {
+                    self.pnl_unrealised = Decimal::ZERO;
+                    true
+                }
+            },
+            None => {
+                self.pnl_unrealised = Decimal::ZERO;
+                false
+            }
+        };
+
+        Ok(SplitResult {
+            remainder: computed.remainder,
+            pnl_unrealised_overflowed,
+        })
+    }
+
+    /// Validate that [`apply_split`](Self::apply_split) would succeed for this position **without
+    /// mutating it**, returning [`SplitError::Overflow`] iff the split arithmetic would overflow
+    /// `Decimal`.
+    ///
+    /// The engine calls this over **every** position an action affects *before* mutating any, so a
+    /// corporate action applies to the whole instrument atomically or not at all — an overflowing
+    /// feed can never leave a subset of positions rescaled.
+    pub fn validate_split(
+        &self,
+        ratio: SplitRatio,
+        policy: SplitRoundingPolicy,
+    ) -> Result<(), SplitError> {
+        self.compute_split(ratio.get(), policy).map(drop)
+    }
+
+    /// Pure split arithmetic — the single source of the rescaling math, shared by
+    /// [`apply_split`](Self::apply_split) (which commits it) and
+    /// [`validate_split`](Self::validate_split) (which discards it). Computes every rescaled field
+    /// with **checked** `Decimal` arithmetic and mutates nothing; returns [`SplitError::Overflow`]
+    /// if any product/quotient exceeds `Decimal::MAX`.
+    fn compute_split(
+        &self,
+        ratio: Decimal,
+        policy: SplitRoundingPolicy,
+    ) -> Result<SplitComputed, SplitError> {
         // Scaled (unfloored) quantity on the new share scale.
-        let scaled_quantity = self.quantity_abs * ratio;
-        let new_quantity = match policy {
+        let scaled_quantity = self
+            .quantity_abs
+            .checked_mul(ratio)
+            .ok_or(SplitError::Overflow)?;
+        let quantity_abs = match policy {
             SplitRoundingPolicy::Floor => scaled_quantity.floor(),
             SplitRoundingPolicy::Fractional => scaled_quantity,
         };
 
-        // Post-split fractional shares disposed, expressed in POST-split share units (the scaled
-        // quantity minus the floored quantity). Zero under `Fractional`, and for any split leaving
-        // a whole share count (all forward splits from a whole-share base).
-        let remainder = scaled_quantity - new_quantity;
+        // Post-split fractional shares disposed, in POST-split units (scaled minus floored).
+        // `scaled_quantity >= quantity_abs` (floor never increases it; equal under `Fractional`),
+        // so this subtraction is a value in `[0, 1)` and cannot overflow.
+        let remainder = scaled_quantity - quantity_abs;
 
-        // Notional-preserving per-share basis: old_avg / ratio (≡ old_notional ÷ the *unfloored*
-        // scaled quantity), independent of rounding.
-        self.price_entry_average /= ratio;
-        self.quantity_abs = new_quantity;
-        // High-water mark scales UNFLOORED even under Floor — it is a proportion denominator
+        // Notional-preserving per-share basis: old_avg / ratio, independent of rounding.
+        let price_entry_average = self
+            .price_entry_average
+            .checked_div(ratio)
+            .ok_or(SplitError::Overflow)?;
+        // High-water mark scales UNFLOORED even under Floor — a proportion denominator
         // (exit fees, returns), not a share lot.
-        self.quantity_abs_max *= ratio;
+        let quantity_abs_max = self
+            .quantity_abs_max
+            .checked_mul(ratio)
+            .ok_or(SplitError::Overflow)?;
 
-        // Eagerly recompute unrealised PnL from the supplied price so a risk check between the
-        // split and the next market tick never reads a stale pre-split value. None ⇒ 0.
-        match last_price {
-            Some(price) => self.update_pnl_unrealised(price),
-            None => self.pnl_unrealised = Decimal::ZERO,
-        }
-
-        SplitResult { remainder }
+        Ok(SplitComputed {
+            quantity_abs,
+            price_entry_average,
+            quantity_abs_max,
+            remainder,
+        })
     }
 }
 
@@ -874,6 +1025,53 @@ pub fn calculate_pnl_unrealised(
     }
 }
 
+/// Checked twin of [`calculate_pnl_unrealised`]: identical math with `checked_*` `Decimal`
+/// arithmetic, returning `None` on overflow instead of panicking.
+///
+/// Used only on the corporate-action split path ([`Position::apply_split`]), where an extreme feed
+/// `last_price` must degrade the derived `pnl_unrealised` to `0` rather than panic part-way through
+/// an atomic multi-position adjustment. The per-market-tick path (`update_from_market` →
+/// [`calculate_pnl_unrealised`]) is deliberately left unchecked here; hardening that hot path for
+/// **all** callers is a separate follow-up (it needs its own policy for a persistent bad feed —
+/// what a live tick returns on overflow — rather than the split path's one-shot degrade-to-zero).
+///
+/// The exit-fee approximation reuses [`approximate_remaining_exit_fees`] **unchecked**, by design:
+/// the only unbounded, feed-controlled input on the split path is `price` (covered by the checked
+/// value terms above). The fee term is `(quantity_abs / quantity_abs_max) × fees_enter`, whose ratio
+/// stays `≤ 1` under the `quantity_abs ≤ quantity_abs_max` invariant that
+/// [`compute_split`](Position::compute_split) preserves (both scale by the same `ratio`; `Floor`
+/// only lowers `quantity_abs`), times a realised, bounded `fees_enter` — so it has no *reachable*
+/// overflow. It is deliberately not re-checked here: guarding that unreachable state would be
+/// over-engineering, and it keeps the per-tick [`calculate_pnl_unrealised`] path untouched.
+fn checked_calculate_pnl_unrealised(
+    position_side: Side,
+    price_entry_average: Decimal,
+    quantity_abs: Decimal,
+    quantity_abs_max: Decimal,
+    fees_enter: Decimal,
+    price: Decimal,
+    contract_size: Decimal,
+) -> Option<Decimal> {
+    let approx_exit_fees =
+        approximate_remaining_exit_fees(quantity_abs, quantity_abs_max, fees_enter);
+
+    let value_quote_current = quantity_abs
+        .checked_mul(price)?
+        .checked_mul(contract_size)?;
+    let value_quote_entry = quantity_abs
+        .checked_mul(price_entry_average)?
+        .checked_mul(contract_size)?;
+
+    match position_side {
+        Side::Buy => value_quote_current
+            .checked_sub(value_quote_entry)?
+            .checked_sub(approx_exit_fees),
+        Side::Sell => value_quote_entry
+            .checked_sub(value_quote_current)?
+            .checked_sub(approx_exit_fees),
+    }
+}
+
 /// Approximate the exit fees from closing a [`Position`] with `quantity_abs`.
 ///
 /// The `fees_enter` value was the fee cost to enter a [`Position`] of `quantity_abs_max`,
@@ -931,6 +1129,7 @@ pub fn calculate_pnl_return(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // test code: panics acceptable
 mod tests {
     use super::*;
     use crate::test_utils::{time_plus_days, trade};
@@ -1748,6 +1947,12 @@ mod tests {
         }
     }
 
+    /// Build a validated [`SplitRatio`] from a raw `Decimal` for test call sites (panics on a
+    /// non-positive ratio, which is fine in test code — and unconstructible in real code).
+    fn sr(ratio: Decimal) -> SplitRatio {
+        SplitRatio::new(ratio).unwrap()
+    }
+
     #[test]
     fn test_apply_split() {
         use SplitRoundingPolicy::{Floor, Fractional};
@@ -1876,7 +2081,9 @@ mod tests {
             let fees_exit_before = p.fees_exit.clone();
             let time_update_before = p.time_exchange_update;
 
-            let result = p.apply_split(tc.ratio, tc.policy, Some(tc.last_price));
+            let result = p
+                .apply_split(sr(tc.ratio), tc.policy, Some(tc.last_price))
+                .unwrap();
 
             assert_eq!(p.quantity_abs, tc.expected_qty, "{}: quantity_abs", tc.name);
             assert_eq!(
@@ -1908,6 +2115,13 @@ mod tests {
             assert_eq!(
                 p.pnl_unrealised, expected_pnl,
                 "{}: pnl_unrealised",
+                tc.name
+            );
+            // The checked split-path recompute must match the unchecked `calculate_pnl_unrealised`
+            // above bit-for-bit on a normal price, and never spuriously flag an overflow.
+            assert!(
+                !result.pnl_unrealised_overflowed,
+                "{}: pnl did not overflow on a normal price",
                 tc.name
             );
             assert_ne!(
@@ -1954,7 +2168,9 @@ mod tests {
         // (post-split units) — NOT 1.0. apply_split only rescales self; the slot
         // removal + PositionExit is the handler's job (asserted at the handler/replica level).
         let mut p = split_position(Side::Buy, dec!(50), dec!(1), dec!(1), dec!(2));
-        let result = p.apply_split(dec!(0.1), SplitRoundingPolicy::Floor, Some(dec!(500)));
+        let result = p
+            .apply_split(sr(dec!(0.1)), SplitRoundingPolicy::Floor, Some(dec!(500)))
+            .unwrap();
 
         assert_eq!(p.quantity_abs, dec!(0), "position floors to zero");
         assert_eq!(
@@ -1982,7 +2198,8 @@ mod tests {
         //     digits — 100/1.5 does not terminate), NOT bit-exact. ---
         let mut p = split_position(Side::Buy, dec!(100), dec!(7), dec!(7), dec!(5));
         let old_notional = dec!(7) * dec!(100);
-        p.apply_split(dec!(1.5), SplitRoundingPolicy::Fractional, None);
+        p.apply_split(sr(dec!(1.5)), SplitRoundingPolicy::Fractional, None)
+            .unwrap();
         let new_notional = p.quantity_abs * p.price_entry_average;
         let tolerance = Decimal::new(1, 20); // 1e-20
         assert!(
@@ -1994,7 +2211,9 @@ mod tests {
         //     old_notional, exactly (avg/ratio terminates: 10/0.5 = 20). ---
         let mut p = split_position(Side::Buy, dec!(10), dec!(101), dec!(101), dec!(5));
         let old_notional = dec!(101) * dec!(10);
-        let result = p.apply_split(dec!(0.5), SplitRoundingPolicy::Floor, None);
+        let result = p
+            .apply_split(sr(dec!(0.5)), SplitRoundingPolicy::Floor, None)
+            .unwrap();
         let reconstructed =
             p.quantity_abs * p.price_entry_average + result.remainder * p.price_entry_average;
         assert_eq!(
@@ -2010,7 +2229,8 @@ mod tests {
         let fee_ratio_before = p.quantity_abs / p.quantity_abs_max; // 4/5 = 0.8
         let exit_fees_before =
             approximate_remaining_exit_fees(p.quantity_abs, p.quantity_abs_max, p.fees_enter.fees);
-        p.apply_split(dec!(1.5), SplitRoundingPolicy::Floor, None);
+        p.apply_split(sr(dec!(1.5)), SplitRoundingPolicy::Floor, None)
+            .unwrap();
         assert_eq!(
             p.quantity_abs,
             dec!(6),
@@ -2037,7 +2257,8 @@ mod tests {
         //     (avg ÷ r cancels max × r), so tear-sheet returns survive the split unchanged. ---
         let mut p = split_position(Side::Buy, dec!(90), dec!(4), dec!(5), dec!(10));
         let denom_before = p.price_entry_average * p.quantity_abs_max; // 90 × 5 = 450
-        p.apply_split(dec!(1.5), SplitRoundingPolicy::Floor, None);
+        p.apply_split(sr(dec!(1.5)), SplitRoundingPolicy::Floor, None)
+            .unwrap();
         let denom_after = p.price_entry_average * p.quantity_abs_max; // 60 × 7.5 = 450
         assert_eq!(
             denom_after, denom_before,
@@ -2050,11 +2271,159 @@ mod tests {
         // None last_price ⇒ pnl_unrealised = 0 (corrected on the next market tick); NOT scaled.
         let mut p = split_position(Side::Buy, dec!(100), dec!(10), dec!(10), dec!(5));
         p.pnl_unrealised = dec!(123.45);
-        let _ = p.apply_split(dec!(2), SplitRoundingPolicy::Floor, None);
+        let result = p
+            .apply_split(sr(dec!(2)), SplitRoundingPolicy::Floor, None)
+            .unwrap();
         assert_eq!(
             p.pnl_unrealised,
             Decimal::ZERO,
             "None last_price ⇒ pnl_unrealised = 0"
+        );
+        // A *missing* price is not an *overflow* — the flag distinguishes the two zero causes.
+        assert!(
+            !result.pnl_unrealised_overflowed,
+            "None last_price zeroes pnl but does NOT flag an overflow"
+        );
+    }
+
+    #[test]
+    fn test_apply_split_ratio_one_is_a_no_op() {
+        // ratio == 1 (a valid `SplitRatio`) leaves quantity/basis/high-water mark unchanged under
+        // both policies — the identity split. `pnl_unrealised` is still recomputed from last_price.
+        for policy in [SplitRoundingPolicy::Floor, SplitRoundingPolicy::Fractional] {
+            let mut p = split_position(Side::Buy, dec!(100), dec!(10), dec!(12), dec!(5));
+            let result = p.apply_split(sr(dec!(1)), policy, None).unwrap();
+            assert_eq!(
+                p.quantity_abs,
+                dec!(10),
+                "{policy:?}: quantity_abs unchanged"
+            );
+            assert_eq!(
+                p.quantity_abs_max,
+                dec!(12),
+                "{policy:?}: quantity_abs_max unchanged"
+            );
+            assert_eq!(
+                p.price_entry_average,
+                dec!(100),
+                "{policy:?}: price_entry_average unchanged"
+            );
+            assert_eq!(result.remainder, dec!(0), "{policy:?}: no remainder");
+        }
+    }
+
+    #[test]
+    fn test_apply_split_zero_quantity_position() {
+        // A zero-quantity position (e.g. a fully-closed slot awaiting cleanup) splits to a still-zero
+        // quantity with no remainder — the arithmetic must not panic or fabricate a fractional sliver.
+        let mut p = split_position(Side::Buy, dec!(100), dec!(0), dec!(0), dec!(0));
+        let result = p
+            .apply_split(sr(dec!(2)), SplitRoundingPolicy::Floor, None)
+            .unwrap();
+        assert_eq!(p.quantity_abs, dec!(0), "zero quantity stays zero");
+        assert_eq!(
+            p.quantity_abs_max,
+            dec!(0),
+            "zero high-water mark stays zero"
+        );
+        assert_eq!(
+            result.remainder,
+            dec!(0),
+            "no remainder from a zero position"
+        );
+    }
+
+    #[test]
+    fn test_apply_split_forward_floor_fractional_start_disposes_remainder() {
+        // L1 guard: a FORWARD split under `Floor` does NOT always leave remainder 0 — a fractional
+        // starting quantity_abs (reachable via a prior `Fractional`-policy split, or a fractional-
+        // share broker) floors to a non-zero remainder. 10.3 shares, 2-for-1 → 20.6, floor → 20,
+        // remainder 0.6. quantity_abs_max scales UNFLOORED (10.3 × 2 = 20.6).
+        let mut p = split_position(Side::Buy, dec!(100), dec!(10.3), dec!(10.3), dec!(5));
+        let result = p
+            .apply_split(sr(dec!(2)), SplitRoundingPolicy::Floor, None)
+            .unwrap();
+        assert_eq!(p.quantity_abs, dec!(20), "20.6 floored to 20");
+        assert_eq!(
+            result.remainder,
+            dec!(0.6),
+            "forward split under Floor disposes a non-zero remainder from a fractional start"
+        );
+        assert_eq!(
+            p.quantity_abs_max,
+            dec!(20.6),
+            "high-water mark scales unfloored"
+        );
+    }
+
+    #[test]
+    fn test_apply_split_ratio_overflow_is_err_and_leaves_position_unmutated() {
+        // A ratio-driven rescale that overflows `Decimal` (quantity_abs × ratio > Decimal::MAX)
+        // must return `Err(SplitError::Overflow)` with EVERY field left byte-for-byte unmutated —
+        // the all-or-nothing contract the engine's pre-validation relies on. `compute_split` runs
+        // before any commit, so not even `pnl_unrealised` (the sentinel 999) is touched.
+        let mut p = split_position(Side::Buy, dec!(100), Decimal::MAX, Decimal::MAX, dec!(5));
+        let before = p.clone();
+
+        let err = p
+            .apply_split(sr(dec!(2)), SplitRoundingPolicy::Floor, Some(dec!(120)))
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            SplitError::Overflow,
+            "overflow surfaces as Err, not panic"
+        );
+        assert_eq!(
+            p, before,
+            "position left fully unmutated on Err (all-or-nothing)"
+        );
+
+        // `validate_split` mirrors the same decision without mutating — the engine's pre-validation
+        // pass uses it to reject the whole action atomically.
+        assert_eq!(
+            p.validate_split(sr(dec!(2)), SplitRoundingPolicy::Floor),
+            Err(SplitError::Overflow),
+        );
+        assert_eq!(p, before, "validate_split never mutates");
+    }
+
+    #[test]
+    fn test_apply_split_extreme_last_price_degrades_pnl_to_zero_atomically() {
+        // (d) fail-soft: an extreme `last_price` whose pnl recompute overflows `Decimal` must NOT
+        // panic or fail the split. The ratio-driven rescale (10→20, 100→50, qmax 10→20) still
+        // applies atomically; only the derived `pnl_unrealised` degrades to 0 with the overflow
+        // flagged on the result, exactly like a `None` last_price. This is the M-A guarantee: a
+        // corrupt feed price can never leave a hedging book half-split mid-loop.
+        let mut p = split_position(Side::Buy, dec!(100), dec!(10), dec!(10), dec!(5));
+        p.pnl_unrealised = dec!(123.45); // sentinel that must be overwritten to 0
+
+        // quantity_abs × ratio = 20 (fine); 20 × Decimal::MAX overflows the pnl value term.
+        let result = p
+            .apply_split(sr(dec!(2)), SplitRoundingPolicy::Floor, Some(Decimal::MAX))
+            .unwrap();
+
+        assert!(
+            result.pnl_unrealised_overflowed,
+            "pnl overflow is flagged on the result for the caller to warn on"
+        );
+        assert_eq!(
+            result.remainder,
+            dec!(0),
+            "forward 2:1 on whole shares leaves no remainder"
+        );
+        assert_eq!(
+            p.pnl_unrealised,
+            Decimal::ZERO,
+            "overflowing pnl recompute ⇒ 0"
+        );
+        // The split itself still applied — atomic, not rejected.
+        assert_eq!(p.quantity_abs, dec!(20), "quantity still rescaled");
+        assert_eq!(p.price_entry_average, dec!(50), "basis still rescaled");
+        assert_eq!(
+            p.quantity_abs_max,
+            dec!(20),
+            "high-water mark still rescaled"
         );
     }
 }

--- a/rustrade/src/engine/state/position.rs
+++ b/rustrade/src/engine/state/position.rs
@@ -695,8 +695,9 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
             SplitRoundingPolicy::Fractional => scaled_quantity,
         };
 
-        // Post-split fractional shares disposed (Convention A). Zero under `Fractional`, and for
-        // any split leaving a whole share count (all forward splits from a whole-share base).
+        // Post-split fractional shares disposed, expressed in POST-split share units (the scaled
+        // quantity minus the floored quantity). Zero under `Fractional`, and for any split leaving
+        // a whole share count (all forward splits from a whole-share base).
         let remainder = scaled_quantity - new_quantity;
 
         // Notional-preserving per-share basis: old_avg / ratio (≡ old_notional ÷ the *unfloored*
@@ -1950,7 +1951,7 @@ mod tests {
     #[test]
     fn test_apply_split_floor_to_zero() {
         // 1 share, reverse 1:10, Floor: floors to 0. remainder is the full scaled fraction 0.1
-        // (post-split units, Convention A) — NOT 1.0. apply_split only rescales self; the slot
+        // (post-split units) — NOT 1.0. apply_split only rescales self; the slot
         // removal + PositionExit is the handler's job (asserted at the handler/replica level).
         let mut p = split_position(Side::Buy, dec!(50), dec!(1), dec!(1), dec!(2));
         let result = p.apply_split(dec!(0.1), SplitRoundingPolicy::Floor, Some(dec!(500)));
@@ -1959,7 +1960,7 @@ mod tests {
         assert_eq!(
             result.remainder,
             dec!(0.1),
-            "remainder is post-split fractional shares (Convention A), not pre-split 1.0"
+            "remainder is post-split fractional shares, not pre-split 1.0"
         );
         assert_eq!(
             p.price_entry_average,

--- a/rustrade/src/lib.rs
+++ b/rustrade/src/lib.rs
@@ -60,8 +60,7 @@ use rustrade_data::{
 };
 use rustrade_execution::AccountEvent;
 use rustrade_instrument::{
-    asset::AssetIndex, corporate_action::CorporateActionKind, exchange::ExchangeIndex,
-    instrument::InstrumentIndex,
+    asset::AssetIndex, exchange::ExchangeIndex, instrument::InstrumentIndex,
 };
 use rustrade_integration::Terminal;
 use serde::{Deserialize, Serialize};
@@ -71,6 +70,17 @@ use smol_str::SmolStr;
 /// Re-export of [`SplitRoundingPolicy`] so callers can construct
 /// [`EngineEvent::CorporateAction`] without depending on the engine's internal module layout.
 pub use crate::engine::state::position::SplitRoundingPolicy;
+
+/// Re-export of the corporate-action public API so callers can build and handle
+/// [`EngineEvent::CorporateAction`] without a direct `rustrade_instrument` dependency — mirroring
+/// the [`SplitRoundingPolicy`] re-export above. [`CorporateActionKind`] is the event's market-fact
+/// `kind`, [`SplitRatio`]/[`InvalidSplitRatio`] are its validated ratio and construction error,
+/// [`SplitAdjustmentKind`] is the OCC option classification, and [`split_effective_instant`]
+/// resolves an effective date to the engine's stamping instant.
+pub use rustrade_instrument::corporate_action::{
+    CorporateActionKind, InvalidSplitRatio, SplitAdjustmentKind, SplitRatio,
+    split_effective_instant,
+};
 
 /// Algorithmic trading `Engine`, and entry points for processing input `Events`.
 ///

--- a/rustrade/src/lib.rs
+++ b/rustrade/src/lib.rs
@@ -186,15 +186,19 @@ pub enum EngineEvent<
     ///   underlying equity key; option positions on that underlying are **not** adjusted here and
     ///   are surfaced via a separate observable output.
     /// - `kind`: the market fact (e.g. [`CorporateActionKind::StockSplit`] carrying the ratio).
-    /// - `policy`: how to round a fractional resulting share count
-    ///   ([`SplitRoundingPolicy`]) — broker-specific, no default.
+    /// - `policy`: how to round a fractional resulting **equity** share count
+    ///   ([`SplitRoundingPolicy`]) — broker-specific, no default. Governs the **equity** leg only;
+    ///   option contract counts are whole integers and are never floored, so a standard option
+    ///   adjustment is exact regardless of this `policy`.
     /// - `effective_time`: the resolved instant the adjustment takes effect. In backtest the
     ///   [`HistoricalClock`](engine::clock::HistoricalClock) advances to this instant so the
     ///   adjustment is stamped and ordered exactly (no look-ahead); in live it is honest metadata.
     ///
     /// # Caller obligations
     /// - Assign a unique `id` per action.
-    /// - Resolve the ticker to the engine's `InstrumentKey`.
+    /// - Resolve the ticker to a **valid** engine `InstrumentKey`. The engine indexes it directly
+    ///   and **panics on an unknown key** (consistent with the rest of the `EngineEvent` API), so
+    ///   validate the key before constructing the event.
     /// - Supply the `policy` (matching the broker's rounding behaviour) and a resolved
     ///   `effective_time` (see [`split_effective_instant`](rustrade_instrument::corporate_action::split_effective_instant)).
     /// - **Inject once**, after the broker has applied the action, before processing new fills on
@@ -202,6 +206,10 @@ pub enum EngineEvent<
     /// - A same-day **correction** is expressed as two distinct events with distinct `id`s — a
     ///   reversal (`ratio = 1 / old`) followed by the corrected split — so neither is suppressed
     ///   by the idempotency guard.
+    /// - Do **not** inject a `ratio == 1` no-op "split". It is a non-event: the engine applies it as
+    ///   a no-op, yet it still classifies as non-standard and emits
+    ///   `OptionPositionsRequireIdentityChange` for any option positions on the underlying —
+    ///   misleading noise for what changed nothing.
     ///
     /// # Missing last price
     /// Unlike [`ContractExpiry`](Self::ContractExpiry) — which bails and is retryable when the
@@ -221,7 +229,8 @@ pub enum EngineEvent<
         instrument: InstrumentKey,
         /// The corporate-action market fact (e.g. a stock split ratio).
         kind: CorporateActionKind,
-        /// How to round a fractional resulting share count (broker-specific; no default).
+        /// How to round a fractional resulting **equity** share count (broker-specific; no
+        /// default). Governs the equity leg only — option contract counts are whole and never floored.
         policy: SplitRoundingPolicy,
         /// The resolved instant the adjustment takes effect (drives the backtest clock).
         effective_time: DateTime<Utc>,

--- a/rustrade/src/lib.rs
+++ b/rustrade/src/lib.rs
@@ -60,11 +60,17 @@ use rustrade_data::{
 };
 use rustrade_execution::AccountEvent;
 use rustrade_instrument::{
-    asset::AssetIndex, exchange::ExchangeIndex, instrument::InstrumentIndex,
+    asset::AssetIndex, corporate_action::CorporateActionKind, exchange::ExchangeIndex,
+    instrument::InstrumentIndex,
 };
 use rustrade_integration::Terminal;
 use serde::{Deserialize, Serialize};
 use shutdown::Shutdown;
+use smol_str::SmolStr;
+
+/// Re-export of [`SplitRoundingPolicy`] so callers can construct
+/// [`EngineEvent::CorporateAction`] without depending on the engine's internal module layout.
+pub use crate::engine::state::position::SplitRoundingPolicy;
 
 /// Algorithmic trading `Engine`, and entry points for processing input `Events`.
 ///
@@ -127,7 +133,12 @@ pub struct Timed<T> {
 /// events, and `Engine` commands.
 ///
 /// Note that the `Engine` can be configured to process custom events.
+///
+/// `#[non_exhaustive]`: new engine-driven event variants (e.g. corporate actions beyond stock
+/// splits) can be added without breaking downstream exhaustive matches. External matchers must
+/// carry a wildcard arm.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, From)]
+#[non_exhaustive]
 pub enum EngineEvent<
     MarketKind = DataKind,
     ExchangeKey = ExchangeIndex,
@@ -153,6 +164,72 @@ pub enum EngineEvent<
     /// Construct this variant directly: `EngineEvent::ContractExpiry(key)`.
     #[from(skip)]
     ContractExpiry(InstrumentKey),
+
+    /// Signal that a corporate action (e.g. a stock split) has taken effect on an instrument and
+    /// the engine's internal position(s) must be adjusted to match.
+    ///
+    /// **Status**: the engine-side handler is not yet wired — receiving this event currently logs
+    /// a warning and performs no adjustment. The behaviour documented below is the intended
+    /// contract.
+    ///
+    /// Positions are fill-derived: even in live trading a broker applying a split overnight does
+    /// **not** fix the engine's internal `quantity`/`price_entry_average`/`pnl_unrealised`, which
+    /// stay on the pre-split scale until something explicitly adjusts them. This event is that
+    /// explicit adjustment, used identically in backtest and live.
+    ///
+    /// The handler is idempotent, keyed on `id` alone (see below), and adjusts **every** open
+    /// position for `instrument` (one in netting mode, N in hedging mode). It does not mutate
+    /// resting orders — a real broker price-adjusts them, so cancelling engine-side would diverge;
+    /// the open orders are surfaced as an observable output instead.
+    ///
+    /// # Fields
+    /// - `id`: a caller-assigned **unique** action identifier (e.g. `"AAPL-2026-06-20-split"`).
+    ///   This is the **sole** idempotency key — the handler records processed `id`s per instrument
+    ///   and skips (with a warning) any `id` it has already seen.
+    /// - `instrument`: the key whose position(s) are adjusted. For a stock split this is the
+    ///   underlying equity key; option positions on that underlying are **not** adjusted here and
+    ///   are surfaced via a separate observable output.
+    /// - `kind`: the market fact (e.g. [`CorporateActionKind::StockSplit`] carrying the ratio).
+    /// - `policy`: how to round a fractional resulting share count
+    ///   ([`SplitRoundingPolicy`]) — broker-specific, no default.
+    /// - `effective_time`: the resolved instant the adjustment takes effect. In backtest the
+    ///   [`HistoricalClock`](engine::clock::HistoricalClock) advances to this instant so the
+    ///   adjustment is stamped and ordered exactly (no look-ahead); in live it is honest metadata.
+    ///
+    /// # Caller obligations
+    /// - Assign a unique `id` per action.
+    /// - Resolve the ticker to the engine's `InstrumentKey`.
+    /// - Supply the `policy` (matching the broker's rounding behaviour) and a resolved
+    ///   `effective_time` (see [`split_effective_instant`](rustrade_instrument::corporate_action::split_effective_instant)).
+    /// - **Inject once**, after the broker has applied the action, before processing new fills on
+    ///   the post-split scale.
+    /// - A same-day **correction** is expressed as two distinct events with distinct `id`s — a
+    ///   reversal (`ratio = 1 / old`) followed by the corrected split — so neither is suppressed
+    ///   by the idempotency guard.
+    ///
+    /// # Missing last price
+    /// Unlike [`ContractExpiry`](Self::ContractExpiry) — which bails and is retryable when the
+    /// underlying price is unavailable — a split needs no price for its quantity/basis arithmetic.
+    /// The adjustment is therefore **applied** and the `id` **recorded** even when the instrument's
+    /// last price is unavailable; `pnl_unrealised` is set to zero (with a warning) and corrected on
+    /// the next market tick. This event is **not** retryable.
+    ///
+    /// Note: `From` is skipped here so the variant is always constructed explicitly — the caller
+    /// must consciously supply `id`, `policy`, and `effective_time` (it is not derivable from any
+    /// single field).
+    #[from(skip)]
+    CorporateAction {
+        /// Caller-assigned unique action identifier; the sole idempotency key.
+        id: SmolStr,
+        /// The instrument whose open position(s) are adjusted.
+        instrument: InstrumentKey,
+        /// The corporate-action market fact (e.g. a stock split ratio).
+        kind: CorporateActionKind,
+        /// How to round a fractional resulting share count (broker-specific; no default).
+        policy: SplitRoundingPolicy,
+        /// The resolved instant the adjustment takes effect (drives the backtest clock).
+        effective_time: DateTime<Utc>,
+    },
 }
 
 impl<MarketKind, ExchangeKey, AssetKey, InstrumentKey> Terminal

--- a/rustrade/src/lib.rs
+++ b/rustrade/src/lib.rs
@@ -168,10 +168,6 @@ pub enum EngineEvent<
     /// Signal that a corporate action (e.g. a stock split) has taken effect on an instrument and
     /// the engine's internal position(s) must be adjusted to match.
     ///
-    /// **Status**: the engine-side handler is not yet wired — receiving this event currently logs
-    /// a warning and performs no adjustment. The behaviour documented below is the intended
-    /// contract.
-    ///
     /// Positions are fill-derived: even in live trading a broker applying a split overnight does
     /// **not** fix the engine's internal `quantity`/`price_entry_average`/`pnl_unrealised`, which
     /// stay on the pre-split scale until something explicitly adjusts them. This event is that

--- a/rustrade/src/lib.rs
+++ b/rustrade/src/lib.rs
@@ -15,6 +15,10 @@
     missing_debug_implementations,
     rust_2018_idioms
 )]
+// Inherited from the barter-rs upstream: the generic, trait-heavy public API legitimately produces
+// complex nested types and many-argument constructors, and `type_alias_bounds` fires on
+// documentation-bearing alias bounds kept intentionally. Denying these adds churn without improving
+// the API.
 #![allow(clippy::type_complexity, clippy::too_many_arguments, type_alias_bounds)]
 
 //! # Barter

--- a/rustrade/src/lib.rs
+++ b/rustrade/src/lib.rs
@@ -225,6 +225,18 @@ pub enum EngineEvent<
     ///   `OptionPositionsRequireIdentityChange` for any option positions on the underlying —
     ///   misleading noise for what changed nothing.
     ///
+    /// # Backtest ordering caveat — inject chronologically
+    /// The no-look-ahead guarantee holds only if actions are injected in **chronological order**.
+    /// The backtest [`HistoricalClock`](engine::clock::HistoricalClock) advances *monotonically* and
+    /// never regresses: it moves to `effective_time` only when that is at or after the clock's
+    /// current time. An action injected **out of order** — with an `effective_time` earlier than an
+    /// already-processed event — is still **applied**, but its outputs (and any folded
+    /// [`PositionExit`](engine::state::position::PositionExited)) are stamped at the clock's
+    /// **current** time, not the earlier `effective_time`. The
+    /// [`AuxEventSource`](backtest::aux_events::AuxEventSource) contract already requires ascending
+    /// `Timed::time` (enforced pre-merge by the backtest harness), so this only bites a caller that
+    /// hand-drives the engine or feeds events off-timeline.
+    ///
     /// # Missing last price
     /// Unlike [`ContractExpiry`](Self::ContractExpiry) — which bails and is retryable when the
     /// underlying price is unavailable — a split needs no price for its quantity/basis arithmetic.

--- a/rustrade/src/lib.rs
+++ b/rustrade/src/lib.rs
@@ -220,9 +220,11 @@ pub enum EngineEvent<
     /// - A same-day **correction** is expressed as two distinct events with distinct `id`s — a
     ///   reversal (`ratio = 1 / old`) followed by the corrected split — so neither is suppressed
     ///   by the idempotency guard.
-    /// - Do **not** inject a `ratio == 1` no-op "split". It is a non-event: the engine applies it as
-    ///   a no-op, yet it still classifies as non-standard and emits
-    ///   `OptionPositionsRequireIdentityChange` for any option positions on the underlying —
+    /// - Do **not** inject a `ratio == 1` no-op "split". It is a non-event, yet it is not silent: it
+    ///   still classifies as non-standard and emits `OptionPositionsRequireIdentityChange` for any
+    ///   option positions on the underlying, and — under [`SplitRoundingPolicy::Floor`] — it floors
+    ///   any pre-existing *fractional* equity `quantity_abs` down to a whole share count, emitting a
+    ///   spurious `SplitRemainder` for a sliver no real corporate action disposed. Both are
     ///   misleading noise for what changed nothing.
     ///
     /// # Backtest ordering caveat — inject chronologically

--- a/rustrade/src/system/mod.rs
+++ b/rustrade/src/system/mod.rs
@@ -45,7 +45,19 @@ where
     /// Handles to auxiliary system components (execution components, event forwarding, etc.).
     pub handles: SystemAuxillaryHandles,
 
-    /// Transmitter for sending events to the `Engine`.
+    /// Transmitter for sending events directly to the `Engine`, bypassing any market/aux merge.
+    ///
+    /// # Ordering obligation (historical / backtest engines)
+    /// Events injected here do **not** pass through the backtest harness's time-ordering asserts
+    /// (`merge_market_with_aux` / `assert_aux_corporate_action_effective_times`). A
+    /// [`HistoricalClock`](crate::engine::clock::HistoricalClock) advances monotonically off each
+    /// event's `time_exchange` and never rewinds, so the caller must feed events in ascending
+    /// simulated-time order — including any injected
+    /// [`EngineEvent::CorporateAction`](crate::EngineEvent::CorporateAction), whose `effective_time`
+    /// the clock advances to *before* the action is validated. Injecting an out-of-order event moves
+    /// the clock forward (observably, via out-of-order logs) and subsequent earlier events will then
+    /// not advance it. A [`LiveClock`](crate::engine::clock::LiveClock) is unaffected (it reads
+    /// `Utc::now()`).
     pub feed_tx: UnboundedTx<Event>,
 
     /// Optional audit snapshot with updates (present when audit sending is enabled).

--- a/rustrade/tests/test_backtest_aux_events.rs
+++ b/rustrade/tests/test_backtest_aux_events.rs
@@ -23,9 +23,15 @@ use rustrade::{
         BacktestArgsConstant, BacktestArgsDynamic, aux_events::AuxEventsInMemory, backtest,
         market_data::MarketDataInMemory, run_backtests,
     },
-    engine::state::{
-        EngineState, builder::EngineStateBuilder, global::DefaultGlobalData,
-        instrument::data::DefaultInstrumentMarketData, trading::TradingState,
+    engine::{
+        command::Command,
+        state::{
+            EngineState,
+            builder::EngineStateBuilder,
+            global::DefaultGlobalData,
+            instrument::{data::DefaultInstrumentMarketData, filter::InstrumentFilter},
+            trading::TradingState,
+        },
     },
     risk::DefaultRiskManager,
     statistic::time::Daily,
@@ -41,6 +47,7 @@ use rustrade_instrument::{
     corporate_action::CorporateActionKind, exchange::ExchangeId, index::IndexedInstruments,
     instrument::InstrumentIndex,
 };
+use rustrade_integration::collection::one_or_many::OneOrMany;
 use serde::Deserialize;
 
 const CONFIG_PATH: &str = concat!(
@@ -66,14 +73,18 @@ fn ts(raw: &str) -> DateTime<Utc> {
     raw.parse().unwrap()
 }
 
-/// A single trade `MarketEvent` for BTCUSDT (instrument index 0).
-fn trade(time: &str, price: Decimal) -> MarketStreamEvent<InstrumentIndex, DataKind> {
+/// A single trade `MarketEvent` for the instrument at `instrument` index.
+fn trade_for(
+    instrument: usize,
+    time: &str,
+    price: Decimal,
+) -> MarketStreamEvent<InstrumentIndex, DataKind> {
     let time = ts(time);
     MarketStreamEvent::Item(MarketEvent {
         time_exchange: time,
         time_received: time,
         exchange: ExchangeId::BinanceSpot,
-        instrument: InstrumentIndex::new(0),
+        instrument: InstrumentIndex::new(instrument),
         kind: DataKind::Trade(PublicTrade {
             id: "trade".into(),
             price,
@@ -81,6 +92,11 @@ fn trade(time: &str, price: Decimal) -> MarketStreamEvent<InstrumentIndex, DataK
             side: None,
         }),
     })
+}
+
+/// A single trade `MarketEvent` for BTCUSDT (instrument index 0).
+fn trade(time: &str, price: Decimal) -> MarketStreamEvent<InstrumentIndex, DataKind> {
+    trade_for(0, time, price)
 }
 
 /// Four BTCUSDT trades spanning 22:00–23:00; any aux event in that window interleaves mid-stream.
@@ -98,6 +114,17 @@ fn args_constant(
 ) -> Arc<
     BacktestArgsConstant<MarketDataInMemory<DataKind>, Daily, AuxBacktestState, DefaultAuxEvents>,
 > {
+    args_constant_with_market_data(aux_events, market_events())
+}
+
+/// As [`args_constant`], but with a caller-supplied market-data series (e.g. to feed a second
+/// pre-declared instrument its own post-split prints).
+fn args_constant_with_market_data(
+    aux_events: DefaultAuxEvents,
+    events: Vec<MarketStreamEvent<InstrumentIndex, DataKind>>,
+) -> Arc<
+    BacktestArgsConstant<MarketDataInMemory<DataKind>, Daily, AuxBacktestState, DefaultAuxEvents>,
+> {
     let Config {
         system: SystemConfig {
             instruments,
@@ -106,7 +133,7 @@ fn args_constant(
     } = load_config();
 
     let instruments = IndexedInstruments::new(instruments);
-    let market_data = MarketDataInMemory::new(Arc::new(market_events()));
+    let market_data = MarketDataInMemory::new(Arc::new(events));
 
     let engine_state = EngineStateBuilder::new(&instruments, DefaultGlobalData, |_| {
         DefaultInstrumentMarketData::default()
@@ -205,4 +232,64 @@ async fn run_backtests_sweep_threads_aux_events() {
     .expect("run_backtests sweep with injected splits must complete");
 
     assert_eq!(summaries.summaries.len(), 2);
+}
+
+/// Market-data series for the two-identity non-standard-split smoke: the "old" identity (idx0,
+/// BTCUSDT) prints across the whole window; the pre-declared "new" identity (idx1, ETHUSDT) prints
+/// ONLY after the 22:30 split — the natural shape, since the new contract did not exist before.
+fn market_events_two_identity() -> Vec<MarketStreamEvent<InstrumentIndex, DataKind>> {
+    vec![
+        trade_for(0, "2025-03-24T22:00:00Z", dec!(60_000)),
+        trade_for(0, "2025-03-24T22:15:00Z", dec!(60_100)),
+        trade_for(0, "2025-03-24T22:45:00Z", dec!(60_200)),
+        trade_for(1, "2025-03-24T22:50:00Z", dec!(2_000)),
+        trade_for(1, "2025-03-24T22:55:00Z", dec!(2_010)),
+        trade_for(0, "2025-03-24T23:00:00Z", dec!(60_300)),
+    ]
+}
+
+/// A `Command::ClosePositions` for `instrument`, wrapped for injection through the aux seam.
+fn close_command_event(time: &str, instrument: usize) -> Timed<EngineEvent> {
+    Timed::new(
+        EngineEvent::Command(Command::ClosePositions(InstrumentFilter::Instruments(
+            OneOrMany::One(InstrumentIndex::new(instrument)),
+        ))),
+        ts(time),
+    )
+}
+
+/// **Structural feasibility smoke for the non-standard-split wrapper flow (plumbing only).**
+///
+/// Proves a downstream wrapper can drive the whole non-standard-split protocol through the public
+/// `backtest()` API with no library re-registration: BOTH identities are pre-declared at
+/// construction (the config registers idx0/idx1/idx2), the aux seam carries BOTH a `CorporateAction`
+/// AND a flatten `Command::ClosePositions`, the new identity receives its own post-split data, and
+/// the run completes to a `BacktestSummary`.
+///
+/// SCOPE — this asserts PLUMBING only, not economics: `backtest()` hardcodes `AuditMode::Disabled`,
+/// so the `OptionPositionsRequireIdentityChange` observable is invisible here (its content is
+/// asserted on the `process_with_audit` path in `test_engine_process_engine_event_with_audit.rs`).
+/// The close trigger is *pre-planned* (injected at the known split time), not *reactive-from-output*
+/// — the identical caveat the `OpenOrdersAtSplit` backtest pattern already carries. Kind-agnostic:
+/// the config's spot instruments stand in for the option identities (a faithful option *trading*
+/// backtest needs a custom strategy + price-bearing mock fills, deferred to a future milestone). The
+/// injected `Command` generates no order — `DefaultStrategy` opens no position — so the MockExchange
+/// price-less-market-order panic cannot fire.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn backtest_non_standard_split_seam_carries_corporate_action_and_close_command() {
+    let aux = AuxEventsInMemory::new(Arc::new(vec![
+        // 3:2 fractional forward ⇒ non-standard (the wrapper must migrate the option identity).
+        split_event("2025-03-24T22:30:00Z", dec!(1.5)),
+        // The wrapper flattens the old identity right after the split.
+        close_command_event("2025-03-24T22:31:00Z", 0),
+    ]));
+
+    let summary = backtest(
+        args_constant_with_market_data(aux, market_events_two_identity()),
+        args_dynamic("non-standard-identity-change"),
+    )
+    .await
+    .expect("backtest carrying a CorporateAction + a flatten Command must complete");
+
+    assert_eq!(summary.id, "non-standard-identity-change");
 }

--- a/rustrade/tests/test_backtest_aux_events.rs
+++ b/rustrade/tests/test_backtest_aux_events.rs
@@ -50,7 +50,9 @@ use rustrade_data::{
     subscription::trade::PublicTrade,
 };
 use rustrade_instrument::{
-    corporate_action::CorporateActionKind, exchange::ExchangeId, index::IndexedInstruments,
+    corporate_action::{CorporateActionKind, SplitRatio},
+    exchange::ExchangeId,
+    index::IndexedInstruments,
     instrument::InstrumentIndex,
 };
 use rustrade_integration::collection::one_or_many::OneOrMany;
@@ -174,7 +176,9 @@ fn split_event(effective: &str, ratio: Decimal) -> Timed<EngineEvent> {
         EngineEvent::CorporateAction {
             id: "btcusdt-2025-03-24-split".into(),
             instrument: InstrumentIndex::new(0),
-            kind: CorporateActionKind::StockSplit { ratio },
+            kind: CorporateActionKind::StockSplit {
+                ratio: SplitRatio::new(ratio).unwrap(),
+            },
             policy: SplitRoundingPolicy::Fractional,
             effective_time: ts(effective),
         },

--- a/rustrade/tests/test_backtest_aux_events.rs
+++ b/rustrade/tests/test_backtest_aux_events.rs
@@ -9,8 +9,14 @@
 //! tie-break / clock-seed logic itself is unit-tested in `backtest::tests`.
 //!
 //! Deep audit-replica + post-split position parity is covered separately via the direct
-//! `process_with_audit` path (it cannot run through `backtest`, which hardcodes
-//! `AuditMode::Disabled`).
+//! `Engine::process_with_audit` path, which `backtest` cannot reach (it hardcodes
+//! `AuditMode::Disabled`, so per-event outputs and final engine state are not observable here). The
+//! value-bearing assertions on post-split `quantity_abs` / `price_entry_average` / `SplitRemainder`
+//! live in `test_engine_process_engine_event_with_audit.rs` —
+//! `test_corporate_action_replica_parity_floor_split` and
+//! `test_corporate_action_injected_mid_stream_clock_and_outputs`. The two files form **one**
+//! contract: this file proves an aux event traverses the `backtest` async/merge/clock-seed path;
+//! that file proves the engine applies the split correctly.
 
 use std::{fs::File, io::BufReader, sync::Arc};
 
@@ -178,6 +184,13 @@ fn split_event(effective: &str, ratio: Decimal) -> Timed<EngineEvent> {
 
 /// A `CorporateAction` injected mid-stream flows through the merge + engine and the backtest
 /// completes (full plumbing: threading, merge, clock seed, `stream::iter`, shutdown).
+///
+/// Plumbing-only by necessity: a mid-stream split is notional-preserving and the position stays
+/// open, so it leaves no trace in the summary-level `trading_summary` (unlike the
+/// before-first-tick case, whose clock seed IS summary-observable — see
+/// `backtest_runs_with_aux_event_before_first_market_event`). The post-split quantity/basis
+/// economics for this exact mid-stream scenario are asserted at the engine seam in
+/// `test_corporate_action_injected_mid_stream_clock_and_outputs`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn backtest_runs_with_corporate_action_injected_mid_stream() {
     let aux = AuxEventsInMemory::new(Arc::new(vec![split_event("2025-03-24T22:30:00Z", dec!(2))]));
@@ -217,6 +230,18 @@ async fn backtest_runs_with_aux_event_before_first_market_event() {
         .expect("backtest with an aux event before the first market tick must complete");
 
     assert_eq!(summary.id, "early-split");
+
+    // Value-bearing seam check (not just "it ran"): the 21:45 aux event is BEFORE the first market
+    // tick (22:00), so it can only influence the engine's start time if the aux source was actually
+    // drained and merged. The clock seeds from `min(first_market, first_aux)`, freezing
+    // `time_engine_start` into [21:45, 22:00); a swallowed aux event would leave it at ~22:00. Exact
+    // equality is avoided because `HistoricalClock::time()` adds a sub-ms wall-clock delta when
+    // `meta.time_start` is captured at `Engine::new` — the 15-minute bracket absorbs that jitter.
+    let start = summary.trading_summary.time_engine_start;
+    assert!(
+        start >= ts("2025-03-24T21:45:00Z") && start < ts("2025-03-24T22:00:00Z"),
+        "clock must seed from the 21:45 aux event, before the 22:00 first market tick; got {start}"
+    );
 }
 
 /// The aux source threads through the concurrent `run_backtests` sweep unchanged.

--- a/rustrade/tests/test_backtest_aux_events.rs
+++ b/rustrade/tests/test_backtest_aux_events.rs
@@ -1,0 +1,208 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics acceptable
+
+//! Integration coverage for the backtest auxiliary-event injection seam.
+//!
+//! These tests exercise the *plumbing* end-to-end through the public [`backtest`] /
+//! [`run_backtests`] API: an [`EngineEvent::CorporateAction`] (and an
+//! [`EngineEvent::ContractExpiry`]) supplied via [`AuxEventsInMemory`] is merged with the market
+//! stream, flows through the engine, and the backtest runs to completion. The merge ordering /
+//! tie-break / clock-seed logic itself is unit-tested in `backtest::tests`.
+//!
+//! Deep audit-replica + post-split position parity is covered separately via the direct
+//! `process_with_audit` path (it cannot run through `backtest`, which hardcodes
+//! `AuditMode::Disabled`).
+
+use std::{fs::File, io::BufReader, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use rustrade::{
+    EngineEvent, SplitRoundingPolicy, Timed,
+    backtest::{
+        BacktestArgsConstant, BacktestArgsDynamic, aux_events::AuxEventsInMemory, backtest,
+        market_data::MarketDataInMemory, run_backtests,
+    },
+    engine::state::{
+        EngineState, builder::EngineStateBuilder, global::DefaultGlobalData,
+        instrument::data::DefaultInstrumentMarketData, trading::TradingState,
+    },
+    risk::DefaultRiskManager,
+    statistic::time::Daily,
+    strategy::DefaultStrategy,
+    system::config::SystemConfig,
+};
+use rustrade_data::{
+    event::{DataKind, MarketEvent},
+    streams::consumer::MarketStreamEvent,
+    subscription::trade::PublicTrade,
+};
+use rustrade_instrument::{
+    corporate_action::CorporateActionKind, exchange::ExchangeId, index::IndexedInstruments,
+    instrument::InstrumentIndex,
+};
+use serde::Deserialize;
+
+const CONFIG_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/config/backtest_config.json"
+);
+
+type AuxBacktestState = EngineState<DefaultGlobalData, DefaultInstrumentMarketData>;
+type DefaultAuxEvents = AuxEventsInMemory;
+
+#[derive(Deserialize)]
+struct Config {
+    // `risk_free_return` is also present in the JSON but unused here; serde ignores it.
+    system: SystemConfig,
+}
+
+fn load_config() -> Config {
+    let reader = BufReader::new(File::open(CONFIG_PATH).expect("backtest_config.json must exist"));
+    serde_json::from_reader(reader).expect("backtest_config.json must deserialize")
+}
+
+fn ts(raw: &str) -> DateTime<Utc> {
+    raw.parse().unwrap()
+}
+
+/// A single trade `MarketEvent` for BTCUSDT (instrument index 0).
+fn trade(time: &str, price: Decimal) -> MarketStreamEvent<InstrumentIndex, DataKind> {
+    let time = ts(time);
+    MarketStreamEvent::Item(MarketEvent {
+        time_exchange: time,
+        time_received: time,
+        exchange: ExchangeId::BinanceSpot,
+        instrument: InstrumentIndex::new(0),
+        kind: DataKind::Trade(PublicTrade {
+            id: "trade".into(),
+            price,
+            amount: dec!(0.01),
+            side: None,
+        }),
+    })
+}
+
+/// Four BTCUSDT trades spanning 22:00–23:00; any aux event in that window interleaves mid-stream.
+fn market_events() -> Vec<MarketStreamEvent<InstrumentIndex, DataKind>> {
+    vec![
+        trade("2025-03-24T22:00:00Z", dec!(60_000)),
+        trade("2025-03-24T22:15:00Z", dec!(60_100)),
+        trade("2025-03-24T22:45:00Z", dec!(60_200)),
+        trade("2025-03-24T23:00:00Z", dec!(60_300)),
+    ]
+}
+
+fn args_constant(
+    aux_events: DefaultAuxEvents,
+) -> Arc<
+    BacktestArgsConstant<MarketDataInMemory<DataKind>, Daily, AuxBacktestState, DefaultAuxEvents>,
+> {
+    let Config {
+        system: SystemConfig {
+            instruments,
+            executions,
+        },
+    } = load_config();
+
+    let instruments = IndexedInstruments::new(instruments);
+    let market_data = MarketDataInMemory::new(Arc::new(market_events()));
+
+    let engine_state = EngineStateBuilder::new(&instruments, DefaultGlobalData, |_| {
+        DefaultInstrumentMarketData::default()
+    })
+    .time_engine_start(ts("2025-03-24T22:00:00Z"))
+    .trading_state(TradingState::Enabled)
+    .build();
+
+    Arc::new(BacktestArgsConstant {
+        instruments,
+        executions,
+        market_data,
+        summary_interval: Daily,
+        engine_state,
+        aux_events,
+    })
+}
+
+fn args_dynamic(
+    id: &str,
+) -> BacktestArgsDynamic<DefaultStrategy<AuxBacktestState>, DefaultRiskManager<AuxBacktestState>> {
+    BacktestArgsDynamic {
+        id: id.into(),
+        risk_free_return: dec!(0.05),
+        strategy: DefaultStrategy::default(),
+        risk: DefaultRiskManager::default(),
+    }
+}
+
+fn split_event(effective: &str, ratio: Decimal) -> Timed<EngineEvent> {
+    Timed::new(
+        EngineEvent::CorporateAction {
+            id: "btcusdt-2025-03-24-split".into(),
+            instrument: InstrumentIndex::new(0),
+            kind: CorporateActionKind::StockSplit { ratio },
+            policy: SplitRoundingPolicy::Fractional,
+            effective_time: ts(effective),
+        },
+        ts(effective),
+    )
+}
+
+/// A `CorporateAction` injected mid-stream flows through the merge + engine and the backtest
+/// completes (full plumbing: threading, merge, clock seed, `stream::iter`, shutdown).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn backtest_runs_with_corporate_action_injected_mid_stream() {
+    let aux = AuxEventsInMemory::new(Arc::new(vec![split_event("2025-03-24T22:30:00Z", dec!(2))]));
+
+    let summary = backtest(args_constant(aux), args_dynamic("with-split"))
+        .await
+        .expect("backtest with an injected split must complete");
+
+    assert_eq!(summary.id, "with-split");
+}
+
+/// A `ContractExpiry` injected mid-stream is now backtest-testable for the first time — assert the
+/// run completes (the aux seam delivers a non-split, non-market `EngineEvent`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn backtest_runs_with_contract_expiry_injected_mid_stream() {
+    let expiry = Timed::new(
+        EngineEvent::ContractExpiry(InstrumentIndex::new(0)),
+        ts("2025-03-24T22:30:00Z"),
+    );
+    let aux = AuxEventsInMemory::new(Arc::new(vec![expiry]));
+
+    let summary = backtest(args_constant(aux), args_dynamic("with-expiry"))
+        .await
+        .expect("backtest with an injected contract expiry must complete");
+
+    assert_eq!(summary.id, "with-expiry");
+}
+
+/// An aux event scheduled *before* the first market tick still drives a complete run (the clock is
+/// seeded from `min(first_market_event, first_aux_event)`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn backtest_runs_with_aux_event_before_first_market_event() {
+    let aux = AuxEventsInMemory::new(Arc::new(vec![split_event("2025-03-24T21:45:00Z", dec!(2))]));
+
+    let summary = backtest(args_constant(aux), args_dynamic("early-split"))
+        .await
+        .expect("backtest with an aux event before the first market tick must complete");
+
+    assert_eq!(summary.id, "early-split");
+}
+
+/// The aux source threads through the concurrent `run_backtests` sweep unchanged.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn run_backtests_sweep_threads_aux_events() {
+    let aux = AuxEventsInMemory::new(Arc::new(vec![split_event("2025-03-24T22:30:00Z", dec!(2))]));
+
+    let summaries = run_backtests(
+        args_constant(aux),
+        [args_dynamic("sweep-a"), args_dynamic("sweep-b")],
+    )
+    .await
+    .expect("run_backtests sweep with injected splits must complete");
+
+    assert_eq!(summaries.summaries.len(), 2);
+}

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -1762,6 +1762,119 @@ fn test_corporate_action_replica_parity_unsupported_non_spot() {
     assert!(replica_instrument.corporate_actions_processed.is_empty());
 }
 
+/// End-to-end: a `CorporateAction` injected **mid-stream** through the audit path — the engine-level
+/// behaviour of the backtest aux-injection seam, asserting what the `backtest()` smoke tests cannot.
+///
+/// `backtest()` hardcodes `AuditMode::Disabled`, so it produces no output/audit stream; the
+/// post-split position, the `SplitRemainder` observable, and the **exact clock stamp** (Option A:
+/// the `HistoricalClock` advances to `effective_time` on the event) are asserted here by driving a
+/// pre-merged, time-ordered event sequence through `process_with_audit`. Ordering is exercised by a
+/// market event *after* the split that must see the post-split position scale.
+#[test]
+fn test_corporate_action_injected_mid_stream_clock_and_outputs() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // Pre-split market context: a trade at t+1 sets the instrument's last (mark) price to 105 — the
+    // source `apply_split` reads for the eager pnl_unrealised recompute, deliberately distinct from
+    // the position's fill basis (100 below) so the pnl assertion pins the mark-price source (not the
+    // entry price reused as the mark) — and advances the clock to t+1.
+    engine.process(market_event_trade(1, 0, dec!(105)));
+
+    // One long position of 101 @ 100 on Spot instrument 0.
+    open_position_via_trade(&mut engine, 0, 2, Side::Buy, dec!(100), dec!(101), "pos");
+
+    // The split, time-ordered after the t+1 market event and before the t+11 one below — exactly
+    // where the backtest seam's merge interleaves it. 1:2 reverse, Floor: floor(101*0.5)=50 survives
+    // with a 0.5 fractional sliver disposed.
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSDT-reverse-1-2".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+
+    // Clock stamp (Option A): the `HistoricalClock` advanced to effective_time on the split. Its
+    // `time()` derives from `time_exchange_last + (now − last_event_live_time)`, so it reads
+    // effective_time plus only the sub-second test-execution delta — proving the split advanced the
+    // clock to its own instant (not the prior market event's t+1, and not beyond), the no-look-ahead
+    // guarantee. An exact `==` is impossible by construction (the wall-clock term is nondeterministic,
+    // the same drift the audit-replica parity tests output-mirror around); a tight bound is the
+    // honest assertion. `context.time` is captured the same way during `audit()`.
+    let drift = engine.time().signed_duration_since(effective_time);
+    assert!(
+        drift >= TimeDelta::zero() && drift < TimeDelta::seconds(1),
+        "clock advanced to ~effective_time (drift {drift})"
+    );
+
+    // The SplitRemainder observable is emitted with post-split-era fields (Convention A).
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    let remainder = outputs
+        .iter()
+        .find_map(|o| match o {
+            EngineOutput::SplitRemainder {
+                instrument,
+                side,
+                quantity_fractional_disposed,
+                price_entry_average_post_split,
+                ..
+            } => Some((
+                *instrument,
+                *side,
+                *quantity_fractional_disposed,
+                *price_entry_average_post_split,
+            )),
+            _ => None,
+        })
+        .expect("a SplitRemainder output must be emitted for the floored fractional sliver");
+    assert_eq!(remainder.0, InstrumentIndex(0));
+    assert_eq!(remainder.1, Side::Buy);
+    assert_eq!(remainder.2, dec!(0.5)); // floor(50.5) disposes 0.5 (post-split units)
+    assert_eq!(remainder.3, dec!(200)); // post-split basis = old_avg / ratio = 100 / 0.5
+
+    // Post-split position: qty floored to 50, avg 200, max 50.5 (unfloored even under Floor),
+    // pnl_unrealised recomputed from the last (mark) price 105 = (105 - 200) * 50 = -4750.
+    let instrument_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    assert_eq!(instrument_state.position.positions.len(), 1);
+    let position = instrument_state.position.positions.values().next().unwrap();
+    assert_eq!(position.quantity_abs, dec!(50));
+    assert_eq!(position.price_entry_average, dec!(200));
+    assert_eq!(position.quantity_abs_max, dec!(50.5));
+    assert_eq!(position.pnl_unrealised, dec!(-4750));
+    assert!(
+        instrument_state
+            .corporate_actions_processed
+            .contains("BTCUSDT-reverse-1-2")
+    );
+
+    // The split read the last price the t+1 market event set (105) for its eager pnl recompute
+    // (-4750 above), proving that earlier market event was processed *before* the split. A market
+    // event AFTER the split (t+11) is then processed in order and updates the instrument's last
+    // price — confirming the split landed mid-stream, between the two. (Position `pnl_unrealised` is
+    // deliberately *not* re-checked here: the engine's market path updates instrument data but does
+    // not re-walk open positions each tick — the very reason `apply_split` recomputes pnl eagerly.)
+    let instrument_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    assert_eq!(instrument_state.data.price(), Some(dec!(105)));
+    engine.process(market_event_trade(11, 0, dec!(90)));
+    let instrument_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    assert_eq!(instrument_state.data.price(), Some(dec!(90)));
+}
+
 // ---------------------------------------------------------------------------
 // T1: ITM Put option expiry
 // ---------------------------------------------------------------------------

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -1195,6 +1195,14 @@ fn build_option_engine(
     trading_state: TradingState,
     execution_tx: UnboundedTx<ExecutionRequest>,
 ) -> TestEngine {
+    build_option_engine_with_oms(trading_state, execution_tx, OmsMode::Netting)
+}
+
+fn build_option_engine_with_oms(
+    trading_state: TradingState,
+    execution_tx: UnboundedTx<ExecutionRequest>,
+    oms_mode: OmsMode,
+) -> TestEngine {
     let expiry = chrono::DateTime::parse_from_rfc3339("2030-01-01T00:00:00Z")
         .unwrap()
         .with_timezone(&Utc);
@@ -1234,6 +1242,7 @@ fn build_option_engine(
     })
     .time_engine_start(STARTING_TIMESTAMP)
     .trading_state(trading_state)
+    .oms_mode(oms_mode)
     .balances([
         (ExchangeId::BinanceSpot, "usd", STARTING_BALANCE_USDT),
         (ExchangeId::BinanceSpot, "btc", STARTING_BALANCE_BTC),
@@ -1873,6 +1882,734 @@ fn test_corporate_action_injected_mid_stream_clock_and_outputs() {
         .instruments
         .instrument_index(&InstrumentIndex(0));
     assert_eq!(instrument_state.data.price(), Some(dec!(90)));
+}
+
+// ---------------------------------------------------------------------------
+// CorporateAction — option standard / non-standard split handling
+// ---------------------------------------------------------------------------
+
+/// Open a long option position (index 0) via a tagged account `Trade`, so that distinct `tag`s
+/// create distinct Hedging slots (the slot is keyed by `order_id`). Mirrors
+/// [`open_position_via_trade`] but uses the option engine's USD quote asset (`AssetIndex(1)`) for
+/// fees — `asset_fees`/`quote_asset_index` map the *spot* engine's instruments only.
+fn open_option_position_via_trade(
+    engine: &mut TestEngine,
+    time_plus: u64,
+    side: Side,
+    price: Decimal,
+    quantity: Decimal,
+    tag: &str,
+) {
+    let event = EngineEvent::Account(AccountStreamEvent::Item(AccountEvent {
+        exchange: ExchangeIndex(0),
+        kind: AccountEventKind::Trade(Trade {
+            id: TradeId::new(tag),
+            order_id: OrderId::new(tag),
+            instrument: InstrumentIndex(0),
+            strategy: strategy_id(),
+            time_exchange: time_plus_days(STARTING_TIMESTAMP, time_plus),
+            side,
+            price,
+            quantity,
+            fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
+        }),
+    }));
+    engine.process(event);
+}
+
+/// Standard (whole-number forward) split on the underlying equity adjusts an option position on
+/// that underlying **in place**: strike ÷ ratio, contracts × ratio, premium basis ÷ ratio, and
+/// `pnl_unrealised` recomputed from the **option's own** mark — `contract_size` (the multiplier)
+/// stays unchanged. One `OptionPositionAdjustedForSplit` per position, plus an `OpenOrdersAtSplit`
+/// for the option's own resting orders; no `SplitRemainder` (integer ratio × integer contracts).
+/// The equity `id` is recorded on the `Spot` target.
+#[test]
+fn test_corporate_action_option_standard_split_adjusts_in_place() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // Distinct marks: the option (idx0) at 1200, the spot (idx1) at 60_000. The split must use the
+    // OPTION's mark for the pnl recompute — distinct values pin that the option's price is read,
+    // not the splitting equity's.
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+
+    // Long call: 2 contracts @ premium 1000.
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+    // A resting order on the OPTION (idx0) — must be surfaced via OpenOrdersAtSplit (Q1).
+    let event = account_event_order_response(0, 1, Side::Buy, 1.0, 0.0);
+    engine.process(event);
+
+    // 2:1 standard forward split, targeting the Spot underlying (idx1).
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+
+    // Option (idx0) adjusted in place: strike halved, multiplier (contract_size) untouched.
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(25_000));
+    assert_eq!(contract.contract_size, dec!(1));
+
+    // Position: contracts ×2 = 4, premium basis ÷2 = 500, pnl recomputed from the OPTION mark 1200:
+    // 4 * (1200 - 500) * contract_size(1) = 2800.
+    assert_eq!(option_state.position.positions.len(), 1);
+    let position = option_state.position.positions.values().next().unwrap();
+    assert_eq!(position.quantity_abs, dec!(4));
+    assert_eq!(position.price_entry_average, dec!(500));
+    assert_eq!(position.pnl_unrealised, dec!(2_800));
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // Exactly one OptionPositionAdjustedForSplit, carrying the expected per-position fields.
+    let adjusted: Vec<_> = outputs
+        .iter()
+        .filter_map(|o| match o {
+            EngineOutput::OptionPositionAdjustedForSplit {
+                option_instrument,
+                ratio,
+                strike_pre_split,
+                strike_post_split,
+                position_id,
+            } => Some((
+                *option_instrument,
+                *ratio,
+                *strike_pre_split,
+                *strike_post_split,
+                position_id.clone(),
+            )),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(adjusted.len(), 1);
+    assert_eq!(adjusted[0].0, InstrumentIndex(0));
+    assert_eq!(adjusted[0].1, dec!(2));
+    assert_eq!(adjusted[0].2, dec!(50_000));
+    assert_eq!(adjusted[0].3, dec!(25_000));
+    assert_eq!(adjusted[0].4, PositionId::NETTING);
+
+    // The option's resting order is surfaced (Q1) — OpenOrdersAtSplit for idx0.
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::OpenOrdersAtSplit { instrument, .. } if *instrument == InstrumentIndex(0)
+        )),
+        "expected OpenOrdersAtSplit for the option's resting order"
+    );
+
+    // No CIL on a standard option adjustment (integer ratio × integer contracts).
+    assert!(
+        !outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::SplitRemainder { .. })),
+        "a standard option split must not produce a SplitRemainder"
+    );
+
+    // The equity split was applied + recorded on the Spot target (idx1).
+    let spot_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(1));
+    assert!(
+        spot_state
+            .corporate_actions_processed
+            .contains("BTCUSD-2-1-split")
+    );
+}
+
+/// Standard split on an option with **no resting orders**: the `if !option_orders.is_empty()`
+/// suppression on the option path must withhold `OpenOrdersAtSplit` for that option, while the
+/// in-place `OptionPositionAdjustedForSplit` is still emitted. Pins that the empty-orders guard
+/// gates *only* the order observable, never the position adjustment — deleting the guard, or
+/// letting it suppress the adjustment too, both fail here.
+#[test]
+fn test_corporate_action_option_standard_split_no_orders_suppresses_open_orders_at_split() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // Marks for the option (idx0) and the splitting spot underlying (idx1).
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+
+    // Open a long option position but place NO resting order on it (the case the guard suppresses).
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+    // 2:1 standard forward split on the Spot underlying (idx1).
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // No resting orders ⇒ the suppression guard withholds OpenOrdersAtSplit for the option.
+    assert!(
+        !outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::OpenOrdersAtSplit { instrument, .. } if *instrument == InstrumentIndex(0)
+        )),
+        "an option with no resting orders must not emit OpenOrdersAtSplit"
+    );
+
+    // Load-bearing: the guard gates ONLY the order observable — the in-place adjustment is still
+    // emitted for the option position even when there are no resting orders.
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::OptionPositionAdjustedForSplit { option_instrument, .. }
+                if *option_instrument == InstrumentIndex(0)
+        )),
+        "the option position must still be adjusted in place even with no resting orders"
+    );
+}
+
+/// Hedging: a standard split emits one `OptionPositionAdjustedForSplit` **per option position**
+/// (per-`position_id` granularity, like `SplitRemainder`), each carrying the same instrument-level
+/// strike change.
+#[test]
+fn test_corporate_action_option_standard_split_hedging_per_position() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine =
+        build_option_engine_with_oms(TradingState::Disabled, execution_tx, OmsMode::Hedging);
+
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+
+    // Two independent option positions — distinct Hedging slots keyed by order_id/tag.
+    open_option_position_via_trade(&mut engine, 1, Side::Buy, dec!(1_000), dec!(2), "opt-a");
+    open_option_position_via_trade(&mut engine, 1, Side::Buy, dec!(1_000), dec!(3), "opt-b");
+
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    let adjusted: Vec<_> = outputs
+        .iter()
+        .filter_map(|o| match o {
+            EngineOutput::OptionPositionAdjustedForSplit {
+                option_instrument,
+                strike_pre_split,
+                strike_post_split,
+                position_id,
+                ..
+            } => Some((
+                *option_instrument,
+                *strike_pre_split,
+                *strike_post_split,
+                position_id.clone(),
+            )),
+            _ => None,
+        })
+        .collect();
+
+    // One record per position (two positions ⇒ two records), each with the same strike change.
+    assert_eq!(adjusted.len(), 2);
+    for (instrument, strike_pre, strike_post, _pos_id) in &adjusted {
+        assert_eq!(*instrument, InstrumentIndex(0));
+        assert_eq!(*strike_pre, dec!(50_000));
+        assert_eq!(*strike_post, dec!(25_000));
+    }
+    // Distinct per-position attribution (Hedging slot id == the order/trade tag).
+    let ids: Vec<_> = adjusted.iter().map(|a| a.3.clone()).collect();
+    assert!(ids.contains(&PositionId::new("opt-a")));
+    assert!(ids.contains(&PositionId::new("opt-b")));
+}
+
+/// Non-standard splits — every fractional forward (3:2) and every reverse split (1:2) — cannot
+/// adjust an option in place (the OCC assigns a new contract identity). The option is left
+/// **unchanged** and a single `OptionPositionsRequireIdentityChange` is emitted; the equity split
+/// is still applied and its `id` recorded.
+#[test]
+fn test_corporate_action_option_non_standard_requires_identity_change() {
+    for (ratio, id) in [
+        (dec!(1.5), "BTCUSD-3-2-split"),   // fractional forward (3:2)
+        (dec!(0.5), "BTCUSD-1-2-reverse"), // reverse (1:2)
+    ] {
+        let (execution_tx, _execution_rx) = mpsc_unbounded();
+        let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
+
+        engine.process(market_event_trade(1, 0, dec!(1200)));
+        open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+        let ca_event = EngineEvent::CorporateAction {
+            id: id.into(),
+            instrument: InstrumentIndex(1),
+            kind: CorporateActionKind::StockSplit { ratio },
+            policy: SplitRoundingPolicy::Floor,
+            effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+        };
+        let audit_tick = process_with_audit(&mut engine, ca_event);
+
+        // Option (idx0) UNCHANGED: strike, qty, and basis all at pre-split terms.
+        let option_state = engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(0));
+        let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+            panic!("instrument 0 must be an option");
+        };
+        assert_eq!(
+            contract.strike,
+            dec!(50_000),
+            "ratio {ratio}: option strike must be untouched"
+        );
+        let position = option_state.position.positions.values().next().unwrap();
+        assert_eq!(position.quantity_abs, dec!(2), "ratio {ratio}");
+        assert_eq!(position.price_entry_average, dec!(1_000), "ratio {ratio}");
+
+        let outputs = match &audit_tick.event {
+            EngineAudit::Process(audit) => &audit.outputs,
+            _ => panic!("expected EngineAudit::Process"),
+        };
+
+        // Exactly one identity-change signal listing the option.
+        let signals: Vec<_> = outputs
+            .iter()
+            .filter_map(|o| match o {
+                EngineOutput::OptionPositionsRequireIdentityChange {
+                    split_instrument,
+                    ratio: r,
+                    affected_options,
+                } => Some((*split_instrument, *r, affected_options.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(signals.len(), 1, "ratio {ratio}");
+        assert_eq!(signals[0].0, InstrumentIndex(1));
+        assert_eq!(signals[0].1, ratio);
+        assert!(
+            signals[0].2.contains(&InstrumentIndex(0)),
+            "ratio {ratio}: affected_options must list the option"
+        );
+
+        // No in-place option adjustment occurred.
+        assert!(
+            !outputs
+                .iter()
+                .any(|o| matches!(o, EngineOutput::OptionPositionAdjustedForSplit { .. })),
+            "ratio {ratio}: must not adjust the option in place"
+        );
+
+        // The equity split is still applied + recorded (the Spot target always splits).
+        let spot_state = engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(1));
+        assert!(
+            spot_state.corporate_actions_processed.contains(id),
+            "ratio {ratio}: equity id must be recorded"
+        );
+    }
+}
+
+/// Live engine vs audit-replica parity for a **standard** option adjustment: the replica
+/// event-replays the in-place strike division + per-position `apply_split` deterministically (no
+/// output-mirror). Full `InstrumentState` equality for BOTH the option (idx0) and the spot (idx1)
+/// guards against the handler and the replica drifting apart on the option path.
+#[test]
+fn test_corporate_action_option_replica_parity_standard_split() {
+    use rustrade::engine::audit::{
+        AuditTick, EngineAudit, context::EngineContext, state_replica::StateReplicaManager,
+    };
+
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // Option mark (idx0) for the eager pnl recompute; spot mark (idx1) deliberately different.
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+    // Seed the replica from the exact pre-split state.
+    let pre_split_state = engine.state.clone();
+
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event.clone());
+
+    let seed_tick: AuditTick<_, EngineContext> = AuditTick {
+        event: pre_split_state,
+        context: EngineContext {
+            time: effective_time,
+            sequence: Sequence(0),
+        },
+    };
+    // Type annotation required for StateReplicaManager::new to infer the iterator element type
+    #[allow(clippy::type_complexity)]
+    let dummy_updates: std::iter::Empty<
+        AuditTick<
+            EngineAudit<
+                EngineEvent<DataKind>,
+                EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
+            >,
+        >,
+    > = std::iter::empty();
+    let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
+
+    // Drive the replica with the live outputs. The standard option adjustment is pure event-replay
+    // (it ignores the outputs), but pass them through to exercise the real run() contract faithfully.
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    replica_manager.update_from_event(ca_event, &outputs);
+
+    // Gold-standard: full InstrumentState parity for BOTH the adjusted option (idx0) and the split
+    // equity (idx1) — positions, instrument kind (strike), tear sheet, processed-id set, …
+    for idx in [InstrumentIndex(0), InstrumentIndex(1)] {
+        let live = engine.state.instruments.instrument_index(&idx);
+        let replica = replica_manager
+            .replica_engine_state()
+            .instruments
+            .instrument_index(&idx);
+        assert_eq!(replica, live, "replica/live divergence at {idx:?}");
+    }
+
+    // Explicit checks that the LIVE handler actually adjusted the option — so the parity assert
+    // above is not vacuously comparing two unchanged states.
+    let option_live = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_live.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(25_000));
+    let position = option_live.position.positions.values().next().unwrap();
+    assert_eq!(position.quantity_abs, dec!(4));
+    assert_eq!(position.price_entry_average, dec!(500));
+}
+
+/// Build an engine with TWO BTC/USD call options on the same underlying plus the BTC/USD spot, for
+/// the non-standard-split wrapper-handling flow. The "old" option is the one held at split time; the
+/// "new" identity is **pre-declared at construction** (never runtime-registered) and only trades
+/// after the wrapper migrates exposure to it.
+///
+/// Indices after the alphabetical `name_internal` sort:
+///   InstrumentIndex(0) = old option   ("binance_btc_call_50k")
+///   InstrumentIndex(1) = new identity  ("binance_btc_call_50k_new")
+///   InstrumentIndex(2) = spot          ("binance_spot_btc_usd")
+fn build_two_option_engine(
+    trading_state: TradingState,
+    execution_tx: UnboundedTx<ExecutionRequest>,
+) -> TestEngine {
+    let expiry = chrono::DateTime::parse_from_rfc3339("2030-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let instruments = IndexedInstruments::builder()
+        // index 0: old option — the identity held across the split.
+        .add_instrument(Instrument::new(
+            ExchangeId::BinanceSpot,
+            "binance_btc_call_50k",
+            "BTC-50000-C",
+            Underlying::new("btc", "usd"),
+            rustrade_instrument::instrument::quote::InstrumentQuoteAsset::UnderlyingQuote,
+            InstrumentKind::Option(OptionContract {
+                contract_size: dec!(1),
+                settlement_asset: "usd".into(),
+                kind: OptionKind::Call,
+                exercise: OptionExercise::European,
+                expiry,
+                strike: dec!(50_000),
+            }),
+            None,
+        ))
+        // index 1: pre-declared new identity (distinct OCC contract after a non-standard split).
+        .add_instrument(Instrument::new(
+            ExchangeId::BinanceSpot,
+            "binance_btc_call_50k_new",
+            "BTC1-33333-C",
+            Underlying::new("btc", "usd"),
+            rustrade_instrument::instrument::quote::InstrumentQuoteAsset::UnderlyingQuote,
+            InstrumentKind::Option(OptionContract {
+                contract_size: dec!(1),
+                settlement_asset: "usd".into(),
+                kind: OptionKind::Call,
+                exercise: OptionExercise::European,
+                expiry,
+                strike: dec!(33_333),
+            }),
+            None,
+        ))
+        // index 2: spot underlying — the CorporateAction target.
+        .add_instrument(Instrument::spot(
+            ExchangeId::BinanceSpot,
+            "binance_spot_btc_usd",
+            "BTCUSD",
+            Underlying::new("btc", "usd"),
+            None,
+        ))
+        .build();
+
+    let clock = HistoricalClock::new(STARTING_TIMESTAMP);
+    let state = EngineState::builder(&instruments, DefaultGlobalData, |_| {
+        DefaultInstrumentMarketData::default()
+    })
+    .time_engine_start(STARTING_TIMESTAMP)
+    .trading_state(trading_state)
+    .balances([
+        (ExchangeId::BinanceSpot, "usd", STARTING_BALANCE_USDT),
+        (ExchangeId::BinanceSpot, "btc", STARTING_BALANCE_BTC),
+    ])
+    .build();
+
+    Engine::new(
+        clock,
+        state,
+        MultiExchangeTxMap::from_iter([(ExchangeId::BinanceSpot, Some(execution_tx))]),
+        TestBuyAndHoldStrategy { id: strategy_id() },
+        DefaultRiskManager::default(),
+    )
+}
+
+/// Build an option-engine Account `Trade` for an arbitrary instrument index, with USD-quote
+/// (`AssetIndex(1)`) zero fees. Returned (not processed) so the caller can `engine.process` an open
+/// or route a close fill through `process_with_audit` when the resulting `PositionExit` matters.
+fn option_trade_event(
+    instrument: usize,
+    time_plus: u64,
+    side: Side,
+    price: Decimal,
+    quantity: Decimal,
+    tag: &str,
+) -> EngineEvent<DataKind> {
+    EngineEvent::Account(AccountStreamEvent::Item(AccountEvent {
+        exchange: ExchangeIndex(0),
+        kind: AccountEventKind::Trade(Trade {
+            id: TradeId::new(tag),
+            order_id: OrderId::new(tag),
+            instrument: InstrumentIndex(instrument),
+            strategy: strategy_id(),
+            time_exchange: time_plus_days(STARTING_TIMESTAMP, time_plus),
+            side,
+            price,
+            quantity,
+            fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
+        }),
+    }))
+}
+
+/// End-to-end proof that a downstream wrapper can handle a **non-standard** split's option-identity
+/// change with existing primitives only — no runtime instrument re-registration. Both the old option
+/// and the new identity are pre-declared at construction; the engine emits the signal, the wrapper
+/// closes the old option via the normal `Command` path, and trades the pre-declared new identity on
+/// its post-split data.
+///
+/// NOTE: the close trigger here is *pre-planned* (the test injects the `Command` directly), not
+/// *reactive-from-output* — the reactive decision logic lives in the wrapper and is unit-tested
+/// there. This direct `process_with_audit` path is the only one where the observable is visible
+/// (`backtest()` hardcodes `AuditMode::Disabled`); the backtest counterpart asserts plumbing only.
+#[test]
+fn test_corporate_action_option_non_standard_wrapper_close_and_new_identity() {
+    let (execution_tx, mut execution_rx) = mpsc_unbounded();
+    let mut engine = build_two_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // Hold the OLD option (idx0): long 2 contracts @ premium 1000. The NEW identity (idx1) holds
+    // nothing at split time.
+    engine.process(option_trade_event(
+        0,
+        1,
+        Side::Buy,
+        dec!(1_000),
+        dec!(2),
+        "old-open",
+    ));
+    // A live mark on the old option — `close_open_positions_with_market_orders` only flattens
+    // instruments with a current price feed (it skips stale/price-less instruments).
+    engine.process(market_event_trade(2, 0, dec!(1_200)));
+
+    // --- Step 1: a NON-STANDARD split on the spot underlying (idx2) signals an identity change. ---
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-3-2-split".into(),
+        instrument: InstrumentIndex(2),
+        // 3:2 fractional forward ⇒ non-standard (the OCC assigns a new contract identity).
+        kind: CorporateActionKind::StockSplit { ratio: dec!(1.5) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // Exactly one identity-change signal, naming the OLD option and NOT the position-less new identity.
+    let signals: Vec<_> = outputs
+        .iter()
+        .filter_map(|o| match o {
+            EngineOutput::OptionPositionsRequireIdentityChange {
+                split_instrument,
+                ratio,
+                affected_options,
+            } => Some((*split_instrument, *ratio, affected_options.clone())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].0, InstrumentIndex(2));
+    assert_eq!(signals[0].1, dec!(1.5));
+    assert!(
+        signals[0].2.contains(&InstrumentIndex(0)),
+        "the held old option must be flagged"
+    );
+    assert!(
+        !signals[0].2.contains(&InstrumentIndex(1)),
+        "the position-less pre-declared new identity must NOT be flagged"
+    );
+
+    // The old option is untouched (the engine cannot mechanically adjust a non-standard split).
+    let old_option = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &old_option.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(50_000));
+    assert_eq!(
+        old_option
+            .position
+            .positions
+            .values()
+            .next()
+            .unwrap()
+            .quantity_abs,
+        dec!(2)
+    );
+
+    // The equity split is applied + id recorded on the Spot target (idx2) regardless.
+    assert!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(2))
+            .corporate_actions_processed
+            .contains("BTCUSD-3-2-split")
+    );
+
+    // --- Step 2: the wrapper closes the OLD option via the normal Command path. ---
+    let audit_tick = process_with_audit(&mut engine, command_close_position(0));
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    // A Commanded(ClosePositions) output fires, carrying a reduce-only Sell order for the old option.
+    let commanded_sell = outputs.iter().any(|o| match o {
+        EngineOutput::Commanded(ActionOutput::ClosePositions(out)) => {
+            out.opens.sent.iter().any(|order| {
+                order.key.instrument == InstrumentIndex(0) && order.state.side == Side::Sell
+            })
+        }
+        _ => false,
+    });
+    assert!(
+        commanded_sell,
+        "expected a Commanded ClosePositions Sell for the old option"
+    );
+    // The close order is actually dispatched to the execution manager.
+    assert!(matches!(
+        execution_rx.next().unwrap(),
+        ExecutionRequest::Open(order)
+            if order.key.instrument == InstrumentIndex(0) && order.state.side == Side::Sell
+    ));
+
+    // Simulate the close fill: a Sell trade of the full quantity nets the old position to zero.
+    let audit_tick = process_with_audit(
+        &mut engine,
+        option_trade_event(0, 11, Side::Sell, dec!(1_500), dec!(2), "old-close"),
+    );
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::PositionExit(p) if p.instrument == InstrumentIndex(0)
+        )),
+        "closing the old option must emit a PositionExit"
+    );
+    assert!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(0))
+            .position
+            .positions
+            .is_empty(),
+        "the old option slot must be empty after the close fill"
+    );
+
+    // --- Step 3: the pre-declared new identity trades on its post-split data. ---
+    // The new identity prints only after the split (natural — it did not exist before).
+    engine.process(market_event_trade(12, 1, dec!(900)));
+    engine.process(option_trade_event(
+        1,
+        13,
+        Side::Buy,
+        dec!(800),
+        dec!(3),
+        "new-open",
+    ));
+
+    assert_eq!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(1))
+            .position
+            .positions
+            .len(),
+        1,
+        "the pre-declared new identity must trade once exposure migrates to it"
+    );
+    // Exposure migrated entirely from the old identity to the new one — no runtime re-registration.
+    assert!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(0))
+            .position
+            .positions
+            .is_empty()
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -61,7 +61,7 @@ use rustrade_execution::{
 use rustrade_instrument::{
     Side, Underlying,
     asset::AssetIndex,
-    corporate_action::CorporateActionKind,
+    corporate_action::{CorporateActionKind, SplitRatio},
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
     instrument::{
@@ -1607,7 +1607,9 @@ fn test_corporate_action_replica_parity_floor_split() {
     let ca_event = EngineEvent::CorporateAction {
         id: "BTCUSDT-reverse-1-2".into(),
         instrument: InstrumentIndex(0),
-        kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(0.5)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time,
     };
@@ -1714,7 +1716,9 @@ fn test_corporate_action_idempotent() {
     let ca_event = EngineEvent::CorporateAction {
         id: "AAPL-2026-split".into(),
         instrument: InstrumentIndex(0),
-        kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(0.5)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time,
     };
@@ -1812,7 +1816,9 @@ fn test_corporate_action_replica_parity_short_reverse_split() {
     let ca_event = EngineEvent::CorporateAction {
         id: "BTCUSDT-reverse-1-2-short".into(),
         instrument: InstrumentIndex(0),
-        kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(0.5)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time,
     };
@@ -1902,7 +1908,9 @@ fn test_corporate_action_replica_parity_unsupported_non_spot() {
     let ca_event = EngineEvent::CorporateAction {
         id: "opt-split".into(),
         instrument: InstrumentIndex(0),
-        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time,
     };
@@ -1989,7 +1997,9 @@ fn test_corporate_action_injected_mid_stream_clock_and_outputs() {
     let ca_event = EngineEvent::CorporateAction {
         id: "BTCUSDT-reverse-1-2".into(),
         instrument: InstrumentIndex(0),
-        kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(0.5)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time,
     };
@@ -2134,7 +2144,9 @@ fn test_corporate_action_option_standard_split_adjusts_in_place() {
     let ca_event = EngineEvent::CorporateAction {
         id: "BTCUSD-2-1-split".into(),
         instrument: InstrumentIndex(1),
-        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
     };
@@ -2176,7 +2188,7 @@ fn test_corporate_action_option_standard_split_adjusts_in_place() {
                 position_id,
             } => Some((
                 *option_instrument,
-                *ratio,
+                ratio.get(),
                 *strike_pre_split,
                 *strike_post_split,
                 position_id.clone(),
@@ -2241,7 +2253,9 @@ fn test_corporate_action_option_standard_split_no_orders_suppresses_open_orders_
     let ca_event = EngineEvent::CorporateAction {
         id: "BTCUSD-2-1-split".into(),
         instrument: InstrumentIndex(1),
-        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
     };
@@ -2291,7 +2305,9 @@ fn test_corporate_action_option_standard_split_hedging_per_position() {
     let ca_event = EngineEvent::CorporateAction {
         id: "BTCUSD-2-1-split".into(),
         instrument: InstrumentIndex(1),
-        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
     };
@@ -2353,7 +2369,9 @@ fn test_corporate_action_option_non_standard_requires_identity_change() {
         let ca_event = EngineEvent::CorporateAction {
             id: id.into(),
             instrument: InstrumentIndex(1),
-            kind: CorporateActionKind::StockSplit { ratio },
+            kind: CorporateActionKind::StockSplit {
+                ratio: SplitRatio::new(ratio).unwrap(),
+            },
             policy: SplitRoundingPolicy::Floor,
             effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
         };
@@ -2389,7 +2407,7 @@ fn test_corporate_action_option_non_standard_requires_identity_change() {
                     split_instrument,
                     ratio: r,
                     affected_options,
-                } => Some((*split_instrument, *r, affected_options.clone())),
+                } => Some((*split_instrument, r.get(), affected_options.clone())),
                 _ => None,
             })
             .collect();
@@ -2446,7 +2464,9 @@ fn test_corporate_action_option_replica_parity_standard_split() {
     let ca_event = EngineEvent::CorporateAction {
         id: "BTCUSD-2-1-split".into(),
         instrument: InstrumentIndex(1),
-        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time,
     };
@@ -2649,7 +2669,9 @@ fn test_corporate_action_option_non_standard_wrapper_close_and_new_identity() {
         id: "BTCUSD-3-2-split".into(),
         instrument: InstrumentIndex(2),
         // 3:2 fractional forward ⇒ non-standard (the OCC assigns a new contract identity).
-        kind: CorporateActionKind::StockSplit { ratio: dec!(1.5) },
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(1.5)).unwrap(),
+        },
         policy: SplitRoundingPolicy::Floor,
         effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
     };
@@ -2667,7 +2689,7 @@ fn test_corporate_action_option_non_standard_wrapper_close_and_new_identity() {
                 split_instrument,
                 ratio,
                 affected_options,
-            } => Some((*split_instrument, *ratio, affected_options.clone())),
+            } => Some((*split_instrument, ratio.get(), affected_options.clone())),
             _ => None,
         })
         .collect();
@@ -3631,5 +3653,355 @@ fn test_contract_expiry_clears_pending_fills() {
     assert!(
         instr.pending_fills.is_empty(),
         "pending_fills must be cleared during contract expiry"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CorporateAction — additional audit-path coverage:
+//   equity-leg OpenOrdersAtSplit, forward split on a populated spot, the
+//   Fractional rounding policy, a post-split unheld-option strike fix, and the
+//   hedging routing-table prune on a floor-to-zero reverse split.
+// ---------------------------------------------------------------------------
+
+/// Equity/spot path: a resting order on the splitting instrument is surfaced via
+/// `OpenOrdersAtSplit` (and left in the book — a broker price-adjusts it, the engine never cancels).
+/// The option path already asserts this observable; this pins it on the equity leg too.
+#[test]
+fn test_corporate_action_spot_split_surfaces_open_orders_at_split() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine(TradingState::Disabled, execution_tx); // Netting spot
+
+    // Last price for the eager pnl recompute, plus a long position on Spot instrument 0.
+    engine.process(market_event_trade(1, 0, dec!(100)));
+    open_position_via_trade(&mut engine, 0, 2, Side::Buy, dec!(100), dec!(10), "pos");
+
+    // A resting order on the same instrument (cid = gen_cid(0)), left unfilled (0 of 1 filled).
+    engine.process(account_event_order_response(0, 1, Side::Buy, 1.0, 0.0));
+
+    // 1:2 reverse split on instrument 0.
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSDT-reverse-1-2".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(0.5)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // The resting order is surfaced for the equity instrument, carrying its pre-split terms.
+    let surfaced = outputs
+        .iter()
+        .find_map(|o| match o {
+            EngineOutput::OpenOrdersAtSplit { instrument, orders }
+                if *instrument == InstrumentIndex(0) =>
+            {
+                Some(orders.clone())
+            }
+            _ => None,
+        })
+        .expect("equity split must surface the instrument's resting orders via OpenOrdersAtSplit");
+    assert!(
+        surfaced
+            .iter()
+            .any(|order| order.cid == gen_cid(0) && order.quantity_pre_split == dec!(1)),
+        "OpenOrdersAtSplit must carry the resting order at its pre-split quantity"
+    );
+
+    // The order is NOT cancelled — it still rests in the engine's order book post-split.
+    assert!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(0))
+            .orders
+            .0
+            .contains_key(&gen_cid(0)),
+        "the resting order must be left in place (surfaced, not cancelled)"
+    );
+}
+
+/// Forward split (`ratio > 1`) on a populated spot position via the audit path: contracts scale up,
+/// basis scales down, the high-water mark scales (unfloored), and pnl is recomputed from the mark —
+/// with NO `SplitRemainder` (an integer ratio on a whole quantity disposes nothing). Existing
+/// coverage exercises only reverse (`0.5`) splits on populated spot, or forward on empty spot.
+#[test]
+fn test_corporate_action_forward_split_populated_spot() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine(TradingState::Disabled, execution_tx); // Netting spot
+
+    // Mark 100, long 10 @ 100 on Spot instrument 0.
+    engine.process(market_event_trade(1, 0, dec!(100)));
+    open_position_via_trade(&mut engine, 0, 2, Side::Buy, dec!(100), dec!(10), "pos");
+
+    // 2:1 forward split.
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSDT-forward-2-1".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // Position scaled: qty 10×2 = 20, avg 100/2 = 50, high-water 10×2 = 20 (unfloored),
+    // pnl_unrealised recomputed from the mark 100 = (100 - 50) × 20 = 1000.
+    let instrument_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    assert_eq!(instrument_state.position.positions.len(), 1);
+    let position = instrument_state.position.positions.values().next().unwrap();
+    assert_eq!(position.quantity_abs, dec!(20));
+    assert_eq!(position.price_entry_average, dec!(50));
+    assert_eq!(position.quantity_abs_max, dec!(20));
+    assert_eq!(position.pnl_unrealised, dec!(1000));
+
+    // A whole-number forward split on a whole quantity disposes no fractional sliver.
+    assert!(
+        !outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::SplitRemainder { .. })),
+        "a forward split on a whole quantity must not emit a SplitRemainder"
+    );
+
+    // The split id is recorded on the target.
+    assert!(
+        instrument_state
+            .corporate_actions_processed
+            .contains("BTCUSDT-forward-2-1")
+    );
+}
+
+/// `SplitRoundingPolicy::Fractional` (fractional-share brokers, e.g. Alpaca) keeps the exact
+/// fractional share count: the quantity is NOT floored and NO `SplitRemainder` is emitted, even when
+/// the scaled quantity is fractional. Previously only smoke-tested through the audit-disabled
+/// backtest path; asserted here on the observable audit path, the `Floor` counterpart's mirror.
+#[test]
+fn test_corporate_action_fractional_policy_keeps_fractional_quantity() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine(TradingState::Disabled, execution_tx); // Netting spot
+
+    // Mark 100, long 21 @ 100 on Spot instrument 0.
+    engine.process(market_event_trade(1, 0, dec!(100)));
+    open_position_via_trade(&mut engine, 0, 2, Side::Buy, dec!(100), dec!(21), "pos");
+
+    // 1:2 reverse split under Fractional: 21 × 0.5 = 10.5 kept (NOT floored to 10).
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSDT-reverse-frac".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(0.5)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Fractional,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // The fractional quantity is preserved exactly: qty 10.5, avg 100/0.5 = 200,
+    // pnl_unrealised = (100 - 200) × 10.5 = -1050.
+    let instrument_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let position = instrument_state.position.positions.values().next().unwrap();
+    assert_eq!(position.quantity_abs, dec!(10.5));
+    assert_eq!(position.price_entry_average, dec!(200));
+    assert_eq!(position.pnl_unrealised, dec!(-1050));
+
+    // Fractional disposes nothing — no cash-in-lieu observable, and the slot is not floored to zero.
+    assert!(
+        !outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::SplitRemainder { .. })),
+        "Fractional policy must not dispose a remainder (no SplitRemainder)"
+    );
+    assert!(
+        !outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::PositionExit(_))),
+        "a Fractional reverse split must not close the position"
+    );
+}
+
+/// A standard split silently corrects the strike of an UNHELD option on the underlying (a registry
+/// fix, no observable), so a position opened on that option AFTER the split settles at expiry against
+/// the POST-split strike. Proves the strike adjustment is not gated on holding a position at split
+/// time — the instrument set is fixed at construction, so an unheld option can be traded later.
+#[test]
+fn test_corporate_action_unheld_option_strike_adjusted_then_settles_post_split() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // Marks for the option (idx0) and spot underlying (idx1). NO option position is opened — the
+    // option is unheld at split time.
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+
+    // 2:1 standard forward split on the Spot underlying (idx1).
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // The unheld option's strike was silently halved (50_000 → 25_000) ...
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(25_000));
+    // ... with NO per-position observable (nothing was held to adjust).
+    assert!(
+        !outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::OptionPositionAdjustedForSplit { .. })),
+        "an unheld option's strike fix must be silent (no OptionPositionAdjustedForSplit)"
+    );
+
+    // Now open a fresh position on the option (post-split) and settle it at expiry. Spot at 30_000 is
+    // ITM against the POST-split strike 25_000 (intrinsic 5_000) but would be OTM against the stale
+    // 50_000 strike — so the settlement pnl pins which strike was used.
+    open_option_position_via_trade(
+        &mut engine,
+        11,
+        Side::Buy,
+        dec!(1_000),
+        dec!(1),
+        "post-split",
+    );
+    engine.process(market_event_trade(12, 1, dec!(30_000)));
+
+    let exited = engine.process_contract_expiry(&InstrumentIndex(0));
+    assert_eq!(exited.len(), 1);
+    // Intrinsic 5_000 (= 30_000 − post-split strike 25_000), premium 1_000, 1 contract:
+    // pnl = (5_000 − 1_000) × 1 = 4_000. Against the stale 50_000 strike it would be −1_000.
+    assert_eq!(exited[0].pnl_realised, dec!(4_000));
+}
+
+/// A reverse split that floors a Hedging position to zero must prune the `position_ids` routing entry
+/// by VALUE (the removed `PositionId`), not via the `cleanup_routing_tables` CID-retention path: the
+/// split deliberately leaves the position's resting order in place, so its CID is still in `orders`.
+/// Without the value-prune a late fill on that order would resolve the dead id and silently REOPEN
+/// the floored-out position.
+#[test]
+fn test_corporate_action_floor_to_zero_prunes_hedging_routing() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine_with_oms(TradingState::Disabled, execution_tx, OmsMode::Hedging);
+
+    // Last price for the eager pnl recompute on Spot instrument 0.
+    engine.process(market_event_trade(1, 0, dec!(100)));
+
+    // Open a Hedging position routed through an explicit PositionId, leaving the order RESTING (acked
+    // + filled, but with no terminal fully-filled snapshot ⇒ the CID stays in `orders`).
+    let cid = ClientOrderId::new("cid-floor");
+    let pos_id = PositionId::new("leg-floor");
+    let exchange_id = OrderId::new("exch-floor");
+    send_open_order_with_position_id(
+        &mut engine,
+        cid.clone(),
+        pos_id.clone(),
+        Side::Buy,
+        dec!(100),
+        false,
+    );
+    send_order_ack(&mut engine, cid.clone(), exchange_id.clone(), Side::Buy);
+    send_fill(&mut engine, exchange_id.clone(), Side::Buy, dec!(100));
+
+    // Pre-split sanity: position open, routing entry present, order resting.
+    let instr = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    assert!(instr.position.positions.contains_key(&pos_id));
+    assert!(instr.position_ids.values().any(|v| *v == pos_id));
+    assert!(instr.orders.0.contains_key(&cid));
+
+    // 1:2 reverse split under Floor: qty 1 → floor(0.5) = 0 ⇒ slot removed.
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSDT-floor-to-zero".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(0.5)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // The floored position exited, and its routing entry was pruned by value ...
+    assert!(
+        outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::PositionExit(p) if p.position_id == pos_id)),
+        "the floored-to-zero position must emit a PositionExit"
+    );
+    let instr = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    assert!(
+        !instr.position.positions.contains_key(&pos_id),
+        "floored position must be removed"
+    );
+    assert!(
+        !instr.position_ids.values().any(|v| *v == pos_id),
+        "the floored position's routing entry must be pruned by value"
+    );
+    // ... while the resting order itself is left in place (the split price-adjusts, never cancels).
+    assert!(
+        instr.orders.0.contains_key(&cid),
+        "the split must leave the resting order in the book"
+    );
+
+    // A late fill on that still-resting order must NOT resurrect the floored PositionId. With the
+    // routing entry pruned, the fill routes via the no-mapping fallback to a position keyed by the
+    // raw exchange OrderId — a fresh slot, never the dead `leg-floor`.
+    send_fill(&mut engine, exchange_id.clone(), Side::Buy, dec!(100));
+    let instr = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    assert!(
+        !instr.position.positions.contains_key(&pos_id),
+        "a late fill must not silently reopen the floored-out position"
+    );
+    assert!(
+        instr
+            .position
+            .positions
+            .contains_key(&PositionId::new(exchange_id.0.clone())),
+        "the late fill opens a fresh slot under the raw order id (no-mapping fallback)"
     );
 }

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -27,7 +27,7 @@ use rustrade::{
                 data::{DefaultInstrumentMarketData, InstrumentDataState},
                 filter::InstrumentFilter,
             },
-            position::{OmsMode, PositionExited},
+            position::{OmsMode, PositionExited, SplitRoundingPolicy},
             trading::TradingState,
         },
     },
@@ -61,6 +61,7 @@ use rustrade_execution::{
 use rustrade_instrument::{
     Side, Underlying,
     asset::AssetIndex,
+    corporate_action::CorporateActionKind,
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
     instrument::{
@@ -892,7 +893,7 @@ impl ClosePositionsStrategy for TestBuyAndHoldStrategy {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 struct OnDisconnectOutput;
 impl
     OnDisconnectStrategy<
@@ -918,7 +919,7 @@ impl
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 struct OnTradingDisabledOutput;
 impl
     OnTradingDisabled<
@@ -946,6 +947,14 @@ impl
 fn build_engine(
     trading_state: TradingState,
     execution_tx: UnboundedTx<ExecutionRequest>,
+) -> TestEngine {
+    build_engine_with_oms(trading_state, execution_tx, OmsMode::Netting)
+}
+
+fn build_engine_with_oms(
+    trading_state: TradingState,
+    execution_tx: UnboundedTx<ExecutionRequest>,
+    oms_mode: OmsMode,
 ) -> TestEngine {
     let instruments = IndexedInstruments::builder()
         .add_instrument(Instrument::spot(
@@ -983,6 +992,7 @@ fn build_engine(
     })
     .time_engine_start(STARTING_TIMESTAMP)
     .trading_state(trading_state)
+    .oms_mode(oms_mode)
     .balances([
         (ExchangeId::BinanceSpot, "usdt", STARTING_BALANCE_USDT),
         (ExchangeId::BinanceSpot, "btc", STARTING_BALANCE_BTC),
@@ -1509,6 +1519,247 @@ fn test_contract_expiry_replica_state_cleared() {
     assert!(replica_instrument.orders.0.is_empty());
     // expiration_processed must be set
     assert!(replica_instrument.expiration_processed);
+}
+
+// ---------------------------------------------------------------------------
+// CorporateAction (stock split) audit-replica parity tests
+// ---------------------------------------------------------------------------
+
+/// Open a position via a bare account `Trade` with an explicit `order_id`/`trade_id` tag.
+///
+/// `tag` populates **both** the `TradeId` and the `OrderId`. In `OmsMode::Hedging` the position
+/// slot is keyed by `trade.order_id`, so distinct tags open distinct positions on the same
+/// instrument (the routing "no order match" fallback). Fees are zero to keep `pnl_realised` clean
+/// for the parity assertions.
+fn open_position_via_trade(
+    engine: &mut TestEngine,
+    instrument: usize,
+    time_plus: u64,
+    side: Side,
+    price: Decimal,
+    quantity: Decimal,
+    tag: &str,
+) {
+    let event = EngineEvent::Account(AccountStreamEvent::Item(AccountEvent {
+        exchange: ExchangeIndex(0),
+        kind: AccountEventKind::Trade(Trade {
+            id: TradeId::new(tag),
+            order_id: OrderId::new(tag),
+            instrument: InstrumentIndex(instrument),
+            strategy: strategy_id(),
+            time_exchange: time_plus_days(STARTING_TIMESTAMP, time_plus),
+            side,
+            price,
+            quantity,
+            fees: asset_fees(instrument, dec!(0)),
+        }),
+    }));
+    engine.process(event);
+}
+
+/// Live engine vs audit-replica parity for a `CorporateAction` reverse split under `Floor`,
+/// across multiple positions (Hedging) — one surviving, one floored to zero.
+///
+/// The replica arm event-replays `apply_split` from the payload (it does **not** mirror outputs),
+/// so this test guards against the live handler (`process_corporate_action`) and the replica
+/// (`StateReplicaManager::update_from_event`) drifting apart. The gold-standard assertion is full
+/// `InstrumentState` equality, which also covers tear-sheet parity for the closed position.
+#[test]
+fn test_corporate_action_replica_parity_floor_split() {
+    use rustrade::engine::audit::{
+        AuditTick, EngineAudit, context::EngineContext, state_replica::StateReplicaManager,
+    };
+
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine_with_oms(TradingState::Disabled, execution_tx, OmsMode::Hedging);
+
+    // Set a last price so apply_split eagerly recomputes pnl_unrealised (not the None⇒0 path).
+    engine.process(market_event_trade(1, 0, dec!(100)));
+
+    // Two long positions on the same Spot instrument (index 0). Under a 1:2 reverse split (Floor):
+    //   - "survivor" 21 → floor(10.5) = 10 (survives, with a 0.5 fractional remainder)
+    //   - "dust"      1 → floor(0.5)  = 0  (floored to zero ⇒ removed + PositionExit)
+    open_position_via_trade(
+        &mut engine,
+        0,
+        2,
+        Side::Buy,
+        dec!(100),
+        dec!(21),
+        "survivor",
+    );
+    open_position_via_trade(&mut engine, 0, 3, Side::Buy, dec!(100), dec!(1), "dust");
+
+    // Seed the replica from the exact pre-split state.
+    let pre_split_state = engine.state.clone();
+
+    // Process the split on the live engine.
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSDT-reverse-1-2".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event.clone());
+
+    // Seed the replica from the pre-split snapshot. The CorporateAction arm output-mirrors the
+    // Floor-to-zero close (folding the live PositionExit), so it does not depend on the seed time.
+    let seed_tick: AuditTick<_, EngineContext> = AuditTick {
+        event: pre_split_state,
+        context: EngineContext {
+            time: effective_time,
+            sequence: Sequence(0),
+        },
+    };
+    // Type annotation required for StateReplicaManager::new to infer the iterator element type
+    #[allow(clippy::type_complexity)]
+    let dummy_updates: std::iter::Empty<
+        AuditTick<
+            EngineAudit<
+                EngineEvent<DataKind>,
+                EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
+            >,
+        >,
+    > = std::iter::empty();
+    let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
+
+    // Drive the replica with the live outputs. The CorporateAction arm event-replays and ignores
+    // them, but pass them through to exercise the real run() contract faithfully.
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    replica_manager.update_from_event(ca_event, &outputs);
+
+    let live_instrument = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let replica_instrument = replica_manager
+        .replica_engine_state()
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+
+    // Gold-standard: full InstrumentState parity (positions, tear sheet, processed-id set, …).
+    assert_eq!(replica_instrument, live_instrument);
+
+    // Explicit checks that the LIVE handler did what we expect — so the parity assert above is
+    // not vacuously comparing two unchanged states.
+    let survivor_id = PositionId::new("survivor");
+    let dust_id = PositionId::new("dust");
+
+    // "dust" floored to zero ⇒ slot removed in both.
+    assert!(!live_instrument.position.positions.contains_key(&dust_id));
+    assert!(!replica_instrument.position.positions.contains_key(&dust_id));
+
+    // "survivor" persists, split-adjusted: qty floor(21*0.5)=10, avg 100/0.5=200, max 21*0.5=10.5
+    // (unfloored), pnl_unrealised recomputed from last price 100 = (100-200)*10 = -1000.
+    let survivor = live_instrument
+        .position
+        .positions
+        .get(&survivor_id)
+        .expect("survivor position should persist");
+    assert_eq!(survivor.quantity_abs, dec!(10));
+    assert_eq!(survivor.price_entry_average, dec!(200));
+    assert_eq!(survivor.quantity_abs_max, dec!(10.5));
+    assert_eq!(survivor.pnl_unrealised, dec!(-1000));
+
+    // Idempotency key recorded in both.
+    assert!(
+        live_instrument
+            .corporate_actions_processed
+            .contains("BTCUSDT-reverse-1-2")
+    );
+    assert!(
+        replica_instrument
+            .corporate_actions_processed
+            .contains("BTCUSDT-reverse-1-2")
+    );
+}
+
+/// Live vs replica parity for a `CorporateAction` targeting a non-`Spot` instrument: both reject
+/// (no state change, `id` not recorded), so the replica's guards must stay symmetric with the
+/// handler's. Validates the `InstrumentKindNotSupported` rejection path.
+#[test]
+fn test_corporate_action_replica_parity_unsupported_non_spot() {
+    use rustrade::engine::{
+        UnsupportedCorporateActionReason,
+        audit::{
+            AuditTick, EngineAudit, context::EngineContext, state_replica::StateReplicaManager,
+        },
+    };
+
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
+
+    // Option position at index 0 (non-Spot). Spot underlying is index 1.
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+    let pre_state = engine.state.clone();
+
+    // Target the OPTION (index 0) — unsupported (equity splits apply to Spot only).
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    let ca_event = EngineEvent::CorporateAction {
+        id: "opt-split".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit { ratio: dec!(2) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event.clone());
+
+    // Live must emit the dedicated rejection output (and NOT record the id ⇒ retryable).
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::UnsupportedCorporateAction {
+                reason: UnsupportedCorporateActionReason::InstrumentKindNotSupported,
+                ..
+            }
+        )),
+        "expected UnsupportedCorporateAction(InstrumentKindNotSupported)"
+    );
+
+    let seed_tick: AuditTick<_, EngineContext> = AuditTick {
+        event: pre_state,
+        context: EngineContext {
+            time: effective_time,
+            sequence: Sequence(0),
+        },
+    };
+    // Type annotation required for StateReplicaManager::new to infer the iterator element type
+    #[allow(clippy::type_complexity)]
+    let dummy_updates: std::iter::Empty<
+        AuditTick<
+            EngineAudit<
+                EngineEvent<DataKind>,
+                EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
+            >,
+        >,
+    > = std::iter::empty();
+    let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
+    replica_manager.update_from_event(ca_event, &outputs);
+
+    let live_instrument = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let replica_instrument = replica_manager
+        .replica_engine_state()
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+
+    // Rejected ⇒ unchanged and symmetric: replica == live, position intact, id NOT recorded.
+    assert_eq!(replica_instrument, live_instrument);
+    assert_eq!(live_instrument.position.positions.len(), 1);
+    assert!(live_instrument.corporate_actions_processed.is_empty());
+    assert!(replica_instrument.corporate_actions_processed.is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -1688,6 +1688,195 @@ fn test_corporate_action_replica_parity_floor_split() {
     );
 }
 
+/// End-to-end idempotency for `CorporateAction`: the identical event fired twice must apply the
+/// split exactly **once**. The second call hits the per-instrument `corporate_actions_processed`
+/// guard (`process_corporate_action` step 1) and must be a no-op — it re-emits no
+/// `SplitRemainder`/`PositionExit` and leaves `quantity_abs`/`price_entry_average` unchanged (a
+/// double-apply would re-scale the basis and re-dispose a remainder). Mirrors
+/// `test_contract_expiry_idempotent` for the split path, exercising the guard end-to-end through
+/// `process_with_audit`.
+#[test]
+fn test_corporate_action_idempotent() {
+    use rustrade::engine::audit::EngineAudit;
+
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine_with_oms(TradingState::Disabled, execution_tx, OmsMode::Hedging);
+
+    // Last price so apply_split takes the eager pnl_unrealised recompute path (not None ⇒ 0).
+    engine.process(market_event_trade(1, 0, dec!(100)));
+
+    // One long position; a 1:2 reverse split under Floor leaves a fractional remainder
+    // (21 → floor(10.5) = 10), so the FIRST application emits a SplitRemainder we can assert is
+    // NOT re-emitted by the second (idempotent) call.
+    open_position_via_trade(&mut engine, 0, 2, Side::Buy, dec!(100), dec!(21), "pos");
+
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    let ca_event = EngineEvent::CorporateAction {
+        id: "AAPL-2026-split".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+
+    // First application: split applied, id recorded, SplitRemainder emitted.
+    let first = process_with_audit(&mut engine, ca_event.clone());
+    let first_outputs = match &first.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    assert!(
+        first_outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::SplitRemainder { .. })),
+        "first application should emit a SplitRemainder (21 → floor(10.5) = 10, 0.5 disposed)"
+    );
+
+    // Snapshot the split-adjusted position after the first application.
+    let pos_id = PositionId::new("pos");
+    let after_first = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0))
+        .position
+        .positions
+        .get(&pos_id)
+        .expect("position should persist after the first split")
+        .clone();
+    assert_eq!(after_first.quantity_abs, dec!(10));
+    assert_eq!(after_first.price_entry_average, dec!(200));
+
+    // Second application of the IDENTICAL event: suppressed by the idempotency guard.
+    let second = process_with_audit(&mut engine, ca_event.clone());
+    let second_outputs = match &second.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    assert!(
+        !second_outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::SplitRemainder { .. } | EngineOutput::PositionExit(_)
+        )),
+        "second (idempotent) application must re-emit no SplitRemainder/PositionExit"
+    );
+
+    // State unchanged by the second call (no double basis-adjust / re-dispose).
+    let after_second = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0))
+        .position
+        .positions
+        .get(&pos_id)
+        .expect("position should still persist")
+        .clone();
+    assert_eq!(after_second, after_first);
+}
+
+/// Live engine vs audit-replica parity for a `CorporateAction` reverse split under `Floor` on
+/// **short** positions (`Side::Sell`), across multiple positions (Hedging) — one surviving, one
+/// floored to zero. `position.rs` unit tests cover shorts, but every other handler/replica parity
+/// test opens `Side::Buy`; this exercises the opposite `pnl_unrealised` sign branch and the
+/// floor-to-zero `PositionExit` for a short at the integration level.
+#[test]
+fn test_corporate_action_replica_parity_short_reverse_split() {
+    use rustrade::engine::audit::{
+        AuditTick, EngineAudit, context::EngineContext, state_replica::StateReplicaManager,
+    };
+
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine_with_oms(TradingState::Disabled, execution_tx, OmsMode::Hedging);
+
+    // Last price so apply_split eagerly recomputes pnl_unrealised (not the None ⇒ 0 path).
+    engine.process(market_event_trade(1, 0, dec!(100)));
+
+    // Two SHORT positions (Side::Sell) on the same Spot instrument (index 0). Under a 1:2 reverse
+    // split (Floor):
+    //   - "survivor" 21 → floor(10.5) = 10 (survives, with a 0.5 fractional remainder)
+    //   - "dust"      1 → floor(0.5)  = 0  (floored to zero ⇒ removed + PositionExit)
+    open_position_via_trade(
+        &mut engine,
+        0,
+        2,
+        Side::Sell,
+        dec!(100),
+        dec!(21),
+        "survivor",
+    );
+    open_position_via_trade(&mut engine, 0, 3, Side::Sell, dec!(100), dec!(1), "dust");
+
+    // Seed the replica from the exact pre-split state.
+    let pre_split_state = engine.state.clone();
+
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSDT-reverse-1-2-short".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit { ratio: dec!(0.5) },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event.clone());
+
+    let seed_tick: AuditTick<_, EngineContext> = AuditTick {
+        event: pre_split_state,
+        context: EngineContext {
+            time: effective_time,
+            sequence: Sequence(0),
+        },
+    };
+    // Type annotation required for StateReplicaManager::new to infer the iterator element type
+    #[allow(clippy::type_complexity)]
+    let dummy_updates: std::iter::Empty<
+        AuditTick<
+            EngineAudit<
+                EngineEvent<DataKind>,
+                EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
+            >,
+        >,
+    > = std::iter::empty();
+    let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    replica_manager.update_from_event(ca_event, &outputs);
+
+    let live_instrument = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let replica_instrument = replica_manager
+        .replica_engine_state()
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+
+    // Gold-standard: full InstrumentState parity (positions, tear sheet, processed-id set, …).
+    assert_eq!(replica_instrument, live_instrument);
+
+    let survivor_id = PositionId::new("survivor");
+    let dust_id = PositionId::new("dust");
+
+    // "dust" short floored to zero ⇒ slot removed in both.
+    assert!(!live_instrument.position.positions.contains_key(&dust_id));
+    assert!(!replica_instrument.position.positions.contains_key(&dust_id));
+
+    // "survivor" short persists, split-adjusted: qty floor(21*0.5)=10, avg 100/0.5=200,
+    // max 21*0.5=10.5 (unfloored). pnl_unrealised uses the SHORT branch:
+    // (entry - price) * qty = (200 - 100) * 10 = +1000 (a short gains as basis > current price).
+    let survivor = live_instrument
+        .position
+        .positions
+        .get(&survivor_id)
+        .expect("survivor short position should persist");
+    assert_eq!(survivor.side, Side::Sell);
+    assert_eq!(survivor.quantity_abs, dec!(10));
+    assert_eq!(survivor.price_entry_average, dec!(200));
+    assert_eq!(survivor.quantity_abs_max, dec!(10.5));
+    assert_eq!(survivor.pnl_unrealised, dec!(1000));
+}
+
 /// Live vs replica parity for a `CorporateAction` targeting a non-`Spot` instrument: both reject
 /// (no state change, `id` not recorded), so the replica's guards must stay symmetric with the
 /// handler's. Validates the `InstrumentKindNotSupported` rejection path.

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -1787,6 +1787,33 @@ fn test_corporate_action_idempotent() {
         "second (idempotent) application must re-emit no SplitRemainder/PositionExit"
     );
 
+    // The idempotent skip IS surfaced on the output/audit stream as exactly one
+    // CorporateActionAlreadyProcessed carrying the re-submitted event's instrument/kind/id — the
+    // observable that lets a stream-only consumer distinguish a duplicate-id skip from a successful
+    // split that had nothing to adjust.
+    assert_eq!(
+        second_outputs
+            .iter()
+            .filter(|o| matches!(o, EngineOutput::CorporateActionAlreadyProcessed { .. }))
+            .count(),
+        1,
+        "second (idempotent) application must emit exactly one CorporateActionAlreadyProcessed"
+    );
+    assert!(
+        second_outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::CorporateActionAlreadyProcessed { instrument, kind, id }
+                if *instrument == InstrumentIndex(0)
+                    && id.as_str() == "AAPL-2026-split"
+                    && matches!(
+                        kind,
+                        CorporateActionKind::StockSplit { ratio }
+                            if *ratio == SplitRatio::new(dec!(0.5)).unwrap()
+                    )
+        )),
+        "CorporateActionAlreadyProcessed must carry the re-submitted event's instrument/kind/id"
+    );
+
     // State unchanged by the second call (no double basis-adjust / re-dispose).
     let after_second = engine
         .state
@@ -2804,6 +2831,106 @@ fn test_corporate_action_option_replica_parity_standard_split() {
     let position = option_live.position.positions.values().next().unwrap();
     assert_eq!(position.quantity_abs, dec!(4));
     assert_eq!(position.price_entry_average, dec!(500));
+}
+
+/// Replica-parity for the **non-standard** option-split branch: a reverse (or fractional-forward)
+/// split leaves held options UNTOUCHED (the OCC assigns a new contract identity the engine cannot
+/// apply in place), so the replica's `adjust_options_in_place == false` skip branch must match the
+/// live handler byte-for-byte. Complements `test_corporate_action_option_replica_parity_standard_split`,
+/// which only exercises the Standard (mutating) branch — this covers the "skip" branch the author's
+/// comments worry could silently drift.
+#[test]
+fn test_corporate_action_option_replica_parity_non_standard_split() {
+    use rustrade::engine::audit::{
+        AuditTick, EngineAudit, context::EngineContext, state_replica::StateReplicaManager,
+    };
+
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+    // Seed the replica from the exact pre-split state.
+    let pre_split_state = engine.state.clone();
+
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    // 1:2 reverse split (non-standard) on the Spot underlying (idx1).
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-1-2-reverse".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(0.5)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event.clone());
+
+    let seed_tick: AuditTick<_, EngineContext> = AuditTick {
+        event: pre_split_state,
+        context: EngineContext {
+            time: effective_time,
+            sequence: Sequence(0),
+        },
+    };
+    let dummy_updates: DummyAuditUpdates = std::iter::empty();
+    let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    replica_manager.update_from_event(ca_event, &outputs);
+
+    // Gold-standard: full InstrumentState parity for BOTH the untouched option (idx0) and the split
+    // equity (idx1) — the replica's "skip" branch must reproduce live byte-for-byte.
+    for idx in [InstrumentIndex(0), InstrumentIndex(1)] {
+        let live = engine.state.instruments.instrument_index(&idx);
+        let replica = replica_manager
+            .replica_engine_state()
+            .instruments
+            .instrument_index(&idx);
+        assert_eq!(replica, live, "replica/live divergence at {idx:?}");
+    }
+
+    // Non-vacuous: the LIVE handler actually took the non-standard branch — the held option was left
+    // UNTOUCHED (strike + position identical to pre-split) and an identity-change signal was emitted.
+    let option_live = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_live.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(
+        contract.strike,
+        dec!(50_000),
+        "a non-standard split must NOT touch the option strike"
+    );
+    let position = option_live.position.positions.values().next().unwrap();
+    assert_eq!(
+        position.quantity_abs,
+        dec!(2),
+        "held option position must be untouched"
+    );
+    assert_eq!(position.price_entry_average, dec!(1_000));
+    assert!(
+        outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::OptionPositionsRequireIdentityChange { .. })),
+        "a non-standard split with a held option must emit OptionPositionsRequireIdentityChange"
+    );
+    // The equity split itself WAS applied and its id recorded on the Spot target (idx1).
+    assert!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(1))
+            .corporate_actions_processed
+            .contains("BTCUSD-1-2-reverse")
+    );
 }
 
 /// Build an engine with TWO BTC/USD call options on the same underlying plus the BTC/USD spot, for
@@ -4186,6 +4313,133 @@ fn test_corporate_action_unheld_option_strike_adjusted_then_settles_post_split()
     // Intrinsic 5_000 (= 30_000 − post-split strike 25_000), premium 1_000, 1 contract:
     // pnl = (5_000 − 1_000) × 1 = 4_000. Against the stale 50_000 strike it would be −1_000.
     assert_eq!(exited[0].pnl_realised, dec!(4_000));
+}
+
+/// An **unheld** option (zero positions) that carries a **resting order** must still have that order
+/// surfaced via `OpenOrdersAtSplit` when its underlying splits — mirroring the equity leg, which
+/// snapshots resting orders regardless of position state. A working order to *open* an option
+/// position is a realistic pre-split state; the standard split silently corrects the strike, so the
+/// resting order is now against the adjusted contract at a stale premium and the wrapper must be told
+/// (and a backtest MockExchange would otherwise fill it against the post-split print). Regression: the
+/// option loop previously `continue`d on `positions.is_empty()` BEFORE snapshotting orders.
+#[test]
+fn test_corporate_action_unheld_option_with_resting_order_surfaces_open_orders_at_split() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // Marks for the option (idx0) and spot underlying (idx1). NO option position is opened.
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+
+    // A resting order on the UNHELD option (idx0) — a working order to open a position.
+    engine.process(account_event_order_response(0, 1, Side::Buy, 1.0, 0.0));
+
+    // 2:1 standard forward split on the Spot underlying (idx1).
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // The resting order on the UNHELD option IS surfaced (the fix — equity-leg parity).
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::OpenOrdersAtSplit { instrument, orders }
+                if *instrument == InstrumentIndex(0) && !orders.is_empty()
+        )),
+        "an unheld option's resting order must be surfaced via OpenOrdersAtSplit"
+    );
+
+    // No per-position observable (nothing was held to adjust) ...
+    assert!(
+        !outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::OptionPositionAdjustedForSplit { .. })),
+        "an unheld option has no position to adjust"
+    );
+
+    // ... and the strike was still corrected (the registry fix runs regardless of position state).
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(25_000));
+}
+
+/// A **rejected** CorporateAction still advances the historical clock to its `effective_time` (the
+/// clock is processed before the handler validates the action), but this does NOT skew the clock for
+/// subsequent in-order events — a later market event still advances it. On the supported backtest
+/// path the merge enforces `effective_time == Timed::time` and emits the action only when
+/// `effective_time <= the next market event`, so `effective_time` is always ≤ every later event and a
+/// rejected action causes no "permanent skew". This locks that behavior in: moving the clock advance
+/// to accept-only would flip the second assertion and force a conscious re-decision.
+#[test]
+fn test_corporate_action_rejected_does_not_skew_clock() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    // idx0 = option, idx1 = spot. Targeting the option rejects with InstrumentKindNotSupported.
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
+
+    // A pre-split market event establishes the clock near STARTING+1d (< effective_time).
+    let m1 = process_with_audit(&mut engine, market_event_trade(1, 1, dec!(60_000)));
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    assert!(m1.context.time < effective_time);
+
+    // A CorporateAction targeting the OPTION (idx0) → rejected (InstrumentKindNotSupported).
+    let ca_event = EngineEvent::CorporateAction {
+        id: "reject-me".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+    let ca_tick = process_with_audit(&mut engine, ca_event);
+    let ca_outputs = match &ca_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    // Non-vacuous: the action really was rejected (nothing mutated, id not recorded).
+    assert!(
+        ca_outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::UnsupportedCorporateAction {
+                reason: UnsupportedCorporateActionReason::InstrumentKindNotSupported,
+                ..
+            }
+        )),
+        "targeting the option must be rejected as InstrumentKindNotSupported"
+    );
+    // Despite the rejection, the clock advanced to effective_time (current, intended behavior).
+    assert!(
+        ca_tick.context.time >= effective_time,
+        "a rejected CorporateAction still advances the clock to effective_time"
+    );
+
+    // A later, in-order market event still advances the clock past effective_time — no skew.
+    let later_time = time_plus_days(STARTING_TIMESTAMP, 20);
+    let m2 = process_with_audit(&mut engine, market_event_trade(20, 1, dec!(70_000)));
+    assert!(
+        m2.context.time >= later_time,
+        "a later market event after a rejected action must still advance the clock (no permanent skew)"
+    );
+    assert!(
+        m2.context.time >= ca_tick.context.time,
+        "clock must remain monotonic non-decreasing across a rejected action"
+    );
 }
 
 /// A reverse split that floors a Hedging position to zero must prune the `position_ids` routing entry

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -7,7 +7,7 @@ use rust_decimal_macros::dec;
 use rustrade::{
     EngineEvent, Sequence, Timed,
     engine::{
-        Engine, EngineOutput, Processor,
+        Engine, EngineOutput, Processor, UnsupportedCorporateActionReason,
         action::{
             ActionOutput,
             generate_algo_orders::GenerateAlgoOrdersOutput,
@@ -1683,6 +1683,34 @@ fn test_corporate_action_replica_parity_floor_split() {
             .corporate_actions_processed
             .contains("BTCUSDT-reverse-1-2")
     );
+
+    // Output ordering: within a single position's processing a `SplitRemainder` is pushed BEFORE its
+    // paired `PositionExit`. "dust" (1 → floor(0.5) = 0) both disposes a 0.5 fractional sliver AND
+    // floors to zero, so it emits BOTH observables — the cash-in-lieu record must precede the close
+    // so a consumer can credit the CIL against a still-referenced position id before seeing it exit.
+    let dust_remainder_idx = outputs
+        .iter()
+        .position(|o| {
+            matches!(
+                o,
+                EngineOutput::SplitRemainder { position_id, .. } if *position_id == dust_id
+            )
+        })
+        .expect("dust must emit a SplitRemainder (0.5 disposed)");
+    let dust_exit_idx = outputs
+        .iter()
+        .position(|o| {
+            matches!(
+                o,
+                EngineOutput::PositionExit(exit) if exit.position_id == dust_id
+            )
+        })
+        .expect("dust floored to zero must emit a PositionExit");
+    assert!(
+        dust_remainder_idx < dust_exit_idx,
+        "SplitRemainder (idx {dust_remainder_idx}) must precede its paired PositionExit \
+         (idx {dust_exit_idx}) for the same floored-to-zero position"
+    );
 }
 
 /// End-to-end idempotency for `CorporateAction`: the identical event fired twice must apply the
@@ -2416,6 +2444,288 @@ fn test_corporate_action_option_non_standard_requires_identity_change() {
             "ratio {ratio}: equity id must be recorded"
         );
     }
+}
+
+/// A **non-standard** split where the affected option holds a **resting order** must NOT emit an
+/// `OpenOrdersAtSplit` for that option. The non-standard path signals a wrapper-side identity change
+/// and touches no option state — it never snapshots the option's resting orders (unlike the standard
+/// path, which price-adjusts them and reports them). Pins that the order snapshot is exclusive to the
+/// in-place-adjustment branch: a resting order on an option facing a reverse/fractional split is
+/// surfaced only via the identity-change signal, never as a now-meaningless `OpenOrdersAtSplit`.
+#[test]
+fn test_corporate_action_option_non_standard_no_open_orders_at_split() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+
+    // Long option position AND a resting order on the OPTION (idx0). The standard path WOULD surface
+    // this order via OpenOrdersAtSplit (see the adjusts-in-place test); the non-standard path must not.
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+    let order_event = account_event_order_response(0, 1, Side::Buy, 1.0, 0.0);
+    engine.process(order_event);
+
+    // 1:2 reverse split on the Spot underlying (idx1) — non-standard (OCC assigns a new identity).
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-1-2-reverse".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(0.5)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // No OpenOrdersAtSplit for the option (idx0): the non-standard path snapshots no option orders.
+    assert!(
+        !outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::OpenOrdersAtSplit { instrument, .. } if *instrument == InstrumentIndex(0)
+        )),
+        "a non-standard split must not emit OpenOrdersAtSplit for an option holding a resting order"
+    );
+
+    // Sanity: the identity-change signal IS emitted for the option, and no in-place adjustment.
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::OptionPositionsRequireIdentityChange { affected_options, .. }
+                if affected_options.contains(&InstrumentIndex(0))
+        )),
+        "the option must be listed for a wrapper-side identity change"
+    );
+    assert!(
+        !outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::OptionPositionAdjustedForSplit { .. })),
+        "a non-standard split must not adjust the option in place"
+    );
+}
+
+/// Pre-validation rejects a standard split **atomically** when a held option position carries a
+/// non-integer contract count (state corruption): the engine emits
+/// `UnsupportedCorporateAction { reason: PositionStateInvalid }`, mutates **nothing** (option strike
+/// and the corrupt quantity are left as-is), and does **not** record the `id` — so the action stays
+/// retryable once the position is reconciled. Directly exercises the read-only pre-validation pass
+/// (`validate_corporate_action_split`) and the new rejection reason.
+#[test]
+fn test_corporate_action_pre_validation_rejects_non_integer_option_contracts() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+
+    // Open a normal (integer) option position, then PLANT corruption: force a fractional contract
+    // count directly on the position slot (a valid feed can never produce this).
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+    engine
+        .state
+        .instruments
+        .instrument_index_mut(&InstrumentIndex(0))
+        .position
+        .positions
+        .get_mut(&PositionId::NETTING)
+        .expect("option position should exist")
+        .quantity_abs = dec!(2.5);
+
+    // 2:1 STANDARD forward split on the Spot underlying (idx1) — would adjust the option in place,
+    // but pre-validation must reject it because idx0 holds 2.5 contracts.
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // Exactly the rejection observable, attributed to the splitting equity with the corruption reason.
+    let rejections: Vec<_> = outputs
+        .iter()
+        .filter_map(|o| match o {
+            EngineOutput::UnsupportedCorporateAction {
+                instrument, reason, ..
+            } => Some((*instrument, *reason)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rejections.len(), 1, "expected exactly one rejection");
+    assert_eq!(rejections[0].0, InstrumentIndex(1));
+    assert_eq!(
+        rejections[0].1,
+        UnsupportedCorporateActionReason::PositionStateInvalid
+    );
+
+    // Atomic: nothing was mutated. Option strike still pre-split, corrupt quantity untouched.
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(
+        contract.strike,
+        dec!(50_000),
+        "option strike must be untouched"
+    );
+    assert_eq!(
+        option_state
+            .position
+            .positions
+            .get(&PositionId::NETTING)
+            .expect("option position should persist")
+            .quantity_abs,
+        dec!(2.5),
+        "the corrupt contract count must be left as-is (no partial rescale)"
+    );
+
+    // The `id` was NOT recorded ⇒ retryable once the position is reconciled.
+    let spot_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(1));
+    assert!(
+        !spot_state
+            .corporate_actions_processed
+            .contains("BTCUSD-2-1-split"),
+        "a rejected action must not record its id"
+    );
+
+    // No adjustment or CIL leaked through.
+    assert!(
+        !outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::OptionPositionAdjustedForSplit { .. }
+                | EngineOutput::SplitRemainder { .. }
+        )),
+        "a rejected split must emit no adjustment or remainder"
+    );
+}
+
+/// Pre-validation rejects a stock split **atomically** when rescaling an affected position would
+/// overflow `Decimal` (an extreme/adversarial quantity, not a transient condition): the engine
+/// emits `UnsupportedCorporateAction { reason: ArithmeticOverflow }`, mutates **nothing**, and does
+/// **not** record the `id`. The end-to-end handler counterpart to the unit-level
+/// `position::tests::test_apply_split_ratio_overflow_is_err_and_leaves_position_unmutated` —
+/// exercising the overflow branch of the read-only pre-validation pass
+/// (`validate_corporate_action_split`) through the full `process_corporate_action` path.
+#[test]
+fn test_corporate_action_pre_validation_rejects_arithmetic_overflow() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine(TradingState::Disabled, execution_tx); // Netting spot
+
+    // Mark 100, long 10 @ 100 on Spot instrument 0.
+    engine.process(market_event_trade(1, 0, dec!(100)));
+    open_position_via_trade(&mut engine, 0, 2, Side::Buy, dec!(100), dec!(10), "pos");
+
+    // PLANT an adversarial quantity a forward split cannot rescale without overflowing `Decimal`
+    // (`Decimal::MAX * 2` has no representation). A valid feed can never produce this.
+    engine
+        .state
+        .instruments
+        .instrument_index_mut(&InstrumentIndex(0))
+        .position
+        .positions
+        .values_mut()
+        .next()
+        .expect("spot position should exist")
+        .quantity_abs = Decimal::MAX;
+
+    // 2:1 STANDARD forward split on the same Spot instrument — pre-validation must reject it because
+    // rescaling the planted quantity overflows before any mutation.
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSDT-overflow-2-1".into(),
+        instrument: InstrumentIndex(0),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // Exactly the rejection observable, attributed to the splitting equity with the overflow reason.
+    let rejections: Vec<_> = outputs
+        .iter()
+        .filter_map(|o| match o {
+            EngineOutput::UnsupportedCorporateAction {
+                instrument, reason, ..
+            } => Some((*instrument, *reason)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rejections.len(), 1, "expected exactly one rejection");
+    assert_eq!(rejections[0].0, InstrumentIndex(0));
+    assert_eq!(
+        rejections[0].1,
+        UnsupportedCorporateActionReason::ArithmeticOverflow
+    );
+
+    // Atomic: nothing was mutated. The planted quantity and its untouched basis / high-water mark
+    // are all left exactly as they were (no partial rescale).
+    let instrument_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let position = instrument_state
+        .position
+        .positions
+        .values()
+        .next()
+        .expect("spot position should persist");
+    assert_eq!(
+        position.quantity_abs,
+        Decimal::MAX,
+        "the planted quantity must be left as-is (no partial rescale)"
+    );
+    assert_eq!(
+        position.price_entry_average,
+        dec!(100),
+        "basis must be untouched"
+    );
+    assert_eq!(
+        position.quantity_abs_max,
+        dec!(10),
+        "high-water mark must be untouched"
+    );
+
+    // The `id` was NOT recorded ⇒ retryable once the feed is corrected.
+    assert!(
+        !instrument_state
+            .corporate_actions_processed
+            .contains("BTCUSDT-overflow-2-1"),
+        "a rejected action must not record its id"
+    );
+
+    // No rescale, remainder, or open-orders snapshot leaked through the rejection.
+    assert!(
+        !outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::SplitRemainder { .. } | EngineOutput::OpenOrdersAtSplit { .. }
+        )),
+        "a rejected split must emit no remainder or open-orders snapshot"
+    );
 }
 
 /// Live engine vs audit-replica parity for a **standard** option adjustment: the replica

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -13,7 +13,7 @@ use rustrade::{
             generate_algo_orders::GenerateAlgoOrdersOutput,
             send_requests::{SendCancelsAndOpensOutput, SendRequestsOutput},
         },
-        audit::EngineAudit,
+        audit::{AuditTick, EngineAudit},
         clock::HistoricalClock,
         command::Command,
         execution_tx::MultiExchangeTxMap,
@@ -113,6 +113,17 @@ type TestEngine = Engine<
     MultiExchangeTxMap<UnboundedTx<ExecutionRequest>>,
     TestBuyAndHoldStrategy,
     DefaultRiskManager<EngineState<DefaultGlobalData, DefaultInstrumentMarketData>>,
+>;
+
+// Empty audit-update iterator for `StateReplicaManager::new` in the parity tests, aliased so the
+// deeply-nested type (and its `clippy::type_complexity` allow) isn't repeated at each call site.
+type DummyAuditUpdates = std::iter::Empty<
+    AuditTick<
+        EngineAudit<
+            EngineEvent<DataKind>,
+            EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
+        >,
+    >,
 >;
 
 #[test]
@@ -1476,16 +1487,8 @@ fn test_contract_expiry_replica_state_cleared() {
         context: seed_context,
     };
 
-    // Type annotation required for StateReplicaManager::new to infer the iterator element type
-    #[allow(clippy::type_complexity)]
-    let dummy_updates: std::iter::Empty<
-        AuditTick<
-            EngineAudit<
-                EngineEvent<DataKind>,
-                EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
-            >,
-        >,
-    > = std::iter::empty();
+    // Type annotation required for StateReplicaManager::new to infer the iterator element type.
+    let dummy_updates: DummyAuditUpdates = std::iter::empty();
     let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
 
     // Extract outputs from the audit to drive the replica update_from_event.
@@ -1624,16 +1627,8 @@ fn test_corporate_action_replica_parity_floor_split() {
             sequence: Sequence(0),
         },
     };
-    // Type annotation required for StateReplicaManager::new to infer the iterator element type
-    #[allow(clippy::type_complexity)]
-    let dummy_updates: std::iter::Empty<
-        AuditTick<
-            EngineAudit<
-                EngineEvent<DataKind>,
-                EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
-            >,
-        >,
-    > = std::iter::empty();
+    // Type annotation required for StateReplicaManager::new to infer the iterator element type.
+    let dummy_updates: DummyAuditUpdates = std::iter::empty();
     let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
 
     // Drive the replica with the live outputs. The CorporateAction arm event-replays and ignores
@@ -1831,16 +1826,8 @@ fn test_corporate_action_replica_parity_short_reverse_split() {
             sequence: Sequence(0),
         },
     };
-    // Type annotation required for StateReplicaManager::new to infer the iterator element type
-    #[allow(clippy::type_complexity)]
-    let dummy_updates: std::iter::Empty<
-        AuditTick<
-            EngineAudit<
-                EngineEvent<DataKind>,
-                EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
-            >,
-        >,
-    > = std::iter::empty();
+    // Type annotation required for StateReplicaManager::new to infer the iterator element type.
+    let dummy_updates: DummyAuditUpdates = std::iter::empty();
     let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
 
     let outputs = match &audit_tick.event {
@@ -1939,16 +1926,8 @@ fn test_corporate_action_replica_parity_unsupported_non_spot() {
             sequence: Sequence(0),
         },
     };
-    // Type annotation required for StateReplicaManager::new to infer the iterator element type
-    #[allow(clippy::type_complexity)]
-    let dummy_updates: std::iter::Empty<
-        AuditTick<
-            EngineAudit<
-                EngineEvent<DataKind>,
-                EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
-            >,
-        >,
-    > = std::iter::empty();
+    // Type annotation required for StateReplicaManager::new to infer the iterator element type.
+    let dummy_updates: DummyAuditUpdates = std::iter::empty();
     let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
     replica_manager.update_from_event(ca_event, &outputs);
 
@@ -2479,16 +2458,8 @@ fn test_corporate_action_option_replica_parity_standard_split() {
             sequence: Sequence(0),
         },
     };
-    // Type annotation required for StateReplicaManager::new to infer the iterator element type
-    #[allow(clippy::type_complexity)]
-    let dummy_updates: std::iter::Empty<
-        AuditTick<
-            EngineAudit<
-                EngineEvent<DataKind>,
-                EngineOutput<OnTradingDisabledOutput, OnDisconnectOutput>,
-            >,
-        >,
-    > = std::iter::empty();
+    // Type annotation required for StateReplicaManager::new to infer the iterator element type.
+    let dummy_updates: DummyAuditUpdates = std::iter::empty();
     let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
 
     // Drive the replica with the live outputs. The standard option adjustment is pure event-replay
@@ -3148,8 +3119,9 @@ fn send_fill(
             side,
             price,
             quantity: dec!(1),
-            // Hedging option engine: quote is USD = AssetIndex(1)
-            fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
+            // BTCUSDT (instrument 0) quote = usdt = AssetIndex(2). Fee is zero here regardless, but
+            // use the correct quote asset for the instrument this helper always fills (index 0).
+            fees: asset_fees(0, Decimal::ZERO),
         }),
     }));
     engine.process(event);


### PR DESCRIPTION
## Summary

Adds end-to-end corporate-action (stock split / reverse split) handling to the engine for **both backtest and live**, covering **equities and options**, plus a PULL sourcing abstraction with three provider surfaces (Massive, Alpaca, IBKR Flex). Before this change rustrade had zero engine handling of splits — open positions stayed on the pre-split scale until something externally rewrote them.

The boundary is deliberate: the **library** owns the mechanical, judgment-free adjustments and emits observables; **policy** (sourcing cadence, rounding choice, ticker→key resolution, cash-in-lieu reconciliation, non-standard option identity changes) stays with the downstream wrapper.

## What's included

**Engine primitive & event**
- `Position::apply_split(ratio, policy, last_price)` — notional-preserving basis (`avg /= ratio`), `quantity_abs *= ratio` (floored only under `SplitRoundingPolicy::Floor`), unfloored `quantity_abs_max`, eager `pnl_unrealised` recompute; returns a fractional `SplitResult` remainder.
- `EngineEvent::CorporateAction { id, instrument, kind, policy, effective_time }` + handler, mirroring the existing `ContractExpiry` precedent. Idempotent per-instrument on a caller-assigned `id`; clock advances to the exact `effective_time` so backtest stamping/ordering is exact.
- Resting orders are **reported** (`OpenOrdersAtSplit`), never engine-cancelled (a real broker price-adjusts them); cash-in-lieu is surfaced as `SplitRemainder`, never written to a balance. A reverse split that floors a position to zero closes it with a `PositionExit`.

**Options on a splitting underlying**
- **Standard** (whole-number forward) splits adjust each option position in place (strike ÷ ratio, contracts × ratio, multiplier unchanged) and emit `OptionPositionAdjustedForSplit` per position.
- **Non-standard** (reverse / fractional-forward) splits require a new contract identity the engine does not register at runtime, so they emit `OptionPositionsRequireIdentityChange` and leave options at pre-split terms; the equity split still applies. The wrapper closes the listed options and/or trades a pre-declared new identity (backtestable via the aux seam).

**Backtest injection seam**
- New `AuxEventSource` trait, zero-cost `NoAuxEvents` default, and `AuxEventsInMemory` interleave non-market `EngineEvent`s with the market stream in simulated-time order — the backtest equivalent of live `feed_tx` injection. Also makes `ContractExpiry` backtest-testable for the first time.

**PULL sourcing**
- `StockSplitSource` trait + `CorporateActionFilter` yielding a generic `CorporateAction<SmolStr>` descriptor; a shared `stock_split(split_to, split_from)` ratio helper so every provider derives the ratio identically.
- Reference impls: **Massive** (`execution_date`) and **Alpaca** (`ex_date`, pinned by a provenance test that rejects `payable_date`). A shared `AlpacaRestClient` transport was factored out of the options client.
- **IBKR Flex** reconciliation surface (2-call Flex Web Service flow, quick-xml parser) yields faithful raw `IbkrFlexCorporateAction` records — intentionally a reconciliation source, **not** a `StockSplitSource` (no library-side ratio derivation; `principal_adjust_factor` is surfaced raw with TIPS-not-ratio rustdoc).

Runnable examples: `corporate_action_injection`, `corporate_action_sourcing`, and `ibkr_flex_corporate_actions`.

## Breaking changes

- `EngineEvent` and `EngineOutput` are now `#[non_exhaustive]` (downstream exhaustive matchers need a wildcard arm). A new `EngineEvent` variant also breaks replay of audit logs persisted before this change.
- `BacktestArgsConstant` gains a defaulted `AuxEvents = NoAuxEvents` generic param + an `aux_events` field (zero behaviour change for existing callers; struct literals add one line).

See `CHANGELOG.md` (`## [Unreleased]`) for the full list.

## Testing

- `test_engine_process_engine_event_with_audit` (handler + live-vs-replica parity + options) — 30 passing
- `test_backtest_aux_events` (injection seam) — 5 passing
- `rustrade` lib (`apply_split`, merge, clock) — 95 passing; `rustrade-instrument` — 30 passing
- `rustrade-data` sourcing with `alpaca,massive,ibkr` — 330 passing (live-network tests are `#[ignore]`)
- Full gate `cargo clippy --workspace --all-targets --all-features` — 0 errors (sole warning is a pre-existing, unrelated `cognitive_complexity` in `rustrade-execution`)
