### PR TITLE
fix(backtest): Advance clock to contract expiry & expose terminal engine state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `result.engine_state`. `run_backtests` is **unchanged** — it still returns `MultiBacktestSummary`
   and does not retain per-run `EngineState` (drive `backtest` directly when the terminal state is
   needed).
+- **`ContractExpiry` now advances the backtest clock to the contract's expiry instant** (`rustrade`).
+  When the engine processes an `EngineEvent::ContractExpiry`, the `HistoricalClock` now advances to
+  the expiring instrument's `expiry` (read from its `InstrumentKind`) before synthesising the
+  settlement fill, so the fill — and the resulting `PositionExit` — is stamped at the expiry instant
+  rather than the prior market tick. Previously the event carried no timestamp on its payload and
+  left the clock unmoved (unlike `CorporateAction`, which advances to its `effective_time`).
+  Non-breaking: adds an `EngineClock::advance_to` **default** method (a no-op, so `LiveClock` and any
+  downstream `EngineClock` impl are unaffected) and a new `InstrumentKind::expiry()` accessor
+  (`rustrade-instrument`, `Some` for `Future`/`Option`, `None` otherwise). A backtest that injects a
+  `ContractExpiry` via an `AuxEventSource` must now position it in the merged stream by the target
+  instrument's own `expiry` (the harness enforces `Timed::time == expiry` with a hard pre-merge
+  panic, mirroring the existing `CorporateAction` `effective_time` check), so a mismatch fails loudly
+  instead of silently ordering the expiry at one instant while settling it at another.
 - **Alpaca client error variants** (`rustrade-data`, feature-gated `alpaca`). `AlpacaOptionsError` is
   now a type alias of the shared `AlpacaRestError`, which adds an `InvalidCredential` variant. The
   `AlpacaOptionsClient` constructor now reports a credential that cannot be encoded as an HTTP header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameters cannot carry a default, so callers that spell the generics explicitly (turbofish, or a
   fully type-annotated function pointer) must account for the extra argument. Callers that rely on
   inference are unaffected.
+- **`backtest` now returns `BacktestResult { summary, engine_state }`, not a bare `BacktestSummary`**
+  (`rustrade`). The terminal `EngineState` is returned alongside the summary so callers can inspect
+  post-run state directly — open positions, balances, instrument state — which the aggregate
+  `TradingSummary` (closed-position statistics only) cannot express. This makes the net effect of a
+  notional-preserving corporate action assertable through the public async `backtest` path (e.g. a
+  stock split's rescaling of a position left open at shutdown). **Breaking**: replace `summary` with
+  `result.summary` at the call site (e.g. `backtest(..).await?.summary`); the new terminal state is
+  `result.engine_state`. `run_backtests` is **unchanged** — it still returns `MultiBacktestSummary`
+  and does not retain per-run `EngineState` (drive `backtest` directly when the terminal state is
+  needed).
 - **Alpaca client error variants** (`rustrade-data`, feature-gated `alpaca`). `AlpacaOptionsError` is
   now a type alias of the shared `AlpacaRestError`, which adds an `InvalidCredential` variant. The
   `AlpacaOptionsClient` constructor now reports a credential that cannot be encoded as an HTTP header

--- a/rustrade-instrument/src/instrument/kind/mod.rs
+++ b/rustrade-instrument/src/instrument/kind/mod.rs
@@ -4,6 +4,7 @@ use crate::instrument::{
         MarketDataFutureContract, MarketDataInstrumentKind, MarketDataOptionContract,
     },
 };
+use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
@@ -36,6 +37,16 @@ impl<AssetKey> InstrumentKind<AssetKey> {
             InstrumentKind::Perpetual(kind) => kind.contract_size,
             InstrumentKind::Future(kind) => kind.contract_size,
             InstrumentKind::Option(kind) => kind.contract_size,
+        }
+    }
+
+    /// Returns the contract expiry instant for expiring kinds (`Future` & `Option`), and `None`
+    /// for the non-expiring `Spot` & `Perpetual` kinds.
+    pub fn expiry(&self) -> Option<DateTime<Utc>> {
+        match self {
+            InstrumentKind::Spot | InstrumentKind::Perpetual(_) => None,
+            InstrumentKind::Future(kind) => Some(kind.expiry),
+            InstrumentKind::Option(kind) => Some(kind.expiry),
         }
     }
 

--- a/rustrade/benches/backtest/mod.rs
+++ b/rustrade/benches/backtest/mod.rs
@@ -221,7 +221,9 @@ fn bench_backtest(
         b.iter_batched(
             || (Arc::clone(&args_constant), args_dynamic.clone()),
             |(constant, dynamic)| {
-                rt.block_on(async move { backtest::backtest(constant, dynamic).await.unwrap() })
+                rt.block_on(
+                    async move { backtest::backtest(constant, dynamic).await.unwrap().summary },
+                )
             },
             criterion::BatchSize::SmallInput,
         );

--- a/rustrade/examples/corporate_action_injection.rs
+++ b/rustrade/examples/corporate_action_injection.rs
@@ -173,7 +173,8 @@ async fn main() {
 
     let summary = backtest(args_constant, args_dynamic)
         .await
-        .expect("backtest with an injected corporate action must complete");
+        .expect("backtest with an injected corporate action must complete")
+        .summary;
 
     println!(
         "Backtest '{}' completed with an injected 2:1 split.",

--- a/rustrade/examples/engine_backtest_with_candle_market_data.rs
+++ b/rustrade/examples/engine_backtest_with_candle_market_data.rs
@@ -115,7 +115,7 @@ async fn main() {
         risk: DefaultRiskManager::<EngineState<DefaultGlobalData, CandleInstrumentData>>::default(),
     };
 
-    let summary = backtest(args_constant, args_dynamic).await.unwrap();
+    let summary = backtest(args_constant, args_dynamic).await.unwrap().summary;
 
     println!("\nBacktest complete (BacktestId = {})", summary.id);
     summary.trading_summary.print_summary();

--- a/rustrade/src/backtest/aux_events.rs
+++ b/rustrade/src/backtest/aux_events.rs
@@ -1,7 +1,8 @@
 use crate::{EngineEvent, Timed};
 use rustrade_data::event::DataKind;
 use rustrade_instrument::{
-    asset::AssetIndex, exchange::ExchangeIndex, instrument::InstrumentIndex,
+    asset::AssetIndex, exchange::ExchangeIndex, index::IndexedInstruments,
+    instrument::InstrumentIndex,
 };
 use std::sync::Arc;
 
@@ -30,16 +31,27 @@ use std::sync::Arc;
 ///   at another. The backtest harness **enforces** this pre-merge via
 ///   [`assert_aux_corporate_action_effective_times`] (a hard panic naming the offending event) — the
 ///   handler itself cannot see the wrapping `Timed`, so keep the two equal to pass the check.
+/// - For an [`EngineEvent::ContractExpiry`](crate::EngineEvent::ContractExpiry), the wrapping
+///   [`Timed::time`] MUST equal the target instrument's own `expiry` (engine-side ground truth on
+///   its `InstrumentKind`). Unlike `CorporateAction`, the instant is not on the payload — the merge
+///   positions the event by `Timed::time`, while the handler advances the clock to the instrument's
+///   `expiry` (see below). A mismatch would *order* the expiry at one instant but *settle* it at
+///   another. Enforced pre-merge via [`assert_aux_contract_expiry_times`] (a hard panic naming the
+///   offending event); non-expiring or unregistered targets are skipped.
 ///
-/// # Limitation — `ContractExpiry` does not advance the backtest clock
-/// [`EngineEvent::ContractExpiry`](crate::EngineEvent::ContractExpiry) carries no timestamp (unlike
-/// [`EngineEvent::CorporateAction`](crate::EngineEvent::CorporateAction), which carries
-/// `effective_time`). An injected expiry is therefore **ordered** correctly within the merged
-/// stream but does **not** advance the
-/// [`HistoricalClock`](crate::engine::clock::HistoricalClock): its synthetic settlement fill is
-/// stamped at the prior market tick, not the expiry instant. `CorporateAction` is unaffected (it
-/// advances the clock to its `effective_time`). If exact expiry-instant stamping matters, drive a
-/// market event at the expiry time alongside the injected `ContractExpiry`.
+/// # `ContractExpiry` clock advance
+/// [`EngineEvent::ContractExpiry`](crate::EngineEvent::ContractExpiry) carries no timestamp on its
+/// payload (unlike [`EngineEvent::CorporateAction`](crate::EngineEvent::CorporateAction), which
+/// carries `effective_time`). Its effective instant is instead engine-side ground truth: the
+/// handler resolves the expiring instrument's `expiry` from its `InstrumentKind` and advances the
+/// [`HistoricalClock`](crate::engine::clock::HistoricalClock) to it via
+/// [`EngineClock::advance_to`](crate::engine::clock::EngineClock::advance_to), so the synthetic
+/// settlement fill is stamped at the expiry instant rather than the prior market tick. As with
+/// `CorporateAction`, position the injected expiry in the merged stream by its [`Timed::time`]; the
+/// handler always settles at the instrument's own `expiry`, so keep the wrapping `Timed::time` equal
+/// to that `expiry` (a mismatch would *order* the expiry at one instant but *settle* it at another).
+/// The harness enforces this equality pre-merge — see the caller obligation above and
+/// [`assert_aux_contract_expiry_times`].
 pub trait AuxEventSource<
     MarketKind = DataKind,
     ExchangeKey = ExchangeIndex,
@@ -137,6 +149,49 @@ pub(crate) fn assert_aux_corporate_action_effective_times<
     }
 }
 
+/// Panic if any injected [`EngineEvent::ContractExpiry`] carries a wrapping [`Timed::time`] that
+/// differs from its target instrument's own `expiry` (the third [`AuxEventSource`] caller
+/// obligation).
+///
+/// Unlike [`assert_aux_corporate_action_effective_times`], the effective instant is **not** on the
+/// event payload — it is engine-side ground truth on the instrument's
+/// [`InstrumentKind`](rustrade_instrument::instrument::kind::InstrumentKind). The merge **positions**
+/// the expiry by `Timed::time`, while the handler advances the
+/// [`HistoricalClock`](crate::engine::clock::HistoricalClock) to the resolved `expiry` and stamps the
+/// synthetic settlement fill there. If the two disagree the expiry is *ordered* at one instant but
+/// *settled* at another — a silent look-ahead / stale-stamp bug with no failure point in a release
+/// build. This resolves each target via [`IndexedInstruments::find_instrument`] and enforces the
+/// equality at the same pre-merge site as [`assert_aux_events_sorted`] (a hard panic in all builds —
+/// the handler itself cannot see the wrapping `Timed`, so the harness is the only place this can be
+/// checked). Events whose target is non-expiring (`expiry() == None`) or not registered are skipped
+/// — those are not this check's concern (the engine surfaces an unregistered target on its own). The
+/// O(N) scan over the handful-sized aux set is negligible, and the message names the offending event
+/// so a failing source is debuggable without a rebuild.
+pub(crate) fn assert_aux_contract_expiry_times<MarketKind, AssetKey>(
+    events: &[Timed<EngineEvent<MarketKind, ExchangeIndex, AssetKey, InstrumentIndex>>],
+    instruments: &IndexedInstruments,
+) {
+    for (i, event) in events.iter().enumerate() {
+        let EngineEvent::ContractExpiry(key) = &event.value else {
+            continue;
+        };
+        // Skip unregistered targets — the engine handler surfaces those separately; this check owns
+        // only the time-vs-expiry equality.
+        let Ok(instrument) = instruments.find_instrument(*key) else {
+            continue;
+        };
+        if let Some(expiry) = instrument.kind.expiry()
+            && expiry != event.time
+        {
+            panic!(
+                "AuxEventSource ContractExpiry ({key}) at events[{i}] must carry Timed::time == \
+                 the instrument's expiry; expiry={expiry:?} != Timed::time={:?}",
+                event.time,
+            );
+        }
+    }
+}
+
 /// In-memory [`AuxEventSource`] backed by an [`Arc`]'d, pre-sorted `Vec`.
 ///
 /// Mirrors [`MarketDataInMemory`](super::market_data::MarketDataInMemory): cloning is O(1) (an
@@ -195,7 +250,7 @@ mod tests {
     use super::*;
     use crate::SplitRoundingPolicy;
     use crate::shutdown::Shutdown;
-    use chrono::DateTime;
+    use chrono::{DateTime, Utc};
     use rust_decimal::Decimal;
     use rustrade_instrument::corporate_action::{CorporateActionKind, SplitRatio};
 
@@ -275,5 +330,86 @@ mod tests {
             AssetIndex,
             InstrumentIndex,
         >(&[corp_action(1_000, 2_000)]);
+    }
+
+    fn time_at(secs: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(secs, 0).expect("valid timestamp")
+    }
+
+    /// A `ContractExpiry` event ordered at `time_secs`, targeting `InstrumentIndex(0)`.
+    fn contract_expiry(time_secs: i64) -> Timed<EngineEvent> {
+        Timed::new(
+            EngineEvent::ContractExpiry(InstrumentIndex::new(0)),
+            time_at(time_secs),
+        )
+    }
+
+    /// `IndexedInstruments` holding one instrument at `InstrumentIndex(0)`, either a `Future`
+    /// expiring at `expiry_secs` (`Some`) or a non-expiring `Spot` (`None`), so the expiry-vs-time
+    /// check and its non-expiring skip branch can both be exercised.
+    fn instruments_with(expiry_secs: Option<i64>) -> IndexedInstruments {
+        use rustrade_instrument::{
+            Underlying,
+            exchange::ExchangeId,
+            index::builder::IndexedInstrumentsBuilder,
+            instrument::{
+                Instrument, kind::InstrumentKind, kind::future::FutureContract,
+                quote::InstrumentQuoteAsset,
+            },
+            test_utils::asset,
+        };
+
+        let kind = match expiry_secs {
+            Some(secs) => InstrumentKind::Future(FutureContract {
+                contract_size: Decimal::from(1),
+                settlement_asset: asset("usdt"),
+                expiry: time_at(secs),
+            }),
+            None => InstrumentKind::Spot,
+        };
+        IndexedInstrumentsBuilder::default()
+            .add_instrument(Instrument::new(
+                ExchangeId::BinanceSpot,
+                "btc_usdt_future",
+                "btc_usdt_future",
+                Underlying::new(asset("btc"), asset("usdt")),
+                InstrumentQuoteAsset::UnderlyingQuote,
+                kind,
+                None,
+            ))
+            .build()
+    }
+
+    #[test]
+    fn assert_aux_contract_expiry_times_accepts_matching_time() {
+        // Timed::time == the Future's own expiry satisfies the contract; the trailing non-expiry
+        // event (Shutdown) is ignored. No panic.
+        assert_aux_contract_expiry_times(
+            &[contract_expiry(2_000), at(3_000)],
+            &instruments_with(Some(2_000)),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Timed::time == the instrument's expiry")]
+    fn assert_aux_contract_expiry_times_panics_on_mismatch() {
+        // Ordered at Timed::time=1000 but the instrument expires at 2000 — a silent look-ahead the
+        // hard assert (all builds) must catch, naming the offending event.
+        assert_aux_contract_expiry_times(&[contract_expiry(1_000)], &instruments_with(Some(2_000)));
+    }
+
+    #[test]
+    fn assert_aux_contract_expiry_times_skips_non_expiring_and_unregistered() {
+        use rustrade_instrument::index::builder::IndexedInstrumentsBuilder;
+
+        // A ContractExpiry targeting a non-expiring (Spot ⇒ expiry() == None) instrument is not
+        // this check's concern — no expiry to compare against — so the time mismatch is ignored.
+        assert_aux_contract_expiry_times(&[contract_expiry(1_000)], &instruments_with(None));
+        // An empty registry ⇒ find_instrument errors ⇒ the target is skipped (the engine surfaces
+        // an unregistered target on its own). No panic despite an arbitrary Timed::time.
+        assert_aux_contract_expiry_times(
+            &[contract_expiry(1_000)],
+            &IndexedInstrumentsBuilder::default().build(),
+        );
     }
 }

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -6,8 +6,8 @@ use crate::{EngineEvent, Timed};
 use crate::{
     backtest::{
         aux_events::{
-            AuxEventSource, NoAuxEvents, assert_aux_corporate_action_effective_times,
-            assert_aux_events_sorted,
+            AuxEventSource, NoAuxEvents, assert_aux_contract_expiry_times,
+            assert_aux_corporate_action_effective_times, assert_aux_events_sorted,
         },
         market_data::BacktestMarketData,
         summary::{BacktestResult, BacktestSummary, MultiBacktestSummary},
@@ -301,6 +301,13 @@ where
     // cannot see the wrapping `Timed`, so this pre-merge site is the only place to catch it. Hard
     // panic, handful-sized scan. See [`assert_aux_corporate_action_effective_times`].
     assert_aux_corporate_action_effective_times(&aux);
+    // Enforce the third `AuxEventSource` obligation: every injected `ContractExpiry`'s wrapping
+    // `Timed::time` must equal its target instrument's own `expiry` (engine-side ground truth on the
+    // `InstrumentKind`). The instant is not on the payload, so — like the corporate-action check —
+    // the handler cannot see the wrapping `Timed`; a mismatch would order the expiry at one instant
+    // but settle it at another (silent look-ahead). Hard panic, handful-sized scan. See
+    // [`assert_aux_contract_expiry_times`].
+    assert_aux_contract_expiry_times(&aux, &args_constant.instruments);
 
     // Seed the clock from the earliest of the first market event and the first aux event, so an aux
     // event scheduled before the first market tick still orders and stamps correctly.

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -10,7 +10,7 @@ use crate::{
             assert_aux_events_sorted,
         },
         market_data::BacktestMarketData,
-        summary::{BacktestSummary, MultiBacktestSummary},
+        summary::{BacktestResult, BacktestSummary, MultiBacktestSummary},
     },
     engine::{
         Processor,
@@ -168,9 +168,18 @@ where
 {
     let time_start = std::time::Instant::now();
 
-    let backtest_futures = args_dynamic_iter
-        .into_iter()
-        .map(|args_dynamic| backtest(Arc::clone(&args_constant), args_dynamic));
+    // Project each run down to its `summary` inside its own future, so the terminal `EngineState`
+    // is dropped as that run completes rather than pinned in the joined output until the whole
+    // batch finishes. The batch path intentionally does not retain per-run terminal `EngineState`
+    // (callers needing it drive `backtest` directly).
+    let backtest_futures = args_dynamic_iter.into_iter().map(|args_dynamic| {
+        let args_constant = Arc::clone(&args_constant);
+        async move {
+            backtest(args_constant, args_dynamic)
+                .await
+                .map(|result| result.summary)
+        }
+    });
 
     // Run all backtests concurrently
     let summaries = try_join_all(backtest_futures).await?;
@@ -194,16 +203,19 @@ where
 /// before the first market tick still orders and stamps correctly. The merge/tie-break/seed logic is
 /// unit-tested in `backtest::tests`.
 ///
-/// # What the returned summary does and does not contain
-/// This function returns only a [`BacktestSummary`] whose `trading_summary` aggregates statistics
-/// derived from **closed** positions (PnL, returns, drawdown per `TearSheet`). It does **not** expose
-/// final engine/position state: a position left **open** at the end of the run — e.g. one that took a
-/// stock split but no subsequent closing fill — contributes nothing to `trading_summary`, and a
-/// notional-preserving split moves no aggregate metric on its own. Callers needing to inspect
-/// post-run positions (or assert that a corporate action mutated a position) must drive their own
-/// engine harness; the split *economics* are asserted at the `Engine::process_with_audit` seam (see
-/// the `test_corporate_action_*` tests), which this path cannot reach because it hardcodes
-/// [`AuditMode::Disabled`] — the per-event `EngineOutput` stream is therefore not observable here.
+/// # What the returned result contains
+/// Returns a [`BacktestResult`] with two parts:
+/// - `summary`: a [`BacktestSummary`] whose `trading_summary` aggregates statistics derived from
+///   **closed** positions (PnL, returns, drawdown per `TearSheet`). A position left **open** at the
+///   end of the run — e.g. one that took a stock split but no subsequent closing fill — contributes
+///   nothing to it, and a notional-preserving split moves no aggregate metric on its own.
+/// - `engine_state`: the terminal [`EngineState`], so callers can inspect post-run positions directly
+///   (e.g. assert a corporate action rescaled an open position's `quantity_abs` /
+///   `price_entry_average`) without driving their own engine harness.
+///
+/// This path hardcodes [`AuditMode::Disabled`], so the per-event `EngineOutput` audit stream is not
+/// observable here; the split *economics per event* are asserted at the `Engine::process_with_audit`
+/// seam (see the `test_corporate_action_*` tests). The terminal `engine_state` exposes the net effect.
 pub async fn backtest<
     MarketData,
     SummaryInterval,
@@ -222,7 +234,7 @@ pub async fn backtest<
         >,
     >,
     args_dynamic: BacktestArgsDynamic<Strategy, Risk>,
-) -> Result<BacktestSummary<SummaryInterval>, BarterError>
+) -> Result<BacktestResult<SummaryInterval, EngineState<GlobalData, InstrumentData>>, BarterError>
 where
     MarketData: BacktestMarketData<Kind = InstrumentData::MarketEventKind>,
     SummaryInterval: TimeInterval,
@@ -345,10 +357,15 @@ where
         .trading_summary_generator(args_dynamic.risk_free_return)
         .generate(args_constant.summary_interval);
 
-    Ok(BacktestSummary {
-        id: args_dynamic.id,
-        risk_free_return: args_dynamic.risk_free_return,
-        trading_summary,
+    // `trading_summary_generator` only borrows the engine, so the terminal state can be moved out
+    // here and returned for direct post-run inspection (open positions, balances, instrument state).
+    Ok(BacktestResult {
+        summary: BacktestSummary {
+            id: args_dynamic.id,
+            risk_free_return: args_dynamic.risk_free_return,
+            trading_summary,
+        },
+        engine_state: engine.state,
     })
 }
 

--- a/rustrade/src/backtest/summary.rs
+++ b/rustrade/src/backtest/summary.rs
@@ -30,6 +30,27 @@ impl<Interval> MultiBacktestSummary<Interval> {
     }
 }
 
+/// Full result of a single [`backtest`](super::backtest) run: the aggregate [`BacktestSummary`]
+/// **and** the terminal engine state.
+///
+/// [`BacktestSummary::trading_summary`] aggregates statistics derived from **closed** positions only,
+/// so it cannot answer questions about state left at the end of the run — e.g. a position still
+/// **open** at shutdown, or the effect of a notional-preserving corporate action that moves no
+/// aggregate metric. `engine_state` exposes that terminal [`EngineState`](crate::engine::state::EngineState):
+/// callers can inspect open positions, balances, and instrument state directly (e.g. assert a stock
+/// split rescaled an open position's `quantity_abs` / `price_entry_average`).
+///
+/// `State` is the engine's state type (`EngineState<GlobalData, InstrumentData>` for the standard
+/// [`backtest`](super::backtest) path); it is left generic so this module stays decoupled from the
+/// engine-state internals.
+#[derive(Debug, PartialEq)]
+pub struct BacktestResult<Interval, State> {
+    /// Aggregate performance summary derived from closed positions.
+    pub summary: BacktestSummary<Interval>,
+    /// Terminal engine state after the run completes (open positions, balances, instrument state).
+    pub engine_state: State,
+}
+
 /// Single backtest `TradingSummary` and associated metadata.
 #[derive(Debug, PartialEq)]
 pub struct BacktestSummary<Interval> {

--- a/rustrade/src/engine/clock.rs
+++ b/rustrade/src/engine/clock.rs
@@ -18,6 +18,29 @@ use tracing::{debug, error, warn};
 /// lookahead; see [`rustrade_data::event::MarketEvent::time_exchange`].
 pub trait EngineClock {
     fn time(&self) -> DateTime<Utc>;
+
+    /// Advance the clock's notion of "current time" to `time`, if `time` is later than the
+    /// current time (**monotonic** — never regresses).
+    ///
+    /// Used for engine events that carry no timestamp in their payload but whose effective
+    /// instant is derivable from engine state — e.g. [`EngineEvent::ContractExpiry`], whose
+    /// handler resolves the expiring instrument's `expiry` and advances the clock to it so a
+    /// backtest stamps the synthetic settlement fill at the expiry instant rather than the prior
+    /// market tick. Events that already carry their instant on the payload (e.g.
+    /// [`EngineEvent::CorporateAction`]'s `effective_time`) advance the clock via the normal
+    /// [`TimeExchange`] path in [`Processor::process`](crate::engine::Processor::process) and do
+    /// not use this method.
+    ///
+    /// The default implementation is a no-op, correct for clocks that derive time externally
+    /// (e.g. [`LiveClock`], which reads `Utc::now()`). [`HistoricalClock`] overrides it.
+    ///
+    /// # Implementors
+    /// If your [`time`](Self::time) is derived from the timestamps of processed events (like
+    /// [`HistoricalClock`]) rather than a live wall-clock source, you **must** override this
+    /// method. The default no-op would otherwise silently prevent payload-timeless events such as
+    /// [`EngineEvent::ContractExpiry`] from advancing your clock to their derived instant —
+    /// reproducing the stale-stamp bug this method exists to fix.
+    fn advance_to(&self, _time: DateTime<Utc>) {}
 }
 
 /// Defines how to extract an "exchange timestamp" from an event.
@@ -86,6 +109,21 @@ impl EngineClock for HistoricalClock {
         match delta_since_last_event_live_time {
             delta if delta.num_milliseconds() >= 0 => time_exchange_last.add(delta),
             _ => time_exchange_last,
+        }
+    }
+
+    fn advance_to(&self, time: DateTime<Utc>) {
+        let mut lock = self.inner.write();
+        // Monotonic: only advance strictly forwards; an earlier — or equal — `time` is a no-op, so
+        // the clock never regresses and repeated advances to the same instant (e.g. several
+        // instruments expiring together) don't keep re-basing the wall-clock delta. This is
+        // stricter than `process`'s in-order branch (`>=`, which re-anchors on an equal
+        // `time_exchange`) — here there is no boundary event to stamp, so the strict `>` is the
+        // cheaper, equivalent choice. On a genuine advance the `time_live_last_event` reset re-bases
+        // the wall-clock delta so `time()` reads from the new `time_exchange_last`.
+        if time > lock.time_exchange_last {
+            lock.time_exchange_last = time;
+            lock.time_live_last_event = Utc::now();
         }
     }
 }
@@ -404,5 +442,23 @@ mod tests {
             intraday_later,
             "an earlier midnight split must not regress time_exchange_last"
         );
+    }
+
+    #[test]
+    fn test_historical_clock_advance_to_is_monotonic() {
+        let base = DateTime::<Utc>::MIN_UTC;
+        let later = base + TimeDelta::days(365);
+
+        // Advancing forward moves time_exchange_last to the target (the ContractExpiry use-case:
+        // jump the clock to a far-future contract expiry before stamping the settlement fill).
+        let clock = HistoricalClock::new(base);
+        clock.advance_to(later);
+        assert_eq!(clock.inner.read().time_exchange_last, later);
+
+        // Advancing to an earlier — or equal — instant is a no-op: the clock never regresses.
+        clock.advance_to(base);
+        assert_eq!(clock.inner.read().time_exchange_last, later);
+        clock.advance_to(later);
+        assert_eq!(clock.inner.read().time_exchange_last, later);
     }
 }

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -472,6 +472,10 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             _ => None,
         };
 
+        // Capture the contract expiry while `instrument_state` is already borrowed (used further
+        // below to advance the engine clock) — avoids a second `instrument_index` lookup for `kind`.
+        let expiry = instrument_state.instrument.kind.expiry();
+
         let spot_price = match option_spec {
             Some((base_key, quote_key, exchange)) => {
                 // Find the spot instrument on the same exchange whose underlying matches
@@ -555,6 +559,16 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             .keys()
             .cloned()
             .collect();
+
+        // Advance the engine clock to the contract's expiry instant before stamping the synthetic
+        // settlement trades below. The `ContractExpiry` event carries no timestamp on its payload
+        // (unlike `CorporateAction`, whose `effective_time` advances the clock via `TimeExchange`),
+        // so without this a backtest would stamp the settlement fill at the prior market tick. The
+        // expiry instant is engine-side ground truth on the instrument's kind (captured above).
+        // `advance_to` is monotonic and a no-op on `LiveClock`; non-expiring kinds yield `None`.
+        if let Some(expiry) = expiry {
+            self.clock.advance_to(expiry);
+        }
 
         // Engine clock time for all synthetic trades in this expiry batch.
         // Using self.time() (not Utc::now()) keeps backtests deterministic.

--- a/rustrade/tests/test_backtest_aux_events.rs
+++ b/rustrade/tests/test_backtest_aux_events.rs
@@ -39,6 +39,7 @@ use rustrade::{
             trading::TradingState,
         },
     },
+    execution::AccountStreamEvent,
     risk::DefaultRiskManager,
     statistic::time::Daily,
     strategy::DefaultStrategy,
@@ -49,9 +50,16 @@ use rustrade_data::{
     streams::consumer::MarketStreamEvent,
     subscription::trade::PublicTrade,
 };
+use rustrade_execution::{
+    AccountEvent, AccountEventKind,
+    order::id::{OrderId, StrategyId},
+    trade::{AssetFees, Trade, TradeId},
+};
 use rustrade_instrument::{
+    Side,
+    asset::AssetIndex,
     corporate_action::{CorporateActionKind, SplitRatio},
-    exchange::ExchangeId,
+    exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
     instrument::InstrumentIndex,
 };
@@ -201,7 +209,8 @@ async fn backtest_runs_with_corporate_action_injected_mid_stream() {
 
     let summary = backtest(args_constant(aux), args_dynamic("with-split"))
         .await
-        .expect("backtest with an injected split must complete");
+        .expect("backtest with an injected split must complete")
+        .summary;
 
     assert_eq!(summary.id, "with-split");
 }
@@ -218,7 +227,8 @@ async fn backtest_runs_with_contract_expiry_injected_mid_stream() {
 
     let summary = backtest(args_constant(aux), args_dynamic("with-expiry"))
         .await
-        .expect("backtest with an injected contract expiry must complete");
+        .expect("backtest with an injected contract expiry must complete")
+        .summary;
 
     assert_eq!(summary.id, "with-expiry");
 }
@@ -231,7 +241,8 @@ async fn backtest_runs_with_aux_event_before_first_market_event() {
 
     let summary = backtest(args_constant(aux), args_dynamic("early-split"))
         .await
-        .expect("backtest with an aux event before the first market tick must complete");
+        .expect("backtest with an aux event before the first market tick must complete")
+        .summary;
 
     assert_eq!(summary.id, "early-split");
 
@@ -318,7 +329,108 @@ async fn backtest_non_standard_split_seam_carries_corporate_action_and_close_com
         args_dynamic("non-standard-identity-change"),
     )
     .await
-    .expect("backtest carrying a CorporateAction + a flatten Command must complete");
+    .expect("backtest carrying a CorporateAction + a flatten Command must complete")
+    .summary;
 
     assert_eq!(summary.id, "non-standard-identity-change");
+}
+
+/// A synthetic fill for `instrument` opening a long position of `quantity` @ `price`, wrapped for
+/// injection through the aux seam. Injecting the fill directly (rather than routing an order through
+/// the `MockExchange`) keeps the open deterministic and in simulated-time order with the split: the
+/// mock's fill is async and latency-delayed, so it would race the split's application.
+fn seed_long_position_event(
+    time: &str,
+    instrument: usize,
+    price: Decimal,
+    quantity: Decimal,
+) -> Timed<EngineEvent> {
+    Timed::new(
+        EngineEvent::Account(AccountStreamEvent::Item(AccountEvent {
+            exchange: ExchangeIndex(0),
+            kind: AccountEventKind::Trade(Trade {
+                id: TradeId::new("seed-fill"),
+                order_id: OrderId::new("seed-fill"),
+                instrument: InstrumentIndex::new(instrument),
+                strategy: StrategyId::new("seed"),
+                time_exchange: ts(time),
+                side: Side::Buy,
+                price,
+                // Zero fees keep `price_entry_average` clean; the asset only needs to be a valid
+                // index (fees don't affect the split-scaled fields asserted below).
+                quantity,
+                fees: AssetFees::new(AssetIndex(0), dec!(0), Some(dec!(0))),
+            }),
+        })),
+        ts(time),
+    )
+}
+
+/// **Value-bearing economics through the public async `backtest()` path — unlocked by returning the
+/// terminal `engine_state`.**
+///
+/// A 2:1 forward stock split is notional-preserving, so it moves no aggregate `trading_summary`
+/// metric and the position stays **open** — meaning before `backtest()` exposed `engine_state`, this
+/// effect was assertable only at the lower-level `process_with_audit` seam (see
+/// `test_engine_process_engine_event_with_audit.rs`). Now the split's rescaling of an open position
+/// is observable directly on the result: `quantity_abs` doubles and `price_entry_average` halves.
+///
+/// Sequencing (merged into simulated-time order by the aux seam): first market tick 22:00 → seed
+/// fill 22:05 (opens 5 @ 100) → split 22:30 (2:1) → later ticks. `DefaultStrategy` issues no orders,
+/// so the seeded position is never closed and survives to the terminal state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn backtest_split_rescales_open_position_observable_in_engine_state() {
+    let aux = AuxEventsInMemory::new(Arc::new(vec![
+        seed_long_position_event("2025-03-24T22:05:00Z", 0, dec!(100), dec!(5)),
+        // 2:1 forward split, Fractional policy (no flooring): quantity_abs ×2, price_entry_average ÷2.
+        split_event("2025-03-24T22:30:00Z", dec!(2)),
+    ]));
+
+    let engine_state = backtest(args_constant(aux), args_dynamic("split-open-position"))
+        .await
+        .expect("backtest applying a split to an open position must complete")
+        .engine_state;
+
+    let instrument_state = engine_state
+        .instruments
+        .instrument_index(&InstrumentIndex::new(0));
+
+    // The notional-preserving split leaves the position open (nothing closes it).
+    assert_eq!(
+        instrument_state.position.positions.len(),
+        1,
+        "the seeded long position must survive the split, still open at shutdown"
+    );
+    let position = instrument_state
+        .position
+        .positions
+        .values()
+        .next()
+        .expect("exactly one open position");
+
+    // The economic assertions the summary-only API could not reach:
+    assert_eq!(
+        position.quantity_abs,
+        dec!(10),
+        "2:1 forward split doubles quantity_abs (5 → 10)"
+    );
+    assert_eq!(
+        position.price_entry_average,
+        dec!(50),
+        "2:1 forward split halves price_entry_average (100 → 50), preserving notional"
+    );
+    assert_eq!(
+        position.quantity_abs_max,
+        dec!(10),
+        "quantity_abs_max scales with the split, unfloored (5 → 10)"
+    );
+
+    // The split's idempotency id is recorded on the instrument, proving the action was applied (not
+    // suppressed) on this path.
+    assert!(
+        instrument_state
+            .corporate_actions_processed
+            .contains("btcusdt-2025-03-24-split"),
+        "the applied split's id must be recorded on the instrument state"
+    );
 }

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -1449,6 +1449,54 @@ fn test_contract_expiry_itm_call() {
     );
 }
 
+/// Regression for #166: `ContractExpiry` advances the `HistoricalClock` to the expiring
+/// instrument's `expiry` — engine-side ground truth on its `InstrumentKind` — so the synthetic
+/// settlement fill is stamped at the expiry instant rather than the prior market tick. The
+/// `ContractExpiry` event carries no timestamp on its payload (unlike `CorporateAction`'s
+/// `effective_time`), so the advance is derived in the handler from state, not the event.
+#[test]
+fn test_contract_expiry_advances_clock_to_expiry() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx);
+
+    // The option's expiry, matching `build_option_engine`. The clock starts at
+    // `STARTING_TIMESTAMP` (MIN_UTC), far before this, so a genuine forward advance is exercised.
+    let expiry = chrono::DateTime::parse_from_rfc3339("2030-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    // ITM call: spot (index 1) above strike (50_000) → settlement produces a closing fill.
+    send_spot_price(&mut engine, 1, dec!(55_000));
+    open_option_position(&mut engine, dec!(1), dec!(2_000));
+
+    // Pre-expiry the clock reflects only the ~MIN_UTC market/open events, nowhere near 2030.
+    assert!(
+        engine.time() < expiry,
+        "precondition: clock has not yet advanced to expiry"
+    );
+
+    let exited = engine.process_contract_expiry(&InstrumentIndex(0));
+    assert_eq!(exited.len(), 1);
+
+    // The settlement fill is stamped at ~expiry: its `time_exit` derives from the synthetic
+    // trade's `time_exchange = self.time()`, read after the clock advanced. An exact `==` is
+    // impossible by construction — `HistoricalClock::time()` adds the sub-second wall-clock delta
+    // since the advance — so a tight forward bound is the honest assertion (mirrors the
+    // `CorporateAction` clock test).
+    let fill_drift = exited[0].time_exit.signed_duration_since(expiry);
+    assert!(
+        fill_drift >= TimeDelta::zero() && fill_drift < TimeDelta::seconds(1),
+        "settlement fill stamped at ~expiry (drift {fill_drift})"
+    );
+
+    // The engine clock itself advanced to ~expiry (monotonic; no look-ahead beyond the expiry).
+    let clock_drift = engine.time().signed_duration_since(expiry);
+    assert!(
+        clock_drift >= TimeDelta::zero() && clock_drift < TimeDelta::seconds(1),
+        "clock advanced to ~expiry (drift {clock_drift})"
+    );
+}
+
 #[test]
 fn test_contract_expiry_idempotent() {
     let (execution_tx, _execution_rx) = mpsc_unbounded();


### PR DESCRIPTION
## Summary

Two related backtest fixes/enhancements around terminal engine state and contract expiry timing.

### Expose terminal engine state alongside summary (#167)
`BacktestSummary` aggregates only closed-position statistics and cannot express the net effect of corporate actions on open positions or other terminal state. `backtest()` now returns `BacktestResult { summary, engine_state }`, so callers can inspect post-run positions, balances, and instrument state directly through the public async API (e.g. assert a stock split rescaled an open position) without building their own engine harness.

- Add `BacktestResult<Interval, State>` struct (`summary` + `engine_state`)
- Change `backtest()` return type from `BacktestSummary` to `BacktestResult`
- `run_backtests()` projects summaries early, dropping terminal state as each run completes (avoids pinning memory until the batch finishes)
- Update all callers to extract `.summary`
- **BREAKING**: callers must access `result.summary` instead of a bare `BacktestSummary`

### Advance HistoricalClock to contract expiry (#166)
Synthetic settlement fills were previously stamped at the prior market tick instead of the contract's expiry instant, causing silent look-ahead bugs where positions exit at different times than the market sees them. The handler now advances the clock to the expiry instant (derived from `InstrumentKind`) before stamping, matching `CorporateAction` semantics.

- Add `InstrumentKind::expiry()` accessor (`Some` for Future/Option, `None` otherwise)
- Add `EngineClock::advance_to()` trait method with a no-op default (`LiveClock` and downstream impls unaffected)
- Implement `HistoricalClock::advance_to()` with monotonic advance semantics
- Advance the clock in `process_contract_expiry` before synthesising the settlement fill
- `assert_aux_contract_expiry_times` validation at the backtest merge point (hard panic on `Timed::time != expiry`)
- Regression test `test_contract_expiry_advances_clock_to_expiry`

## Test plan
- New regression test `test_contract_expiry_advances_clock_to_expiry`
- New test `backtest_split_rescales_open_position_observable_in_engine_state()`
- Existing backtest / aux-event / audit test suites updated to the new API

Closes #166
Closes #167
