### PR TITLE
refactor(corporate-action): two-phase split — atomic strike division, fail-loud invariants, live/replica dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Corporate-action stock-split processing** (`rustrade`). The engine now handles
   `EngineEvent::CorporateAction` for stock/reverse splits, adjusting every open position on the
-  target Spot instrument via `Position::apply_split` and emitting observables — `SplitRemainder`
+  target Spot instrument (the same per-position rescale as `Position::apply_split`) and emitting
+  observables — `SplitRemainder`
   (cash-in-lieu of the fractional sliver disposed under `SplitRoundingPolicy::Floor`),
   `OpenOrdersAtSplit` (resting orders are reported, never engine-cancelled),
   `UnsupportedCorporateAction`, and `CorporateActionAlreadyProcessed`. Application is idempotent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from a successful split with nothing to adjust); a reverse split that floors a position to zero
   quantity closes it with a `PositionExit`. `Position::apply_split` takes a validated `SplitRatio`
   and is fallible (`Result<SplitResult, SplitError>`, with a companion `Position::validate_split`);
-  the engine **pre-validates** every affected position before mutating any, so an
-  arithmetically-unrepresentable ratio or a corrupted (non-integer) option contract count rejects the
-  whole action atomically — emitting `UnsupportedCorporateAction` with the new
+  the engine **pre-computes** every affected position rescale and option-strike division before
+  committing any (a two-phase prepare/commit, single-sourced across the live handler and the audit
+  replica), so an arithmetically-unrepresentable ratio, an option strike that would overflow on
+  division, or a corrupted (non-integer) option contract count rejects the whole action atomically —
+  emitting `UnsupportedCorporateAction` with the new
   `UnsupportedCorporateActionReason::ArithmeticOverflow` / `PositionStateInvalid` reasons, leaving the
-  `id` unrecorded and no position partially rescaled. The eager post-split `pnl_unrealised` recompute
+  `id` unrecorded and nothing partially mutated. The eager post-split `pnl_unrealised` recompute
   degrades gracefully: an extreme last price that would overflow `Decimal` zeroes the (derived,
   self-correcting) value and flags `SplitResult::pnl_unrealised_overflowed` rather than panicking
   part-way through the adjustment, preserving that atomicity.

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -337,12 +337,21 @@ where
                         .replica_engine_state_mut()
                         .instruments
                         .instrument_index_mut(&instrument);
-                    if let Some(position) = instrument_state.position.positions.get_mut(&pos_id) {
-                        // Infallible: the shared prepare pass already computed (and overflow-checked)
-                        // this position's rescale into `prepared`. The replica discards the returned
-                        // `SplitResult` — it mirrors state, not outputs.
-                        position.commit_split(prepared, last_price);
-                    }
+                    // Fail loudly on a missing id (matching the live handler + the option leg below):
+                    // the plan collected `pos_id` from this same replayed positions map, so a miss is
+                    // a plan/state divergence = corruption, which must crash rather than silently
+                    // drop a position and let replica state drift from the live engine.
+                    let Some(position) = instrument_state.position.positions.get_mut(&pos_id)
+                    else {
+                        unreachable!(
+                            "replica: SplitPlan carried equity position id {pos_id:?} absent from \
+                             instrument {instrument:?}'s positions map (id={id}, ratio={ratio})"
+                        );
+                    };
+                    // Infallible: the shared prepare pass already computed (and overflow-checked)
+                    // this position's rescale into `prepared`. The replica discards the returned
+                    // `SplitResult` — it mirrors state, not outputs.
+                    position.commit_split(prepared, last_price);
                 }
 
                 // Mirror Floor-to-zero closes from the live `PositionExit` outputs: remove the slot
@@ -402,7 +411,8 @@ where
                         let InstrumentKind::Option(ref mut contract) = option_state.instrument.kind
                         else {
                             unreachable!(
-                                "replica: SplitPlan carried a non-Option instrument {opt_key:?}"
+                                "replica: SplitPlan carried a non-Option instrument {opt_key:?} \
+                                 (id={id}, ratio={ratio})"
                             );
                         };
                         contract.strike = opt_plan.strike_post_split;
@@ -421,7 +431,7 @@ where
                             else {
                                 unreachable!(
                                     "replica: SplitPlan carried position id {pos_id:?} absent from \
-                                     this option's positions map"
+                                     option {opt_key:?}'s positions map (id={id}, ratio={ratio})"
                                 );
                             };
                             // Infallible: the shared prepare pass pre-computed this option leg's

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -3,6 +3,7 @@ use crate::{
     engine::{
         EngineMeta, EngineOutput, Processor,
         audit::{AuditTick, EngineAudit, ProcessAudit, context::EngineContext},
+        classify_option_split, split_plan_position_mut,
         state::{EngineState, instrument::data::InstrumentDataState},
     },
     execution::AccountStreamEvent,
@@ -12,7 +13,7 @@ use rustrade_integration::collection::none_one_or_many::NoneOneOrMany;
 use rustrade_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
 use rustrade_execution::AccountEvent;
 use rustrade_instrument::{
-    corporate_action::{CorporateActionKind, SplitAdjustmentKind},
+    corporate_action::CorporateActionKind,
     instrument::{InstrumentIndex, kind::InstrumentKind},
 };
 use rustrade_integration::Terminal;
@@ -289,15 +290,16 @@ where
                 // division) now lives in the shared prepare pass, so — like the live handler — the
                 // replica no longer extracts the inner `Decimal` here.
 
-                // Classify for option handling ONCE, up front (mirrors the live handler's Step 2c).
-                // `SplitAdjustmentKind` is `#[non_exhaustive]` (another crate) and cannot be matched
-                // exhaustively here; only a Standard split mutates option state in the replica —
-                // NonStandard, any future variant, and the unreachable None deliberately skip (the
-                // live handler emits only a signal output for them, which the replica — mirroring
-                // state, not outputs — has nothing to apply). Hoisted above the mutation so
-                // pre-validation and application share one classification and cannot drift.
-                let adjust_options_in_place =
-                    matches!(kind.split_kind(), Some(SplitAdjustmentKind::Standard));
+                // Classify for option handling ONCE, up front (mirrors the live handler's Step 2c),
+                // via the shared `classify_option_split` so the replica and the live handler collapse
+                // `SplitAdjustmentKind` into the same Standard→adjust-in-place decision by
+                // construction. Only a Standard split mutates option state here; NonStandard, any
+                // future `#[non_exhaustive]` variant, and the unreachable non-split (all `Err(_)` ⇒
+                // `false`) deliberately skip — the live handler emits only a signal output for them,
+                // which the replica (mirroring state, not outputs) has nothing to apply. No `warn!`
+                // (the live engine already logged it). Hoisted above the mutation so pre-validation
+                // and application share one classification and cannot drift.
+                let adjust_options_in_place = classify_option_split(&kind).unwrap_or(false);
 
                 // Pre-compute the whole action BEFORE mutating anything, mirroring the live
                 // handler's Step 2c: if the live engine rejected it (Decimal overflow — equity,
@@ -337,17 +339,17 @@ where
                         .replica_engine_state_mut()
                         .instruments
                         .instrument_index_mut(&instrument);
-                    // Fail loudly on a missing id (matching the live handler + the option leg below):
-                    // the plan collected `pos_id` from this same replayed positions map, so a miss is
-                    // a plan/state divergence = corruption, which must crash rather than silently
-                    // drop a position and let replica state drift from the live engine.
-                    let Some(position) = instrument_state.position.positions.get_mut(&pos_id)
-                    else {
-                        unreachable!(
-                            "replica: SplitPlan carried equity position id {pos_id:?} absent from \
-                             instrument {instrument:?}'s positions map (id={id}, ratio={ratio})"
-                        );
-                    };
+                    // Fail loudly on a missing id (see `split_plan_position_mut`): the plan collected
+                    // `pos_id` from this same replayed map, so a miss is plan/state corruption that
+                    // must crash rather than let replica state drift from the live engine.
+                    let position = split_plan_position_mut(
+                        &mut instrument_state.position.positions,
+                        &pos_id,
+                        "replica equity",
+                        &instrument,
+                        &id,
+                        ratio,
+                    );
                     // Infallible: the shared prepare pass already computed (and overflow-checked)
                     // this position's rescale into `prepared`. The replica discards the returned
                     // `SplitResult` — it mirrors state, not outputs.
@@ -424,16 +426,16 @@ where
                         }
                         let option_last_price = option_state.data.price();
                         for (pos_id, prepared) in opt_plan.positions {
-                            // The plan collected `pos_id` from this map; fail loudly (matching the
-                            // strike-adjust `unreachable!` above) if that ever changes, mirroring the
-                            // live handler.
-                            let Some(position) = option_state.position.positions.get_mut(&pos_id)
-                            else {
-                                unreachable!(
-                                    "replica: SplitPlan carried position id {pos_id:?} absent from \
-                                     option {opt_key:?}'s positions map (id={id}, ratio={ratio})"
-                                );
-                            };
+                            // Fail loudly on a missing id (see `split_plan_position_mut`), mirroring
+                            // the live handler.
+                            let position = split_plan_position_mut(
+                                &mut option_state.position.positions,
+                                &pos_id,
+                                "replica option",
+                                &opt_key,
+                                &id,
+                                ratio,
+                            );
                             // Infallible: the shared prepare pass pre-computed this option leg's
                             // rescale into `prepared` (with `Fractional`, as the live handler does —
                             // the equity's whole-share-lot policy does not govern option legs). The

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -3,11 +3,7 @@ use crate::{
     engine::{
         EngineMeta, EngineOutput, Processor,
         audit::{AuditTick, EngineAudit, ProcessAudit, context::EngineContext},
-        state::{
-            EngineState,
-            instrument::data::InstrumentDataState,
-            position::{PositionId, SplitRoundingPolicy},
-        },
+        state::{EngineState, instrument::data::InstrumentDataState},
     },
     execution::AccountStreamEvent,
 };
@@ -255,8 +251,9 @@ where
                 effective_time: _,
             } => {
                 // Hybrid replay (mirrors the live `process_corporate_action`):
-                //  - `apply_split` is deterministic ⇒ event-replay it for every position to
-                //    reproduce the quantity / basis / unrealised-PnL adjustment exactly.
+                //  - the split rescale is deterministic ⇒ event-replay it for every position
+                //    (commit the shared `prepare_corporate_action_split` plan via `commit_split`)
+                //    to reproduce the quantity / basis / unrealised-PnL adjustment exactly.
                 //  - the Floor-to-zero close is OUTPUT-MIRRORED (like the `ContractExpiry` arm),
                 //    because the live handler stamps the closing `PositionExit.time_exit` with
                 //    `self.time()`, which is wall-clock-derived on `HistoricalClock` and cannot be
@@ -287,12 +284,10 @@ where
                 let CorporateActionKind::StockSplit { ratio } = kind else {
                     return;
                 };
-                // Keep the typed `SplitRatio` (`ratio`) for `apply_split` and derive its inner
-                // `Decimal` (`ratio_decimal`) for the option strike division — mirroring the live
-                // handler's split of the two. (The live handler additionally carries the typed
-                // `SplitRatio` into output records; the replica emits none, so it needs the typed
-                // value only for `apply_split`.)
-                let ratio_decimal = ratio.get();
+                // The typed `SplitRatio` (`ratio`) threads into `prepare_corporate_action_split`
+                // and each `commit_split`; the split arithmetic (including the option strike
+                // division) now lives in the shared prepare pass, so — like the live handler — the
+                // replica no longer extracts the inner `Decimal` here.
 
                 // Classify for option handling ONCE, up front (mirrors the live handler's Step 2c).
                 // `SplitAdjustmentKind` is `#[non_exhaustive]` (another crate) and cannot be matched
@@ -304,26 +299,26 @@ where
                 let adjust_options_in_place =
                     matches!(kind.split_kind(), Some(SplitAdjustmentKind::Standard));
 
-                // Pre-validate the whole action BEFORE mutating anything, mirroring the live
-                // handler's Step 2c: if the live engine rejected it (Decimal overflow or a corrupted
-                // option contract count) it recorded no `id` and mutated nothing, so the replica
-                // must do the same or state parity drifts. Single-sourced via the same
-                // `validate_corporate_action_split` the live handler calls, so both reach the
-                // identical accept/reject decision. No output emitted — the replica mirrors state,
-                // and the live engine already logged the rejection.
-                if self
+                // Pre-compute the whole action BEFORE mutating anything, mirroring the live
+                // handler's Step 2c: if the live engine rejected it (Decimal overflow — equity,
+                // option strike, or option position — or a corrupted option contract count) it
+                // recorded no `id` and mutated nothing, so the replica must do the same or state
+                // parity drifts. Single-sourced via the same `prepare_corporate_action_split` the
+                // live handler calls, so both reach the identical accept/reject decision AND the
+                // identical committed values. No output emitted — the replica mirrors state, and the
+                // live engine already logged the rejection.
+                let split_plan = match self
                     .replica_engine_state()
                     .instruments
-                    .validate_corporate_action_split(
+                    .prepare_corporate_action_split(
                         &instrument,
                         ratio,
                         policy,
                         adjust_options_in_place,
-                    )
-                    .is_err()
-                {
-                    return;
-                }
+                    ) {
+                    Ok(plan) => plan,
+                    Err(_) => return,
+                };
 
                 // Last price for the eager `pnl_unrealised` recompute — same source the live
                 // handler reads. Identical here because the replica replayed the same market data.
@@ -334,32 +329,19 @@ where
                     .data
                     .price();
 
-                // Event-replay `apply_split` on ALL positions (N in Hedging). Collect ids first to
-                // avoid a borrow conflict with the per-position re-borrow, like the live handler.
-                let position_ids: Vec<PositionId> = self
-                    .replica_engine_state()
-                    .instruments
-                    .instrument_index(&instrument)
-                    .position
-                    .positions
-                    .keys()
-                    .cloned()
-                    .collect();
-                for pos_id in position_ids {
+                // Commit the split to ALL positions (N in Hedging), driving from the plan's
+                // pre-computed rescales (mirrors the live handler). The plan already carries owned
+                // ids, so no separate collection is needed to avoid the per-position re-borrow.
+                for (pos_id, prepared) in split_plan.equity_positions {
                     let instrument_state = self
                         .replica_engine_state_mut()
                         .instruments
                         .instrument_index_mut(&instrument);
                     if let Some(position) = instrument_state.position.positions.get_mut(&pos_id) {
-                        // Pre-validated above ⇒ `Err` is unreachable; `unreachable!` mirrors the live
-                        // handler (a live panic here must be a replica panic too, or audit parity
-                        // drifts). The replica discards the `Ok` value, so `if let Err` suffices.
-                        if let Err(error) = position.apply_split(ratio, policy, last_price) {
-                            unreachable!(
-                                "replica: equity apply_split failed after pre-validation for \
-                                 {pos_id:?}: {error}"
-                            );
-                        }
+                        // Infallible: the shared prepare pass already computed (and overflow-checked)
+                        // this position's rescale into `prepared`. The replica discards the returned
+                        // `SplitResult` — it mirrors state, not outputs.
+                        position.commit_split(prepared, last_price);
                     }
                 }
 
@@ -392,97 +374,61 @@ where
 
                 // Standard option adjustment (mirrors the live handler's option-handling step).
                 // For a STANDARD (whole-number forward) split, the engine adjusts each option on
-                // this underlying IN PLACE: strike ÷ ratio + apply_split per option position. This
-                // is fully deterministic (strike division + apply_split reading the option's own
+                // this underlying: the pre-computed post-split strike is assigned and each held
+                // position is committed via `commit_split`. This is fully deterministic (the shared
+                // prepare pass already overflow-checked the strike; commit reads the option's own
                 // replayed price), so it is PURE event-replay — options never floor-to-zero on a
                 // forward split, so no output-mirror is needed (unlike the equity Floor-to-zero
                 // close above). NON-standard splits leave options untouched (the live handler only
                 // emits a signal and mutates no option state), so this whole block is skipped.
                 // Branches on `adjust_options_in_place` computed up front (see the hoist above).
                 if adjust_options_in_place {
-                    let (equity_base, equity_quote, equity_exchange) = {
-                        let equity = self
-                            .replica_engine_state()
-                            .instruments
-                            .instrument_index(&instrument);
-                        (
-                            equity.instrument.underlying.base,
-                            equity.instrument.underlying.quote,
-                            equity.instrument.exchange,
-                        )
-                    };
-                    // Scan ALL options on the underlying (held OR unheld), mirroring the live
-                    // handler: a standard split divides the strike of every registered option so
-                    // the registry stays consistent for positions opened later. Unheld options get
-                    // the strike fix only; held options additionally event-replay `apply_split`.
-                    let options_on_underlying: Vec<InstrumentIndex> = self
-                        .replica_engine_state()
-                        .instruments
-                        .0
-                        .values()
-                        .filter(|state| {
-                            state.is_option_on_underlying(
-                                &equity_base,
-                                &equity_quote,
-                                &equity_exchange,
-                            )
-                        })
-                        .map(|state| state.key)
-                        .collect();
-                    for opt_key in options_on_underlying {
+                    // Drive from the pre-computed `SplitPlan` (mirrors the live handler): one
+                    // `OptionSplitPlan` per registered option on the underlying (held OR unheld),
+                    // carrying the CHECKED post-split strike and a `PreparedSplit` per held position.
+                    // No re-scan and no in-place `strike /=` — the shared prepare pass already
+                    // overflow-checked the strike division, so the replica commits it infallibly.
+                    // Unheld options get the strike fix only; held options additionally commit each
+                    // per-position rescale.
+                    for opt_plan in split_plan.options {
+                        let opt_key = opt_plan.key;
                         let option_state = self
                             .replica_engine_state_mut()
                             .instruments
                             .instrument_index_mut(&opt_key);
-                        // Mirror the live handler's loud unreachable: the scan only matched Option
+                        // Mirror the live handler's loud unreachable: the plan carried only Option
                         // instruments, so a non-Option here is corruption — fail observably rather
-                        // than apply_split without adjusting the strike.
+                        // than commit a position rescale without adjusting the strike.
                         let InstrumentKind::Option(ref mut contract) = option_state.instrument.kind
                         else {
                             unreachable!(
-                                "replica: is_option_on_underlying matched a non-Option instrument \
-                                 {opt_key:?}"
+                                "replica: SplitPlan carried a non-Option instrument {opt_key:?}"
                             );
                         };
-                        contract.strike /= ratio_decimal;
+                        contract.strike = opt_plan.strike_post_split;
 
                         // Unheld option: strike correction is the whole job (silent registry fix),
                         // mirroring the live handler.
-                        if option_state.position.positions.is_empty() {
+                        if opt_plan.positions.is_empty() {
                             continue;
                         }
                         let option_last_price = option_state.data.price();
-                        let opt_position_ids: Vec<PositionId> =
-                            option_state.position.positions.keys().cloned().collect();
-                        for pos_id in opt_position_ids {
-                            // `pos_id` was just collected from this map; fail loudly (matching the
+                        for (pos_id, prepared) in opt_plan.positions {
+                            // The plan collected `pos_id` from this map; fail loudly (matching the
                             // strike-adjust `unreachable!` above) if that ever changes, mirroring the
                             // live handler.
                             let Some(position) = option_state.position.positions.get_mut(&pos_id)
                             else {
                                 unreachable!(
-                                    "replica: position id {pos_id:?} collected from this option's \
-                                     positions map"
+                                    "replica: SplitPlan carried position id {pos_id:?} absent from \
+                                     this option's positions map"
                                 );
                             };
-                            // Pass `Fractional` explicitly, NOT the equity `policy`, mirroring the
-                            // live handler (`process_corporate_action`): pre-validation already
-                            // rejected any non-integer contract count (as `PositionStateInvalid`), so
-                            // the policy is a no-op here and the equity's whole-share-lot policy does
-                            // not govern option legs. Pre-validated ⇒ `Err` is unreachable;
-                            // `unreachable!` mirrors the live handler (a live panic here must be a
-                            // replica panic too, or audit parity drifts). The replica discards the
-                            // `Ok` value, so `if let Err` suffices.
-                            if let Err(error) = position.apply_split(
-                                ratio,
-                                SplitRoundingPolicy::Fractional,
-                                option_last_price,
-                            ) {
-                                unreachable!(
-                                    "replica: option apply_split failed after pre-validation for \
-                                     {pos_id:?}: {error}"
-                                );
-                            }
+                            // Infallible: the shared prepare pass pre-computed this option leg's
+                            // rescale into `prepared` (with `Fractional`, as the live handler does —
+                            // the equity's whole-share-lot policy does not govern option legs). The
+                            // replica discards the returned `SplitResult` — it mirrors state.
+                            position.commit_split(prepared, option_last_price);
                         }
                     }
                 }

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -1,7 +1,7 @@
 use crate::{
     EngineEvent,
     engine::{
-        EngineMeta, EngineOutput, Processor,
+        EngineMeta, EngineOutput, Processor, SplitCommitContext,
         audit::{AuditTick, EngineAudit, ProcessAudit, context::EngineContext},
         classify_option_split, split_plan_position_mut,
         state::{EngineState, instrument::data::InstrumentDataState},
@@ -345,10 +345,12 @@ where
                     let position = split_plan_position_mut(
                         &mut instrument_state.position.positions,
                         &pos_id,
-                        "replica equity",
-                        &instrument,
-                        &id,
-                        ratio,
+                        SplitCommitContext {
+                            leg: "replica equity",
+                            instrument: &instrument,
+                            id: &id,
+                            ratio,
+                        },
                     );
                     // Infallible: the shared prepare pass already computed (and overflow-checked)
                     // this position's rescale into `prepared`. The replica discards the returned
@@ -431,10 +433,12 @@ where
                             let position = split_plan_position_mut(
                                 &mut option_state.position.positions,
                                 &pos_id,
-                                "replica option",
-                                &opt_key,
-                                &id,
-                                ratio,
+                                SplitCommitContext {
+                                    leg: "replica option",
+                                    instrument: &opt_key,
+                                    id: &id,
+                                    ratio,
+                                },
                             );
                             // Infallible: the shared prepare pass pre-computed this option leg's
                             // rescale into `prepared` (with `Fractional`, as the live handler does —

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -872,8 +872,16 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
 
         for (pos_id, prepared) in split_plan.equity_positions {
             let instrument_state = self.state.instruments.instrument_index_mut(key);
+            // The plan collected `pos_id` from this same positions map in a single-threaded engine
+            // (only Step 3's read-only order snapshot ran since), so the re-borrow cannot miss; fail
+            // loudly — matching the option leg below — rather than silently dropping a position the
+            // pre-validated `SplitPlan` already committed us to rescaling (a missing id here is a
+            // plan/state divergence = corruption, which must crash, never silently continue).
             let Some(position) = instrument_state.position.positions.get_mut(&pos_id) else {
-                continue;
+                unreachable!(
+                    "SplitPlan carried equity position id {pos_id:?} absent from instrument \
+                     {key:?}'s positions map (id={id}, ratio={ratio})"
+                );
             };
 
             let side = position.side;
@@ -974,7 +982,10 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                 // instruments (`is_option_on_underlying`), so the `else` is a structural invariant;
                 // fail loudly rather than silently misadjust if it is ever broken.
                 let InstrumentKind::Option(ref mut contract) = option_state.instrument.kind else {
-                    unreachable!("SplitPlan carried a non-Option instrument {opt_key:?}");
+                    unreachable!(
+                        "SplitPlan carried a non-Option instrument {opt_key:?} \
+                         (id={id}, ratio={ratio})"
+                    );
                 };
                 let strike_pre_split = contract.strike;
                 contract.strike = opt_plan.strike_post_split;
@@ -1030,8 +1041,8 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                     // OptionPositionAdjustedForSplit whose contract asserts the position WAS adjusted.
                     let Some(position) = option_state.position.positions.get_mut(&pos_id) else {
                         unreachable!(
-                            "SplitPlan carried position id {pos_id:?} absent from this option's \
-                             positions map"
+                            "SplitPlan carried position id {pos_id:?} absent from option \
+                             {opt_key:?}'s positions map (id={id}, ratio={ratio})"
                         );
                     };
 

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -678,7 +678,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     ///    - action kind is not a stock split ⇒ [`UnsupportedCorporateActionReason::ActionKindNotSupported`]
     ///      (the compiler-mandated arm for the `#[non_exhaustive]` [`CorporateActionKind`]).
     /// 3. Snapshot resting orders into [`EngineOutput::OpenOrdersAtSplit`] (no cancellation).
-    /// 4. Apply the split to every open position via
+    /// 4. Apply the split to every open position per
     ///    [`Position::apply_split`](crate::engine::state::position::Position::apply_split); emit one
     ///    [`EngineOutput::SplitRemainder`] per position that disposed a fractional sliver. A
     ///    position floored to zero quantity is removed and folded as an
@@ -686,7 +686,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     /// 5. Scan for option positions on the same underlying and handle them per the OCC
     ///    standard/non-standard rule ([`CorporateActionKind::split_kind`]):
     ///    - **standard** (whole-number forward split) ⇒ adjust each option **in place**
-    ///      (strike ÷ `ratio`, contracts × `ratio` via
+    ///      (strike ÷ `ratio`, contracts × `ratio` per
     ///      [`Position::apply_split`](crate::engine::state::position::Position::apply_split), multiplier
     ///      unchanged), emitting one [`EngineOutput::OptionPositionAdjustedForSplit`] per position
     ///      plus — if the option has resting orders — an [`EngineOutput::OpenOrdersAtSplit`] for them
@@ -792,10 +792,10 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
         // `ratio` is a validated `SplitRatio` (always `> 0`, enforced at construction and on
         // deserialization), so the engine's split arithmetic can never receive a degenerate ratio
         // through the event path. Copy the `SplitRatio` out (it is `Copy`) to carry the type-level
-        // invariant unbroken into the output records, and extract the inner `Decimal` for the
-        // arithmetic below.
+        // invariant unbroken into the output records and into pre-validation; the split arithmetic
+        // (including the option strike division) now lives in `prepare_corporate_action_split`, so
+        // the handler no longer extracts the inner `Decimal` here.
         let ratio: SplitRatio = *ratio;
-        let ratio_decimal = ratio.get();
 
         // Classify the split for OPTION handling ONCE, up front: `true` ⇒ adjust the options in
         // place (standard whole-number forward split); `false` ⇒ signal a downstream identity
@@ -803,34 +803,42 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
         // identical classification and can never drift.
         let adjust_options_in_place = option_split_adjust_in_place(id, key, kind);
 
-        // Step 2c: PRE-VALIDATE the split against EVERY position it would mutate, WITHOUT mutating
-        // anything, BEFORE Step 3's output push and Step 4's mutation. A feed that would overflow
-        // `Decimal`, or a corrupted (non-integer) option contract count, rejects the action
-        // ATOMICALLY here — no position is partially rescaled and the `id` is NOT recorded
-        // (retryable once the blocking condition is resolved). Single-sourced with the audit replica
-        // via `InstrumentStates::validate_corporate_action_split`, so both reach the identical
-        // accept/reject decision by construction rather than by hand-mirrored vigilance.
-        if let Err(reason) = self.state.instruments.validate_corporate_action_split(
+        // Step 2c: PRE-COMPUTE the whole split against EVERY position and option strike it would
+        // mutate, WITHOUT mutating anything, BEFORE Step 3's output push and Step 4's mutation —
+        // producing a `SplitPlan` the commit phase (Steps 4–5) applies INFALLIBLY. A feed that would
+        // overflow `Decimal` (an equity/option-position rescale OR an option strike division), or a
+        // corrupted (non-integer) option contract count, rejects the action ATOMICALLY here — no
+        // position or strike is partially mutated and the `id` is NOT recorded (retryable once the
+        // blocking condition is resolved). Single-sourced with the audit replica via
+        // `InstrumentStates::prepare_corporate_action_split`, so both reach the identical
+        // accept/reject decision AND the identical committed values by construction rather than by
+        // hand-mirrored vigilance. Because every fallible arithmetic step ran here, the commit loops
+        // below carry no overflow error path — the previous per-position `apply_split` `unreachable!`
+        // arms are gone by construction.
+        let split_plan = match self.state.instruments.prepare_corporate_action_split(
             key,
             ratio,
             policy,
             adjust_options_in_place,
         ) {
-            warn!(
-                %id,
-                instrument = ?key,
-                ?reason,
-                "CorporateAction: split failed pre-validation (applying it would mutate positions \
-                 non-atomically) — emitting UnsupportedCorporateAction; id NOT recorded (retryable \
-                 once the blocking condition is resolved)."
-            );
-            outputs.push(EngineOutput::UnsupportedCorporateAction {
-                instrument: *key,
-                kind: kind.clone(),
-                reason,
-            });
-            return outputs;
-        }
+            Ok(plan) => plan,
+            Err(reason) => {
+                warn!(
+                    %id,
+                    instrument = ?key,
+                    ?reason,
+                    "CorporateAction: split failed pre-validation (applying it would mutate \
+                     positions non-atomically) — emitting UnsupportedCorporateAction; id NOT \
+                     recorded (retryable once the blocking condition is resolved)."
+                );
+                outputs.push(EngineOutput::UnsupportedCorporateAction {
+                    instrument: *key,
+                    kind: kind.clone(),
+                    reason,
+                });
+                return outputs;
+            }
+        };
 
         // Step 3: snapshot resting orders as an observable — do NOT cancel (a broker price-adjusts
         // them, so an engine-side cancel would diverge from the broker). Re-borrow the instrument
@@ -850,38 +858,29 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             );
         }
 
-        // Step 4: apply to ALL open positions (N in Hedging mode). Collect ids first to avoid a
-        // borrow conflict with the per-position re-borrow, mirroring process_contract_expiry.
-        let position_ids: Vec<PositionId> = instrument_state
-            .position
-            .positions
-            .keys()
-            .cloned()
-            .collect();
+        // Step 4: COMMIT the split to ALL open positions (N in Hedging mode). Drive the loop from the
+        // `SplitPlan`'s pre-computed rescales — one `(PositionId, PreparedSplit)` per open position,
+        // captured in position-map order — instead of re-collecting ids: the plan already snapshots
+        // exactly the positions Step 2c pre-computed, so committing them cannot overflow (the
+        // fallible arithmetic is already done). The per-position re-borrow still needs owned ids,
+        // which the plan carries.
         // Pre-size for the equity leg: up to a SplitRemainder + a PositionExit per position, plus the
         // equity OpenOrdersAtSplit and one option-handling observable. This is a lower-bound hint, not
         // an exact count — the standard-option path may push further OptionPositionAdjustedForSplit /
         // per-option OpenOrdersAtSplit outputs, which the `Vec` accommodates by growing as needed.
-        outputs.reserve(position_ids.len() * 2 + 2);
+        outputs.reserve(split_plan.equity_positions.len() * 2 + 2);
 
-        for pos_id in position_ids {
+        for (pos_id, prepared) in split_plan.equity_positions {
             let instrument_state = self.state.instruments.instrument_index_mut(key);
             let Some(position) = instrument_state.position.positions.get_mut(&pos_id) else {
                 continue;
             };
 
             let side = position.side;
-            let result = match position.apply_split(ratio, policy, last_price) {
-                Ok(result) => result,
-                // Step 2c pre-validation already proved every equity position rescales without
-                // `Decimal` overflow, so an `Err` here is genuinely unreachable unless that
-                // invariant is broken; fail loudly rather than silently skip the split. (An
-                // extreme `last_price` does NOT reach this arm — the derived `pnl_unrealised`
-                // recompute degrades to 0 and is flagged on the `Ok` result, see below.)
-                Err(error) => {
-                    unreachable!("apply_split failed after pre-validation for {pos_id:?}: {error}")
-                }
-            };
+            // Infallible: Step 2c pre-computed (and overflow-checked) this position's rescale into
+            // `prepared`, so the commit only writes fields + does the self-correcting `pnl_unrealised`
+            // recompute (which degrades to 0 on an extreme `last_price`, flagged on the result).
+            let result = position.commit_split(prepared, last_price);
             if result.pnl_unrealised_overflowed {
                 warn!(
                     %id,
@@ -892,7 +891,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                      (quantity/basis) was still applied atomically."
                 );
             }
-            // Read the post-split basis AFTER apply_split overwrote it: quantity
+            // Read the post-split basis AFTER commit_split overwrote it: quantity
             // and price then share the post-split era, valuing the disposed sliver with one
             // multiply and no ratio knowledge.
             let price_entry_average_post_split = position.price_entry_average;
@@ -945,23 +944,8 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
 
         // Step 5: options-on-underlying handling. A split targets the underlying equity; listed
         // options on that underlying must also be adjusted (standard split) or flagged for a
-        // wrapper-side identity change (non-standard split). The scan mirrors the spot-given-option
-        // scan in process_contract_expiry, inverted: find Option instruments whose underlying
-        // matches this equity's, on the same exchange.
+        // wrapper-side identity change (non-standard split).
         //
-        // Both `base` AND `quote` are matched: `Underlying` is a full pair identity, and a
-        // `CorporateAction` targets a single `InstrumentIndex`. Without the quote filter, a
-        // BTC/USDT split would also touch BTC/USDC options the engine never adjusted — wrong.
-        // Mirrors the base+quote filter in process_contract_expiry's underlying-spot scan.
-        let (equity_base, equity_quote, equity_exchange) = {
-            let equity = self.state.instruments.instrument_index(key);
-            (
-                equity.instrument.underlying.base,
-                equity.instrument.underlying.quote,
-                equity.instrument.exchange,
-            )
-        };
-
         // Step 5 branches on the option classification computed up front in Step 2c — reused here
         // (rather than recomputed) so application can never diverge from what pre-validation
         // checked. `true` ⇒ adjust the options in place (standard split); `false` ⇒ signal a
@@ -969,38 +953,32 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
         if adjust_options_in_place {
             // STANDARD (whole-number forward split, OCC Art. VI §11): the option keeps its contract
             // identity, so the adjustment is purely mechanical (strike ÷ ratio; contracts × ratio
-            // for held positions; multiplier/contract_size unchanged). Adjust the strike of EVERY
-            // registered option on the underlying — held OR unheld. The instrument set is fixed at
+            // for held positions; multiplier/contract_size unchanged). The strike of EVERY registered
+            // option on the underlying — held OR unheld — is adjusted. The instrument set is fixed at
             // construction, so an option that is unheld at split time can have a position opened
             // later and then settle at expiry against its strike; leaving it on the pre-split strike
             // would mis-settle that future position. Unheld options get the strike correction
             // SILENTLY (a registry fix, no position event); held options additionally get
-            // per-position `apply_split` + observables.
-            let options_on_underlying: Vec<InstrumentIndex> = self
-                .state
-                .instruments
-                .0
-                .values()
-                .filter(|state| {
-                    state.is_option_on_underlying(&equity_base, &equity_quote, &equity_exchange)
-                })
-                .map(|state| state.key)
-                .collect();
-
-            for opt_key in options_on_underlying {
+            // per-position commit + observables.
+            //
+            // Drive the loop from the pre-computed `SplitPlan`: one `OptionSplitPlan` per registered
+            // option on the underlying (held OR unheld), each carrying the CHECKED post-split strike
+            // and a `PreparedSplit` for every held position. No re-scan and no in-place `strike /=`
+            // (the previously-unchecked division was overflow-checked in Step 2c) — the plan is
+            // authoritative.
+            for opt_plan in split_plan.options {
+                let opt_key = opt_plan.key;
                 let option_state = self.state.instruments.instrument_index_mut(&opt_key);
 
-                // Adjust the strike in place. The scan only matched Option instruments, so the
-                // `else` arm is unreachable; fail loudly rather than silently misadjust if that
-                // invariant is ever broken (a re-borrow on a freshly-collected key cannot miss).
+                // Commit the pre-checked strike in place. The plan was built only from Option
+                // instruments (`is_option_on_underlying`), so the `else` is a structural invariant;
+                // fail loudly rather than silently misadjust if it is ever broken.
                 let InstrumentKind::Option(ref mut contract) = option_state.instrument.kind else {
-                    unreachable!(
-                        "is_option_on_underlying matched a non-Option instrument {opt_key:?}"
-                    );
+                    unreachable!("SplitPlan carried a non-Option instrument {opt_key:?}");
                 };
                 let strike_pre_split = contract.strike;
-                contract.strike /= ratio_decimal;
-                let strike_post_split = contract.strike;
+                contract.strike = opt_plan.strike_post_split;
+                let strike_post_split = opt_plan.strike_post_split;
 
                 // Snapshot the option's resting orders as an observable BEFORE the unheld early-out
                 // and before adjusting any positions — a broker price-adjusts them, so the engine
@@ -1012,9 +990,9 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                 let option_orders = snapshot_open_orders_at_split(&option_state.orders);
 
                 // Unheld option: the strike correction + resting-order snapshot above are the whole
-                // job — no positions to split. Still surface any resting orders (equity-leg parity),
-                // then move on; no per-position observable applies.
-                if option_state.position.positions.is_empty() {
+                // job — no positions to split (`opt_plan.positions` is empty). Still surface any
+                // resting orders (equity-leg parity), then move on; no per-position observable applies.
+                if opt_plan.positions.is_empty() {
                     if !option_orders.is_empty() {
                         outputs.push(EngineOutput::OpenOrdersAtSplit {
                             instrument: opt_key,
@@ -1038,41 +1016,29 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                     );
                 }
 
-                // Apply the split to EACH of the option's positions (N in Hedging) and emit one
-                // per-position record. A whole-number ratio × an integer contract count leaves a
-                // whole contract count ⇒ no fractional remainder, no CIL, no floor-to-zero,
-                // regardless of `policy`.
-                let opt_position_ids: Vec<PositionId> =
-                    option_state.position.positions.keys().cloned().collect();
-                for pos_id in opt_position_ids {
-                    // `pos_id` was just collected from this same positions map in a single-threaded
+                // Commit the split to EACH of the option's positions (N in Hedging) and emit one
+                // per-position record, driving from the plan's pre-computed rescales. A whole-number
+                // ratio × an integer contract count leaves a whole contract count ⇒ no fractional
+                // remainder, no CIL, no floor-to-zero, regardless of `policy` — Step 2c pre-computed
+                // each leg with `Fractional` (the equity's whole-share-lot `SplitRoundingPolicy` does
+                // not govern option legs) having already rejected any non-integer contract count as
+                // `PositionStateInvalid`.
+                for (pos_id, prepared) in opt_plan.positions {
+                    // The plan collected `pos_id` from this same positions map in a single-threaded
                     // engine, so the re-borrow cannot miss; fail loudly (matching the strike-adjust
                     // `unreachable!` above) if that ever changes, rather than silently skipping an
                     // OptionPositionAdjustedForSplit whose contract asserts the position WAS adjusted.
                     let Some(position) = option_state.position.positions.get_mut(&pos_id) else {
                         unreachable!(
-                            "position id {pos_id:?} collected from this option's positions map"
+                            "SplitPlan carried position id {pos_id:?} absent from this option's \
+                             positions map"
                         );
                     };
 
-                    // Option contract counts are whole and a standard split is a whole-number ratio,
-                    // so `integer × integer` stays integer with no fractional remainder — the
-                    // equity's `SplitRoundingPolicy` (a whole-share-lot concept) does not govern
-                    // option legs, so pass `Fractional` explicitly (threading the equity policy here
-                    // would falsely imply it governs option legs). Step 2c pre-validation already
-                    // rejected any non-integer contract count (as `PositionStateInvalid`) and proved
-                    // this rescale cannot overflow, so no remainder or floor-to-zero can arise and
-                    // the `Err` arm is genuinely unreachable.
-                    let opt_result = match position.apply_split(
-                        ratio,
-                        SplitRoundingPolicy::Fractional,
-                        option_last_price,
-                    ) {
-                        Ok(result) => result,
-                        Err(error) => unreachable!(
-                            "option apply_split failed after pre-validation for {pos_id:?}: {error}"
-                        ),
-                    };
+                    // Infallible: Step 2c pre-computed (and overflow-checked) this option leg's
+                    // rescale into `prepared`; the commit only writes fields + the self-correcting
+                    // `pnl_unrealised` recompute (degrades to 0 on an extreme premium, flagged).
+                    let opt_result = position.commit_split(prepared, option_last_price);
                     if opt_result.pnl_unrealised_overflowed {
                         warn!(
                             %id,
@@ -1107,6 +1073,20 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             // in-place strike fix, since the deliverable itself changes. Touch NO option strikes;
             // only signal the wrapper about HELD option positions that need an identity change. The
             // equity split itself is still applied and the `id` recorded below.
+            //
+            // The base/quote/exchange identity is computed here because only the non-standard path
+            // needs it now — the standard path's option scan moved into the pre-computed `SplitPlan`
+            // (Step 2c). Both `base` AND `quote` are matched: `Underlying` is a full pair identity,
+            // and a `CorporateAction` targets a single `InstrumentIndex`; without the quote filter a
+            // BTC/USDT split would also touch BTC/USDC options the engine never adjusted — wrong.
+            let (equity_base, equity_quote, equity_exchange) = {
+                let equity = self.state.instruments.instrument_index(key);
+                (
+                    equity.instrument.underlying.base,
+                    equity.instrument.underlying.quote,
+                    equity.instrument.exchange,
+                )
+            };
             let affected_options: Vec<InstrumentIndex> = self
                 .state
                 .instruments

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -679,15 +679,18 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     ///    - action kind is not a stock split ⇒ [`UnsupportedCorporateActionReason::ActionKindNotSupported`]
     ///      (the compiler-mandated arm for the `#[non_exhaustive]` [`CorporateActionKind`]).
     /// 3. Snapshot resting orders into [`EngineOutput::OpenOrdersAtSplit`] (no cancellation).
-    /// 4. Apply the split to every open position per
-    ///    [`Position::apply_split`](crate::engine::state::position::Position::apply_split); emit one
+    /// 4. Apply the split to every open position — the same per-position rescale as
+    ///    [`Position::apply_split`](crate::engine::state::position::Position::apply_split), but the
+    ///    handler does **not** call it directly: it pre-computes every affected position atomically
+    ///    (prepare) then writes each infallibly (commit), so a mid-batch overflow rejects the whole
+    ///    action rather than leaving a subset rescaled. Emit one
     ///    [`EngineOutput::SplitRemainder`] per position that disposed a fractional sliver. A
     ///    position floored to zero quantity is removed and folded as an
     ///    [`EngineOutput::PositionExit`].
     /// 5. Scan for option positions on the same underlying and handle them per the OCC
     ///    standard/non-standard rule ([`CorporateActionKind::split_kind`]):
     ///    - **standard** (whole-number forward split) ⇒ adjust each option **in place**
-    ///      (strike ÷ `ratio`, contracts × `ratio` per
+    ///      (strike ÷ `ratio`, contracts × `ratio` — the same rescale as
     ///      [`Position::apply_split`](crate::engine::state::position::Position::apply_split), multiplier
     ///      unchanged), emitting one [`EngineOutput::OptionPositionAdjustedForSplit`] per position
     ///      plus — if the option has resting orders — an [`EngineOutput::OpenOrdersAtSplit`] for them
@@ -879,10 +882,12 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             let position = split_plan_position_mut(
                 &mut instrument_state.position.positions,
                 &pos_id,
-                "equity",
-                key,
-                id,
-                ratio,
+                SplitCommitContext {
+                    leg: "equity",
+                    instrument: key,
+                    id,
+                    ratio,
+                },
             );
 
             let side = position.side;
@@ -1042,10 +1047,12 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                     let position = split_plan_position_mut(
                         &mut option_state.position.positions,
                         &pos_id,
-                        "option",
-                        &opt_key,
-                        id,
-                        ratio,
+                        SplitCommitContext {
+                            leg: "option",
+                            instrument: &opt_key,
+                            id,
+                            ratio,
+                        },
                     );
 
                     // Infallible: Step 2c pre-computed (and overflow-checked) this option leg's
@@ -1191,6 +1198,22 @@ fn option_split_adjust_in_place(
     })
 }
 
+/// Diagnostic context threaded into [`split_plan_position_mut`]'s cold `unreachable!` path. Every
+/// field feeds **only** the panic message; grouping them here keeps the hot lookup signature down to
+/// the map and the position id. `leg` and `instrument` distinguish which of the four commit loops (live +
+/// replica × equity + option) diverged; `id` and `ratio` identify the split.
+pub(crate) struct SplitCommitContext<'a, InstrumentKey> {
+    /// Which commit loop hit the divergence: `"equity"`, `"option"`, `"replica equity"`, or
+    /// `"replica option"`.
+    pub leg: &'a str,
+    /// The underlying/option instrument key whose positions map the plan indexed.
+    pub instrument: &'a InstrumentKey,
+    /// The corporate-action `id` being committed.
+    pub id: &'a SmolStr,
+    /// The (validated, strictly positive) split ratio.
+    pub ratio: SplitRatio,
+}
+
 /// Look up a position the pre-validated [`SplitPlan`](crate::engine::state::instrument::SplitPlan)
 /// committed the handler to rescaling, panicking loudly if it is absent.
 ///
@@ -1202,16 +1225,14 @@ fn option_split_adjust_in_place(
 ///
 /// `#[track_caller]` so the panic reports the **calling** commit loop's location, not this shared
 /// helper's — preserving the per-site diagnosability of the four distinct `unreachable!`s it replaces.
-/// `context` (e.g. `"equity"` / `"replica option"`) and `instrument` carry each site's distinguishing
-/// category and key, preserving per-site diagnosability under one shared, normalized message template.
+/// The [`SplitCommitContext`] carries each site's distinguishing `leg` (e.g. `"equity"` /
+/// `"replica option"`) and `instrument` key, preserving per-site diagnosability under one shared,
+/// normalized message template.
 #[track_caller]
 pub(crate) fn split_plan_position_mut<'m, AssetKey, InstrumentKey>(
     positions: &'m mut IndexMap<PositionId, Position<AssetKey, InstrumentKey>>,
     pos_id: &PositionId,
-    context: &str,
-    instrument: &InstrumentKey,
-    id: &SmolStr,
-    ratio: SplitRatio,
+    context: SplitCommitContext<'_, InstrumentKey>,
 ) -> &'m mut Position<AssetKey, InstrumentKey>
 where
     InstrumentKey: Debug,
@@ -1220,10 +1241,18 @@ where
         Some(position) => position,
         // Plan/state divergence = corruption (see above): `unreachable!`, matching the sibling
         // invariant checks and the four inline `unreachable!`s this helper replaces.
-        None => unreachable!(
-            "SplitPlan carried {context} position id {pos_id:?} absent from instrument \
-             {instrument:?}'s positions map (id={id}, ratio={ratio})"
-        ),
+        None => {
+            let SplitCommitContext {
+                leg,
+                instrument,
+                id,
+                ratio,
+            } = context;
+            unreachable!(
+                "SplitPlan carried {leg} position id {pos_id:?} absent from instrument \
+                 {instrument:?}'s positions map (id={id}, ratio={ratio})"
+            )
+        }
     }
 }
 
@@ -1348,8 +1377,9 @@ pub enum EngineOutput<
 
     /// Observable record that a **standard** (OCC even / whole-number-forward) split on an
     /// underlying equity was applied to one option position on that underlying **in place**: the
-    /// option's strike was divided by `ratio`, its contract count multiplied by `ratio` (via
-    /// [`Position::apply_split`](crate::engine::state::position::Position::apply_split)), and its
+    /// option's strike was divided by `ratio`, its contract count multiplied by `ratio` (the same
+    /// rescale as [`Position::apply_split`](crate::engine::state::position::Position::apply_split),
+    /// which the handler does not call directly), and its
     /// cost basis divided by `ratio`. The deliverable/multiplier (`contract_size`) is **unchanged**
     /// — the OCC standard rule keeps the same contract identity, so the engine's ledger stays valid
     /// without any instrument re-registration.

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -16,7 +16,7 @@ use crate::{
             EngineState,
             instrument::data::InstrumentDataState,
             order::{Orders, in_flight_recorder::InFlightRequestRecorder, manager::OrderManager},
-            position::{PositionExited, PositionId, SplitRoundingPolicy},
+            position::{Position, PositionExited, PositionId, SplitRoundingPolicy},
             trading::TradingState,
         },
     },
@@ -31,6 +31,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use derive_more::Constructor;
+use indexmap::IndexMap;
 use rust_decimal::Decimal;
 use rustrade_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
 use rustrade_execution::{
@@ -872,17 +873,17 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
 
         for (pos_id, prepared) in split_plan.equity_positions {
             let instrument_state = self.state.instruments.instrument_index_mut(key);
-            // The plan collected `pos_id` from this same positions map in a single-threaded engine
-            // (only Step 3's read-only order snapshot ran since), so the re-borrow cannot miss; fail
-            // loudly — matching the option leg below — rather than silently dropping a position the
-            // pre-validated `SplitPlan` already committed us to rescaling (a missing id here is a
-            // plan/state divergence = corruption, which must crash, never silently continue).
-            let Some(position) = instrument_state.position.positions.get_mut(&pos_id) else {
-                unreachable!(
-                    "SplitPlan carried equity position id {pos_id:?} absent from instrument \
-                     {key:?}'s positions map (id={id}, ratio={ratio})"
-                );
-            };
+            // Fail loudly on a missing id (see `split_plan_position_mut`): the plan collected
+            // `pos_id` from this same map (only Step 3's read-only order snapshot ran since), so a
+            // miss is plan/state corruption that must crash, never silently continue.
+            let position = split_plan_position_mut(
+                &mut instrument_state.position.positions,
+                &pos_id,
+                "equity",
+                key,
+                id,
+                ratio,
+            );
 
             let side = position.side;
             // Infallible: Step 2c pre-computed (and overflow-checked) this position's rescale into
@@ -1035,16 +1036,17 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                 // not govern option legs) having already rejected any non-integer contract count as
                 // `PositionStateInvalid`.
                 for (pos_id, prepared) in opt_plan.positions {
-                    // The plan collected `pos_id` from this same positions map in a single-threaded
-                    // engine, so the re-borrow cannot miss; fail loudly (matching the strike-adjust
-                    // `unreachable!` above) if that ever changes, rather than silently skipping an
+                    // Fail loudly on a missing id (see `split_plan_position_mut`), matching the
+                    // strike-adjust `unreachable!` above rather than silently skipping an
                     // OptionPositionAdjustedForSplit whose contract asserts the position WAS adjusted.
-                    let Some(position) = option_state.position.positions.get_mut(&pos_id) else {
-                        unreachable!(
-                            "SplitPlan carried position id {pos_id:?} absent from option \
-                             {opt_key:?}'s positions map (id={id}, ratio={ratio})"
-                        );
-                    };
+                    let position = split_plan_position_mut(
+                        &mut option_state.position.positions,
+                        &pos_id,
+                        "option",
+                        &opt_key,
+                        id,
+                        ratio,
+                    );
 
                     // Infallible: Step 2c pre-computed (and overflow-checked) this option leg's
                     // rescale into `prepared`; the commit only writes fields + the self-correcting
@@ -1141,35 +1143,87 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     }
 }
 
-/// Classify a stock split for **option** handling: `true` ⇒ the engine can adjust the affected
-/// options **in place** (a standard whole-number forward split, OCC Art. VI §11); `false` ⇒ it must
-/// leave them at pre-split terms and signal a downstream identity change (every reverse split, every
-/// fractional forward split, and the `ratio == 1` no-op).
+/// Collapse a stock split's OCC [`SplitAdjustmentKind`] into the engine **policy** decision of
+/// whether this engine can adjust affected option positions **in place**:
+/// - `Ok(true)` — a **standard** whole-number forward split (OCC Art. VI §11): strike ÷ ratio,
+///   contracts × ratio, same contract identity ⇒ adjustable in place;
+/// - `Ok(false)` — a **non-standard** split (every reverse split, every fractional forward split, and
+///   the `ratio == 1` no-op): the OCC assigns a new contract identity the engine cannot represent ⇒
+///   leave the options at pre-split terms;
+/// - `Err(other)` — the kind is not a split (unreachable once `StockSplit` is destructured) **or** a
+///   future `#[non_exhaustive]` [`SplitAdjustmentKind`] variant this engine does not yet classify.
+///   The conservative fallback (treat as non-standard) and any logging are the **caller's** choice, so
+///   this stays pure and side-effect-free — letting the live handler `warn!` while the audit replica
+///   (which re-derives state silently) does not.
 ///
-/// [`SplitAdjustmentKind`] is `#[non_exhaustive]` and defined in another crate, so it cannot be
-/// matched exhaustively here — a future variant will **not** raise a compile error. Rather than let
-/// one silently take the non-standard path, this names the known classifications and routes anything
-/// unexpected through the conservative non-standard path with a `warn!` (observable over silent). The
-/// `None` arm (kind is not a split) is unreachable at the call site — the `StockSplit` is destructured
-/// before this runs — but is folded into the same conservative branch.
+/// Single-sourced so the live [`Engine::process_corporate_action`] and the audit replica reach the
+/// identical Standard→in-place decision by construction rather than by two hand-mirrored matches. This
+/// is engine **policy**, not an OCC/domain fact (the fact is [`CorporateActionKind::split_kind`]), so
+/// it lives here in the engine crate, `pub(crate)`.
+pub(crate) fn classify_option_split(
+    kind: &CorporateActionKind,
+) -> Result<bool, Option<SplitAdjustmentKind>> {
+    match kind.split_kind() {
+        Some(SplitAdjustmentKind::Standard) => Ok(true),
+        Some(SplitAdjustmentKind::NonStandard) => Ok(false),
+        other => Err(other),
+    }
+}
+
+/// The live handler's thin wrapper over [`classify_option_split`]: same Standard→`true` /
+/// non-standard→`false` decision, but `warn!`ing (observable over silent) when the classification is
+/// an unexpected/future variant before conservatively taking the non-standard path. The audit replica
+/// calls [`classify_option_split`] directly (no `warn!` — the live engine already logged it).
 fn option_split_adjust_in_place(
     id: &SmolStr,
     key: &InstrumentIndex,
     kind: &CorporateActionKind,
 ) -> bool {
-    match kind.split_kind() {
-        Some(SplitAdjustmentKind::Standard) => true,
-        Some(SplitAdjustmentKind::NonStandard) => false,
-        other => {
-            warn!(
-                %id,
-                instrument = ?key,
-                classification = ?other,
-                "CorporateAction: unexpected option split classification — handling conservatively \
-                 as non-standard (engine cannot adjust options in place)."
-            );
-            false
-        }
+    classify_option_split(kind).unwrap_or_else(|other| {
+        warn!(
+            %id,
+            instrument = ?key,
+            classification = ?other,
+            "CorporateAction: unexpected option split classification — handling conservatively \
+             as non-standard (engine cannot adjust options in place)."
+        );
+        false
+    })
+}
+
+/// Look up a position the pre-validated [`SplitPlan`](crate::engine::state::instrument::SplitPlan)
+/// committed the handler to rescaling, panicking loudly if it is absent.
+///
+/// The plan collected `pos_id` from this same positions map earlier in the same single-threaded
+/// commit, so a miss is a plan/state divergence = state corruption, which **must** crash rather than
+/// silently drop a position and let the live engine and its audit replica drift (per CQRS: a
+/// post-validation application failure is corruption, never a retryable domain error). Shared by all
+/// four split commit loops (live + replica × equity + option) so they fail identically.
+///
+/// `#[track_caller]` so the panic reports the **calling** commit loop's location, not this shared
+/// helper's — preserving the per-site diagnosability of the four distinct `unreachable!`s it replaces.
+/// `context` (e.g. `"equity"` / `"replica option"`) and `instrument` carry each site's distinguishing
+/// category and key, preserving per-site diagnosability under one shared, normalized message template.
+#[track_caller]
+pub(crate) fn split_plan_position_mut<'m, AssetKey, InstrumentKey>(
+    positions: &'m mut IndexMap<PositionId, Position<AssetKey, InstrumentKey>>,
+    pos_id: &PositionId,
+    context: &str,
+    instrument: &InstrumentKey,
+    id: &SmolStr,
+    ratio: SplitRatio,
+) -> &'m mut Position<AssetKey, InstrumentKey>
+where
+    InstrumentKey: Debug,
+{
+    match positions.get_mut(pos_id) {
+        Some(position) => position,
+        // Plan/state divergence = corruption (see above): `unreachable!`, matching the sibling
+        // invariant checks and the four inline `unreachable!`s this helper replaces.
+        None => unreachable!(
+            "SplitPlan carried {context} position id {pos_id:?} absent from instrument \
+             {instrument:?}'s positions map (id={id}, ratio={ratio})"
+        ),
     }
 }
 

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -224,7 +224,7 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
             // structural invariant, mirroring the handler's loud arm.
             let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
                 unreachable!(
-                    "is_option_on_underlying matched a non-Option instrument {:?}",
+                    "is_option_on_underlying matched a non-Option instrument {:?} (ratio={ratio})",
                     option_state.key
                 );
             };

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -181,9 +181,11 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
         let equity_state = self.instrument_index(equity);
         let mut equity_positions = Vec::with_capacity(equity_state.position.positions.len());
         for (pos_id, position) in &equity_state.position.positions {
-            // Match the variant explicitly (not `|_|`): `SplitError` is `#[non_exhaustive]`, so if a
-            // future non-overflow cause is added this mapping fails to compile here rather than
-            // silently mislabelling it `ArithmeticOverflow`.
+            // Match the variant explicitly (not `|_|`): the irrefutable `|SplitError::Overflow|`
+            // closure pattern stops compiling (E0005) if a future non-overflow variant is added, so a
+            // new cause surfaces here as a compile error rather than being silently mislabelled
+            // `ArithmeticOverflow`. (Ordinary intra-crate exhaustiveness — `#[non_exhaustive]` only
+            // governs downstream crates.)
             let prepared =
                 position
                     .prepare_split(ratio, policy)
@@ -243,7 +245,7 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
                 // Held option legs rescale with `Fractional` (the integer invariant above makes the
                 // equity `policy` a no-op), matching the handler's per-option commit. Variant match
                 // (not `|_|`) so a future `SplitError` variant is a compile error here, not a silent
-                // `ArithmeticOverflow` mislabel.
+                // `ArithmeticOverflow` mislabel — same intra-crate exhaustiveness as the equity leg above.
                 let prepared = position
                     .prepare_split(ratio, SplitRoundingPolicy::Fractional)
                     .map_err(|SplitError::Overflow| {
@@ -554,7 +556,7 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
 
     /// `true` if this is an **option** on the underlying `(base, quote)` traded on `exchange` that
     /// currently **holds at least one open position** — i.e. the options whose held positions a
-    /// corporate action must event-adjust (per-position `apply_split` + observables) or, on a
+    /// corporate action must event-adjust (per-position rescale + observables) or, on a
     /// non-standard split, flag for a wrapper-side identity change.
     ///
     /// This is [`Self::is_option_on_underlying`] plus the non-empty-position gate. The strike

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -5,7 +5,8 @@ use crate::{
             instrument::{data::InstrumentDataState, filter::InstrumentFilter},
             order::{Orders, manager::OrderManager},
             position::{
-                OmsMode, PnlUnrealisedUpdate, PositionExited, PositionManager, SplitRoundingPolicy,
+                OmsMode, PnlUnrealisedUpdate, PositionExited, PositionManager, PreparedSplit,
+                SplitError, SplitRoundingPolicy,
             },
         },
     },
@@ -14,6 +15,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use fnv::{FnvHashMap, FnvHashSet};
 use itertools::Either;
+use rust_decimal::Decimal;
 use rustrade_data::event::MarketEvent;
 use rustrade_execution::{
     FeeModel, FeeModelConfig, InstrumentAccountSnapshot,
@@ -67,6 +69,37 @@ pub struct InstrumentStates<
     >,
 );
 
+/// The full, pre-computed mutation a stock split applies — produced by
+/// [`InstrumentStates::prepare_corporate_action_split`] with **no** mutation, then committed by the
+/// corporate-action handler (and its audit replica).
+///
+/// Splitting *prepare* (fallible arithmetic) from *commit* (infallible writes) makes the whole
+/// action atomic by construction: every `Decimal` overflow — including the option **strike**
+/// division — and every corrupted option-contract count is caught while building this plan, before
+/// any position or strike is touched, so a partially-applied split is impossible. Both the live
+/// handler and the audit replica build the plan from the same single-sourced pass, so they reach the
+/// identical accept/reject decision and identical committed values.
+pub(crate) struct SplitPlan {
+    /// Pre-computed rescale for every open position on the splitting equity, in position-map order.
+    pub(crate) equity_positions: Vec<(PositionId, PreparedSplit)>,
+    /// One entry per registered option on the underlying (held OR unheld) for a **standard** split;
+    /// empty for a non-standard split (which touches no option state).
+    pub(crate) options: Vec<OptionSplitPlan>,
+}
+
+/// The pre-computed standard-split adjustment for a single option instrument on the splitting
+/// underlying: its checked post-split strike plus a [`PreparedSplit`] for each held position.
+pub(crate) struct OptionSplitPlan {
+    /// The option instrument to adjust in place.
+    pub(crate) key: InstrumentIndex,
+    /// `strike ÷ ratio`, pre-checked for `Decimal` overflow. Applied to the option whether it is
+    /// held OR unheld, so the registry stays consistent for positions opened later.
+    pub(crate) strike_post_split: Decimal,
+    /// Pre-computed rescale for each held position on this option, in position-map order. Empty for
+    /// an unheld option (the strike correction is its whole adjustment).
+    pub(crate) positions: Vec<(PositionId, PreparedSplit)>,
+}
+
 impl<InstrumentData> InstrumentStates<InstrumentData> {
     /// Return a reference to the `InstrumentState` associated with an `InstrumentIndex`.
     ///
@@ -113,70 +146,123 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
             .unwrap_or_else(|| panic!("InstrumentStates does not contain: {key}"))
     }
 
-    /// Pre-validate a stock split against **every** position it would mutate, **without mutating
-    /// anything**, so `process_corporate_action` (and its audit replica) can reject an
-    /// un-applicable action *atomically* — no partial rescaling on an overflowing feed or a
-    /// corrupted option contract count.
+    /// Pre-compute a stock split against **every** position and option it would mutate, **without
+    /// mutating anything**, returning the full [`SplitPlan`] the handler will commit — so
+    /// `process_corporate_action` (and its audit replica) can reject an un-applicable action
+    /// *atomically*: no partial rescaling on an overflowing feed, a corrupted option contract count,
+    /// or an option strike that would overflow on division.
     ///
-    /// Single-sourced so the live handler and the audit replica reach the identical decision by
-    /// construction (not by hand-mirrored vigilance). Checks, in the same order the handler mutates:
-    /// - every open position on the splitting `equity` can be rescaled without `Decimal` overflow
-    ///   (equity quantities may legitimately be fractional, so there is no integer check here);
-    /// - iff `adjust_options_in_place` (a standard, whole-number forward split), every **held**
-    ///   option position on the same underlying holds an **integer** contract count (a non-integer
-    ///   count is state corruption) and can be rescaled without overflow.
+    /// Single-sourced so the live handler and the audit replica reach the identical decision — and
+    /// the identical pre-computed values — by construction, not by hand-mirrored vigilance. Checks,
+    /// in the same order the handler commits:
+    /// - every open position on the splitting `equity` rescales without `Decimal` overflow (equity
+    ///   quantities may legitimately be fractional, so there is no integer check here);
+    /// - iff `adjust_options_in_place` (a standard, whole-number forward split), for every registered
+    ///   option on the same underlying (held **or** unheld): its **strike** divides by `ratio`
+    ///   without `Decimal` overflow, and — for each **held** position — the contract count is an
+    ///   **integer** (a non-integer count is state corruption) and rescales without overflow.
+    ///
+    /// The strike check is why unheld options are pre-computed here at all: the handler divides the
+    /// strike of *every* registered option in place (so a position opened later settles against the
+    /// correct strike), and that division is otherwise unchecked. A non-standard split touches no
+    /// option state, so only the equity positions are pre-computed for it.
     ///
     /// Returns the [`UnsupportedCorporateActionReason`] the caller should surface on the first
-    /// failure, or `Ok(())` when the whole action can be applied. Non-standard splits touch no
-    /// option state, so only the equity positions are validated for them.
-    pub(crate) fn validate_corporate_action_split(
+    /// failure, or the [`SplitPlan`] to commit when the whole action can be applied.
+    pub(crate) fn prepare_corporate_action_split(
         &self,
         equity: &InstrumentIndex,
         ratio: SplitRatio,
         policy: SplitRoundingPolicy,
         adjust_options_in_place: bool,
-    ) -> Result<(), UnsupportedCorporateActionReason> {
+    ) -> Result<SplitPlan, UnsupportedCorporateActionReason> {
         // Equity positions: overflow only. A fractional equity quantity is legitimate (fractional-
         // share brokers), so there is no integer invariant to check here — unlike option contracts.
         let equity_state = self.instrument_index(equity);
-        for position in equity_state.position.positions.values() {
-            position
-                .validate_split(ratio, policy)
-                .map_err(|_overflow| UnsupportedCorporateActionReason::ArithmeticOverflow)?;
+        let mut equity_positions = Vec::with_capacity(equity_state.position.positions.len());
+        for (pos_id, position) in &equity_state.position.positions {
+            // Match the variant explicitly (not `|_|`): `SplitError` is `#[non_exhaustive]`, so if a
+            // future non-overflow cause is added this mapping fails to compile here rather than
+            // silently mislabelling it `ArithmeticOverflow`.
+            let prepared =
+                position
+                    .prepare_split(ratio, policy)
+                    .map_err(|SplitError::Overflow| {
+                        UnsupportedCorporateActionReason::ArithmeticOverflow
+                    })?;
+            equity_positions.push((pos_id.clone(), prepared));
         }
 
         // Non-standard splits leave all option state untouched (the handler only emits a signal),
-        // so there is nothing further to validate.
+        // so there is nothing further to pre-compute.
         if !adjust_options_in_place {
-            return Ok(());
+            return Ok(SplitPlan {
+                equity_positions,
+                options: Vec::new(),
+            });
         }
 
-        // Standard split: mirror the handler's held-option scan (base + quote + exchange identity)
-        // and enforce the integer-contract invariant + overflow-safety on every held option
-        // position BEFORE the handler mutates any of them.
+        // Standard split: mirror the handler's option scan (base + quote + exchange identity) and
+        // pre-compute, for EVERY registered option on the underlying (held OR unheld), the checked
+        // post-split strike (`strike ÷ ratio`) plus the integer-contract invariant + overflow-safe
+        // rescale of every HELD option position — all BEFORE the handler mutates any of them.
         let base = equity_state.instrument.underlying.base;
         let quote = equity_state.instrument.underlying.quote;
         let exchange = equity_state.instrument.exchange;
+        let ratio_decimal = ratio.get();
+        let mut options = Vec::new();
         for option_state in self
             .0
             .values()
             .filter(|state| state.is_option_on_underlying(&base, &quote, &exchange))
         {
-            for position in option_state.position.positions.values() {
+            // Strike overflow: pre-check the `strike ÷ ratio` the handler applies in place to every
+            // registered option, held OR unheld — the fix for the previously unchecked strike
+            // `DivAssign` (which could panic on a degenerate-but-positive ratio and was never
+            // validated: the old pass checked only positions, skipping unheld options entirely).
+            // `is_option_on_underlying` matched only Option instruments, so the `else` is a
+            // structural invariant, mirroring the handler's loud arm.
+            let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+                unreachable!(
+                    "is_option_on_underlying matched a non-Option instrument {:?}",
+                    option_state.key
+                );
+            };
+            let strike_post_split = contract
+                .strike
+                .checked_div(ratio_decimal)
+                .ok_or(UnsupportedCorporateActionReason::ArithmeticOverflow)?;
+
+            let mut positions = Vec::with_capacity(option_state.position.positions.len());
+            for (pos_id, position) in &option_state.position.positions {
                 // Option contract counts are whole; a non-integer count is corruption the handler
                 // must not silently floor/carry. Surfaced as an observable rejection, not a panic.
                 if !position.quantity_abs.fract().is_zero() {
                     return Err(UnsupportedCorporateActionReason::PositionStateInvalid);
                 }
-                // Held option legs are rescaled with `Fractional` (the integer invariant above makes
-                // the equity `policy` a no-op), matching the handler's per-option `apply_split`.
-                position
-                    .validate_split(ratio, SplitRoundingPolicy::Fractional)
-                    .map_err(|_overflow| UnsupportedCorporateActionReason::ArithmeticOverflow)?;
+                // Held option legs rescale with `Fractional` (the integer invariant above makes the
+                // equity `policy` a no-op), matching the handler's per-option commit. Variant match
+                // (not `|_|`) so a future `SplitError` variant is a compile error here, not a silent
+                // `ArithmeticOverflow` mislabel.
+                let prepared = position
+                    .prepare_split(ratio, SplitRoundingPolicy::Fractional)
+                    .map_err(|SplitError::Overflow| {
+                        UnsupportedCorporateActionReason::ArithmeticOverflow
+                    })?;
+                positions.push((pos_id.clone(), prepared));
             }
+
+            options.push(OptionSplitPlan {
+                key: option_state.key,
+                strike_post_split,
+                positions,
+            });
         }
 
-        Ok(())
+        Ok(SplitPlan {
+            equity_positions,
+            options,
+        })
     }
 
     /// Return an `Iterator` of references to `InstrumentState`s being tracked, optionally filtered

--- a/rustrade/src/engine/state/position.rs
+++ b/rustrade/src/engine/state/position.rs
@@ -142,10 +142,22 @@ pub enum PnlRealisedUpdate {
     Overflowed,
 }
 
-/// The rescaled field values a split produces, computed by [`Position::compute_split`] without
-/// mutating the position — committed by [`Position::apply_split`], discarded by
-/// [`Position::validate_split`].
-struct SplitComputed {
+/// The rescaled field values a split produces, pre-computed by [`Position::prepare_split`] without
+/// mutating the position, then written by [`Position::commit_split`].
+///
+/// Carrying the pre-computed values lets the corporate-action handler run **all** fallible split
+/// arithmetic up front (the engine's atomic pre-validation pass), then commit every affected
+/// position infallibly — so a mid-commit `Decimal` overflow is impossible *by construction* rather
+/// than merely caught by an `unreachable!`.
+///
+/// `pub(crate)`: the handler's pre-validation ([`InstrumentStates::prepare_corporate_action_split`])
+/// carries a batch of these in its [`SplitPlan`]; the fields stay private so only [`Position`] can
+/// read them back (via [`Position::commit_split`]).
+///
+/// [`InstrumentStates::prepare_corporate_action_split`]: super::instrument::InstrumentStates::prepare_corporate_action_split
+/// [`SplitPlan`]: super::instrument::SplitPlan
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PreparedSplit {
     quantity_abs: Decimal,
     price_entry_average: Decimal,
     quantity_abs_max: Decimal,
@@ -880,22 +892,47 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
     /// ratio or quantity driving `quantity_abs × ratio`, `price_entry_average ÷ ratio`, or
     /// `quantity_abs_max × ratio` past `Decimal::MAX`. All three are computed **before** any field
     /// is written, so on `Err` the [`Position`] is left **unmutated** and the caller can reject the
-    /// action atomically (see [`Position::validate_split`] to pre-validate a batch of positions).
+    /// action atomically (see [`Position::validate_split`] to pre-check a single position without
+    /// mutating it).
     pub fn apply_split(
         &mut self,
         ratio: SplitRatio,
         policy: SplitRoundingPolicy,
         last_price: Option<Decimal>,
     ) -> Result<SplitResult, SplitError> {
-        // `ratio` is a `SplitRatio` (`> 0` by construction), so no runtime sign check is needed.
-        // Compute the rescaled fields first; an overflow returns `Err` with `self` untouched.
-        let computed = self.compute_split(ratio.get(), policy)?;
+        // Two-phase: prepare (fallible arithmetic, no mutation) then commit (infallible). Kept as a
+        // single call for callers that apply one position in isolation; the corporate-action handler
+        // instead batches `prepare_split` across every affected position (atomic pre-validation) via
+        // `InstrumentStates::prepare_corporate_action_split`, then commits each with `commit_split`,
+        // so a mid-batch overflow can never leave a subset of positions rescaled.
+        let prepared = self.prepare_split(ratio, policy)?;
+        Ok(self.commit_split(prepared, last_price))
+    }
 
-        // All arithmetic succeeded — commit atomically.
-        self.price_entry_average = computed.price_entry_average;
-        self.quantity_abs = computed.quantity_abs;
-        // High-water mark scales UNFLOORED even under Floor (see `compute_split`).
-        self.quantity_abs_max = computed.quantity_abs_max;
+    /// Write a [`PreparedSplit`] (from [`prepare_split`](Self::prepare_split)) to this position,
+    /// **infallibly**. The fallible split arithmetic already ran in `prepare_split`, so this only
+    /// commits the pre-computed rescaled fields and performs the eager, self-correcting
+    /// `pnl_unrealised` recompute.
+    ///
+    /// Splitting apply into prepare + commit lets the engine pre-validate a whole batch of positions
+    /// *before* mutating any (see [`apply_split`](Self::apply_split)); a partial-commit-then-overflow
+    /// is then impossible by construction.
+    ///
+    /// `last_price` drives the eager unrealised-PnL recompute exactly as in
+    /// [`apply_split`](Self::apply_split): `None` ⇒ `pnl_unrealised = 0`; an extreme price whose
+    /// recompute overflows `Decimal` ALSO ⇒ `0` with [`SplitResult::pnl_unrealised_overflowed`] set —
+    /// never a panic (the quantity/basis rescale is already committed and must stay atomic). The
+    /// value self-corrects on the next market tick.
+    pub(crate) fn commit_split(
+        &mut self,
+        prepared: PreparedSplit,
+        last_price: Option<Decimal>,
+    ) -> SplitResult {
+        // All arithmetic already succeeded in `prepare_split` — commit atomically.
+        self.price_entry_average = prepared.price_entry_average;
+        self.quantity_abs = prepared.quantity_abs;
+        // High-water mark scales UNFLOORED even under Floor (see `prepare_split`).
+        self.quantity_abs_max = prepared.quantity_abs_max;
 
         // Eagerly recompute unrealised PnL from the supplied price so a risk check between the
         // split and the next market tick never reads a stale pre-split value. `None` (no market
@@ -922,37 +959,47 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
             }
         };
 
-        Ok(SplitResult {
-            remainder: computed.remainder,
+        SplitResult {
+            remainder: prepared.remainder,
             pnl_unrealised_overflowed,
-        })
+        }
     }
 
     /// Validate that [`apply_split`](Self::apply_split) would succeed for this position **without
     /// mutating it**, returning [`SplitError::Overflow`] iff the split arithmetic would overflow
     /// `Decimal`.
     ///
-    /// The engine calls this over **every** position an action affects *before* mutating any, so a
-    /// corporate action applies to the whole instrument atomically or not at all — an overflowing
-    /// feed can never leave a subset of positions rescaled.
+    /// A standalone, single-position convenience: it runs the same checked split arithmetic and
+    /// discards the result. The engine's own corporate-action path does **not** call this — it
+    /// pre-computes the whole action atomically across every affected position (and every option
+    /// strike) *before* mutating any, so an overflowing feed can never leave a subset of positions
+    /// rescaled.
     pub fn validate_split(
         &self,
         ratio: SplitRatio,
         policy: SplitRoundingPolicy,
     ) -> Result<(), SplitError> {
-        self.compute_split(ratio.get(), policy).map(drop)
+        self.prepare_split(ratio, policy).map(drop)
     }
 
-    /// Pure split arithmetic — the single source of the rescaling math, shared by
-    /// [`apply_split`](Self::apply_split) (which commits it) and
-    /// [`validate_split`](Self::validate_split) (which discards it). Computes every rescaled field
-    /// with **checked** `Decimal` arithmetic and mutates nothing; returns [`SplitError::Overflow`]
-    /// if any product/quotient exceeds `Decimal::MAX`.
-    fn compute_split(
+    /// Pre-compute a split's rescaled fields with **checked** `Decimal` arithmetic, **without
+    /// mutating** the position — the single source of the rescaling math, shared by
+    /// [`apply_split`](Self::apply_split) / [`commit_split`](Self::commit_split) (which write it) and
+    /// [`validate_split`](Self::validate_split) (which discards it). Returns [`SplitError::Overflow`]
+    /// if any product/quotient exceeds `Decimal::MAX`, leaving nothing to commit.
+    ///
+    /// `pub(crate)` so the engine's atomic pre-validation
+    /// ([`InstrumentStates::prepare_corporate_action_split`](super::instrument::InstrumentStates::prepare_corporate_action_split))
+    /// can pre-compute every affected position *before* [`commit_split`](Self::commit_split) mutates
+    /// any.
+    pub(crate) fn prepare_split(
         &self,
-        ratio: Decimal,
+        ratio: SplitRatio,
         policy: SplitRoundingPolicy,
-    ) -> Result<SplitComputed, SplitError> {
+    ) -> Result<PreparedSplit, SplitError> {
+        // `ratio` is a `SplitRatio` (`> 0` by construction), so no runtime sign check is needed.
+        let ratio = ratio.get();
+
         // Scaled (unfloored) quantity on the new share scale.
         let scaled_quantity = self
             .quantity_abs
@@ -980,7 +1027,7 @@ impl<AssetKey, InstrumentKey> Position<AssetKey, InstrumentKey> {
             .checked_mul(ratio)
             .ok_or(SplitError::Overflow)?;
 
-        Ok(SplitComputed {
+        Ok(PreparedSplit {
             quantity_abs,
             price_entry_average,
             quantity_abs_max,
@@ -1135,7 +1182,7 @@ fn calculate_price_entry_average(
 /// The exit-fee approximation reuses `approximate_remaining_exit_fees` **unchecked**, by design:
 /// the only unbounded, feed-controlled input is `price` (covered by the checked value terms below).
 /// The fee term is `(quantity_abs / quantity_abs_max) × fees_enter`, whose ratio stays `≤ 1` under
-/// the `quantity_abs ≤ quantity_abs_max` invariant that `compute_split` preserves (both scale by the
+/// the `quantity_abs ≤ quantity_abs_max` invariant that `prepare_split` preserves (both scale by the
 /// same `ratio`; `Floor` only lowers `quantity_abs`), times a realised, bounded `fees_enter` — so it
 /// has no *reachable* overflow, and guarding it would be over-engineering.
 pub fn calculate_pnl_unrealised(
@@ -2662,7 +2709,7 @@ mod tests {
     fn test_apply_split_ratio_overflow_is_err_and_leaves_position_unmutated() {
         // A ratio-driven rescale that overflows `Decimal` (quantity_abs × ratio > Decimal::MAX)
         // must return `Err(SplitError::Overflow)` with EVERY field left byte-for-byte unmutated —
-        // the all-or-nothing contract the engine's pre-validation relies on. `compute_split` runs
+        // the all-or-nothing contract the engine's pre-validation relies on. `prepare_split` runs
         // before any commit, so not even `pnl_unrealised` (the sentinel 999) is touched.
         let mut p = split_position(Side::Buy, dec!(100), Decimal::MAX, Decimal::MAX, dec!(5));
         let before = p.clone();

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -2602,8 +2602,8 @@ fn test_corporate_action_option_non_standard_no_open_orders_at_split() {
 /// non-integer contract count (state corruption): the engine emits
 /// `UnsupportedCorporateAction { reason: PositionStateInvalid }`, mutates **nothing** (option strike
 /// and the corrupt quantity are left as-is), and does **not** record the `id` — so the action stays
-/// retryable once the position is reconciled. Directly exercises the read-only pre-validation pass
-/// (`validate_corporate_action_split`) and the new rejection reason.
+/// retryable once the position is reconciled. Directly exercises the read-only pre-computation pass
+/// (`prepare_corporate_action_split`) and the new rejection reason.
 #[test]
 fn test_corporate_action_pre_validation_rejects_non_integer_option_contracts() {
     let (execution_tx, _execution_rx) = mpsc_unbounded();
@@ -2712,8 +2712,8 @@ fn test_corporate_action_pre_validation_rejects_non_integer_option_contracts() {
 /// emits `UnsupportedCorporateAction { reason: ArithmeticOverflow }`, mutates **nothing**, and does
 /// **not** record the `id`. The end-to-end handler counterpart to the unit-level
 /// `position::tests::test_apply_split_ratio_overflow_is_err_and_leaves_position_unmutated` —
-/// exercising the overflow branch of the read-only pre-validation pass
-/// (`validate_corporate_action_split`) through the full `process_corporate_action` path.
+/// exercising the overflow branch of the read-only pre-computation pass
+/// (`prepare_corporate_action_split`) through the full `process_corporate_action` path.
 #[test]
 fn test_corporate_action_pre_validation_rejects_arithmetic_overflow() {
     let (execution_tx, _execution_rx) = mpsc_unbounded();
@@ -2817,9 +2817,135 @@ fn test_corporate_action_pre_validation_rejects_arithmetic_overflow() {
     );
 }
 
+/// A **standard** split on an underlying whose option leg would overflow `Decimal` on rescale is
+/// rejected **atomically** — the option's strike is left at its pre-split value rather than being
+/// divided in place before the overflow. This is the option-path analog of
+/// `test_corporate_action_pre_validation_rejects_arithmetic_overflow` (which plants the overflow on
+/// the equity leg), and it exercises the fix that extended the read-only pre-computation pass
+/// (`prepare_corporate_action_split`) to cover **every option on the underlying** before any
+/// mutation: the handler used to divide `contract.strike` in place first, then panic when a held
+/// option position could not be rescaled, leaving a half-adjusted strike behind.
+///
+/// Note on the strike arithmetic itself: a standard split's `ratio` is always a whole number ≥ 2
+/// (OCC classification, `SplitAdjustmentKind::Standard`), so `strike ÷ ratio` only ever *shrinks*
+/// the strike and cannot itself overflow — its `checked_div` is defence-in-depth. The reachable
+/// option-leg overflow is the position's `quantity_abs × ratio`, planted here on a held option; the
+/// pre-computation still rejects the whole action before the strike (or anything else) is touched.
+#[test]
+fn test_corporate_action_pre_validation_rejects_option_leg_overflow() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // Marks for the option (idx0) and the spot underlying (idx1); open a small long call on the
+    // option so it is HELD (an unheld option's only split arithmetic is the strike division, which
+    // cannot overflow — see the doc comment).
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+    // PLANT an adversarial contract count a forward split cannot rescale without overflowing
+    // `Decimal` (`Decimal::MAX × 2` has no representation). It is still a whole number, so it passes
+    // the integer-contract invariant and is rejected on the overflow branch, not `PositionStateInvalid`.
+    engine
+        .state
+        .instruments
+        .instrument_index_mut(&InstrumentIndex(0))
+        .position
+        .positions
+        .values_mut()
+        .next()
+        .expect("option position should exist")
+        .quantity_abs = Decimal::MAX;
+
+    // 2:1 STANDARD forward split on the Spot underlying (idx1). Pre-computation reaches the option
+    // scan (standard classification), pre-checks the strike (fine), then overflows on the option
+    // position rescale — rejecting the whole action.
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-option-overflow-2-1".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // Exactly the rejection observable, attributed to the splitting equity with the overflow reason.
+    let rejections: Vec<_> = outputs
+        .iter()
+        .filter_map(|o| match o {
+            EngineOutput::UnsupportedCorporateAction {
+                instrument, reason, ..
+            } => Some((*instrument, *reason)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rejections.len(), 1, "expected exactly one rejection");
+    assert_eq!(rejections[0].0, InstrumentIndex(1));
+    assert_eq!(
+        rejections[0].1,
+        UnsupportedCorporateActionReason::ArithmeticOverflow
+    );
+
+    // Atomic — the key #181 assertion: the option's STRIKE was NOT divided in place. Before the fix
+    // the handler halved it (50_000 → 25_000) before hitting the un-rescalable position; now the
+    // whole action is rejected before any strike or position is touched.
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(
+        contract.strike,
+        dec!(50_000),
+        "the option strike must be left at its pre-split value (no partial in-place division)"
+    );
+    let position = option_state
+        .position
+        .positions
+        .values()
+        .next()
+        .expect("option position should persist");
+    assert_eq!(
+        position.quantity_abs,
+        Decimal::MAX,
+        "the planted contract count must be left as-is (no partial rescale)"
+    );
+
+    // The `id` was NOT recorded on the Spot target ⇒ retryable once the feed is corrected.
+    assert!(
+        !engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(1))
+            .corporate_actions_processed
+            .contains("BTCUSD-option-overflow-2-1"),
+        "a rejected action must not record its id"
+    );
+
+    // No option adjustment, remainder, or open-orders snapshot leaked through the rejection.
+    assert!(
+        !outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::OptionPositionAdjustedForSplit { .. }
+                | EngineOutput::SplitRemainder { .. }
+                | EngineOutput::OpenOrdersAtSplit { .. }
+        )),
+        "a rejected split must emit no option adjustment, remainder, or open-orders snapshot"
+    );
+}
+
 /// Live engine vs audit-replica parity for a **standard** option adjustment: the replica
-/// event-replays the in-place strike division + per-position `apply_split` deterministically (no
-/// output-mirror). Full `InstrumentState` equality for BOTH the option (idx0) and the spot (idx1)
+/// commits the pre-computed `SplitPlan` (post-split strike + per-position rescale) deterministically
+/// (no output-mirror). Full `InstrumentState` equality for BOTH the option (idx0) and the spot (idx1)
 /// guards against the handler and the replica drifting apart on the option path.
 #[test]
 fn test_corporate_action_option_replica_parity_standard_split() {


### PR DESCRIPTION
## Summary

Hardens corporate-action stock-split handling and de-duplicates the live handler ↔ audit-replica
paths. Three related refactors, delivered as a two-phase (prepare/commit) split so atomicity,
fail-loud invariants, and single-sourcing all fall out of one shared plan.

Fixes #181 · Closes #176 · Closes #175 · Closes #183

## What changed

### Two-phase split — fixes an unchecked strike-division panic (#181)
- Split handling is now **prepare** (all fallible arithmetic, zero mutation → `SplitPlan`) then
  **commit** (infallible writes). A `Decimal` overflow — equity/option position rescale *or* the
  option **strike** division — now rejects the whole action atomically via
  `UnsupportedCorporateActionReason::ArithmeticOverflow`, leaving nothing partially mutated and the
  action `id` unrecorded (retryable).
- The previously unchecked in-place `contract.strike /= ratio` is gone. The strike now divides via
  `checked_div` in the prepare pass for **every registered option on the underlying — held or
  unheld** (the old validation pass skipped unheld options entirely).
- New `SplitPlan` / `OptionSplitPlan` types; `Position::prepare_split` (checked) + `commit_split`
  (infallible), with `apply_split` retained as a single-position convenience over the two.
- New test `test_corporate_action_pre_validation_rejects_option_leg_overflow` asserts the atomicity
  guarantee: an overflowing option leg leaves the strike un-divided and the position un-rescaled.

### Fail-loud commit invariants (#176)
- The fallible per-position `apply_split` error arms are gone by construction (fallible prepare →
  observable rejection; infallible commit). Remaining `unreachable!` sites are plan-invariants kept
  as **release panics** (plan/state divergence = corruption → crash, never a silent continue).
- Harmonized both equity legs to fail loudly: the live handler's silent `else { continue; }` and the
  replica's silent `if let Some` now both treat a missing plan id as corruption. Enriched every
  split `unreachable!` message with `id` / `ratio` / instrument context.

### Single-source classification & position lookup (#175, #183)
- New `classify_option_split()` single-sources the Standard→adjust-in-place policy decision (live
  wraps it with `warn!` on unexpected variants; replica calls it directly). Removes the
  hand-duplicated classification match.
- New `#[track_caller] split_plan_position_mut()` collapses the four duplicated
  `get_mut(&pos_id) + unreachable!` sites (live/replica × equity/option) into one lookup-or-panic,
  with `#[track_caller]` preserving each call site's panic location.

## Testing
- `cargo test --test test_engine_process_engine_event_with_audit` → **45 passed** (full
  money-math + live/replica parity suite).
- Pre-commit clippy gate (`--workspace --all-targets --all-features`, correctness/suspicious/style/perf
  denied) → **0 errors** (the lone `-W complexity` note on `process_corporate_action` is
  pre-existing and non-gating; this change lowered it).

## Notes
- No public API breaks — `Position`, `SplitRatio`, `SplitResult`, `SplitError` unchanged; the new
  `prepare`/`commit` split surface is `pub(crate)`. Accept/reject semantics and emitted observables
  are unchanged.
- CHANGELOG updated under `## [Unreleased]` (the new `ArithmeticOverflow` / `PositionStateInvalid`
  reasons and the two-phase atomicity guarantee). No version bump.
