### PR TITLE
fix(position): pnl_unrealised correctness — fee units, overflow safety, per-tick refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   routes through `InstrumentState::update_from_market`, so every open position is revalued and its
   `time_exchange_update` advanced on each priced market event. The audit-replica path shares this
   method and revalues identically. (#186)
+- **Public `calculate_pnl_unrealised` no longer panics on `Decimal` overflow** (`rustrade`). The free
+  function `engine::state::position::calculate_pnl_unrealised` now performs checked arithmetic and
+  returns `Option<Decimal>` (`None` on overflow); the previously-private checked twin is folded into
+  it, leaving a single public arithmetic core that every `pnl_unrealised` recompute routes through.
+  Removes a latent panic vector for external callers that computed unrealised PnL directly.
+  **Breaking:** the return type changed from `Decimal` to `Option<Decimal>`; callers must handle
+  `None`.
+- **`Position::pnl_realised` accumulation no longer panics on `Decimal` overflow** (`rustrade`).
+  `calculate_pnl_realised` and `calculate_pnl_return` now use checked arithmetic and return
+  `Option<Decimal>` (`None` on overflow). `Position::update_pnl_realised` checks both the closed
+  delta and its accumulation into the running total, and on overflow **holds** the last-good
+  cumulative `pnl_realised` (the failing close's contribution is not applied — there is no safe
+  fallback for a monotonic ledger) and logs a `warn!`; the entry-fee deduction on the position-
+  increase path and the statistics `PnLReturns::update` accumulation are hardened the same way, with
+  the returns path skipping the affected data point. **Breaking:** `calculate_pnl_realised` and
+  `calculate_pnl_return` now return `Option<Decimal>` (was `Decimal`); `Position::update_pnl_realised`
+  now returns `#[must_use] PnlRealisedUpdate { Updated, Overflowed }` (was `()`); direct callers must
+  handle the new return values.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   paths degrade to `0` (the basis has just changed). **Breaking:** `Position::update_pnl_unrealised`
   now returns `#[must_use] PnlUnrealisedUpdate { Updated, Overflowed }` (was `()`); direct callers
   must bind the result. (#177)
+- **`Position::pnl_unrealised` now updates on market ticks** (`rustrade`). `EngineState::update_from_market`
+  previously refreshed only the instrument's market-data state, never the open positions, so
+  `pnl_unrealised` stayed frozen at its last post-fill value (e.g. `0` for a freshly opened position)
+  no matter how far the market moved — contradicting the field's documented per-tick contract. It now
+  routes through `InstrumentState::update_from_market`, so every open position is revalued and its
+  `time_exchange_update` advanced on each priced market event. The audit-replica path shares this
+  method and revalues identically. (#186)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `fees` only when no quote-equivalent is derivable), matching the realised-PnL convention. Fixes a
   dimensionally-inconsistent `pnl_unrealised` when the entry fee was paid in a base asset (e.g. BTC)
   rather than the quote asset. (#165)
+- **`Position::pnl_unrealised` recompute no longer panics on an extreme price** (`rustrade`). The
+  per-tick recompute now routes through checked `Decimal` arithmetic instead of the panicking
+  unchecked path, so a corrupted feed price near `Decimal::MAX` can no longer bring down the engine.
+  On overflow the market path **holds** the last-good value (a tick does not change the cost basis,
+  so the prior estimate beats a fabricated `0`) and logs a `warn!`, while the post-trade and split
+  paths degrade to `0` (the basis has just changed). **Breaking:** `Position::update_pnl_unrealised`
+  now returns `#[must_use] PnlUnrealisedUpdate { Updated, Overflowed }` (was `()`); direct callers
+  must bind the result. (#177)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `OptionPositionsRequireIdentityChange` (non-standard, wrapper-handled). Relevant only to code
   tracking this unreleased development line, where both the old and new variants are pre-release.
 
+### Fixed
+
+- **`Position::pnl_unrealised` fee units** (`rustrade`). The per-tick unrealised-PnL exit-fee
+  estimate now uses the quote-equivalent entry fee (`fees_enter.fees_quote`, falling back to raw
+  `fees` only when no quote-equivalent is derivable), matching the realised-PnL convention. Fixes a
+  dimensionally-inconsistent `pnl_unrealised` when the entry fee was paid in a base asset (e.g. BTC)
+  rather than the quote asset. (#165)
+
 ### Security
 
 - Upgraded `anyhow` to 1.0.103 and `quick-xml` to 0.41.0 to clear three RUSTSEC advisories:

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -4,7 +4,9 @@ use crate::{
         state::{
             instrument::{data::InstrumentDataState, filter::InstrumentFilter},
             order::{Orders, manager::OrderManager},
-            position::{OmsMode, PositionExited, PositionManager, SplitRoundingPolicy},
+            position::{
+                OmsMode, PnlUnrealisedUpdate, PositionExited, PositionManager, SplitRoundingPolicy,
+            },
         },
     },
     statistic::summary::instrument::TearSheetGenerator,
@@ -903,13 +905,17 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
 
     /// Updates the instrument state based on a new market event.
     ///
-    /// If the market event has a price associated with it (eg/ `PublicTrade`, `OrderBookL1`), any
-    /// open [`Position`](super::position::Position) `pnl_unrealised` is re-calculated.
+    /// If the market event has a price associated with it (eg/ `PublicTrade`, `OrderBookL1`), each
+    /// open [`Position`](super::position::Position) has its `pnl_unrealised` re-calculated and its
+    /// `time_exchange_update` advanced to the event's exchange timestamp.
     pub fn update_from_market(
         &mut self,
         event: &MarketEvent<InstrumentKey, InstrumentData::MarketEventKind>,
     ) where
         InstrumentData: InstrumentDataState<ExchangeKey, AssetKey, InstrumentKey>,
+        // For the overflow `warn!` diagnostic context; satisfied by the concrete `InstrumentIndex`
+        // the engine drives this with.
+        InstrumentKey: std::fmt::Debug,
     {
         self.data.process(event);
 
@@ -918,7 +924,19 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
         };
 
         for position in self.position.positions.values_mut() {
-            position.update_pnl_unrealised(price);
+            // A market fact landed regardless of whether the derived PnL turned out to be
+            // representable, so advance the update clock unconditionally. This also finally
+            // honours `Position::time_exchange_update`'s documented contract that a market-price
+            // update advances it (previously no code did).
+            position.time_exchange_update = event.time_exchange;
+
+            if let PnlUnrealisedUpdate::Overflowed = position.update_pnl_unrealised(price) {
+                warn!(
+                    instrument = ?event.instrument,
+                    %price,
+                    "pnl_unrealised recompute overflowed Decimal; holding last-good value"
+                );
+            }
         }
     }
 }

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -913,15 +913,18 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
         event: &MarketEvent<InstrumentKey, InstrumentData::MarketEventKind>,
     ) where
         InstrumentData: InstrumentDataState<ExchangeKey, AssetKey, InstrumentKey>,
-        // For the overflow `warn!` diagnostic context; satisfied by the concrete `InstrumentIndex`
-        // the engine drives this with.
-        InstrumentKey: std::fmt::Debug,
     {
         self.data.process(event);
 
         let Some(price) = self.data.price() else {
             return;
         };
+
+        // The event is dispatched to this instrument, so `self.instrument` names it. Unlike the
+        // generic `InstrumentKey`, `InstrumentNameInternal` is unconditionally `Display` — so the
+        // diagnostic needs no `Debug` bound on the public method and logs a readable name
+        // (`btc_usdt`) rather than an opaque index.
+        let instrument = &self.instrument.name_internal;
 
         for position in self.position.positions.values_mut() {
             // A market fact landed regardless of whether the derived PnL turned out to be
@@ -930,9 +933,9 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
             // update advances it (previously no code did).
             position.time_exchange_update = event.time_exchange;
 
-            if let PnlUnrealisedUpdate::Overflowed = position.update_pnl_unrealised(price) {
+            if position.update_pnl_unrealised(price) == PnlUnrealisedUpdate::Overflowed {
                 warn!(
-                    instrument = ?event.instrument,
+                    %instrument,
                     %price,
                     "pnl_unrealised recompute overflowed Decimal; holding last-good value"
                 );

--- a/rustrade/src/engine/state/mod.rs
+++ b/rustrade/src/engine/state/mod.rs
@@ -196,7 +196,10 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
     /// - Sets the market data [`ConnectivityState`](connectivity::ConnectivityState) to
     ///   [`Health::Healthy`](connectivity::Health::Healthy) if it was not previously.
     /// - Updates the `GlobalData` with the `MarketEvent`.
-    /// - Updates the associated [`InstrumentDataState`] with the `MarketEvent`.
+    /// - Refreshes the associated instrument via
+    ///   [`InstrumentState::update_from_market`](instrument::InstrumentState::update_from_market),
+    ///   which updates its [`InstrumentDataState`] and then, for each open position, re-computes
+    ///   `pnl_unrealised` and advances `time_exchange_update` from the new market price.
     pub fn update_from_market(
         &mut self,
         event: &MarketEvent<InstrumentIndex, InstrumentData::MarketEventKind>,
@@ -211,7 +214,10 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
         let instrument_state = self.instruments.instrument_index_mut(&event.instrument);
 
         self.global.process(event);
-        instrument_state.data.process(event);
+        // Refreshes `data` (via `self.data.process`) AND re-computes each open position's
+        // `pnl_unrealised` + advances `time_exchange_update` — previously only `data.process` ran,
+        // leaving `pnl_unrealised` stale between fills despite its documented per-tick contract.
+        instrument_state.update_from_market(event);
     }
 }
 

--- a/rustrade/src/engine/state/position.rs
+++ b/rustrade/src/engine/state/position.rs
@@ -10,7 +10,7 @@ use rustrade_instrument::{
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use thiserror::Error;
-use tracing::error;
+use tracing::{error, warn};
 
 /// Order Management System mode governing how positions are tracked.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
@@ -119,6 +119,26 @@ pub enum PnlUnrealisedUpdate {
     /// The checked recompute overflowed `Decimal`; the previous `pnl_unrealised` was **held**
     /// unchanged (the basis is unaltered on a market tick, so the last-good value beats a
     /// fabricated `0`). See [`Position::update_pnl_unrealised`].
+    Overflowed,
+}
+
+/// Outcome of [`Position::update_pnl_realised`]: whether the checked `pnl_realised` update
+/// succeeded or overflowed `Decimal`.
+///
+/// `#[must_use]` so a caller cannot silently ignore an overflow (`update_pnl_realised` itself warns
+/// on it); `#[non_exhaustive]` per library convention, so a future outcome can be added without
+/// breaking downstream exhaustive matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+#[non_exhaustive]
+pub enum PnlRealisedUpdate {
+    /// The checked update succeeded and the cumulative `pnl_realised` was advanced.
+    Updated,
+    /// The checked update overflowed `Decimal`; the previous cumulative `pnl_realised` was **held**
+    /// unchanged and this close's realised contribution was **not** applied. Unlike the unrealised
+    /// path there is no safe fallback for a booked, monotonic ledger — `0` would erase real
+    /// accumulated PnL and saturating would freeze a meaningless ceiling — so the last-good total
+    /// is kept. See [`Position::update_pnl_realised`].
     Overflowed,
 }
 
@@ -511,7 +531,19 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
                 // quote-equivalent. Downstream is responsible for applying a converted
                 // fee impact when accurate quote-denominated P&L is required for those
                 // assets (see `AssetFees::fees_quote` doc).
-                self.pnl_realised -= trade.fees.fees_quote.unwrap_or(trade.fees.fees);
+                //
+                // Checked, hold-last-good on overflow (consistent with `update_pnl_realised`): a
+                // deduction that can't be represented holds the prior cumulative value rather than
+                // panicking. Unreachable without a `~Decimal::MAX` cumulative PnL.
+                let entry_fee = trade.fees.fees_quote.unwrap_or(trade.fees.fees);
+                match self.pnl_realised.checked_sub(entry_fee) {
+                    Some(new_total) => self.pnl_realised = new_total,
+                    None => warn!(
+                        %entry_fee,
+                        pnl_realised_held = %self.pnl_realised,
+                        "pnl_realised entry-fee deduction overflowed Decimal; holding last-good value"
+                    ),
+                }
                 self.fees_enter.fees += trade.fees.fees;
                 self.fees_enter.fees_quote =
                     match (self.fees_enter.fees_quote, trade.fees.fees_quote) {
@@ -528,7 +560,8 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
                 // Use quote-equivalent fee for P&L; fall back to raw fees.fees for
                 // third-party fee assets (caller must layer their own conversion).
                 let closed_fee_quote = trade.fees.fees_quote.unwrap_or(trade.fees.fees);
-                self.update_pnl_realised(trade.quantity, trade.price, closed_fee_quote);
+                // Overflow is held + warned inside `update_pnl_realised`; observed via logs here.
+                let _ = self.update_pnl_realised(trade.quantity, trade.price, closed_fee_quote);
 
                 // Update remaining Position state
                 self.quantity_abs -= trade.quantity.abs();
@@ -556,7 +589,8 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
                 };
                 self.time_exchange_update = trade.time_exchange;
                 let closed_fee_quote = trade.fees.fees_quote.unwrap_or(trade.fees.fees);
-                self.update_pnl_realised(trade.quantity, trade.price, closed_fee_quote);
+                // Overflow is held + warned inside `update_pnl_realised`; observed via logs here.
+                let _ = self.update_pnl_realised(trade.quantity, trade.price, closed_fee_quote);
                 self.update_pnl_unrealised_post_trade(trade.price);
 
                 (None, Some(PositionExited::from(self)))
@@ -599,7 +633,8 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
                     _ => None,
                 };
                 self.time_exchange_update = trade.time_exchange;
-                self.update_pnl_realised(
+                // Overflow is held + warned inside `update_pnl_realised`; observed via logs here.
+                let _ = self.update_pnl_realised(
                     self.quantity_abs,
                     trade.price,
                     fee_exit_quote.unwrap_or(fee_exit),
@@ -642,8 +677,7 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// the prior value remains a valid (if marginally stale) estimate and beats a fabricated `0`
     /// that would misreport a real open loss as flat. This differs from the post-trade and split
     /// paths, where the basis has *just* changed and so overflow degrades to `0` instead (see
-    /// [`update_pnl_unrealised_post_trade`](Self::update_pnl_unrealised_post_trade) and
-    /// [`apply_split`](Self::apply_split)).
+    /// `update_pnl_unrealised_post_trade` and [`apply_split`](Self::apply_split)).
     ///
     /// The price may be a recent [`Trade`] price or one derived from a model over public market
     /// data. The `#[must_use]` return lets the caller observe overflow (the market caller emits a
@@ -666,10 +700,11 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// to hold — an overflow degrades to `0`, mirroring the split path
     /// ([`apply_split`](Self::apply_split)). The value self-corrects on the next market tick.
     ///
-    /// Overflow is provably unreachable at 2 of the 4 trade call sites — the exact-close (`:542`)
-    /// and flip (`:590`) paths set `quantity_abs == 0` before calling, zeroing the value terms — and
-    /// needs a `price ≈ Decimal::MAX` at the other two, so degrade-to-`0` is a defensive floor
-    /// rather than an expected path.
+    /// Overflow is provably unreachable at 2 of the 4 trade call sites — the exact-close and
+    /// position-flip paths zero `quantity_abs` before calling, so the checked value terms are `0`
+    /// regardless of `price` — and needs a `price ≈ Decimal::MAX` at the other two (the increase
+    /// and partial-reduce paths), so degrade-to-`0` is a defensive floor rather than an expected
+    /// path.
     fn update_pnl_unrealised_post_trade(&mut self, price: Decimal) {
         self.pnl_unrealised = self.checked_pnl_unrealised(price).unwrap_or(Decimal::ZERO);
     }
@@ -684,9 +719,9 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// - [`update_pnl_unrealised_post_trade`](Self::update_pnl_unrealised_post_trade) and
     ///   [`apply_split`](Self::apply_split) — degrade to `0` (basis just changed).
     ///
-    /// See [`checked_calculate_pnl_unrealised`].
+    /// See [`calculate_pnl_unrealised`].
     fn checked_pnl_unrealised(&self, price: Decimal) -> Option<Decimal> {
-        checked_calculate_pnl_unrealised(
+        calculate_pnl_unrealised(
             self.side,
             self.price_entry_average,
             self.quantity_abs,
@@ -699,22 +734,54 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
         )
     }
 
-    /// Updates the [`Position`] `pnl_realised` from a closed portion of the [`Position`] quantity.
+    /// Update the [`Position`] `pnl_realised` from a closed portion of the [`Position`] quantity,
+    /// using **checked** `Decimal` arithmetic on both the closed-quantity PnL and the running-total
+    /// accumulation.
+    ///
+    /// On success the cumulative `pnl_realised` is advanced and [`PnlRealisedUpdate::Updated`] is
+    /// returned. On `Decimal` overflow of *either* step **nothing is mutated** — the last-good
+    /// cumulative value is **held**, a `warn!` is emitted, and [`PnlRealisedUpdate::Overflowed`] is
+    /// returned. Holding is the only sound fallback for a booked, monotonic ledger (`0` would erase
+    /// real accumulated PnL; saturating would freeze a meaningless ceiling). The one documented
+    /// cost is that the failing close's realised contribution is dropped rather than retried — this
+    /// needs a `> Decimal::MAX` (~7.9e28) notional and is effectively unreachable with real data.
     pub fn update_pnl_realised(
         &mut self,
         closed_quantity: Decimal,
         closed_price: Decimal,
         closed_fee: Decimal,
-    ) {
-        // Update total Position pnl_realised with closed quantity PnL
-        self.pnl_realised += calculate_pnl_realised(
+    ) -> PnlRealisedUpdate {
+        // Check both the closed-quantity delta AND its accumulation into the running total; a small
+        // delta could still overflow a `pnl_realised` already near `Decimal::MAX`.
+        let updated = calculate_pnl_realised(
             self.side,
             self.price_entry_average,
             closed_quantity,
             closed_price,
             closed_fee,
             self.contract_size,
-        );
+        )
+        .and_then(|delta| self.pnl_realised.checked_add(delta));
+
+        match updated {
+            Some(new_total) => {
+                self.pnl_realised = new_total;
+                PnlRealisedUpdate::Updated
+            }
+            None => {
+                warn!(
+                    side = ?self.side,
+                    price_entry_average = %self.price_entry_average,
+                    %closed_quantity,
+                    %closed_price,
+                    %closed_fee,
+                    pnl_realised_held = %self.pnl_realised,
+                    "pnl_realised recompute/accumulation overflowed Decimal; holding last-good \
+                     cumulative value (this close's realised contribution was not applied)"
+                );
+                PnlRealisedUpdate::Overflowed
+            }
+        }
     }
 
     /// Apply a stock split / reverse split to this [`Position`] in place, returning the
@@ -1052,51 +1119,26 @@ fn calculate_price_entry_average(
 }
 
 /// Calculate the estimated unrealised PnL from closing a [`Position`] `quantity_abs` at the
-/// provided price.
+/// provided `price`, using **checked** `Decimal` arithmetic — returning `None` on overflow
+/// instead of panicking.
+///
+/// This is the single arithmetic core behind every `pnl_unrealised` recompute reached through the
+/// engine — the per-market-tick path ([`Position::update_pnl_unrealised`]), the post-trade path
+/// (`update_pnl_unrealised_post_trade`) and the corporate-action split path
+/// ([`Position::apply_split`]) all route through `Position::checked_pnl_unrealised` into here.
+/// Each caller chooses its own overflow fallback (hold-last-good on a tick, degrade-to-`0` once the
+/// basis has changed).
 ///
 /// The `contract_size` multiplier converts price-based PnL to actual dollar PnL for derivatives.
 /// For spot instruments, pass `Decimal::ONE`.
+///
+/// The exit-fee approximation reuses `approximate_remaining_exit_fees` **unchecked**, by design:
+/// the only unbounded, feed-controlled input is `price` (covered by the checked value terms below).
+/// The fee term is `(quantity_abs / quantity_abs_max) × fees_enter`, whose ratio stays `≤ 1` under
+/// the `quantity_abs ≤ quantity_abs_max` invariant that `compute_split` preserves (both scale by the
+/// same `ratio`; `Floor` only lowers `quantity_abs`), times a realised, bounded `fees_enter` — so it
+/// has no *reachable* overflow, and guarding it would be over-engineering.
 pub fn calculate_pnl_unrealised(
-    position_side: Side,
-    price_entry_average: Decimal,
-    quantity_abs: Decimal,
-    quantity_abs_max: Decimal,
-    fees_enter: Decimal,
-    price: Decimal,
-    contract_size: Decimal,
-) -> Decimal {
-    let approx_exit_fees =
-        approximate_remaining_exit_fees(quantity_abs, quantity_abs_max, fees_enter);
-
-    let value_quote_current = quantity_abs * price * contract_size;
-    let value_quote_entry = quantity_abs * price_entry_average * contract_size;
-
-    match position_side {
-        Side::Buy => value_quote_current - value_quote_entry - approx_exit_fees,
-        Side::Sell => value_quote_entry - value_quote_current - approx_exit_fees,
-    }
-}
-
-/// Checked twin of [`calculate_pnl_unrealised`]: identical math with `checked_*` `Decimal`
-/// arithmetic, returning `None` on overflow instead of panicking.
-///
-/// This is the arithmetic core behind every `pnl_unrealised` recompute reached through the engine —
-/// the per-market-tick path ([`Position::update_pnl_unrealised`]), the post-trade path
-/// ([`Position::update_pnl_unrealised_post_trade`]) and the corporate-action split path
-/// ([`Position::apply_split`]) all route through [`Position::checked_pnl_unrealised`] into here. Each
-/// caller chooses its own overflow fallback (hold-last-good on a tick, degrade-to-`0` once the basis
-/// has changed). The still-`pub` unchecked [`calculate_pnl_unrealised`] remains a latent panic vector
-/// for direct external callers — hardening or deprecating that entry point is a separate follow-up.
-///
-/// The exit-fee approximation reuses [`approximate_remaining_exit_fees`] **unchecked**, by design:
-/// the only unbounded, feed-controlled input on the split path is `price` (covered by the checked
-/// value terms above). The fee term is `(quantity_abs / quantity_abs_max) × fees_enter`, whose ratio
-/// stays `≤ 1` under the `quantity_abs ≤ quantity_abs_max` invariant that
-/// [`compute_split`](Position::compute_split) preserves (both scale by the same `ratio`; `Floor`
-/// only lowers `quantity_abs`), times a realised, bounded `fees_enter` — so it has no *reachable*
-/// overflow. It is deliberately not re-checked here: guarding that unreachable state would be
-/// over-engineering, and it keeps the per-tick [`calculate_pnl_unrealised`] path untouched.
-fn checked_calculate_pnl_unrealised(
     position_side: Side,
     price_entry_average: Decimal,
     quantity_abs: Decimal,
@@ -1142,7 +1184,8 @@ fn approximate_remaining_exit_fees(
 }
 
 /// Calculate the realised PnL generated from closing the provided [`Position`] quantity, at the
-/// specified price and closing fee.
+/// specified price and closing fee, using **checked** `Decimal` arithmetic — returning `None` on
+/// overflow instead of panicking.
 ///
 /// The `contract_size` multiplier converts price-based PnL to actual dollar PnL for derivatives.
 /// For spot instruments, pass `Decimal::ONE`. For standard equity options (100 shares/contract),
@@ -1154,31 +1197,46 @@ pub fn calculate_pnl_realised(
     closed_price: Decimal,
     closed_fee: Decimal,
     contract_size: Decimal,
-) -> Decimal {
+) -> Option<Decimal> {
     let close_quantity = closed_quantity.abs();
-    let value_quote_closed = close_quantity * closed_price * contract_size;
-    let value_quote_entry = close_quantity * price_entry_average * contract_size;
+    let value_quote_closed = close_quantity
+        .checked_mul(closed_price)?
+        .checked_mul(contract_size)?;
+    let value_quote_entry = close_quantity
+        .checked_mul(price_entry_average)?
+        .checked_mul(contract_size)?;
 
     match position_side {
-        Side::Buy => value_quote_closed - value_quote_entry - closed_fee,
-        Side::Sell => value_quote_entry - value_quote_closed - closed_fee,
+        Side::Buy => value_quote_closed
+            .checked_sub(value_quote_entry)?
+            .checked_sub(closed_fee),
+        Side::Sell => value_quote_entry
+            .checked_sub(value_quote_closed)?
+            .checked_sub(closed_fee),
     }
 }
 
-/// Calculate the PnL returns.
+/// Calculate the PnL returns, using **checked** `Decimal` arithmetic — returning `None` on overflow
+/// instead of panicking.
 ///
 /// Returns = pnl_realised / cost_of_investment
+///
+/// A zero cost-of-investment basis (zero entry price or zero max quantity) is a legitimate,
+/// non-error case and yields `Some(Decimal::ZERO)`; `None` signals an arithmetic result that cannot
+/// be represented as a `Decimal` (overflow of the `price_entry_average × quantity_abs_max` basis, or
+/// of the division).
 ///
 /// See docs: <https://www.investopedia.com/articles/basics/10/guide-to-calculating-roi.asp>
 pub fn calculate_pnl_return(
     pnl_realised: Decimal,
     price_entry_average: Decimal,
     quantity_abs_max: Decimal,
-) -> Decimal {
+) -> Option<Decimal> {
     if price_entry_average.is_zero() || quantity_abs_max.is_zero() {
-        return Decimal::ZERO;
+        return Some(Decimal::ZERO);
     }
-    pnl_realised / (price_entry_average * quantity_abs_max)
+    let cost_of_investment = price_entry_average.checked_mul(quantity_abs_max)?;
+    pnl_realised.checked_div(cost_of_investment)
 }
 
 #[cfg(test)]
@@ -1188,6 +1246,29 @@ mod tests {
     use crate::test_utils::{time_plus_days, trade};
     use rust_decimal_macros::dec;
     use rustrade_instrument::{asset::QuoteAsset, instrument::name::InstrumentNameInternal};
+
+    /// Independent, unchecked re-implementation of the `pnl_unrealised` formula, kept solely as a
+    /// cross-check oracle: the production **checked** [`calculate_pnl_unrealised`] (reached via the
+    /// split path) must match this separately-written naive formula bit-for-bit on non-overflowing
+    /// inputs. Deliberately not sharing code with the production function so the two can disagree.
+    fn naive_calculate_pnl_unrealised(
+        position_side: Side,
+        price_entry_average: Decimal,
+        quantity_abs: Decimal,
+        quantity_abs_max: Decimal,
+        fees_enter: Decimal,
+        price: Decimal,
+        contract_size: Decimal,
+    ) -> Decimal {
+        let approx_exit_fees =
+            approximate_remaining_exit_fees(quantity_abs, quantity_abs_max, fees_enter);
+        let value_quote_current = quantity_abs * price * contract_size;
+        let value_quote_entry = quantity_abs * price_entry_average * contract_size;
+        match position_side {
+            Side::Buy => value_quote_current - value_quote_entry - approx_exit_fees,
+            Side::Sell => value_quote_entry - value_quote_current - approx_exit_fees,
+        }
+    }
 
     #[test]
     fn test_position_update_from_trade() {
@@ -1644,7 +1725,7 @@ mod tests {
                 Decimal::ONE,
             );
 
-            assert_eq!(actual, test.expected, "TC{} failed", index);
+            assert_eq!(actual, Some(test.expected), "TC{} failed", index);
         }
     }
 
@@ -1662,7 +1743,7 @@ mod tests {
             dec!(15.0),  // current price per share
             dec!(100.0), // 100 shares per contract
         );
-        assert_eq!(pnl, dec!(499.0));
+        assert_eq!(pnl, Some(dec!(499.0)));
 
         // Short 2 puts sold at $5/share, current price $3/share, $2 entry fee
         // Unrealised PnL = (5 - 3) * 2 * 100 - 2 = 398
@@ -1675,7 +1756,7 @@ mod tests {
             dec!(3.0),   // current price per share
             dec!(100.0), // 100 shares per contract
         );
-        assert_eq!(pnl, dec!(398.0));
+        assert_eq!(pnl, Some(dec!(398.0)));
     }
 
     #[test]
@@ -1758,6 +1839,50 @@ mod tests {
 
         // fees_quote is None ⇒ fall back to raw fees (2.0): 1_000 − 2 = 998.0.
         assert_eq!(position.pnl_unrealised, dec!(998.0));
+    }
+
+    #[test]
+    fn test_update_pnl_unrealised_holds_last_good_on_overflow() {
+        // Regression for the overflow-safety contract (#177): on the per-market-tick path an
+        // extreme feed `price` that overflows `Decimal` must NOT panic, must report
+        // `PnlUnrealisedUpdate::Overflowed`, and must leave the prior `pnl_unrealised`
+        // byte-for-byte unchanged (hold-last-good — a market tick does not change the cost basis,
+        // so the last good value beats a fabricated `0` that would misreport a real open loss as
+        // flat). This exercises the novel `Overflowed` branch the other unit tests never reach.
+        let sentinel = dec!(-123.45); // a real held open loss carried from the last good tick
+        let mut position = Position {
+            instrument: InstrumentNameInternal::new("btc_usdt"),
+            side: Side::Buy,
+            price_entry_average: dec!(100.0),
+            // quantity_abs > 1 so `quantity_abs × price` overflows at `price ≈ Decimal::MAX`
+            // (with quantity_abs == 1 the first checked multiply cannot exceed `Decimal::MAX`).
+            quantity_abs: dec!(2.0),
+            quantity_abs_max: dec!(2.0),
+            pnl_unrealised: sentinel,
+            pnl_realised: dec!(0.0),
+            fees_enter: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
+            },
+            fees_exit: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
+            },
+            time_enter: DateTime::<Utc>::MIN_UTC,
+            time_exchange_update: DateTime::<Utc>::MIN_UTC,
+            trades: vec![TradeId::new("t")],
+            contract_size: Decimal::ONE,
+        };
+
+        // `2 × Decimal::MAX` overflows the first checked multiply ⇒ no panic, `Overflowed`.
+        assert_eq!(
+            position.update_pnl_unrealised(Decimal::MAX),
+            PnlUnrealisedUpdate::Overflowed
+        );
+        // Hold-last-good: the previous value is untouched, not zeroed.
+        assert_eq!(position.pnl_unrealised, sentinel);
     }
 
     #[test]
@@ -1951,7 +2076,7 @@ mod tests {
                 Decimal::ONE,
             );
 
-            assert_eq!(actual, test.expected, "TC{} failed", index);
+            assert_eq!(actual, Some(test.expected), "TC{} failed", index);
         }
     }
 
@@ -1968,7 +2093,7 @@ mod tests {
             dec!(1.0),   // $1 fee
             dec!(100.0), // 100 shares per contract
         );
-        assert_eq!(pnl, dec!(499.0));
+        assert_eq!(pnl, Some(dec!(499.0)));
 
         // SHORT option scenario: sell 2 puts at $5/share, buy back at $3/share, $2 fee
         // PnL = (5 - 3) * 2 * 100 - 2 = 398
@@ -1980,7 +2105,49 @@ mod tests {
             dec!(2.0),   // $2 fee
             dec!(100.0), // 100 shares per contract
         );
-        assert_eq!(pnl, dec!(398.0));
+        assert_eq!(pnl, Some(dec!(398.0)));
+    }
+
+    #[test]
+    fn test_update_pnl_realised_holds_last_good_on_overflow() {
+        // Regression for the realised overflow-safety contract: realised PnL is a booked,
+        // cumulative ledger value, so on `Decimal` overflow of either the close-delta computation
+        // or the running-total accumulation, `update_pnl_realised` must NOT panic, must report
+        // `PnlRealisedUpdate::Overflowed`, and must hold the prior cumulative `pnl_realised`
+        // unchanged (0 would erase real booked PnL; saturating would freeze a meaningless ceiling).
+        // Requires a `~Decimal::MAX` notional — unreachable with real data.
+        let sentinel = dec!(1_234.56); // real booked PnL accumulated from prior closes
+        let mut position = Position {
+            instrument: InstrumentNameInternal::new("btc_usdt"),
+            side: Side::Buy,
+            price_entry_average: dec!(100.0),
+            quantity_abs: dec!(5.0),
+            quantity_abs_max: dec!(5.0),
+            pnl_unrealised: dec!(0.0),
+            pnl_realised: sentinel,
+            fees_enter: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
+            },
+            fees_exit: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
+            },
+            time_enter: DateTime::<Utc>::MIN_UTC,
+            time_exchange_update: DateTime::<Utc>::MIN_UTC,
+            trades: vec![TradeId::new("t")],
+            contract_size: Decimal::ONE,
+        };
+
+        // closed_quantity 2 × closed_price Decimal::MAX overflows the delta's first checked multiply.
+        assert_eq!(
+            position.update_pnl_realised(dec!(2.0), Decimal::MAX, dec!(0.0)),
+            PnlRealisedUpdate::Overflowed
+        );
+        // Hold-last-good: the booked cumulative value is untouched.
+        assert_eq!(position.pnl_realised, sentinel);
     }
 
     #[test]
@@ -2044,7 +2211,7 @@ mod tests {
                 test.quantity_abs_max,
             );
 
-            assert_eq!(actual, test.expected, "TC{} failed", index);
+            assert_eq!(actual, Some(test.expected), "TC{} failed", index);
         }
     }
 
@@ -2238,7 +2405,7 @@ mod tests {
             );
 
             // pnl_unrealised eagerly recomputed from last_price using the POST-split fields.
-            let expected_pnl = calculate_pnl_unrealised(
+            let expected_pnl = naive_calculate_pnl_unrealised(
                 tc.side,
                 tc.expected_avg,
                 tc.expected_qty,
@@ -2252,7 +2419,7 @@ mod tests {
                 "{}: pnl_unrealised",
                 tc.name
             );
-            // The checked split-path recompute must match the unchecked `calculate_pnl_unrealised`
+            // The checked split-path recompute must match the independent naive re-implementation
             // above bit-for-bit on a normal price, and never spuriously flag an overflow.
             assert!(
                 !result.pnl_unrealised_overflowed,

--- a/rustrade/src/engine/state/position.rs
+++ b/rustrade/src/engine/state/position.rs
@@ -104,6 +104,24 @@ pub enum SplitError {
     Overflow,
 }
 
+/// Outcome of [`Position::update_pnl_unrealised`]: whether the checked `pnl_unrealised` recompute
+/// succeeded or overflowed `Decimal`.
+///
+/// `#[must_use]` so a caller cannot silently ignore an overflow (the per-tick market path warns on
+/// it); `#[non_exhaustive]` per library convention, so a future outcome can be added without
+/// breaking downstream exhaustive matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+#[non_exhaustive]
+pub enum PnlUnrealisedUpdate {
+    /// The checked recompute succeeded and `pnl_unrealised` was updated to the new value.
+    Updated,
+    /// The checked recompute overflowed `Decimal`; the previous `pnl_unrealised` was **held**
+    /// unchanged (the basis is unaltered on a market tick, so the last-good value beats a
+    /// fabricated `0`). See [`Position::update_pnl_unrealised`].
+    Overflowed,
+}
+
 /// The rescaled field values a split produces, computed by [`Position::compute_split`] without
 /// mutating the position — committed by [`Position::apply_split`], discarded by
 /// [`Position::validate_split`].
@@ -501,7 +519,7 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
                         _ => None,
                     };
                 self.time_exchange_update = trade.time_exchange;
-                self.update_pnl_unrealised(trade.price);
+                self.update_pnl_unrealised_post_trade(trade.price);
 
                 (Some(self), None)
             }
@@ -523,7 +541,7 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
                 self.time_exchange_update = trade.time_exchange;
 
                 // Update pnl_unrealised for remaining Position
-                self.update_pnl_unrealised(trade.price);
+                self.update_pnl_unrealised_post_trade(trade.price);
 
                 (Some(self), None)
             }
@@ -539,7 +557,7 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
                 self.time_exchange_update = trade.time_exchange;
                 let closed_fee_quote = trade.fees.fees_quote.unwrap_or(trade.fees.fees);
                 self.update_pnl_realised(trade.quantity, trade.price, closed_fee_quote);
-                self.update_pnl_unrealised(trade.price);
+                self.update_pnl_unrealised_post_trade(trade.price);
 
                 (None, Some(PositionExited::from(self)))
             }
@@ -587,7 +605,7 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
                     fee_exit_quote.unwrap_or(fee_exit),
                 );
                 self.quantity_abs = Decimal::ZERO;
-                self.update_pnl_unrealised(trade.price);
+                self.update_pnl_unrealised_post_trade(trade.price);
 
                 // Propagate contract_size from closing position to the new flipped position
                 let mut next_position = Self::from(&next_position_trade);
@@ -611,33 +629,62 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
         );
     }
 
-    /// Update [`Position::pnl_unrealised`](Position) with the estimated PnL from closing
-    /// the [`Position`] at the provided price.
+    /// Recompute [`Position::pnl_unrealised`](Position) — the estimated PnL from closing the
+    /// [`Position`] at `price` — using **checked** `Decimal` arithmetic.
     ///
-    /// Note that this could be called with a recent [`Trade`] price, or a price generated from
-    /// a model based on public market data.
-    pub fn update_pnl_unrealised(&mut self, price: Decimal) {
-        self.pnl_unrealised = calculate_pnl_unrealised(
-            self.side,
-            self.price_entry_average,
-            self.quantity_abs,
-            self.quantity_abs_max,
-            // Quote-equivalent entry fee for the exit-fee estimate, matching the realised-PnL
-            // convention (`Position::from` `:889`, closing-trade paths `:496`/`:540`). Falls back
-            // to raw `fees` only for third-party fee assets where no quote-equivalent is derivable.
-            self.fees_enter.fees_quote.unwrap_or(self.fees_enter.fees),
-            price,
-            self.contract_size,
-        );
+    /// This is the per-market-tick path: it is called for every open position on every price
+    /// update (via [`InstrumentState::update_from_market`](super::instrument::InstrumentState::update_from_market)),
+    /// so it must never panic on an extreme feed `price`. On success the new value is stored and
+    /// [`PnlUnrealisedUpdate::Updated`] is returned; on `Decimal` overflow **nothing is mutated**
+    /// (the previous `pnl_unrealised` is held) and [`PnlUnrealisedUpdate::Overflowed`] is returned.
+    ///
+    /// Hold-last-good is deliberate: a market tick does not change the position's cost basis, so
+    /// the prior value remains a valid (if marginally stale) estimate and beats a fabricated `0`
+    /// that would misreport a real open loss as flat. This differs from the post-trade and split
+    /// paths, where the basis has *just* changed and so overflow degrades to `0` instead (see
+    /// [`update_pnl_unrealised_post_trade`](Self::update_pnl_unrealised_post_trade) and
+    /// [`apply_split`](Self::apply_split)).
+    ///
+    /// The price may be a recent [`Trade`] price or one derived from a model over public market
+    /// data. The `#[must_use]` return lets the caller observe overflow (the market caller emits a
+    /// `warn!`).
+    pub fn update_pnl_unrealised(&mut self, price: Decimal) -> PnlUnrealisedUpdate {
+        match self.checked_pnl_unrealised(price) {
+            Some(pnl) => {
+                self.pnl_unrealised = pnl;
+                PnlUnrealisedUpdate::Updated
+            }
+            None => PnlUnrealisedUpdate::Overflowed,
+        }
     }
 
-    /// Checked, non-mutating twin of [`update_pnl_unrealised`](Self::update_pnl_unrealised):
-    /// computes the unrealised PnL at `price`, returning `None` if the `Decimal` arithmetic
-    /// overflows instead of panicking.
+    /// Recompute [`Position::pnl_unrealised`](Position) after a trade fill has just changed the
+    /// position's cost basis, degrading to `0` on `Decimal` overflow.
     ///
-    /// Used by [`apply_split`](Self::apply_split) to degrade the eager post-split `pnl_unrealised`
-    /// recompute to `0` on an extreme `last_price` rather than panic mid-way through an atomic
-    /// multi-position corporate-action adjustment. See [`checked_calculate_pnl_unrealised`].
+    /// Unlike the per-tick [`update_pnl_unrealised`](Self::update_pnl_unrealised) (which holds the
+    /// last-good value), the basis has *just* been rewritten here, so there is no valid prior value
+    /// to hold — an overflow degrades to `0`, mirroring the split path
+    /// ([`apply_split`](Self::apply_split)). The value self-corrects on the next market tick.
+    ///
+    /// Overflow is provably unreachable at 2 of the 4 trade call sites — the exact-close (`:542`)
+    /// and flip (`:590`) paths set `quantity_abs == 0` before calling, zeroing the value terms — and
+    /// needs a `price ≈ Decimal::MAX` at the other two, so degrade-to-`0` is a defensive floor
+    /// rather than an expected path.
+    fn update_pnl_unrealised_post_trade(&mut self, price: Decimal) {
+        self.pnl_unrealised = self.checked_pnl_unrealised(price).unwrap_or(Decimal::ZERO);
+    }
+
+    /// Checked, non-mutating core shared by every `pnl_unrealised` recompute: computes the
+    /// unrealised PnL at `price`, returning `None` if the `Decimal` arithmetic overflows instead
+    /// of panicking.
+    ///
+    /// Callers pick the overflow fallback that fits their basis state:
+    /// - [`update_pnl_unrealised`](Self::update_pnl_unrealised) (per market tick) — *holds* the
+    ///   last-good value (basis unchanged).
+    /// - [`update_pnl_unrealised_post_trade`](Self::update_pnl_unrealised_post_trade) and
+    ///   [`apply_split`](Self::apply_split) — degrade to `0` (basis just changed).
+    ///
+    /// See [`checked_calculate_pnl_unrealised`].
     fn checked_pnl_unrealised(&self, price: Decimal) -> Option<Decimal> {
         checked_calculate_pnl_unrealised(
             self.side,
@@ -1033,12 +1080,13 @@ pub fn calculate_pnl_unrealised(
 /// Checked twin of [`calculate_pnl_unrealised`]: identical math with `checked_*` `Decimal`
 /// arithmetic, returning `None` on overflow instead of panicking.
 ///
-/// Used only on the corporate-action split path ([`Position::apply_split`]), where an extreme feed
-/// `last_price` must degrade the derived `pnl_unrealised` to `0` rather than panic part-way through
-/// an atomic multi-position adjustment. The per-market-tick path (`update_from_market` →
-/// [`calculate_pnl_unrealised`]) is deliberately left unchecked here; hardening that hot path for
-/// **all** callers is a separate follow-up (it needs its own policy for a persistent bad feed —
-/// what a live tick returns on overflow — rather than the split path's one-shot degrade-to-zero).
+/// This is the arithmetic core behind every `pnl_unrealised` recompute reached through the engine —
+/// the per-market-tick path ([`Position::update_pnl_unrealised`]), the post-trade path
+/// ([`Position::update_pnl_unrealised_post_trade`]) and the corporate-action split path
+/// ([`Position::apply_split`]) all route through [`Position::checked_pnl_unrealised`] into here. Each
+/// caller chooses its own overflow fallback (hold-last-good on a tick, degrade-to-`0` once the basis
+/// has changed). The still-`pub` unchecked [`calculate_pnl_unrealised`] remains a latent panic vector
+/// for direct external callers — hardening or deprecating that entry point is a separate follow-up.
 ///
 /// The exit-fee approximation reuses [`approximate_remaining_exit_fees`] **unchecked**, by design:
 /// the only unbounded, feed-controlled input on the split path is `price` (covered by the checked
@@ -1662,7 +1710,10 @@ mod tests {
             contract_size: Decimal::ONE,
         };
 
-        position.update_pnl_unrealised(dec!(51_000.0));
+        assert_eq!(
+            position.update_pnl_unrealised(dec!(51_000.0)),
+            PnlUnrealisedUpdate::Updated
+        );
 
         // (51_000 − 50_000) × 1 − exit_fee, with exit_fee = (1/1) × fees_quote = $50.
         //   correct (quote fee):   1_000 − 50    = 950.0
@@ -1700,7 +1751,10 @@ mod tests {
             contract_size: Decimal::ONE,
         };
 
-        position.update_pnl_unrealised(dec!(51_000.0));
+        assert_eq!(
+            position.update_pnl_unrealised(dec!(51_000.0)),
+            PnlUnrealisedUpdate::Updated
+        );
 
         // fees_quote is None ⇒ fall back to raw fees (2.0): 1_000 − 2 = 998.0.
         assert_eq!(position.pnl_unrealised, dec!(998.0));

--- a/rustrade/src/engine/state/position.rs
+++ b/rustrade/src/engine/state/position.rs
@@ -622,7 +622,10 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
             self.price_entry_average,
             self.quantity_abs,
             self.quantity_abs_max,
-            self.fees_enter.fees,
+            // Quote-equivalent entry fee for the exit-fee estimate, matching the realised-PnL
+            // convention (`Position::from` `:889`, closing-trade paths `:496`/`:540`). Falls back
+            // to raw `fees` only for third-party fee assets where no quote-equivalent is derivable.
+            self.fees_enter.fees_quote.unwrap_or(self.fees_enter.fees),
             price,
             self.contract_size,
         );
@@ -641,7 +644,9 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
             self.price_entry_average,
             self.quantity_abs,
             self.quantity_abs_max,
-            self.fees_enter.fees,
+            // Quote-equivalent entry fee (see `update_pnl_unrealised`), for dimensional
+            // consistency with the quote-denominated PnL terms.
+            self.fees_enter.fees_quote.unwrap_or(self.fees_enter.fees),
             price,
             self.contract_size,
         )
@@ -1623,6 +1628,82 @@ mod tests {
             dec!(100.0), // 100 shares per contract
         );
         assert_eq!(pnl, dec!(398.0));
+    }
+
+    #[test]
+    fn test_update_pnl_unrealised_uses_quote_equivalent_entry_fee() {
+        // Regression for the fee-units bug (#165): the per-tick `pnl_unrealised` exit-fee
+        // estimate must use the QUOTE-equivalent entry fee (`fees_quote`), not the raw
+        // fee-asset units (`fees`), so it is dimensionally consistent with the
+        // quote-denominated PnL terms — mirroring the realised-PnL paths.
+        //
+        // Base-asset fee: 0.001 BTC paid to enter 1 BTC @ $50,000, i.e. fees_quote = $50.
+        let mut position = Position {
+            instrument: InstrumentNameInternal::new("btc_usdt"),
+            side: Side::Buy,
+            price_entry_average: dec!(50_000.0),
+            quantity_abs: dec!(1.0),
+            quantity_abs_max: dec!(1.0),
+            pnl_unrealised: dec!(0.0),
+            pnl_realised: dec!(0.0),
+            fees_enter: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(0.001),            // raw fee in BASE asset units (BTC)
+                fees_quote: Some(dec!(50.0)), // quote-equivalent (0.001 BTC × $50,000)
+            },
+            fees_exit: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
+            },
+            time_enter: DateTime::<Utc>::MIN_UTC,
+            time_exchange_update: DateTime::<Utc>::MIN_UTC,
+            trades: vec![TradeId::new("t")],
+            contract_size: Decimal::ONE,
+        };
+
+        position.update_pnl_unrealised(dec!(51_000.0));
+
+        // (51_000 − 50_000) × 1 − exit_fee, with exit_fee = (1/1) × fees_quote = $50.
+        //   correct (quote fee):   1_000 − 50    = 950.0
+        //   buggy  (raw base fee): 1_000 − 0.001 = 999.999
+        assert_eq!(position.pnl_unrealised, dec!(950.0));
+    }
+
+    #[test]
+    fn test_update_pnl_unrealised_falls_back_to_raw_fee_when_quote_absent() {
+        // Documented residual (out of scope for #165): a third-party fee asset with no
+        // derivable quote-equivalent (`fees_quote == None`, e.g. a BNB fee) falls back to the
+        // raw `fees` on BOTH the realised and unrealised paths — accurate quote-denominated
+        // handling needs external price data the library does not carry.
+        let mut position = Position {
+            instrument: InstrumentNameInternal::new("btc_usdt"),
+            side: Side::Buy,
+            price_entry_average: dec!(50_000.0),
+            quantity_abs: dec!(1.0),
+            quantity_abs_max: dec!(1.0),
+            pnl_unrealised: dec!(0.0),
+            pnl_realised: dec!(0.0),
+            fees_enter: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(2.0),
+                fees_quote: None, // no quote-equivalent derivable
+            },
+            fees_exit: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
+            },
+            time_enter: DateTime::<Utc>::MIN_UTC,
+            time_exchange_update: DateTime::<Utc>::MIN_UTC,
+            trades: vec![TradeId::new("t")],
+            contract_size: Decimal::ONE,
+        };
+
+        position.update_pnl_unrealised(dec!(51_000.0));
+
+        // fees_quote is None ⇒ fall back to raw fees (2.0): 1_000 − 2 = 998.0.
+        assert_eq!(position.pnl_unrealised, dec!(998.0));
     }
 
     #[test]

--- a/rustrade/src/statistic/summary/pnl.rs
+++ b/rustrade/src/statistic/summary/pnl.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 /// Records Profit and Loss (PnL) data.
 ///
@@ -40,22 +41,122 @@ pub struct PnLReturns {
 
 impl PnLReturns {
     /// Update the `PnLReturns` from the next [`PositionExited`].
+    ///
+    /// Uses **checked** `Decimal` arithmetic on both accumulations so a corrupt or extreme
+    /// `pnl_realised` cannot panic this reporting path:
+    /// - The raw-PnL total holds its last-good value on overflow (consistent with
+    ///   `Position::update_pnl_realised`) and emits a `warn!`.
+    /// - If the per-position return is not representable (see [`calculate_pnl_return`]), that single
+    ///   data point is **skipped** — `total` and `losses` are left untouched and a `warn!` is emitted
+    ///   — rather than dropping the whole update.
     pub fn update<AssetKey, InstrumentKey>(
         &mut self,
         position: &PositionExited<AssetKey, InstrumentKey>,
     ) {
-        self.pnl_raw += position.pnl_realised;
+        // Checked, hold-last-good on overflow (consistent with `Position::update_pnl_realised`):
+        // a raw-PnL accumulation that can't be represented holds the prior total rather than
+        // panicking this reporting path.
+        match self.pnl_raw.checked_add(position.pnl_realised) {
+            Some(new_total) => self.pnl_raw = new_total,
+            None => warn!(
+                pnl_raw_held = %self.pnl_raw,
+                position_pnl_realised = %position.pnl_realised,
+                "pnl_raw accumulation overflowed Decimal; holding last-good value"
+            ),
+        }
 
-        let pnl_return = calculate_pnl_return(
+        let Some(pnl_return) = calculate_pnl_return(
             position.pnl_realised,
             position.price_entry_average,
             position.quantity_abs_max,
-        );
+        ) else {
+            warn!(
+                position_pnl_realised = %position.pnl_realised,
+                "pnl_return computation overflowed Decimal; skipping this return data point"
+            );
+            return;
+        };
 
         self.total.update(pnl_return);
 
         if pnl_return.is_sign_negative() {
             self.losses.update(pnl_return)
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // test code: panics acceptable
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+    use rust_decimal_macros::dec;
+    use rustrade_execution::{
+        order::id::PositionId,
+        trade::{AssetFees, TradeId},
+    };
+    use rustrade_instrument::{Side, asset::QuoteAsset, instrument::name::InstrumentNameInternal};
+
+    /// Build a closed-position record carrying the three fields `PnLReturns::update` reads
+    /// (`pnl_realised`, `price_entry_average`, `quantity_abs_max`); the rest are inert filler.
+    fn exited(
+        pnl_realised: Decimal,
+        price_entry_average: Decimal,
+        quantity_abs_max: Decimal,
+    ) -> PositionExited<QuoteAsset, InstrumentNameInternal> {
+        PositionExited {
+            position_id: PositionId::NETTING,
+            instrument: InstrumentNameInternal::new("btc_usdt"),
+            side: Side::Buy,
+            price_entry_average,
+            quantity_abs_max,
+            pnl_realised,
+            fees_enter: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
+            },
+            fees_exit: AssetFees {
+                asset: QuoteAsset,
+                fees: dec!(0.0),
+                fees_quote: Some(dec!(0.0)),
+            },
+            time_enter: DateTime::<Utc>::MIN_UTC,
+            time_exit: DateTime::<Utc>::MIN_UTC,
+            trades: vec![TradeId::new("t")],
+        }
+    }
+
+    #[test]
+    fn test_update_holds_pnl_raw_on_overflow() {
+        // Mirrors the position-layer overflow-safety tests for the statistics layer: a raw-PnL
+        // accumulation that overflows `Decimal` must NOT panic and must hold the last-good `pnl_raw`
+        // rather than corrupting the running total. Needs a `~Decimal::MAX` prior total —
+        // unreachable with real data.
+        let mut returns = PnLReturns {
+            pnl_raw: Decimal::MAX,
+            ..Default::default()
+        };
+
+        // `Decimal::MAX + 1` overflows the checked accumulation ⇒ no panic, prior total held.
+        returns.update(&exited(dec!(1.0), dec!(100.0), dec!(1.0)));
+
+        assert_eq!(returns.pnl_raw, Decimal::MAX);
+    }
+
+    #[test]
+    fn test_update_skips_data_point_when_return_not_representable() {
+        // When `calculate_pnl_return` cannot represent the return (here the cost-of-investment basis
+        // `price_entry_average × quantity_abs_max` overflows `Decimal`), that single sample is
+        // skipped: `total`/`losses` stay untouched and the update does not panic.
+        let mut returns = PnLReturns::default();
+
+        // basis = `Decimal::MAX × 2` overflows ⇒ `calculate_pnl_return` returns `None` ⇒ skip.
+        returns.update(&exited(dec!(100.0), Decimal::MAX, dec!(2.0)));
+
+        // `pnl_raw` still accumulates (that step did not overflow), but no return sample was recorded.
+        assert_eq!(returns.pnl_raw, dec!(100.0));
+        assert_eq!(returns.total, DataSetSummary::default());
+        assert_eq!(returns.losses, DataSetSummary::default());
     }
 }

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -746,6 +746,68 @@ fn test_engine_process_engine_event_with_audit() {
     assert_eq!(eth_btc_sheet.pnl, dec!(-0.065));
 }
 
+/// Regression for #186: an open position's `pnl_unrealised` (and `time_exchange_update`) must
+/// refresh on **every market tick**, not only on trade fills.
+///
+/// Before the wiring fix, `EngineState::update_from_market` called only
+/// `instrument_state.data.process(event)` and never `InstrumentState::update_from_market` (its only
+/// caller repo-wide), so `pnl_unrealised` stayed frozen at its post-fill value between fills — `0`
+/// for a freshly opened position, regardless of how far the market moved. This drives a bare market
+/// tick (no trade) through the real engine dispatch and asserts the position revalues.
+#[test]
+fn test_pnl_unrealised_updates_on_market_tick() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine(TradingState::Disabled, execution_tx);
+
+    let read_btc_position = |engine: &TestEngine| {
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(0))
+            .position
+            .positions
+            .get(&PositionId::NETTING)
+            .cloned()
+            .expect("btc_usdt netting position should be open")
+    };
+
+    // Seed the account snapshot, then a first market price so btc_usdt is Healthy and priced.
+    // (Bind the snapshot first — it borrows `engine.state` immutably, which cannot overlap the
+    // `&mut engine` the call needs.)
+    let snapshot = account_event_snapshot(&engine.state.assets);
+    let _ = process_with_audit(&mut engine, snapshot);
+    let _ = process_with_audit(&mut engine, market_event_trade(1, 0, dec!(10_000)));
+
+    // Open a 1-unit btc_usdt LONG at 10_000 via an account Trade at day 2 (fees_quote = 10% of
+    // notional = 1_000 usdt). `Position::from` seeds `pnl_unrealised = 0` — it is NOT recomputed on
+    // open — so the position starts flat and only a later revaluation can move it.
+    let _ = process_with_audit(
+        &mut engine,
+        account_event_trade(0, 2, Side::Buy, 10_000.0, 1.0),
+    );
+
+    let opened = read_btc_position(&engine);
+    assert_eq!(opened.pnl_unrealised, dec!(0));
+    assert_eq!(
+        opened.time_exchange_update,
+        time_plus_days(STARTING_TIMESTAMP, 2)
+    );
+
+    // A bare market tick at 20_000 (day 5, no trade) must now revalue the open position AND advance
+    // its update clock — the exact refresh the pre-#186 engine skipped.
+    let _ = process_with_audit(&mut engine, market_event_trade(5, 0, dec!(20_000)));
+
+    let ticked = read_btc_position(&engine);
+    // (20_000 − 10_000) × 1 − exit_fee, exit_fee = (qty/qty_max) × fees_enter.fees_quote
+    //   = (1/1) × 1_000 = 1_000  ⇒  10_000 − 1_000 = 9_000.
+    assert_eq!(ticked.pnl_unrealised, dec!(9_000));
+    // Advanced to the tick's exchange time — proving a market tick, not a trade, refreshed it.
+    assert_eq!(
+        ticked.time_exchange_update,
+        time_plus_days(STARTING_TIMESTAMP, 5)
+    );
+}
+
 /// Routes a `BalanceStreamUpdate` (the WS-sourced partial) end-to-end through
 /// `EngineState::update_from_account` → `AssetState::apply_balance_update`, asserting both the
 /// resulting balance state and the audit trail.


### PR DESCRIPTION
## Summary

Three related `Position::pnl_unrealised` correctness fixes, landed as independent, individually
reviewable/revertable commits.

### `#165` — fee units (Fixed)
The per-tick unrealised-PnL exit-fee estimate now uses the quote-equivalent entry fee
(`fees_enter.fees_quote`, falling back to raw `fees` only when no quote-equivalent is derivable),
matching the realised-PnL convention. Fixes a dimensionally-inconsistent `pnl_unrealised` when the
entry fee was paid in a base asset (e.g. BTC) rather than the quote asset.

### `#177` — overflow safety (Fixed, **breaking API**)
The per-tick recompute now routes through checked `Decimal` arithmetic instead of the panicking
unchecked path, so a corrupted feed price near `Decimal::MAX` can no longer bring down the engine.
On overflow the market path **holds** the last-good value (a tick does not change the cost basis, so
the prior estimate beats a fabricated `0` that would mask an open loss as flat) and logs a `warn!`;
the post-trade and split paths degrade to `0` (the basis has just changed).

**Breaking:** `Position::update_pnl_unrealised` now returns
`#[must_use] PnlUnrealisedUpdate { Updated, Overflowed }` (was `()`). Direct callers must bind the
result.

### `#186` — per-tick refresh (Fixed, **behavior change**)
`EngineState::update_from_market` previously refreshed only the instrument's market-data state and
never the open positions, so `pnl_unrealised` stayed frozen at its last post-fill value (`0` for a
freshly opened position) no matter how far the market moved — contradicting the field's documented
per-tick contract. It now routes through `InstrumentState::update_from_market`, revaluing every open
position and advancing `time_exchange_update` on each priced tick. The audit-replica path shares this
method and revalues identically.

**Behavior change:** downstream consumers that assumed `pnl_unrealised` only moves on fills will now
see it move between fills, per the documented contract.

## Testing
- `cargo test -p rustrade --lib` → **107 passed**
- `cargo test -p rustrade --test test_engine_process_engine_event_with_audit` → **44 passed**
  (includes a new end-to-end regression test driving a bare market tick through the engine and
  asserting the open position revalues + its update clock advances)
- `cargo clippy --workspace --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious -D clippy::style -W clippy::complexity -D clippy::perf` → clean
  (only the two pre-existing cognitive-complexity warnings remain, untouched)

Fixes #165, #177, #186.
