### PR TITLE
perf(engine): Shrink action output aggregates via root-level payload boxing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enum ~928 → ~608 B (largest remaining variant `ClosePositions`). **Breaking** only for downstream
   code that matched or constructed `ActionOutput::GenerateAlgoOrders` (no in-tree or known downstream
   use). Migration: delete any such match arm; algo-order work is surfaced via `EngineOutput::AlgoOrders`.
+- **`SendRequestsOutput` and `GenerateAlgoOrdersOutput` order payloads are now boxed** (`rustrade`).
+  Each `OrderEvent`/error/refusal is stored boxed inside its `NoneOneOrMany` field
+  (`SendRequestsOutput::sent`/`errors`, `GenerateAlgoOrdersOutput::cancels_refused`/`opens_refused`),
+  shrinking `GenerateAlgoOrdersOutput` ~928 → ~144 B and `ActionOutput` ~608 → ~96 B (small enough
+  that its `#[allow(clippy::large_enum_variant)]` is removed). This fixes at the root the size the
+  `EngineOutput`/`ActionOutput` boxing (above) worked around one level up. **Breaking** for downstream
+  code that destructures these public fields: the collection item type is now `Box<…>`, so bind and
+  deref — e.g. `output.sent.iter().map(|order| &**order)` (or the provided `output.sent_iter()`
+  helper, which yields `&OrderEvent`), or `NoneOneOrMany::One(Box::new(order))` when constructing.
+  Field/read access is unchanged (auto-derefs through the box: `order.key`, `order.state`).
+  **No wire change**: `Box<T>` serializes identically to `T`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unstable box patterns and must be rewritten this way. Value **construction** only needs `Box::new(..)`
   around the payload. **No wire change**: `Box<T>` serializes identically to `T`, so persisted audit
   streams are unaffected.
+- **`ActionOutput::GenerateAlgoOrders` variant removed** (`rustrade`). The variant was never
+  constructed by the engine — `Command` has no algo-order variant, `Engine::action()` only emits
+  `CancelOrders`/`OpenOrders`/`ClosePositions`, and the per-tick algo path builds
+  `EngineOutput::AlgoOrders` directly — so it was reachable only through the derived `From` impl. Its
+  ~928 B `GenerateAlgoOrdersOutput` payload set `ActionOutput`'s size floor; removing it drops the
+  enum ~928 → ~608 B (largest remaining variant `ClosePositions`). **Breaking** only for downstream
+  code that matched or constructed `ActionOutput::GenerateAlgoOrders` (no in-tree or known downstream
+  use). Migration: delete any such match arm; algo-order work is surfaced via `EngineOutput::AlgoOrders`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,18 +198,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   end-of-data batch (and see *why*) programmatically instead of by parsing logs. `HistoricalTicks<T>`
   also implements `IntoIterator` (yielding the ticks) for callers that only need the data. Migration:
   read `.ticks` for the previous `Vec<T>`, or iterate the value directly.
-- **`EngineOutput::AlgoOrders` and `EngineOutput::Commanded` now carry a `Box`** (`rustrade`). Both
-  variants embedded a ~928 B `GenerateAlgoOrdersOutput` — `AlgoOrders` directly, `Commanded` via
-  `ActionOutput` — which pinned `EngineOutput`'s size, and therefore the `ProcessAudit` value moved
-  on **every** processed event, to ~936 B even on the common no-order market tick. Boxing both moves
-  the payload off the stack (`EngineOutput` ~936 → ~232 B, with a proportional cut to the per-tick
-  `ProcessAudit` copy) and allocates only when the variant is actually produced. **Breaking** for
-  downstream code that destructures these two variants' payloads: bind the box and deref — e.g.
-  `EngineOutput::AlgoOrders(output)` then `&**output`, or match one level then `match *boxed { … }`.
-  Nested patterns such as `EngineOutput::Commanded(ActionOutput::ClosePositions(..))` rely on Rust's
-  unstable box patterns and must be rewritten this way. Value **construction** only needs `Box::new(..)`
-  around the payload. **No wire change**: `Box<T>` serializes identically to `T`, so persisted audit
-  streams are unaffected.
+- **`EngineOutput` shrunk ~936 → ~232 B** (`rustrade`). Its `AlgoOrders` and `Commanded` variants
+  embedded large order aggregates (`GenerateAlgoOrdersOutput` directly, `ActionOutput` via
+  `Commanded`) that pinned the enum's size, so the `ProcessAudit`/`AuditTick` value copied on
+  **every** processed event was ~936 B — even on the common no-order market tick. Root-boxing those
+  aggregates' order payloads (see the `SendRequestsOutput`/`GenerateAlgoOrdersOutput` entry below)
+  shrinks them to ~144 B / ~96 B, both well under the ~232 B `PositionExit` variant that now floors
+  the enum, so both variants are carried **inline** — no per-variant heap allocation and no pointer
+  indirection on the audit path — and `EngineOutput`'s stack size (and the per-tick copy) drops
+  proportionally. The variant shapes are unchanged (`AlgoOrders(GenerateAlgoOrdersOutput)`,
+  `Commanded(ActionOutput)`), so matching/constructing them needs no box wrapper or deref. **No wire
+  change**: the audit format is byte-identical.
 - **`ActionOutput::GenerateAlgoOrders` variant removed** (`rustrade`). The variant was never
   constructed by the engine — `Command` has no algo-order variant, `Engine::action()` only emits
   `CancelOrders`/`OpenOrders`/`ClosePositions`, and the per-tick algo path builds
@@ -222,9 +221,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Each `OrderEvent`/error/refusal is stored boxed inside its `NoneOneOrMany` field
   (`SendRequestsOutput::sent`/`errors`, `GenerateAlgoOrdersOutput::cancels_refused`/`opens_refused`),
   shrinking `GenerateAlgoOrdersOutput` ~928 → ~144 B and `ActionOutput` ~608 → ~96 B (small enough
-  that its `#[allow(clippy::large_enum_variant)]` is removed). This fixes at the root the size the
-  `EngineOutput`/`ActionOutput` boxing (above) worked around one level up. **Breaking** for downstream
-  code that destructures these public fields: the collection item type is now `Box<…>`, so bind and
+  that its `#[allow(clippy::large_enum_variant)]` is removed). Shrinking the payloads at the root is
+  what lets `EngineOutput` carry those aggregates inline (above) instead of behind an outer `Box`.
+  **Breaking** for downstream code that destructures these public fields: the collection item type is
+  now `Box<…>`, so bind and
   deref — e.g. `output.sent.iter().map(|order| &**order)` (or the provided `output.sent_iter()`
   helper, which yields `&OrderEvent`), or `NoneOneOrMany::One(Box::new(order))` when constructing.
   Field/read access is unchanged (auto-derefs through the box: `order.key`, `order.state`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `calculate_pnl_return` now return `Option<Decimal>` (was `Decimal`); `Position::update_pnl_realised`
   now returns `#[must_use] PnlRealisedUpdate { Updated, Overflowed }` (was `()`); direct callers must
   handle the new return values.
+- **Backtest benches no longer panic at setup** (`rustrade`, benches only). The shared
+  `market_data_from_file` helper now sorts the recorded fixture ascending by `time_exchange` before
+  constructing `MarketDataInMemory`, which hard-asserts sorted input. The committed fixture is
+  interleaved across three instruments (not globally sorted), so the `bench_backtest` and
+  `bench_backtests_concurrent` groups previously panicked during setup and could not run — meaning any
+  prior `--save-baseline` numbers for those two groups are not comparable across this change (they
+  never completed). Benchmark-only; no library behaviour changes.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   end-of-data batch (and see *why*) programmatically instead of by parsing logs. `HistoricalTicks<T>`
   also implements `IntoIterator` (yielding the ticks) for callers that only need the data. Migration:
   read `.ticks` for the previous `Vec<T>`, or iterate the value directly.
+- **`EngineOutput::AlgoOrders` and `EngineOutput::Commanded` now carry a `Box`** (`rustrade`). Both
+  variants embedded a ~928 B `GenerateAlgoOrdersOutput` — `AlgoOrders` directly, `Commanded` via
+  `ActionOutput` — which pinned `EngineOutput`'s size, and therefore the `ProcessAudit` value moved
+  on **every** processed event, to ~936 B even on the common no-order market tick. Boxing both moves
+  the payload off the stack (`EngineOutput` ~936 → ~232 B, with a proportional cut to the per-tick
+  `ProcessAudit` copy) and allocates only when the variant is actually produced. **Breaking** for
+  downstream code that destructures these two variants' payloads: bind the box and deref — e.g.
+  `EngineOutput::AlgoOrders(output)` then `&**output`, or match one level then `match *boxed { … }`.
+  Nested patterns such as `EngineOutput::Commanded(ActionOutput::ClosePositions(..))` rely on Rust's
+  unstable box patterns and must be rewritten this way. Value **construction** only needs `Box::new(..)`
+  around the payload. **No wire change**: `Box<T>` serializes identically to `T`, so persisted audit
+  streams are unaffected.
 
 ### Removed
 

--- a/rustrade/benches/backtest/mod.rs
+++ b/rustrade/benches/backtest/mod.rs
@@ -400,6 +400,13 @@ fn bench_aux_seam(c: &mut Criterion) {
 // the `AuditTick` size, so it is the wall-clock counterpart to the `size_of` guards in the engine
 // tests (root-boxing the order payloads shrank the tick this path moves). Compare across revisions
 // with `--save-baseline` / `--baseline`.
+//
+// Caveat: both cases run on a `new_current_thread()` runtime, so in `AuditEnabled` the per-event
+// `audit_tx.send(audit)` producer and the spawned drain contend for the *same* thread. That folds
+// single-thread producer/drain scheduling overhead into the measured delta — overhead not present in
+// a multi-threaded production deployment — so this A/B likely *over*-states the send cost. That makes
+// it a conservative regression guard (a real regression can only be larger than measured), not an
+// absolute production figure; profile on a multi-thread runtime if the absolute cost matters.
 // ---------------------------------------------------------------------------------------------
 fn bench_audit_seam(c: &mut Criterion) {
     let Config {
@@ -894,8 +901,26 @@ where
 
     // `MarketDataInMemory::new` hard-asserts events are globally sorted ascending by `time_exchange`
     // (the backtest time-merge relies on it). The recorded fixture interleaves three instruments and
-    // is NOT globally sorted, so sort here (stable) before construction. Applied identically to every
-    // bench case, so it does not bias the aux-seam A/B.
+    // is NOT globally sorted (10k+ inversions), so before this helper sorted, `new` panicked at bench
+    // *setup* — `bench_backtest`/`bench_backtests_concurrent` could not run at all, and any prior
+    // `--baseline` numbers for those two groups are not comparable (they never completed). Sorting
+    // here (stable) fixes that. Applied identically to every bench case, so it does not bias the
+    // aux-seam / audit A/Bs.
+    //
+    // These synthetic corpora are Item-only. The sort key below maps `Reconnecting` to `None`, which
+    // `Option`'s `Ord` sorts before every `Some` — so a `Reconnecting` event would be hoisted to the
+    // front of the corpus regardless of when it occurred (this matches `new`'s own sortedness check,
+    // which uses the same key, but is not a meaningful replay order). Assert the Item-only invariant
+    // so a future fixture that contains reconnects fails loudly here instead of being quietly
+    // reordered.
+    assert!(
+        events
+            .iter()
+            .all(|event| matches!(event, MarketStreamEvent::Item(_))),
+        "market_data_from_file expects an Item-only corpus: the time sort cannot order Reconnecting \
+         events (they collapse to `None`, sorting to the front). Filter or stable-partition them \
+         first."
+    );
     events.sort_by_key(|event| match event {
         MarketStreamEvent::Item(event) => Some(event.time_exchange),
         MarketStreamEvent::Reconnecting(_) => None,

--- a/rustrade/benches/backtest/mod.rs
+++ b/rustrade/benches/backtest/mod.rs
@@ -6,8 +6,10 @@ use rust_decimal::Decimal;
 use rustrade::{
     backtest,
     backtest::{
-        BacktestArgsConstant, BacktestArgsDynamic, aux_events::NoAuxEvents,
-        market_data::MarketDataInMemory,
+        BacktestArgsConstant, BacktestArgsDynamic,
+        aux_events::NoAuxEvents,
+        market_data::{BacktestMarketData, MarketDataInMemory},
+        summary::BacktestSummary,
     },
     engine::{
         Engine, Processor,
@@ -25,6 +27,8 @@ use rustrade::{
             trading::TradingState,
         },
     },
+    error::BarterError,
+    execution::builder::{ExecutionBuild, ExecutionBuilder},
     risk::DefaultRiskManager,
     statistic::time::Daily,
     strategy::{
@@ -33,7 +37,10 @@ use rustrade::{
         on_disconnect::OnDisconnectStrategy,
         on_trading_disabled::OnTradingDisabled,
     },
-    system::config::{ExecutionConfig, InstrumentConfig, SystemConfig},
+    system::{
+        builder::{AuditMode, EngineFeedMode, SystemBuild},
+        config::{ExecutionConfig, InstrumentConfig, SystemConfig},
+    },
 };
 use rustrade_data::{
     event::{DataKind, MarketEvent},
@@ -186,10 +193,13 @@ fn benchmark_backtest() {
     let args_constant = args_constant(instruments, executions);
     let args_dynamic = args_dynamic(risk_free_return);
 
-    let mut c = Criterion::default().without_plots();
+    // `configure_from_args` lets callers target a single group/case (e.g. `-- "AuxSeam"`) and use
+    // criterion's `--save-baseline` / `--baseline` regression workflow; with no args it runs all.
+    let mut c = Criterion::default().without_plots().configure_from_args();
 
     bench_backtest(&mut c, Arc::clone(&args_constant), &args_dynamic);
     bench_backtests_concurrent(&mut c, args_constant, args_dynamic);
+    bench_aux_seam(&mut c);
 }
 
 fn bench_backtest(
@@ -286,6 +296,276 @@ fn bench_backtests_concurrent(
     group.sample_size(10);
     group.bench_function("500", |b| bench_func(b, 500));
     group.finish();
+}
+
+// ---------------------------------------------------------------------------------------------
+// Aux-event seam A/B benchmark (issue #179)
+//
+// `backtest()` always wraps the market stream in `TimedMergeStream` to interleave auxiliary
+// (non-market) events in simulated-time order, even when there are none (`NoAuxEvents`). This group
+// measures the per-event overhead of that seam by comparing two throughput cases over the same
+// fixture:
+//   - `NoAuxEvents` — the shipped `backtest()` path (market stream flows through the merge).
+//   - `MarketOnly`  — the pre-corporate-action baseline: the raw market stream fed straight to the
+//                     engine, no merge (see `backtest_market_only`, a faithful copy of the pre-seam
+//                     `backtest()` body).
+// The delta between the two events/sec figures IS the seam cost, guarding the "negligible overhead"
+// claim against regression. Both cases use a genuinely no-op strategy so that per-tick order
+// generation / `MockExchange` task spawns (which dwarf the seam by orders of magnitude) don't drown
+// the signal. Compare across revisions with `--save-baseline` / `--baseline`.
+// ---------------------------------------------------------------------------------------------
+
+/// [`EngineState`] used by the aux-seam A/B — the library's `DefaultInstrumentMarketData` (already
+/// implements every required trait) rather than a bespoke instrument-data type.
+type SeamState = EngineState<DefaultGlobalData, DefaultInstrumentMarketData>;
+/// Shared constants for the aux-seam A/B. `AuxEvents` defaults to [`NoAuxEvents`].
+type SeamConstant = BacktestArgsConstant<MarketDataInMemory<DataKind>, Daily, SeamState>;
+/// Per-run variables for the aux-seam A/B (no-op strategy + default risk).
+type SeamDynamic = BacktestArgsDynamic<NoOpStrategy, DefaultRiskManager<SeamState>>;
+
+fn bench_aux_seam(c: &mut Criterion) {
+    let Config {
+        risk_free_return,
+        system: SystemConfig {
+            instruments,
+            executions,
+        },
+    } = serde_json::from_str(CONFIG).unwrap();
+
+    let (args_constant, num_events) = args_constant_seam(instruments, executions);
+    let args_dynamic = args_dynamic_seam(risk_free_return);
+
+    let mut group = c.benchmark_group("Backtest AuxSeam");
+    group.warm_up_time(std::time::Duration::from_secs(1));
+    group.measurement_time(std::time::Duration::from_secs(10));
+    group.sample_size(50);
+    // Each iteration drives the whole fixture once, so reporting events/sec makes the per-event seam
+    // overhead directly visible as the throughput delta between the two cases below.
+    group.throughput(Throughput::Elements(num_events as u64));
+
+    // A — shipped path: `NoAuxEvents` still routes the market stream through `TimedMergeStream`.
+    group.bench_function("NoAuxEvents", |b| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        b.iter_batched(
+            || (Arc::clone(&args_constant), args_dynamic.clone()),
+            |(constant, dynamic)| {
+                rt.block_on(
+                    async move { backtest::backtest(constant, dynamic).await.unwrap().summary },
+                )
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    // B — pre-seam baseline: raw market stream fed straight to the engine, no merge.
+    group.bench_function("MarketOnly", |b| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        b.iter_batched(
+            || (Arc::clone(&args_constant), args_dynamic.clone()),
+            |(constant, dynamic)| {
+                rt.block_on(async move { backtest_market_only(constant, dynamic).await.unwrap() })
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+/// Pre-corporate-action ("pre-seam") backtest baseline: mirrors [`backtest::backtest`] exactly except
+/// it feeds the raw market stream straight to the engine, bypassing the `TimedMergeStream` aux merge.
+///
+/// This is a faithful copy of the pre-seam `backtest()` body (git `6824b47^`), rebuilt here purely
+/// from the public API so the A/B needs no library changes. `EngineEvent: From<MarketStreamEvent>` is
+/// derived, so `SystemBuild` accepts the raw `MarketStreamEvent` stream via its
+/// `Event: From<MarketStream::Item>` bound.
+async fn backtest_market_only(
+    args_constant: Arc<SeamConstant>,
+    args_dynamic: SeamDynamic,
+) -> Result<BacktestSummary<Daily>, BarterError> {
+    let market_first = args_constant.market_data.time_first_event().await?;
+    let raw_market = args_constant.market_data.stream().await?;
+    let clock = HistoricalClock::new(market_first);
+
+    let ExecutionBuild {
+        execution_tx_map,
+        account_channel,
+        futures,
+    } = args_constant
+        .executions
+        .clone()
+        .into_iter()
+        .try_fold(
+            ExecutionBuilder::new(&args_constant.instruments),
+            |builder, config| match config {
+                ExecutionConfig::Mock(mock_config) => builder.add_mock(mock_config, clock.clone()),
+            },
+        )?
+        .build();
+
+    let engine = Engine::new(
+        clock,
+        args_constant.engine_state.clone(),
+        execution_tx_map,
+        args_dynamic.strategy,
+        args_dynamic.risk,
+    );
+
+    // No merge — the raw market stream is fed directly (the pre-seam path this baseline measures).
+    let system = SystemBuild::new(
+        engine,
+        EngineFeedMode::Stream,
+        AuditMode::Disabled,
+        raw_market,
+        account_channel,
+        futures,
+    )
+    .init()
+    .await?;
+
+    let (engine, _shutdown_audit) = system.shutdown_after_backtest().await?;
+
+    // Mirror the seam case's downstream work so the A/B isolates the merge, not summary generation.
+    let trading_summary = engine
+        .trading_summary_generator(args_dynamic.risk_free_return)
+        .generate(args_constant.summary_interval);
+
+    Ok(BacktestSummary {
+        id: args_dynamic.id,
+        risk_free_return: args_dynamic.risk_free_return,
+        trading_summary,
+    })
+}
+
+/// Zero-work strategy for the aux-seam A/B: emits no orders on any event, so the benchmark measures
+/// the per-event stream/engine path (where the seam sits) instead of order-generation +
+/// `MockExchange` latency-task overhead.
+#[derive(Debug, Clone, Default)]
+struct NoOpStrategy;
+
+impl AlgoStrategy for NoOpStrategy {
+    type State = SeamState;
+
+    fn generate_algo_orders(
+        &self,
+        _state: &Self::State,
+    ) -> (
+        impl IntoIterator<Item = OrderRequestCancel<ExchangeIndex, InstrumentIndex>>,
+        impl IntoIterator<Item = OrderRequestOpen<ExchangeIndex, InstrumentIndex>>,
+    ) {
+        (std::iter::empty(), std::iter::empty())
+    }
+}
+
+impl ClosePositionsStrategy for NoOpStrategy {
+    type State = SeamState;
+
+    fn close_positions_requests<'a>(
+        &'a self,
+        _state: &'a Self::State,
+        _filter: &'a InstrumentFilter,
+    ) -> (
+        impl IntoIterator<Item = OrderRequestCancel<ExchangeIndex, InstrumentIndex>> + 'a,
+        impl IntoIterator<Item = OrderRequestOpen<ExchangeIndex, InstrumentIndex>> + 'a,
+    )
+    where
+        ExchangeIndex: 'a,
+        AssetIndex: 'a,
+        InstrumentIndex: 'a,
+    {
+        (std::iter::empty(), std::iter::empty())
+    }
+}
+
+impl
+    OnDisconnectStrategy<
+        HistoricalClock,
+        SeamState,
+        MultiExchangeTxMap,
+        DefaultRiskManager<SeamState>,
+    > for NoOpStrategy
+{
+    type OnDisconnect = ();
+
+    fn on_disconnect(
+        _: &mut Engine<
+            HistoricalClock,
+            SeamState,
+            MultiExchangeTxMap,
+            Self,
+            DefaultRiskManager<SeamState>,
+        >,
+        _: ExchangeId,
+    ) -> Self::OnDisconnect {
+    }
+}
+
+impl
+    OnTradingDisabled<HistoricalClock, SeamState, MultiExchangeTxMap, DefaultRiskManager<SeamState>>
+    for NoOpStrategy
+{
+    type OnTradingDisabled = ();
+
+    fn on_trading_disabled(
+        _: &mut Engine<
+            HistoricalClock,
+            SeamState,
+            MultiExchangeTxMap,
+            Self,
+            DefaultRiskManager<SeamState>,
+        >,
+    ) -> Self::OnTradingDisabled {
+    }
+}
+
+/// Build the shared constants for the aux-seam A/B, returning the market-event count so the group can
+/// report events/sec.
+fn args_constant_seam(
+    instruments: Vec<InstrumentConfig>,
+    executions: Vec<ExecutionConfig>,
+) -> (Arc<SeamConstant>, usize) {
+    let instruments = IndexedInstruments::new(instruments);
+
+    let market_events = market_data_from_file(FILE_PATH_MARKET_DATA_INDEXED);
+    let num_events = market_events.len();
+    let market_data = MarketDataInMemory::new(Arc::new(market_events));
+    let time_engine_start = DateTime::<Utc>::from_str("2025-03-25T23:07:00.773674205Z").unwrap();
+
+    let engine_state = EngineStateBuilder::new(&instruments, DefaultGlobalData, |_| {
+        DefaultInstrumentMarketData::default()
+    })
+    .time_engine_start(time_engine_start)
+    .trading_state(TradingState::Enabled)
+    .build();
+
+    (
+        Arc::new(BacktestArgsConstant {
+            instruments,
+            executions,
+            market_data,
+            summary_interval: Daily,
+            engine_state,
+            aux_events: NoAuxEvents,
+        }),
+        num_events,
+    )
+}
+
+fn args_dynamic_seam(risk_free_return: Decimal) -> SeamDynamic {
+    BacktestArgsDynamic {
+        id: SmolStr::new("benches/backtest/aux_seam"),
+        risk_free_return,
+        strategy: NoOpStrategy,
+        risk: DefaultRiskManager::default(),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -491,13 +771,24 @@ where
     let file = File::open(file_path).unwrap();
     let reader = BufReader::new(file);
 
-    reader
+    let mut events = reader
         .lines()
         .map(|line_result| {
             let line = line_result.unwrap();
             serde_json::from_str::<MarketStreamEvent<InstrumentKey, Kind>>(&line).unwrap()
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    // `MarketDataInMemory::new` hard-asserts events are globally sorted ascending by `time_exchange`
+    // (the backtest time-merge relies on it). The recorded fixture interleaves three instruments and
+    // is NOT globally sorted, so sort here (stable) before construction. Applied identically to every
+    // bench case, so it does not bias the aux-seam A/B.
+    events.sort_by_key(|event| match event {
+        MarketStreamEvent::Item(event) => Some(event.time_exchange),
+        MarketStreamEvent::Reconnecting(_) => None,
+    });
+
+    events
 }
 
 fn args_dynamic(

--- a/rustrade/benches/backtest/mod.rs
+++ b/rustrade/benches/backtest/mod.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use criterion::{Criterion, Throughput};
+use futures::StreamExt;
 use rust_decimal::Decimal;
 use rustrade::{
     backtest,
@@ -200,6 +201,7 @@ fn benchmark_backtest() {
     bench_backtest(&mut c, Arc::clone(&args_constant), &args_dynamic);
     bench_backtests_concurrent(&mut c, args_constant, args_dynamic);
     bench_aux_seam(&mut c);
+    bench_audit_seam(&mut c);
 }
 
 fn bench_backtest(
@@ -371,7 +373,89 @@ fn bench_aux_seam(c: &mut Criterion) {
         b.iter_batched(
             || (Arc::clone(&args_constant), args_dynamic.clone()),
             |(constant, dynamic)| {
-                rt.block_on(async move { backtest_market_only(constant, dynamic).await.unwrap() })
+                rt.block_on(async move {
+                    backtest_market_only(constant, dynamic, AuditMode::Disabled)
+                        .await
+                        .unwrap()
+                })
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------------------------
+// Audit-stream A/B benchmark
+//
+// The engine builds a full `AuditTick` on **every** processed event regardless of audit mode — both
+// `async_run` and `async_run_with_audit` call `process_with_audit`. The only per-event work the audit
+// stream adds is the `audit_tx.send(audit)` that moves that tick into the audit channel. This group
+// isolates that send cost by running the same fixture + no-op strategy twice, differing ONLY in
+// `AuditMode`:
+//   - `AuditDisabled` — `async_run`: builds each tick, drops it (no channel).
+//   - `AuditEnabled`  — `async_run_with_audit`: builds each tick AND sends it to a drained consumer.
+// The delta between the two events/sec figures IS the per-event audit-send cost. That cost scales with
+// the `AuditTick` size, so it is the wall-clock counterpart to the `size_of` guards in the engine
+// tests (root-boxing the order payloads shrank the tick this path moves). Compare across revisions
+// with `--save-baseline` / `--baseline`.
+// ---------------------------------------------------------------------------------------------
+fn bench_audit_seam(c: &mut Criterion) {
+    let Config {
+        risk_free_return,
+        system: SystemConfig {
+            instruments,
+            executions,
+        },
+    } = serde_json::from_str(CONFIG).unwrap();
+
+    let (args_constant, num_events) = args_constant_seam(instruments, executions);
+    let args_dynamic = args_dynamic_seam(risk_free_return);
+
+    let mut group = c.benchmark_group("Backtest AuditSeam");
+    group.warm_up_time(std::time::Duration::from_secs(1));
+    group.measurement_time(std::time::Duration::from_secs(10));
+    group.sample_size(50);
+    // Each iteration drives the whole fixture once, so events/sec makes the per-event audit-send cost
+    // directly visible as the throughput delta between the two cases.
+    group.throughput(Throughput::Elements(num_events as u64));
+
+    // A — audit stream off: the engine builds each tick and drops it.
+    group.bench_function("AuditDisabled", |b| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        b.iter_batched(
+            || (Arc::clone(&args_constant), args_dynamic.clone()),
+            |(constant, dynamic)| {
+                rt.block_on(async move {
+                    backtest_market_only(constant, dynamic, AuditMode::Disabled)
+                        .await
+                        .unwrap()
+                })
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    // B — audit stream on: each tick is additionally sent to (and drained by) a live receiver.
+    group.bench_function("AuditEnabled", |b| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        b.iter_batched(
+            || (Arc::clone(&args_constant), args_dynamic.clone()),
+            |(constant, dynamic)| {
+                rt.block_on(async move {
+                    backtest_market_only(constant, dynamic, AuditMode::Enabled)
+                        .await
+                        .unwrap()
+                })
             },
             criterion::BatchSize::SmallInput,
         );
@@ -387,9 +471,15 @@ fn bench_aux_seam(c: &mut Criterion) {
 /// from the public API so the A/B needs no library changes. `EngineEvent: From<MarketStreamEvent>` is
 /// derived, so `SystemBuild` accepts the raw `MarketStreamEvent` stream via its
 /// `Event: From<MarketStream::Item>` bound.
+///
+/// `audit_mode` parameterises this baseline for two A/Bs: the aux-seam group always passes
+/// [`AuditMode::Disabled`], while [`bench_audit_seam`] runs it at both modes so the throughput delta
+/// isolates the per-event `audit_tx.send(audit)` cost. When enabled, the audit stream is drained
+/// concurrently (see below), so the send actually enqueues to and is consumed by a live receiver.
 async fn backtest_market_only(
     args_constant: Arc<SeamConstant>,
     args_dynamic: SeamDynamic,
+    audit_mode: AuditMode,
 ) -> Result<BacktestSummary<Daily>, BarterError> {
     let market_first = args_constant.market_data.time_first_event().await?;
     let raw_market = args_constant.market_data.stream().await?;
@@ -420,10 +510,10 @@ async fn backtest_market_only(
     );
 
     // No merge — the raw market stream is fed directly (the pre-seam path this baseline measures).
-    let system = SystemBuild::new(
+    let mut system = SystemBuild::new(
         engine,
         EngineFeedMode::Stream,
-        AuditMode::Disabled,
+        audit_mode,
         raw_market,
         account_channel,
         futures,
@@ -431,7 +521,30 @@ async fn backtest_market_only(
     .init()
     .await?;
 
+    // With the audit stream enabled, drain it concurrently on the runtime so each per-event
+    // `audit_tx.send(audit)` actually enqueues to (and is consumed by) a live receiver. Without a
+    // drain, `shutdown_after_backtest` drops the audit receiver up front and every send early-returns
+    // a no-op — hiding the very send cost the audit A/B measures. `take_audit()` returns `None` under
+    // `AuditMode::Disabled`, so the disabled path is byte-for-byte the pre-seam baseline.
+    let audit_drain = system.take_audit().map(|audit| {
+        tokio::spawn(async move {
+            let mut updates = audit.updates.into_stream();
+            let mut count: u64 = 0;
+            while updates.next().await.is_some() {
+                count += 1;
+            }
+            count
+        })
+    });
+
     let (engine, _shutdown_audit) = system.shutdown_after_backtest().await?;
+
+    if let Some(handle) = audit_drain {
+        // Join the drain so its consume-side cost is folded into the measured wall-clock. Surface a
+        // drain-task panic instead of swallowing it — a dead drain would silently undercount the
+        // per-event audit-send cost this A/B exists to measure.
+        handle.await.expect("audit drain task panicked");
+    }
 
     // Mirror the seam case's downstream work so the A/B isolates the merge, not summary generation.
     let trading_summary = engine

--- a/rustrade/src/engine/action/cancel_orders.rs
+++ b/rustrade/src/engine/action/cancel_orders.rs
@@ -56,7 +56,7 @@ where
         let cancels = self.send_requests(requests);
 
         // Record in flight order requests
-        self.state.record_in_flight_cancels(&cancels.sent);
+        self.state.record_in_flight_cancels(cancels.sent_iter());
 
         cancels
     }

--- a/rustrade/src/engine/action/close_positions.rs
+++ b/rustrade/src/engine/action/close_positions.rs
@@ -61,8 +61,8 @@ where
         let opens = self.send_requests(opens);
 
         // Record in flight order requests
-        self.state.record_in_flight_cancels(&cancels.sent);
-        self.state.record_in_flight_opens(&opens.sent);
+        self.state.record_in_flight_cancels(cancels.sent_iter());
+        self.state.record_in_flight_opens(opens.sent_iter());
 
         SendCancelsAndOpensOutput::new(cancels, opens)
     }

--- a/rustrade/src/engine/action/generate_algo_orders.rs
+++ b/rustrade/src/engine/action/generate_algo_orders.rs
@@ -56,12 +56,12 @@ where
         let opens = self.send_requests(opens.into_iter().map(|RiskApproved(open)| open));
 
         // Collect remaining Iterators (so we can access &mut self)
-        let cancels_refused = refused_cancels.into_iter().collect();
-        let opens_refused = refused_opens.into_iter().collect();
+        let cancels_refused = refused_cancels.into_iter().map(Box::new).collect();
+        let opens_refused = refused_opens.into_iter().map(Box::new).collect();
 
         // Record in flight order requests
-        self.state.record_in_flight_cancels(cancels.sent.iter());
-        self.state.record_in_flight_opens(opens.sent.iter());
+        self.state.record_in_flight_cancels(cancels.sent_iter());
+        self.state.record_in_flight_opens(opens.sent_iter());
 
         GenerateAlgoOrdersOutput::new(cancels, opens, cancels_refused, opens_refused)
     }
@@ -72,20 +72,27 @@ where
 /// Contains the complete result of an algorithmic order generation action,
 /// including successful and risk-refused orders, as well as any errors that occurred.
 ///
-/// # Size note
-/// This type is ~928 B (mostly `OrderEvent`s inlined via `NoneOneOrMany`). [`EngineOutput`] boxes the
-/// variants that carry it (#172) to keep the per-tick audit copy small; shrinking it at the root is
-/// tracked in #195.
+/// # Size
+/// Every order/refusal payload is boxed inside its [`NoneOneOrMany`] field — via
+/// [`SendRequestsOutput`] for the sent/errored requests and the `*_refused` fields below — so this
+/// aggregate stays small (~144 B) instead of inlining six full `OrderEvent`s (~928 B, #195).
+/// [`EngineOutput`] additionally boxes the variants that carry it (#172). `Box<T>` is
+/// serde-transparent, so the wire format is unchanged.
 ///
 /// [`EngineOutput`]: crate::engine::EngineOutput
+/// [`SendRequestsOutput`]: crate::engine::action::send_requests::SendRequestsOutput
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 pub struct GenerateAlgoOrdersOutput<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> {
     /// Generates orders that were approved by the [`RiskManager`] and sent for execution.
     pub cancels_and_opens: SendCancelsAndOpensOutput<ExchangeKey, InstrumentKey>,
-    /// Generated cancel requests that were refused by the [`RiskManager`].
-    pub cancels_refused: NoneOneOrMany<RiskRefused<OrderRequestCancel<ExchangeKey, InstrumentKey>>>,
-    /// Generated open requests that were refused by the [`RiskManager`].
-    pub opens_refused: NoneOneOrMany<RiskRefused<OrderRequestOpen<ExchangeKey, InstrumentKey>>>,
+    /// Generated cancel requests that were refused by the [`RiskManager`] (payload boxed — see the
+    /// type's `# Size` note).
+    pub cancels_refused:
+        NoneOneOrMany<Box<RiskRefused<OrderRequestCancel<ExchangeKey, InstrumentKey>>>>,
+    /// Generated open requests that were refused by the [`RiskManager`] (payload boxed — see the
+    /// type's `# Size` note).
+    pub opens_refused:
+        NoneOneOrMany<Box<RiskRefused<OrderRequestOpen<ExchangeKey, InstrumentKey>>>>,
 }
 
 impl<ExchangeKey, InstrumentKey> GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey> {
@@ -93,8 +100,12 @@ impl<ExchangeKey, InstrumentKey> GenerateAlgoOrdersOutput<ExchangeKey, Instrumen
     pub fn new(
         cancels: SendRequestsOutput<RequestCancel, ExchangeKey, InstrumentKey>,
         opens: SendRequestsOutput<RequestOpen, ExchangeKey, InstrumentKey>,
-        cancels_refused: NoneOneOrMany<RiskRefused<OrderRequestCancel<ExchangeKey, InstrumentKey>>>,
-        opens_refused: NoneOneOrMany<RiskRefused<OrderRequestOpen<ExchangeKey, InstrumentKey>>>,
+        cancels_refused: NoneOneOrMany<
+            Box<RiskRefused<OrderRequestCancel<ExchangeKey, InstrumentKey>>>,
+        >,
+        opens_refused: NoneOneOrMany<
+            Box<RiskRefused<OrderRequestOpen<ExchangeKey, InstrumentKey>>>,
+        >,
     ) -> Self {
         Self {
             cancels_and_opens: SendCancelsAndOpensOutput::new(cancels, opens),

--- a/rustrade/src/engine/action/generate_algo_orders.rs
+++ b/rustrade/src/engine/action/generate_algo_orders.rs
@@ -71,6 +71,13 @@ where
 ///
 /// Contains the complete result of an algorithmic order generation action,
 /// including successful and risk-refused orders, as well as any errors that occurred.
+///
+/// # Size note
+/// This type is ~928 B (mostly `OrderEvent`s inlined via `NoneOneOrMany`). [`EngineOutput`] boxes the
+/// variants that carry it (#172) to keep the per-tick audit copy small; shrinking it at the root is
+/// tracked in #195.
+///
+/// [`EngineOutput`]: crate::engine::EngineOutput
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 pub struct GenerateAlgoOrdersOutput<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> {
     /// Generates orders that were approved by the [`RiskManager`] and sent for execution.

--- a/rustrade/src/engine/action/generate_algo_orders.rs
+++ b/rustrade/src/engine/action/generate_algo_orders.rs
@@ -75,8 +75,9 @@ where
 /// # Size
 /// Every order/refusal payload is boxed inside its [`NoneOneOrMany`] field — via
 /// [`SendRequestsOutput`] for the sent/errored requests and the `*_refused` fields below — so this
-/// aggregate stays small (~144 B) instead of inlining six full `OrderEvent`s (~928 B, #195).
-/// [`EngineOutput`] additionally boxes the variants that carry it (#172). `Box<T>` is
+/// aggregate stays small (~144 B) instead of inlining six full `OrderEvent`s (~928 B, #195). That is
+/// small enough for [`EngineOutput`]'s `AlgoOrders` variant to carry it **inline** (it sits under the
+/// ~232 B `PositionExit` variant that floors `EngineOutput`), so no outer box is needed. `Box<T>` is
 /// serde-transparent, so the wire format is unchanged.
 ///
 /// [`EngineOutput`]: crate::engine::EngineOutput

--- a/rustrade/src/engine/action/generate_algo_orders.rs
+++ b/rustrade/src/engine/action/generate_algo_orders.rs
@@ -137,3 +137,22 @@ impl<ExchangeKey, InstrumentKey> Default for GenerateAlgoOrdersOutput<ExchangeKe
         }
     }
 }
+
+#[cfg(test)]
+mod size_guard {
+    use super::*;
+
+    /// Regression guard for #195: `GenerateAlgoOrdersOutput` boxes each order/refusal payload inside
+    /// its six `NoneOneOrMany` fields, so the aggregate stays ~144 B instead of inlining six full
+    /// `OrderEvent`s (~928 B). This bound (<= 160 B) catches a re-inlining of any of those payloads.
+    #[test]
+    fn generate_algo_orders_output_stays_small() {
+        let size = std::mem::size_of::<GenerateAlgoOrdersOutput<ExchangeIndex, InstrumentIndex>>();
+        assert!(
+            size <= 160,
+            "GenerateAlgoOrdersOutput grew to {size} B (expected <= 160): did a SendRequestsOutput \
+             or *_refused payload lose its Box? Payloads must stay boxed to keep the aggregate small \
+             (#195)."
+        );
+    }
+}

--- a/rustrade/src/engine/action/mod.rs
+++ b/rustrade/src/engine/action/mod.rs
@@ -22,13 +22,11 @@ pub mod generate_algo_orders;
 pub mod send_requests;
 
 /// Output of the `Engine` after actioning a [`Command`](super::command::Command).
+///
+/// `ClosePositions` (a cancels+opens pair) previously dwarfed `CancelOrders` (~608 B vs ~208 B) — a
+/// spread past 200 B that tripped `clippy::large_enum_variant`. With [`SendRequestsOutput`]'s order
+/// payloads boxed at the root (#195) that spread is gone, so no `#[allow]` is needed here.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, From)]
-// `ClosePositions` (a cancels+opens pair, ~608 B) dwarfs `CancelOrders` (~208 B); the >200 B spread
-// trips `clippy::large_enum_variant`. This is a command-response type, not the per-tick hot path,
-// and its largest member is already boxed one level up (`EngineOutput::Commanded(Box<ActionOutput>)`),
-// so boxing a variant here would only add an allocation for no measured benefit. The root-cause
-// shrink of `SendCancelsAndOpensOutput` itself is tracked separately in #195.
-#[allow(clippy::large_enum_variant)]
 pub enum ActionOutput<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> {
     CancelOrders(SendRequestsOutput<RequestCancel, ExchangeKey, InstrumentKey>),
     OpenOrders(SendRequestsOutput<RequestOpen, ExchangeKey, InstrumentKey>),

--- a/rustrade/src/engine/action/mod.rs
+++ b/rustrade/src/engine/action/mod.rs
@@ -44,3 +44,26 @@ impl<ExchangeKey, InstrumentKey> ActionOutput<ExchangeKey, InstrumentKey> {
         .into_option()
     }
 }
+
+#[cfg(test)]
+mod size_guard {
+    use super::*;
+
+    /// Regression guard for #194 + #195. #194 removed the never-constructed
+    /// `ActionOutput::GenerateAlgoOrders` variant (a ~928 B `GenerateAlgoOrdersOutput`); #195 then
+    /// boxed `SendRequestsOutput`'s order payloads at the root, collapsing the largest live variant
+    /// `ClosePositions(SendCancelsAndOpensOutput)` from ~608 B to ~96 B and removing the
+    /// `#[allow(clippy::large_enum_variant)]` `ActionOutput` used to carry. This bound (<= 128 B)
+    /// catches a re-inlining of an order payload (which jumps back to hundreds of bytes) while
+    /// leaving headroom.
+    #[test]
+    fn action_output_stays_small() {
+        let size = std::mem::size_of::<ActionOutput<ExchangeIndex, InstrumentIndex>>();
+        assert!(
+            size <= 128,
+            "ActionOutput grew to {size} B (expected <= 128): did a SendRequestsOutput order \
+             payload lose its root Box? Boxing keeps ActionOutput small enough to drop the \
+             large_enum_variant allow (#195)."
+        );
+    }
+}

--- a/rustrade/src/engine/action/mod.rs
+++ b/rustrade/src/engine/action/mod.rs
@@ -28,6 +28,10 @@ pub mod send_requests;
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, From)]
 #[allow(clippy::large_enum_variant)]
 pub enum ActionOutput<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> {
+    // NOTE (#194): never constructed by the engine — `Command` has no `GenerateAlgoOrders` variant,
+    // and `Engine::action()` only emits `CancelOrders`/`OpenOrders`/`ClosePositions`; the per-tick
+    // algo path builds `EngineOutput::AlgoOrders` directly. Reachable only via the `From` derive.
+    // Its ~928 B payload sets this enum's size floor; tracked for removal (breaking) in #194.
     GenerateAlgoOrders(GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>),
     CancelOrders(SendRequestsOutput<RequestCancel, ExchangeKey, InstrumentKey>),
     OpenOrders(SendRequestsOutput<RequestOpen, ExchangeKey, InstrumentKey>),

--- a/rustrade/src/engine/action/mod.rs
+++ b/rustrade/src/engine/action/mod.rs
@@ -1,8 +1,5 @@
 use crate::engine::{
-    action::{
-        generate_algo_orders::GenerateAlgoOrdersOutput,
-        send_requests::{SendCancelsAndOpensOutput, SendRequestsOutput},
-    },
+    action::send_requests::{SendCancelsAndOpensOutput, SendRequestsOutput},
     error::UnrecoverableEngineError,
 };
 use derive_more::From;
@@ -26,13 +23,13 @@ pub mod send_requests;
 
 /// Output of the `Engine` after actioning a [`Command`](super::command::Command).
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, From)]
+// `ClosePositions` (a cancels+opens pair, ~608 B) dwarfs `CancelOrders` (~208 B); the >200 B spread
+// trips `clippy::large_enum_variant`. This is a command-response type, not the per-tick hot path,
+// and its largest member is already boxed one level up (`EngineOutput::Commanded(Box<ActionOutput>)`),
+// so boxing a variant here would only add an allocation for no measured benefit. The root-cause
+// shrink of `SendCancelsAndOpensOutput` itself is tracked separately in #195.
 #[allow(clippy::large_enum_variant)]
 pub enum ActionOutput<ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> {
-    // NOTE (#194): never constructed by the engine — `Command` has no `GenerateAlgoOrders` variant,
-    // and `Engine::action()` only emits `CancelOrders`/`OpenOrders`/`ClosePositions`; the per-tick
-    // algo path builds `EngineOutput::AlgoOrders` directly. Reachable only via the `From` derive.
-    // Its ~928 B payload sets this enum's size floor; tracked for removal (breaking) in #194.
-    GenerateAlgoOrders(GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>),
     CancelOrders(SendRequestsOutput<RequestCancel, ExchangeKey, InstrumentKey>),
     OpenOrders(SendRequestsOutput<RequestOpen, ExchangeKey, InstrumentKey>),
     ClosePositions(SendCancelsAndOpensOutput<ExchangeKey, InstrumentKey>),
@@ -42,7 +39,6 @@ impl<ExchangeKey, InstrumentKey> ActionOutput<ExchangeKey, InstrumentKey> {
     /// Returns any unrecoverable errors that occurred during an `Engine` action.
     pub fn unrecoverable_errors(&self) -> Option<OneOrMany<UnrecoverableEngineError>> {
         match self {
-            ActionOutput::GenerateAlgoOrders(algo) => algo.cancels_and_opens.unrecoverable_errors(),
             ActionOutput::CancelOrders(cancels) => cancels.unrecoverable_errors(),
             ActionOutput::OpenOrders(opens) => opens.unrecoverable_errors(),
             ActionOutput::ClosePositions(requests) => requests.unrecoverable_errors(),

--- a/rustrade/src/engine/action/send_requests.rs
+++ b/rustrade/src/engine/action/send_requests.rs
@@ -194,16 +194,21 @@ impl<Kind, ExchangeKey, InstrumentKey> SendRequestsOutput<Kind, ExchangeKey, Ins
     pub fn unrecoverable_errors(&self) -> NoneOneOrMany<UnrecoverableEngineError> {
         self.errors
             .iter()
-            .filter_map(|entry| match &entry.1 {
-                EngineError::Unrecoverable(error) => Some(error.clone()),
-                _ => None,
+            .filter_map(|entry| {
+                // `entry` is `&Box<(OrderEvent, EngineError)>` (payload boxed, see `# Size`);
+                // deref through the box to destructure the tuple.
+                let (_, error) = &**entry;
+                match error {
+                    EngineError::Unrecoverable(error) => Some(error.clone()),
+                    _ => None,
+                }
             })
             .collect()
     }
 }
 
-impl<ExchangeKey, InstrumentKey, Kind> Default
-    for SendRequestsOutput<ExchangeKey, InstrumentKey, Kind>
+impl<Kind, ExchangeKey, InstrumentKey> Default
+    for SendRequestsOutput<Kind, ExchangeKey, InstrumentKey>
 {
     fn default() -> Self {
         Self {

--- a/rustrade/src/engine/action/send_requests.rs
+++ b/rustrade/src/engine/action/send_requests.rs
@@ -71,7 +71,10 @@ where
             })
             .partition_result();
 
-        SendRequestsOutput::new(NoneOneOrMany::from(sent), NoneOneOrMany::from(errors))
+        SendRequestsOutput::new(
+            sent.into_iter().map(Box::new).collect(),
+            errors.into_iter().map(Box::new).collect(),
+        )
     }
 
     fn send_request<Kind>(
@@ -156,12 +159,23 @@ impl<ExchangeKey, InstrumentKey> Default for SendCancelsAndOpensOutput<ExchangeK
 }
 
 /// Summary of order requests (cancel _or_ open) sent by the [`Engine`] to the `ExecutionManager`.
+///
+/// # Size
+/// Each [`OrderEvent`] payload is boxed inside its [`NoneOneOrMany`] field. An unboxed
+/// `OrderEvent` (~184 B for an open) inlined into [`NoneOneOrMany::One`] is the root of the size of
+/// the aggregates that embed this type
+/// ([`GenerateAlgoOrdersOutput`](super::generate_algo_orders::GenerateAlgoOrdersOutput),
+/// [`SendCancelsAndOpensOutput`], [`ActionOutput`](super::ActionOutput)); boxing keeps each field to
+/// a pointer (#195). `Box<T>` is serde-transparent, so the wire format is unchanged.
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
 )]
 pub struct SendRequestsOutput<Kind, ExchangeKey = ExchangeIndex, InstrumentKey = InstrumentIndex> {
-    pub sent: NoneOneOrMany<OrderEvent<Kind, ExchangeKey, InstrumentKey>>,
-    pub errors: NoneOneOrMany<(OrderEvent<Kind, ExchangeKey, InstrumentKey>, EngineError)>,
+    /// Order requests successfully sent for execution (payload boxed — see the type's `# Size` note).
+    pub sent: NoneOneOrMany<Box<OrderEvent<Kind, ExchangeKey, InstrumentKey>>>,
+    /// Order requests that failed to send, each paired with the [`EngineError`] that occurred
+    /// (payload boxed — see the type's `# Size` note).
+    pub errors: NoneOneOrMany<Box<(OrderEvent<Kind, ExchangeKey, InstrumentKey>, EngineError)>>,
 }
 
 impl<Kind, ExchangeKey, InstrumentKey> SendRequestsOutput<Kind, ExchangeKey, InstrumentKey> {
@@ -170,11 +184,17 @@ impl<Kind, ExchangeKey, InstrumentKey> SendRequestsOutput<Kind, ExchangeKey, Ins
         self.sent.is_none() && self.errors.is_none()
     }
 
+    /// Iterates the successfully-sent order requests, dereferencing through the boxed payload (see
+    /// the type's `# Size` note) so callers receive `&OrderEvent` rather than `&Box<OrderEvent>`.
+    pub fn sent_iter(&self) -> impl Iterator<Item = &OrderEvent<Kind, ExchangeKey, InstrumentKey>> {
+        self.sent.iter().map(|order| &**order)
+    }
+
     /// Returns any unrecoverable errors that occurred during order request sending.
     pub fn unrecoverable_errors(&self) -> NoneOneOrMany<UnrecoverableEngineError> {
         self.errors
             .iter()
-            .filter_map(|(_order, error)| match error {
+            .filter_map(|entry| match &entry.1 {
                 EngineError::Unrecoverable(error) => Some(error.clone()),
                 _ => None,
             })

--- a/rustrade/src/engine/action/send_requests.rs
+++ b/rustrade/src/engine/action/send_requests.rs
@@ -167,6 +167,15 @@ impl<ExchangeKey, InstrumentKey> Default for SendCancelsAndOpensOutput<ExchangeK
 /// ([`GenerateAlgoOrdersOutput`](super::generate_algo_orders::GenerateAlgoOrdersOutput),
 /// [`SendCancelsAndOpensOutput`], [`ActionOutput`](super::ActionOutput)); boxing keeps each field to
 /// a pointer (#195). `Box<T>` is serde-transparent, so the wire format is unchanged.
+///
+/// The box is deliberately at the *item* level (`NoneOneOrMany<Box<T>>`), not the *field* level
+/// (`Box<NoneOneOrMany<T>>`). Item-level boxing keeps the empty/no-order case allocation-free —
+/// [`NoneOneOrMany::None`] holds no box, so the common per-tick path that constructs an empty output
+/// (see [`is_empty`](Self::is_empty)) never touches the heap. A field-level box would instead
+/// allocate one heap block on *every* output, empty or not, regressing that hot path; its only edge
+/// is one fewer allocation on the rare multi-order (`Many`) tick, which is dominated by the
+/// per-order `request.clone()` + channel send already on that path. Item-level boxing is the right
+/// trade for a type whose empty case is the overwhelmingly common one.
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
 )]

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -1627,3 +1627,27 @@ impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
         Self::AlgoOrders(value)
     }
 }
+
+#[cfg(test)]
+mod size_guard {
+    use super::*;
+
+    /// Regression guard: `EngineOutput` stays small so the per-tick `ProcessAudit` copy is cheap. Its
+    /// floor is the largest variant `PositionExit(PositionExited)` (~232 B). The `AlgoOrders`/
+    /// `Commanded` variants are carried inline, but their order payloads are boxed at the root (#195)
+    /// — `GenerateAlgoOrdersOutput` ~144 B, `ActionOutput` ~96 B — so both sit under the
+    /// `PositionExit` floor and neither dominates. This bound (<= 256 B) catches a large regression —
+    /// a new big inline variant, or a re-inlined order payload that lifts `AlgoOrders`/`Commanded`
+    /// above the floor — while leaving headroom for unrelated growth.
+    #[test]
+    fn engine_output_stays_small() {
+        // Measured 232 B, floored by the PositionExit variant.
+        let size = std::mem::size_of::<EngineOutput<(), (), ExchangeIndex, InstrumentIndex>>();
+        assert!(
+            size <= 256,
+            "EngineOutput grew to {size} B (expected <= 256): a variant gained a large inline \
+             payload. AlgoOrders/Commanded order payloads must stay root-boxed (#195) so those \
+             variants sit under the ~232 B PositionExit floor."
+        );
+    }
+}

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -1340,14 +1340,14 @@ pub enum EngineOutput<
 > {
     /// Output of an actioned [`Command`](super::command::Command).
     ///
-    /// **Boxed:** [`ActionOutput`] is this command-only variant's payload and is rarely the output a
-    /// tick produces, so it is boxed to keep `EngineOutput`'s stack size — and thus the per-tick
-    /// [`ProcessAudit`](super::audit::ProcessAudit) copy — off the common path (`EngineOutput`
-    /// 936 → 232 B). Its inner order payloads are themselves boxed at the root (#195), so
-    /// `ActionOutput` is now small; the outer box is retained pending a separate re-evaluation of
-    /// whether a second indirection still earns its keep. `Box<T>` is serde-transparent, so the
-    /// audit wire format is unchanged.
-    Commanded(Box<ActionOutput<ExchangeKey, InstrumentKey>>),
+    /// **Inline.** [`ActionOutput`]'s inner order payloads are boxed at the root (#195), so
+    /// `ActionOutput` is only ~96 B — well under the ~232 B [`PositionExit`](Self::PositionExit)
+    /// variant that floors this enum's size. Carrying it inline therefore costs `EngineOutput`
+    /// nothing in stack size (and thus in the per-tick [`ProcessAudit`](super::audit::ProcessAudit)
+    /// copy), while avoiding a heap allocation and pointer indirection on the command path that an
+    /// outer `Box` would add. The audit wire format is unchanged (a newtype variant serializes its
+    /// payload identically whether boxed or not).
+    Commanded(ActionOutput<ExchangeKey, InstrumentKey>),
     OnTradingDisabled(OnTradingDisabled),
     AccountDisconnect(OnDisconnect),
     PositionExit(PositionExited<AssetIndex, InstrumentKey>),
@@ -1356,14 +1356,15 @@ pub enum EngineOutput<
     /// Summary of algorithmic orders generated for a processed event (the per-tick auto-generation
     /// path).
     ///
-    /// **Boxed:** this variant is only produced when the strategy actually emits orders (the empty
-    /// case short-circuits before construction), so keeping it inline would tax every no-order
-    /// tick's [`ProcessAudit`](super::audit::ProcessAudit) copy for a rarely-populated payload.
-    /// Boxing allocates only when orders exist and keeps `EngineOutput` small (936 → 232 B).
-    /// `GenerateAlgoOrdersOutput`'s inner order payloads are additionally boxed at the root (#195),
-    /// so the boxed payload is now ~144 B; the outer box is retained pending a separate
-    /// re-evaluation. `Box<T>` is serde-transparent, so the audit wire format is unchanged.
-    AlgoOrders(Box<GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>>),
+    /// **Inline.** `GenerateAlgoOrdersOutput`'s inner order payloads are boxed at the root (#195),
+    /// so it is only ~144 B — under the ~232 B [`PositionExit`](Self::PositionExit) variant that
+    /// floors this enum's size. Carrying it inline therefore costs `EngineOutput` nothing in stack
+    /// size (and thus in the per-tick [`ProcessAudit`](super::audit::ProcessAudit) copy). The
+    /// only allocation is the root boxing of the orders themselves, paid solely when the strategy
+    /// actually emits some — the empty no-order case short-circuits before this variant is even
+    /// constructed. The audit wire format is unchanged (a newtype variant serializes its payload
+    /// identically whether boxed or not).
+    AlgoOrders(GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>),
 
     /// Cash-in-lieu observable: a corporate-action split disposed a fractional share quantity
     /// (under [`SplitRoundingPolicy::Floor`]) from one open position. Emitted **per position**
@@ -1605,7 +1606,7 @@ impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
     for EngineOutput<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
 {
     fn from(value: ActionOutput<ExchangeKey, InstrumentKey>) -> Self {
-        Self::Commanded(Box::new(value))
+        Self::Commanded(value)
     }
 }
 
@@ -1623,6 +1624,6 @@ impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
     for EngineOutput<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
 {
     fn from(value: GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>) -> Self {
-        Self::AlgoOrders(Box::new(value))
+        Self::AlgoOrders(value)
     }
 }

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -1338,12 +1338,30 @@ pub enum EngineOutput<
     ExchangeKey = ExchangeIndex,
     InstrumentKey = InstrumentIndex,
 > {
-    Commanded(ActionOutput<ExchangeKey, InstrumentKey>),
+    /// Output of an actioned [`Command`](super::command::Command).
+    ///
+    /// **Boxed:** [`ActionOutput`] embeds a `GenerateAlgoOrdersOutput` (~928 B), which would
+    /// otherwise pin `EngineOutput`'s stack size — and thus the per-tick
+    /// [`ProcessAudit`](super::audit::ProcessAudit) copy — to that size on **every** event, even
+    /// though this command-only variant is rarely the one produced. Boxing moves the payload to the
+    /// heap so the common per-tick outputs stay small (`EngineOutput` 936 → 232 B). `Box<T>` is
+    /// serde-transparent, so the audit wire format is unchanged.
+    Commanded(Box<ActionOutput<ExchangeKey, InstrumentKey>>),
     OnTradingDisabled(OnTradingDisabled),
     AccountDisconnect(OnDisconnect),
     PositionExit(PositionExited<AssetIndex, InstrumentKey>),
     MarketDisconnect(OnDisconnect),
-    AlgoOrders(GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>),
+
+    /// Summary of algorithmic orders generated for a processed event (the per-tick auto-generation
+    /// path).
+    ///
+    /// **Boxed:** `GenerateAlgoOrdersOutput` is ~928 B and this variant is only produced when the
+    /// strategy actually emits orders (the empty case short-circuits before construction), so
+    /// keeping it inline would tax every no-order tick's [`ProcessAudit`](super::audit::ProcessAudit)
+    /// copy for a rarely-populated payload. Boxing allocates only when orders exist and keeps
+    /// `EngineOutput` small (936 → 232 B); `Box<T>` is serde-transparent, so the audit wire format
+    /// is unchanged.
+    AlgoOrders(Box<GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>>),
 
     /// Cash-in-lieu observable: a corporate-action split disposed a fractional share quantity
     /// (under [`SplitRoundingPolicy::Floor`]) from one open position. Emitted **per position**
@@ -1585,7 +1603,7 @@ impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
     for EngineOutput<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
 {
     fn from(value: ActionOutput<ExchangeKey, InstrumentKey>) -> Self {
-        Self::Commanded(value)
+        Self::Commanded(Box::new(value))
     }
 }
 
@@ -1603,6 +1621,6 @@ impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
     for EngineOutput<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>
 {
     fn from(value: GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>) -> Self {
-        Self::AlgoOrders(value)
+        Self::AlgoOrders(Box::new(value))
     }
 }

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -266,13 +266,13 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                     "Engine actioning user Command::SendCancelRequests"
                 );
                 let output = self.send_requests(requests.clone());
-                self.state.record_in_flight_cancels(&output.sent);
+                self.state.record_in_flight_cancels(output.sent_iter());
                 ActionOutput::CancelOrders(output)
             }
             Command::SendOpenRequests(requests) => {
                 info!(?requests, "Engine actioning user Command::SendOpenRequests");
                 let output = self.send_requests(requests.clone());
-                self.state.record_in_flight_opens(&output.sent);
+                self.state.record_in_flight_opens(output.sent_iter());
                 ActionOutput::OpenOrders(output)
             }
             Command::ClosePositions(filter) => {
@@ -438,7 +438,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             .filter_map(Order::to_request_cancel)
             .collect();
         let cancels = self.send_requests(cancel_requests);
-        self.state.record_in_flight_cancels(&cancels.sent);
+        self.state.record_in_flight_cancels(cancels.sent_iter());
 
         // Re-borrow after send_requests (which takes &self for execution_txs).
         let instrument_state = self.state.instruments.instrument_index_mut(key);
@@ -1340,12 +1340,13 @@ pub enum EngineOutput<
 > {
     /// Output of an actioned [`Command`](super::command::Command).
     ///
-    /// **Boxed:** [`ActionOutput`] embeds a `GenerateAlgoOrdersOutput` (~928 B), which would
-    /// otherwise pin `EngineOutput`'s stack size — and thus the per-tick
-    /// [`ProcessAudit`](super::audit::ProcessAudit) copy — to that size on **every** event, even
-    /// though this command-only variant is rarely the one produced. Boxing moves the payload to the
-    /// heap so the common per-tick outputs stay small (`EngineOutput` 936 → 232 B). `Box<T>` is
-    /// serde-transparent, so the audit wire format is unchanged.
+    /// **Boxed:** [`ActionOutput`] is this command-only variant's payload and is rarely the output a
+    /// tick produces, so it is boxed to keep `EngineOutput`'s stack size — and thus the per-tick
+    /// [`ProcessAudit`](super::audit::ProcessAudit) copy — off the common path (`EngineOutput`
+    /// 936 → 232 B). Its inner order payloads are themselves boxed at the root (#195), so
+    /// `ActionOutput` is now small; the outer box is retained pending a separate re-evaluation of
+    /// whether a second indirection still earns its keep. `Box<T>` is serde-transparent, so the
+    /// audit wire format is unchanged.
     Commanded(Box<ActionOutput<ExchangeKey, InstrumentKey>>),
     OnTradingDisabled(OnTradingDisabled),
     AccountDisconnect(OnDisconnect),
@@ -1355,12 +1356,13 @@ pub enum EngineOutput<
     /// Summary of algorithmic orders generated for a processed event (the per-tick auto-generation
     /// path).
     ///
-    /// **Boxed:** `GenerateAlgoOrdersOutput` is ~928 B and this variant is only produced when the
-    /// strategy actually emits orders (the empty case short-circuits before construction), so
-    /// keeping it inline would tax every no-order tick's [`ProcessAudit`](super::audit::ProcessAudit)
-    /// copy for a rarely-populated payload. Boxing allocates only when orders exist and keeps
-    /// `EngineOutput` small (936 → 232 B); `Box<T>` is serde-transparent, so the audit wire format
-    /// is unchanged.
+    /// **Boxed:** this variant is only produced when the strategy actually emits orders (the empty
+    /// case short-circuits before construction), so keeping it inline would tax every no-order
+    /// tick's [`ProcessAudit`](super::audit::ProcessAudit) copy for a rarely-populated payload.
+    /// Boxing allocates only when orders exist and keeps `EngineOutput` small (936 → 232 B).
+    /// `GenerateAlgoOrdersOutput`'s inner order payloads are additionally boxed at the root (#195),
+    /// so the boxed payload is now ~144 B; the outer box is retained pending a separate
+    /// re-evaluation. `Box<T>` is serde-transparent, so the audit wire format is unchanged.
     AlgoOrders(Box<GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>>),
 
     /// Cash-in-lieu observable: a corporate-action split disposed a fractional share quantity

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -99,6 +99,21 @@ fn engine_output_stays_boxed_and_small() {
     );
 }
 
+/// Regression guard for #194: the never-constructed `ActionOutput::GenerateAlgoOrders` variant
+/// (a ~928 B `GenerateAlgoOrdersOutput`) was removed, dropping `ActionOutput`'s size floor to its
+/// largest live variant `ClosePositions(SendCancelsAndOpensOutput)` (~608 B). This bound catches a
+/// reintroduction of an algo-order-sized variant (which would jump back to ~928 B) while leaving
+/// headroom for unrelated field growth.
+#[test]
+fn action_output_stays_small_after_dropping_algo_variant() {
+    let size = std::mem::size_of::<ActionOutput<ExchangeIndex, InstrumentIndex>>();
+    assert!(
+        size <= 640,
+        "ActionOutput grew to {size} B (expected <= 640): was a GenerateAlgoOrders-sized variant \
+         reintroduced? The dead algo variant was removed to drop the size floor (#194)."
+    );
+}
+
 const STARTING_TIMESTAMP: DateTime<Utc> = DateTime::<Utc>::MIN_UTC;
 const RISK_FREE_RETURN: Decimal = dec!(0.05);
 const STARTING_BALANCE_USDT: Balance = Balance::new(dec!(40_000.0), dec!(40_000.0));

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -83,18 +83,20 @@ use rustrade_integration::{
 
 /// Regression guard: `EngineOutput` stays small so the per-tick
 /// [`ProcessAudit`](rustrade::engine::audit::ProcessAudit) copy is cheap. Its floor is the largest
-/// unboxed variant `PositionExit(PositionExited)` (~232 B). The `AlgoOrders`/`Commanded` variants are
-/// boxed (#172) and their order payloads are additionally boxed at the root (#195), so neither
-/// dominates. This bound (<= 256 B) catches a large regression — a new big inline variant, or a
-/// re-inlined algo-order payload — while leaving headroom for unrelated field growth.
+/// variant `PositionExit(PositionExited)` (~232 B). The `AlgoOrders`/`Commanded` variants are carried
+/// inline, but their order payloads are boxed at the root (#195) — `GenerateAlgoOrdersOutput` ~144 B,
+/// `ActionOutput` ~96 B — so both sit under the `PositionExit` floor and neither dominates. This bound
+/// (<= 256 B) catches a large regression — a new big inline variant, or a re-inlined order payload
+/// that lifts `AlgoOrders`/`Commanded` above the floor — while leaving headroom for unrelated growth.
 #[test]
-fn engine_output_stays_boxed_and_small() {
-    // Measured 232 B, floored by the unboxed PositionExit variant.
+fn engine_output_stays_small() {
+    // Measured 232 B, floored by the PositionExit variant.
     let size = std::mem::size_of::<EngineOutput<(), (), ExchangeIndex, InstrumentIndex>>();
     assert!(
         size <= 256,
         "EngineOutput grew to {size} B (expected <= 256): a variant gained a large inline payload. \
-         AlgoOrders/Commanded should stay boxed (#172) with root-boxed payloads (#195)."
+         AlgoOrders/Commanded order payloads must stay root-boxed (#195) so those variants sit under \
+         the ~232 B PositionExit floor."
     );
 }
 
@@ -244,7 +246,7 @@ fn test_engine_process_engine_event_with_audit() {
         audit.event,
         EngineAudit::process_with_output(
             EngineEvent::TradingStateUpdate(TradingState::Enabled),
-            EngineOutput::AlgoOrders(Box::new(GenerateAlgoOrdersOutput {
+            EngineOutput::AlgoOrders(GenerateAlgoOrdersOutput {
                 cancels_and_opens: SendCancelsAndOpensOutput {
                     cancels: SendRequestsOutput::default(),
                     opens: SendRequestsOutput {
@@ -256,7 +258,7 @@ fn test_engine_process_engine_event_with_audit() {
                     },
                 },
                 ..Default::default()
-            }))
+            })
         )
     );
 
@@ -434,15 +436,13 @@ fn test_engine_process_engine_event_with_audit() {
         audit.event,
         EngineAudit::process_with_output(
             event,
-            EngineOutput::Commanded(Box::new(ActionOutput::ClosePositions(
-                SendCancelsAndOpensOutput {
-                    cancels: SendRequestsOutput::default(),
-                    opens: SendRequestsOutput {
-                        sent: NoneOneOrMany::One(Box::new(btc_usdt_sell_order.clone())),
-                        errors: NoneOneOrMany::None,
-                    },
-                }
-            )))
+            EngineOutput::Commanded(ActionOutput::ClosePositions(SendCancelsAndOpensOutput {
+                cancels: SendRequestsOutput::default(),
+                opens: SendRequestsOutput {
+                    sent: NoneOneOrMany::One(Box::new(btc_usdt_sell_order.clone())),
+                    errors: NoneOneOrMany::None,
+                },
+            }))
         )
     );
 
@@ -601,10 +601,10 @@ fn test_engine_process_engine_event_with_audit() {
         audit.event,
         EngineAudit::process_with_output(
             event,
-            EngineOutput::Commanded(Box::new(ActionOutput::OpenOrders(SendRequestsOutput {
+            EngineOutput::Commanded(ActionOutput::OpenOrders(SendRequestsOutput {
                 sent: NoneOneOrMany::One(Box::new(eth_btc_sell_order.clone())),
                 errors: NoneOneOrMany::None,
-            })))
+            }))
         )
     );
 
@@ -3437,13 +3437,13 @@ fn test_corporate_action_option_non_standard_wrapper_close_and_new_identity() {
     };
     // A Commanded(ClosePositions) output fires, carrying a reduce-only Sell order for the old option.
     let commanded_sell = outputs.iter().any(|o| match o {
-        // `Commanded` carries a `Box<ActionOutput>`; box patterns are unstable, so deref one level.
-        EngineOutput::Commanded(action) => match &**action {
-            ActionOutput::ClosePositions(out) => out.opens.sent.iter().any(|order| {
+        // `Commanded` now carries `ActionOutput` inline, so the nested variant is matched directly
+        // (no `Box` deref / unstable box pattern needed).
+        EngineOutput::Commanded(ActionOutput::ClosePositions(out)) => {
+            out.opens.sent_iter().any(|order| {
                 order.key.instrument == InstrumentIndex(0) && order.state.side == Side::Sell
-            }),
-            _ => false,
-        },
+            })
+        }
         _ => false,
     });
     assert!(

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -81,36 +81,51 @@ use rustrade_integration::{
     collection::{none_one_or_many::NoneOneOrMany, one_or_many::OneOrMany, snapshot::Snapshot},
 };
 
-/// Regression guard for #172: `EngineOutput::AlgoOrders` and `EngineOutput::Commanded` both embed a
-/// ~928 B `GenerateAlgoOrdersOutput` and are boxed so the per-tick
-/// [`ProcessAudit`](rustrade::engine::audit::ProcessAudit) copy stays small. Leaving *either* inline
-/// re-pins `EngineOutput` at ~936 B; boxed, the enum floors at its next-largest variant
-/// `PositionExit(PositionExited)` (~232 B). This bound catches a re-inlining regression (which jumps
-/// back to ~936 B) while leaving headroom for unrelated field growth.
+/// Regression guard: `EngineOutput` stays small so the per-tick
+/// [`ProcessAudit`](rustrade::engine::audit::ProcessAudit) copy is cheap. Its floor is the largest
+/// unboxed variant `PositionExit(PositionExited)` (~232 B). The `AlgoOrders`/`Commanded` variants are
+/// boxed (#172) and their order payloads are additionally boxed at the root (#195), so neither
+/// dominates. This bound (<= 256 B) catches a large regression — a new big inline variant, or a
+/// re-inlined algo-order payload — while leaving headroom for unrelated field growth.
 #[test]
 fn engine_output_stays_boxed_and_small() {
-    // OnTradingDisabled/OnDisconnect params are small variants that never dominate; measured 232 B
-    // with both giants boxed (was 936 B when inline).
+    // Measured 232 B, floored by the unboxed PositionExit variant.
     let size = std::mem::size_of::<EngineOutput<(), (), ExchangeIndex, InstrumentIndex>>();
     assert!(
         size <= 256,
-        "EngineOutput grew to {size} B (expected <= 256): did AlgoOrders or Commanded lose its \
-         Box? Both must stay boxed to keep the per-tick ProcessAudit copy small (#172)."
+        "EngineOutput grew to {size} B (expected <= 256): a variant gained a large inline payload. \
+         AlgoOrders/Commanded should stay boxed (#172) with root-boxed payloads (#195)."
     );
 }
 
-/// Regression guard for #194: the never-constructed `ActionOutput::GenerateAlgoOrders` variant
-/// (a ~928 B `GenerateAlgoOrdersOutput`) was removed, dropping `ActionOutput`'s size floor to its
-/// largest live variant `ClosePositions(SendCancelsAndOpensOutput)` (~608 B). This bound catches a
-/// reintroduction of an algo-order-sized variant (which would jump back to ~928 B) while leaving
-/// headroom for unrelated field growth.
+/// Regression guard for #194 + #195. #194 removed the never-constructed
+/// `ActionOutput::GenerateAlgoOrders` variant (a ~928 B `GenerateAlgoOrdersOutput`); #195 then boxed
+/// [`SendRequestsOutput`](rustrade::engine::action::send_requests::SendRequestsOutput)'s order
+/// payloads at the root, collapsing the largest live variant
+/// `ClosePositions(SendCancelsAndOpensOutput)` from ~608 B to ~96 B and removing the
+/// `#[allow(clippy::large_enum_variant)]` `ActionOutput` used to carry. This bound (<= 128 B) catches
+/// a re-inlining of an order payload (which jumps back to hundreds of bytes) while leaving headroom.
 #[test]
-fn action_output_stays_small_after_dropping_algo_variant() {
+fn action_output_stays_small() {
     let size = std::mem::size_of::<ActionOutput<ExchangeIndex, InstrumentIndex>>();
     assert!(
-        size <= 640,
-        "ActionOutput grew to {size} B (expected <= 640): was a GenerateAlgoOrders-sized variant \
-         reintroduced? The dead algo variant was removed to drop the size floor (#194)."
+        size <= 128,
+        "ActionOutput grew to {size} B (expected <= 128): did a SendRequestsOutput order payload \
+         lose its root Box? Boxing keeps ActionOutput small enough to drop the large_enum_variant \
+         allow (#195)."
+    );
+}
+
+/// Regression guard for #195: `GenerateAlgoOrdersOutput` boxes each order/refusal payload inside its
+/// six `NoneOneOrMany` fields, so the aggregate stays ~144 B instead of inlining six full
+/// `OrderEvent`s (~928 B). This bound (<= 160 B) catches a re-inlining of any of those payloads.
+#[test]
+fn generate_algo_orders_output_stays_small() {
+    let size = std::mem::size_of::<GenerateAlgoOrdersOutput<ExchangeIndex, InstrumentIndex>>();
+    assert!(
+        size <= 160,
+        "GenerateAlgoOrdersOutput grew to {size} B (expected <= 160): did a SendRequestsOutput or \
+         *_refused payload lose its Box? Payloads must stay boxed to keep the aggregate small (#195)."
     );
 }
 
@@ -234,8 +249,8 @@ fn test_engine_process_engine_event_with_audit() {
                     cancels: SendRequestsOutput::default(),
                     opens: SendRequestsOutput {
                         sent: NoneOneOrMany::Many(vec![
-                            btc_usdt_buy_order.clone(),
-                            eth_btc_buy_order.clone(),
+                            Box::new(btc_usdt_buy_order.clone()),
+                            Box::new(eth_btc_buy_order.clone()),
                         ]),
                         errors: NoneOneOrMany::None,
                     },
@@ -423,7 +438,7 @@ fn test_engine_process_engine_event_with_audit() {
                 SendCancelsAndOpensOutput {
                     cancels: SendRequestsOutput::default(),
                     opens: SendRequestsOutput {
-                        sent: NoneOneOrMany::One(btc_usdt_sell_order.clone()),
+                        sent: NoneOneOrMany::One(Box::new(btc_usdt_sell_order.clone())),
                         errors: NoneOneOrMany::None,
                     },
                 }
@@ -587,7 +602,7 @@ fn test_engine_process_engine_event_with_audit() {
         EngineAudit::process_with_output(
             event,
             EngineOutput::Commanded(Box::new(ActionOutput::OpenOrders(SendRequestsOutput {
-                sent: NoneOneOrMany::One(eth_btc_sell_order.clone()),
+                sent: NoneOneOrMany::One(Box::new(eth_btc_sell_order.clone())),
                 errors: NoneOneOrMany::None,
             })))
         )

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -81,56 +81,6 @@ use rustrade_integration::{
     collection::{none_one_or_many::NoneOneOrMany, one_or_many::OneOrMany, snapshot::Snapshot},
 };
 
-/// Regression guard: `EngineOutput` stays small so the per-tick
-/// [`ProcessAudit`](rustrade::engine::audit::ProcessAudit) copy is cheap. Its floor is the largest
-/// variant `PositionExit(PositionExited)` (~232 B). The `AlgoOrders`/`Commanded` variants are carried
-/// inline, but their order payloads are boxed at the root (#195) — `GenerateAlgoOrdersOutput` ~144 B,
-/// `ActionOutput` ~96 B — so both sit under the `PositionExit` floor and neither dominates. This bound
-/// (<= 256 B) catches a large regression — a new big inline variant, or a re-inlined order payload
-/// that lifts `AlgoOrders`/`Commanded` above the floor — while leaving headroom for unrelated growth.
-#[test]
-fn engine_output_stays_small() {
-    // Measured 232 B, floored by the PositionExit variant.
-    let size = std::mem::size_of::<EngineOutput<(), (), ExchangeIndex, InstrumentIndex>>();
-    assert!(
-        size <= 256,
-        "EngineOutput grew to {size} B (expected <= 256): a variant gained a large inline payload. \
-         AlgoOrders/Commanded order payloads must stay root-boxed (#195) so those variants sit under \
-         the ~232 B PositionExit floor."
-    );
-}
-
-/// Regression guard for #194 + #195. #194 removed the never-constructed
-/// `ActionOutput::GenerateAlgoOrders` variant (a ~928 B `GenerateAlgoOrdersOutput`); #195 then boxed
-/// [`SendRequestsOutput`](rustrade::engine::action::send_requests::SendRequestsOutput)'s order
-/// payloads at the root, collapsing the largest live variant
-/// `ClosePositions(SendCancelsAndOpensOutput)` from ~608 B to ~96 B and removing the
-/// `#[allow(clippy::large_enum_variant)]` `ActionOutput` used to carry. This bound (<= 128 B) catches
-/// a re-inlining of an order payload (which jumps back to hundreds of bytes) while leaving headroom.
-#[test]
-fn action_output_stays_small() {
-    let size = std::mem::size_of::<ActionOutput<ExchangeIndex, InstrumentIndex>>();
-    assert!(
-        size <= 128,
-        "ActionOutput grew to {size} B (expected <= 128): did a SendRequestsOutput order payload \
-         lose its root Box? Boxing keeps ActionOutput small enough to drop the large_enum_variant \
-         allow (#195)."
-    );
-}
-
-/// Regression guard for #195: `GenerateAlgoOrdersOutput` boxes each order/refusal payload inside its
-/// six `NoneOneOrMany` fields, so the aggregate stays ~144 B instead of inlining six full
-/// `OrderEvent`s (~928 B). This bound (<= 160 B) catches a re-inlining of any of those payloads.
-#[test]
-fn generate_algo_orders_output_stays_small() {
-    let size = std::mem::size_of::<GenerateAlgoOrdersOutput<ExchangeIndex, InstrumentIndex>>();
-    assert!(
-        size <= 160,
-        "GenerateAlgoOrdersOutput grew to {size} B (expected <= 160): did a SendRequestsOutput or \
-         *_refused payload lose its Box? Payloads must stay boxed to keep the aggregate small (#195)."
-    );
-}
-
 const STARTING_TIMESTAMP: DateTime<Utc> = DateTime::<Utc>::MIN_UTC;
 const RISK_FREE_RETURN: Decimal = dec!(0.05);
 const STARTING_BALANCE_USDT: Balance = Balance::new(dec!(40_000.0), dec!(40_000.0));

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -81,6 +81,24 @@ use rustrade_integration::{
     collection::{none_one_or_many::NoneOneOrMany, one_or_many::OneOrMany, snapshot::Snapshot},
 };
 
+/// Regression guard for #172: `EngineOutput::AlgoOrders` and `EngineOutput::Commanded` both embed a
+/// ~928 B `GenerateAlgoOrdersOutput` and are boxed so the per-tick
+/// [`ProcessAudit`](rustrade::engine::audit::ProcessAudit) copy stays small. Leaving *either* inline
+/// re-pins `EngineOutput` at ~936 B; boxed, the enum floors at its next-largest variant
+/// `PositionExit(PositionExited)` (~232 B). This bound catches a re-inlining regression (which jumps
+/// back to ~936 B) while leaving headroom for unrelated field growth.
+#[test]
+fn engine_output_stays_boxed_and_small() {
+    // OnTradingDisabled/OnDisconnect params are small variants that never dominate; measured 232 B
+    // with both giants boxed (was 936 B when inline).
+    let size = std::mem::size_of::<EngineOutput<(), (), ExchangeIndex, InstrumentIndex>>();
+    assert!(
+        size <= 256,
+        "EngineOutput grew to {size} B (expected <= 256): did AlgoOrders or Commanded lose its \
+         Box? Both must stay boxed to keep the per-tick ProcessAudit copy small (#172)."
+    );
+}
+
 const STARTING_TIMESTAMP: DateTime<Utc> = DateTime::<Utc>::MIN_UTC;
 const RISK_FREE_RETURN: Decimal = dec!(0.05);
 const STARTING_BALANCE_USDT: Balance = Balance::new(dec!(40_000.0), dec!(40_000.0));
@@ -196,7 +214,7 @@ fn test_engine_process_engine_event_with_audit() {
         audit.event,
         EngineAudit::process_with_output(
             EngineEvent::TradingStateUpdate(TradingState::Enabled),
-            EngineOutput::AlgoOrders(GenerateAlgoOrdersOutput {
+            EngineOutput::AlgoOrders(Box::new(GenerateAlgoOrdersOutput {
                 cancels_and_opens: SendCancelsAndOpensOutput {
                     cancels: SendRequestsOutput::default(),
                     opens: SendRequestsOutput {
@@ -208,7 +226,7 @@ fn test_engine_process_engine_event_with_audit() {
                     },
                 },
                 ..Default::default()
-            })
+            }))
         )
     );
 
@@ -386,13 +404,15 @@ fn test_engine_process_engine_event_with_audit() {
         audit.event,
         EngineAudit::process_with_output(
             event,
-            EngineOutput::Commanded(ActionOutput::ClosePositions(SendCancelsAndOpensOutput {
-                cancels: SendRequestsOutput::default(),
-                opens: SendRequestsOutput {
-                    sent: NoneOneOrMany::One(btc_usdt_sell_order.clone()),
-                    errors: NoneOneOrMany::None,
-                },
-            }))
+            EngineOutput::Commanded(Box::new(ActionOutput::ClosePositions(
+                SendCancelsAndOpensOutput {
+                    cancels: SendRequestsOutput::default(),
+                    opens: SendRequestsOutput {
+                        sent: NoneOneOrMany::One(btc_usdt_sell_order.clone()),
+                        errors: NoneOneOrMany::None,
+                    },
+                }
+            )))
         )
     );
 
@@ -551,10 +571,10 @@ fn test_engine_process_engine_event_with_audit() {
         audit.event,
         EngineAudit::process_with_output(
             event,
-            EngineOutput::Commanded(ActionOutput::OpenOrders(SendRequestsOutput {
+            EngineOutput::Commanded(Box::new(ActionOutput::OpenOrders(SendRequestsOutput {
                 sent: NoneOneOrMany::One(eth_btc_sell_order.clone()),
                 errors: NoneOneOrMany::None,
-            }))
+            })))
         )
     );
 
@@ -3387,11 +3407,13 @@ fn test_corporate_action_option_non_standard_wrapper_close_and_new_identity() {
     };
     // A Commanded(ClosePositions) output fires, carrying a reduce-only Sell order for the old option.
     let commanded_sell = outputs.iter().any(|o| match o {
-        EngineOutput::Commanded(ActionOutput::ClosePositions(out)) => {
-            out.opens.sent.iter().any(|order| {
+        // `Commanded` carries a `Box<ActionOutput>`; box patterns are unstable, so deref one level.
+        EngineOutput::Commanded(action) => match &**action {
+            ActionOutput::ClosePositions(out) => out.opens.sent.iter().any(|order| {
                 order.key.instrument == InstrumentIndex(0) && order.state.side == Side::Sell
-            })
-        }
+            }),
+            _ => false,
+        },
         _ => false,
     });
     assert!(


### PR DESCRIPTION
## Summary

Shrinks the engine's per-tick action output aggregates so they fit comfortably on the stack, reducing the copy cost paid on every tick (especially with the audit seam enabled). Fixes the root cause identified in #195.

The core move: box `OrderEvent` payloads **at the root**, inside the types that actually contain multiple large orders (`SendRequestsOutput`, `GenerateAlgoOrdersOutput`), rather than one level up in `EngineOutput`/`ActionOutput`. This keeps the outer enums small and removes the need for `#[allow(clippy::large_enum_variant)]`.

## Changes

- **Box order payloads at root** in `SendRequestsOutput::{sent, errors}` and in `GenerateAlgoOrdersOutput::{cancels_refused, opens_refused}`
  - Add `sent_iter()` helper to yield `&OrderEvent` without manual dereferencing
  - `GenerateAlgoOrdersOutput`: ~928 B → ~144 B
- **Remove dead `ActionOutput::GenerateAlgoOrders` variant** (never constructed; only reachable via derived `From`). This dropped the enum's size floor: `ActionOutput` ~928 B → ~608 B → ~96 B after root boxing.
- **Remove `#[allow(clippy::large_enum_variant)]`** from `ActionOutput` — no longer needed.
- **Update call sites** (`send_requests`, `cancel_orders`, `close_positions`, `generate_algo_orders`) to use `sent_iter()`; update test helpers to construct boxed fields.
- **Regression guards**: tighten `action_output_stays_small` to a 128 B bound; add `generate_algo_orders_output_stays_small` (160 B bound).
- **Docs**: CHANGELOG + rustdoc updated; serde wire format unchanged (boxing is transparent).

## Breaking changes

- Downstream code destructuring `SendRequestsOutput`/`GenerateAlgoOrdersOutput` fields now gets `Box<T>` (auto-deref covers most read paths).
- Code matching or constructing `ActionOutput::GenerateAlgoOrders` must delete that arm.

Closes #195