### PR TITLE
Harden Massive REST pagination/auth and IBKR Flex diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Fixed a bearer-token leak in Massive REST pagination** (`rustrade-data`). The client attaches its
+  API key as an `Authorization: Bearer` default header sent with every request, and validated each
+  server-supplied `next_url` with a `starts_with(base_url)` prefix check before following it. A
+  look-alike host that merely shares the prefix — `https://api.massive.com.attacker.example` or even
+  the separator-less `https://api.massive.comevil.example` — passed that check and would have received
+  the token. Pagination now parses both URLs and compares their [origins][url-origin]
+  (scheme + host + port), rejecting any `next_url` whose origin differs or that fails to parse
+  (fail-closed) so the token is never sent to an untrusted host. The check moved into the single
+  request chokepoint (`fetch_page_body`) so it cannot be bypassed by a future paginated fetch, and the
+  client now disables HTTP redirect following (`redirect::Policy::none()`) so a server-issued 3xx
+  cannot bounce an origin-validated request to another host behind the guard — the guarantee no longer
+  depends on reqwest's internal cross-origin header stripping. A new
+  `MassiveError::UntrustedNextUrl { next_url, expected_origin }` variant carries the diagnosis
+  (`MassiveError` is `#[non_exhaustive]`, so the addition is not a breaking change).
+
+  [url-origin]: https://docs.rs/url/latest/url/struct.Url.html#method.origin
+
 - Upgraded `anyhow` to 1.0.103 and `quick-xml` to 0.41.0 to clear three RUSTSEC advisories:
   RUSTSEC-2026-0190 (unsoundness in `anyhow::Error::downcast_mut`), RUSTSEC-2026-0194 (quadratic
   run time when checking a start tag for duplicate attribute names) and RUSTSEC-2026-0195

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request path can carry it to a host that has not been validated, even if a future paginated fetch
   omitted the guard. `reqwest`'s `bearer_auth` additionally marks the header sensitive (redacted in
   its logs). No public API change and no behaviour change for well-behaved responses. (#198)
+- **Bounded error-path response reads for the REST clients** (`rustrade-data`, `massive` and `ibkr`
+  features; defense-in-depth). On a non-success HTTP status, the Massive (`fetch_page_body`) and IBKR
+  Flex (`get_with_query`) clients now read the diagnostic body only up to a fixed cap instead of
+  buffering it in full. Previously a pathological proxy/CDN returning an unbounded error body was
+  downloaded entirely before being truncated for the error message; the cap bounds that memory use
+  while staying far above any legitimate error/status envelope (so a Flex `1019`/error response is
+  never truncated). Success bodies (real payload) are still read in full. No public API or
+  error-message change.
 - Upgraded `anyhow` to 1.0.103 and `quick-xml` to 0.41.0 to clear three RUSTSEC advisories:
   RUSTSEC-2026-0190 (unsoundness in `anyhow::Error::downcast_mut`), RUSTSEC-2026-0194 (quadratic
   run time when checking a start tag for duplicate attribute names) and RUSTSEC-2026-0195

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`MassiveError` is now `#[non_exhaustive]`** (`rustrade-data`). Lets new variants (such as the
   pagination-robustness errors above) be added without further breaking changes. **Breaking** for
   downstream code matching `MassiveError` exhaustively — add a wildcard (`_`) arm.
+- **BREAKING: `MassiveRestClient::with_base_url` now returns `Result<Self, MassiveError>`**
+  (`rustrade-data`). The base URL is parsed into its trusted origin once, at construction, and cached
+  on the client — so a base URL that is not a valid URL now fails fast with
+  `MassiveError::InvalidInput` here instead of surfacing as a deferred error on the first request, and
+  every `next_url` origin check compares against the cached origin rather than re-parsing the base URL
+  per page. Migration: append `?` or `.expect(..)` to existing `with_base_url(..)` calls. (#198)
 - **`EngineEvent` is now `#[non_exhaustive]` and gains a `CorporateAction` variant** (`rustrade`).
   Marking it non-exhaustive lets future engine-driven event variants be added without further
   breaking changes. **Breaking** for downstream code matching `EngineEvent` exhaustively — add a
@@ -331,6 +337,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   [url-origin]: https://docs.rs/url/latest/url/struct.Url.html#method.origin
 
+- **Hardened Massive REST authentication against future token leaks** (`rustrade-data`;
+  defense-in-depth follow-up to the origin-validation fix above). The API key is no longer installed
+  as a client-wide `Authorization: Bearer` default header on the underlying `reqwest::Client`, where
+  it rode every request regardless of destination host. It is now attached per-request inside the
+  single origin-validated request chokepoint (`fetch_page_body`), only *after* the destination origin
+  passes `validate_next_url`. The credential is thus coupled to the origin check by construction — no
+  request path can carry it to a host that has not been validated, even if a future paginated fetch
+  omitted the guard. `reqwest`'s `bearer_auth` additionally marks the header sensitive (redacted in
+  its logs). No public API change and no behaviour change for well-behaved responses. (#198)
 - Upgraded `anyhow` to 1.0.103 and `quick-xml` to 0.41.0 to clear three RUSTSEC advisories:
   RUSTSEC-2026-0190 (unsoundness in `anyhow::Error::downcast_mut`), RUSTSEC-2026-0194 (quadratic
   run time when checking a start tag for duplicate attribute names) and RUSTSEC-2026-0195

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now caps the number of pages it will follow and detects a `next_url` that revisits an
   already-fetched page, yielding a terminal error instead of paginating without bound. Because a
   silently truncated result is indistinguishable from a genuinely small one for a market-data
-  client, incomplete pagination fails loudly rather than returning a partial result. Two new
-  `MassiveError` variants carry the diagnosis: `PaginationLimitExceeded { pages, limit }` and
-  `CyclicPagination { url }`.
+  client, incomplete pagination fails loudly rather than returning a partial result. Three new
+  `MassiveError` variants carry the diagnosis: `PaginationLimitExceeded { pages, limit }`,
+  `CyclicPagination { url }` and `PaginationUrlTooLong { len, limit, prefix }`. `CyclicPagination`
+  and `UntrustedNextUrl` store their URL in full but bound it when rendered via `Display`, so an
+  oversized server-supplied URL cannot flood a log line; a bounded render ends in `...` so a cut is
+  never mistaken for the whole URL.
 
 - **Corporate-action stock-split processing** (`rustrade`). The engine now handles
   `EngineEvent::CorporateAction` for stock/reverse splits, adjusting every open position on the
@@ -275,6 +278,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Published rustdoc no longer points at items readers cannot open** (`rustrade-data`). Twelve
+  public items across the IBKR Flex, Massive and Alpaca surfaces linked to private items, which
+  render on docs.rs as dead, non-hyperlinked code — a reader following "see `X`" found nothing. Each
+  now states the fact inline (e.g. a cap's literal value) or links a public item instead. Two
+  genuinely broken links in `ibkr::historical` are fixed too: they referenced
+  `HistoricalTicks::truncated_by_error`, a field renamed to `truncation_error`. Most substantively,
+  `IbkrFlexCorporateAction`'s limitations — that it is a reconciliation record and not a
+  split-ratio source, that it is post-hoc and cannot drive a live split, and that its
+  `quantity_delta` is account-scoped — were previously only in a private module's docs and so were
+  never published; they now appear on the type itself. `rustdoc::private_intra_doc_links` is denied
+  crate-wide so this cannot silently recur. Documentation only; no API or behaviour change.
 - **`Position::pnl_unrealised` fee units** (`rustrade`). The per-tick unrealised-PnL exit-fee
   estimate now uses the quote-equivalent entry fee (`fees_enter.fees_quote`, falling back to raw
   `fees` only when no quote-equivalent is derivable), matching the realised-PnL convention. Fixes a
@@ -349,14 +363,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request path can carry it to a host that has not been validated, even if a future paginated fetch
   omitted the guard. `reqwest`'s `bearer_auth` additionally marks the header sensitive (redacted in
   its logs). No public API change and no behaviour change for well-behaved responses. (#198)
-- **Bounded error-path response reads for the REST clients** (`rustrade-data`, `massive` and `ibkr`
-  features; defense-in-depth). On a non-success HTTP status, the Massive (`fetch_page_body`) and IBKR
-  Flex (`get_with_query`) clients now read the diagnostic body only up to a fixed cap instead of
-  buffering it in full. Previously a pathological proxy/CDN returning an unbounded error body was
-  downloaded entirely before being truncated for the error message; the cap bounds that memory use
-  while staying far above any legitimate error/status envelope (so a Flex `1019`/error response is
-  never truncated). Success bodies (real payload) are still read in full. No public API or
-  error-message change.
+- **Bounded error-path response reads for the REST clients** (`rustrade-data`; defense-in-depth). On
+  a non-success HTTP status, the Massive (`fetch_page_body`), IBKR Flex (`get_with_query`) and
+  Binance historical (`fetch_page`) clients now read the diagnostic body only up to a fixed cap
+  instead of buffering it in full. Previously a pathological proxy/CDN returning an unbounded error
+  body was downloaded entirely before being truncated for the error message; the cap bounds that
+  memory use while staying far above any legitimate error/status envelope (so a Flex `1019`/error
+  response is never truncated). All three REST clients are covered — Binance is the one that is not
+  feature-gated, so it is compiled into every dependent build. Success bodies (real payload) are
+  still read in full. No public API or error-message change.
+- **Bounded the memory a misbehaving Massive origin can force during pagination** (`rustrade-data`).
+  A page's `next_url` is server-supplied and success bodies are read in full, so the pagination
+  guard previously retained up to `MAX_PAGES` (10,000) unbounded URL strings per stream for cycle
+  detection, and `MassiveError::CyclicPagination` / `UntrustedNextUrl` rendered one in full into
+  every log line. The guard now records a fixed-size fingerprint per page instead of the URL itself,
+  and rejects any URL past a new byte cap up front with the additive
+  `MassiveError::PaginationUrlTooLong { len, limit, prefix }`. Fingerprints are keyed by a
+  per-stream random hash key rather than the fixed-key `DefaultHasher`, so a server cannot
+  precompute two colliding `next_url`s to force a spurious `CyclicPagination`. Cycle detection is
+  unchanged for well-behaved servers: the fingerprint covers the whole URL, so two long URLs sharing
+  a prefix remain distinct pages.
+- **Token-scrubbed and bounded `IbkrFlexError::Parse`** (`rustrade-data`, `ibkr` feature). An XML
+  deserialiser embeds fragments of the offending input in its error message, so a `Parse` message's
+  length tracked the *document* rather than the failure, and a body that reflected the request line
+  could carry the `t=` Flex token into the stored error — the protection
+  `IbkrFlexError::HttpStatus` already had. Parse messages raised while interpreting a SendRequest or
+  GetStatement response now go through the same redaction and bounding. The statement re-parse
+  behind `parse_corporate_actions` is covered too: called directly, with no token in scope to
+  redact, it still bounds its message; called from `IbkrFlexClient::fetch_corporate_actions` the
+  token is threaded into the parse, so redaction runs while the message is still unbounded. That
+  ordering is load-bearing rather than incidental — redaction matches the full token, so scrubbing
+  an already-bounded message would leave a credential straddling the cap present as an unmatched
+  prefix fragment, and both cuts use the same width, leaving no protective gap.
+  `Parse` is now bounded on every path and scrubbed on every path where a token is in scope.
 - Upgraded `anyhow` to 1.0.103 and `quick-xml` to 0.41.0 to clear three RUSTSEC advisories:
   RUSTSEC-2026-0190 (unsoundness in `anyhow::Error::downcast_mut`), RUSTSEC-2026-0194 (quadratic
   run time when checking a start tag for duplicate attribute names) and RUSTSEC-2026-0195

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Richer IBKR Flex transport diagnostics + configurable poll budget** (`rustrade-data`, `ibkr`
+  feature). `IbkrFlexClient` now reads the HTTP response body **before** branching on status, so a
+  non-2xx response's diagnostic body (IBKR/proxy/CDN error pages) is preserved instead of being
+  discarded by `error_for_status`. A non-success status whose body is not a recognizable Flex
+  envelope surfaces as the new `IbkrFlexError::HttpStatus { status, body }` — the body bounded and
+  **token-scrubbed** (a proxy that echoes the request URL cannot leak the `t=` Flex token); an IBKR
+  application error that arrives under a non-2xx status still surfaces as the richer
+  `IbkrFlexError::Flex`. As a side effect this also fixes a retry-path bypass: a `1019` ("statement
+  still generating") returned under a non-2xx status is now honored as retryable rather than aborting
+  the poll. Poll timing is now configurable via the new `FlexPollPolicy { initial_delay, interval,
+  max_attempts }` (set with `IbkrFlexClient::with_poll_policy`); a short `initial_delay` before the
+  first poll (5 s by default) keeps the near-certain first `1019` from consuming one of the bounded
+  attempts. `IbkrFlexError` is `#[non_exhaustive]`, so the new variant is additive.
+
 - **Bounded, cycle-safe pagination for Massive REST fetches** (`rustrade-data`). Every Massive
   `next_url`-paginated fetch (`fetch_aggregates`, `fetch_trades`, `fetch_quotes`, `fetch_tickers`,
   `fetch_dividends`, `fetch_splits_raw`, `fetch_option_contracts`, `fetch_option_chain_snapshot`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,10 +144,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   downstream code matching `MassiveError` exhaustively — add a wildcard (`_`) arm.
 - **BREAKING: `MassiveRestClient::with_base_url` now returns `Result<Self, MassiveError>`**
   (`rustrade-data`). The base URL is parsed into its trusted origin once, at construction, and cached
-  on the client — so a base URL that is not a valid URL now fails fast with
-  `MassiveError::InvalidInput` here instead of surfacing as a deferred error on the first request, and
-  every `next_url` origin check compares against the cached origin rather than re-parsing the base URL
-  per page. Migration: append `?` or `.expect(..)` to existing `with_base_url(..)` calls. (#198)
+  on the client — so a base URL that is not a valid URL, or one whose scheme is not `http`/`https`,
+  now fails fast with `MassiveError::InvalidInput` here instead of surfacing as a deferred error on
+  the first request, and every `next_url` origin check compares against the cached origin rather than
+  re-parsing the base URL per page. (Rejecting non-`http(s)` schemes at construction avoids a
+  confusing failure mode: a scheme such as `file:` parses but yields an opaque origin that never
+  compares equal, which would otherwise brick every request with a misleading `UntrustedNextUrl`.)
+  Migration: append `?` or `.expect(..)` to existing `with_base_url(..)` calls. (#198)
 - **`EngineEvent` is now `#[non_exhaustive]` and gains a `CorporateAction` variant** (`rustrade`).
   Marking it non-exhaustive lets future engine-driven event variants be added without further
   breaking changes. **Breaking** for downstream code matching `EngineEvent` exhaustively — add a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Bounded, cycle-safe pagination for Massive REST fetches** (`rustrade-data`). Every Massive
+  `next_url`-paginated fetch (`fetch_aggregates`, `fetch_trades`, `fetch_quotes`, `fetch_tickers`,
+  `fetch_dividends`, `fetch_splits_raw`, `fetch_option_contracts`, `fetch_option_chain_snapshot`)
+  now caps the number of pages it will follow and detects a `next_url` that revisits an
+  already-fetched page, yielding a terminal error instead of paginating without bound. Because a
+  silently truncated result is indistinguishable from a genuinely small one for a market-data
+  client, incomplete pagination fails loudly rather than returning a partial result. Two new
+  `MassiveError` variants carry the diagnosis: `PaginationLimitExceeded { pages, limit }` and
+  `CyclicPagination { url }`.
+
 - **Corporate-action stock-split processing** (`rustrade`). The engine now handles
   `EngineEvent::CorporateAction` for stock/reverse splits, adjusting every open position on the
   target Spot instrument (the same per-position rescale as `Position::apply_split`) and emitting
@@ -115,6 +125,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`MassiveError` is now `#[non_exhaustive]`** (`rustrade-data`). Lets new variants (such as the
+  pagination-robustness errors above) be added without further breaking changes. **Breaking** for
+  downstream code matching `MassiveError` exhaustively — add a wildcard (`_`) arm.
 - **`EngineEvent` is now `#[non_exhaustive]` and gains a `CorporateAction` variant** (`rustrade`).
   Marking it non-exhaustive lets future engine-driven event variants be added without further
   breaking changes. **Breaking** for downstream code matching `EngineEvent` exhaustively — add a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -396,6 +396,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an already-bounded message would leave a credential straddling the cap present as an unmatched
   prefix fragment, and both cuts use the same width, leaving no protective gap.
   `Parse` is now bounded on every path and scrubbed on every path where a token is in scope.
+- **Token-scrubbed and bounded `IbkrFlexError::Flex`** (`rustrade-data`, `ibkr` feature). A terminal
+  Flex error's `message` is the `<ErrorMessage>` element lifted verbatim from the same server-supplied
+  body that `HttpStatus`/`Parse` already scrub, so a proxy reflecting the request line into it could
+  carry the `t=` token into the stored error, and an oversized element could bloat it. Both fields
+  (`code` and `message`) now pass through the same redact-before-bound path (capped at 1 KiB) when the
+  interpreter finalises a Flex error; the scrub is a no-op for a real numeric Flex code/message. No
+  public API change and no change for well-behaved responses.
 - Upgraded `anyhow` to 1.0.103 and `quick-xml` to 0.41.0 to clear three RUSTSEC advisories:
   RUSTSEC-2026-0190 (unsoundness in `anyhow::Error::downcast_mut`), RUSTSEC-2026-0194 (quadratic
   run time when checking a start tag for duplicate attribute names) and RUSTSEC-2026-0195

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4498,6 +4498,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-util",
+ "http 1.4.0",
  "hyperliquid_rust_sdk",
  "ibapi",
  "itertools 0.15.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,6 +4524,7 @@ dependencies = [
  "url",
  "urlencoding",
  "vecmap-rs",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ quick-xml = { version = "0.41", features = ["serialize"] }
 # Protocol
 url = { version = "2.5.4" }
 reqwest = { version = "0.13.3", default-features = false, features = ["rustls", "json", "query"] }
+# HTTP type definitions. Used in tests to build synthetic `reqwest::Response`s via reqwest's
+# `From<http::Response<_>>`; already in the tree as a reqwest dependency.
+http = { version = "1" }
 tokio-tungstenite = { version = "0.30.0", features = ["url","rustls-tls-webpki-roots"] }
 
 # Data Structures

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -32,6 +32,7 @@ time = { version = "0.3", features = ["macros"] }  # For ibkr tests and databent
 temp-env = { workspace = true }
 serial_test = { workspace = true }  # For Massive WebSocket tests (1 connection limit)
 wiremock = { workspace = true }  # For Massive REST pagination tests (mock next_url chains)
+http = { workspace = true }  # Builds synthetic `reqwest::Response`s (via reqwest's `From<http::Response<_>>`) for socket-free transport tests; already in the tree via reqwest
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }  # `test-util` = paused-clock poll-timing tests
 
 [dependencies]

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -31,6 +31,7 @@ rust_decimal_macros = { workspace = true }
 time = { version = "0.3", features = ["macros"] }  # For ibkr tests and databento examples
 temp-env = { workspace = true }
 serial_test = { workspace = true }  # For Massive WebSocket tests (1 connection limit)
+wiremock = { workspace = true }  # For Massive REST pagination tests (mock next_url chains)
 
 [dependencies]
 # Rustrade Ecosystem

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -32,6 +32,7 @@ time = { version = "0.3", features = ["macros"] }  # For ibkr tests and databent
 temp-env = { workspace = true }
 serial_test = { workspace = true }  # For Massive WebSocket tests (1 connection limit)
 wiremock = { workspace = true }  # For Massive REST pagination tests (mock next_url chains)
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }  # `test-util` = paused-clock poll-timing tests
 
 [dependencies]
 # Rustrade Ecosystem

--- a/rustrade-data/src/exchange/alpaca/reference.rs
+++ b/rustrade-data/src/exchange/alpaca/reference.rs
@@ -1,10 +1,9 @@
 //! Alpaca corporate-actions reference data (`GET /v1beta1/corporate-actions`).
 //!
-//! The raw REST surface behind the [`StockSplitSource`] adapter (see
-//! [`corporate_action`](super::corporate_action)): a [`CorporateActionsQuery`] builder, the nested
-//! response types, and the paginated [`AlpacaRestClient::fetch_splits_raw`] stream. Only stock-split
-//! actions are requested (`types=forward_split,reverse_split`); each row is normalised into an
-//! [`AlpacaStockSplit`].
+//! The raw REST surface behind the [`StockSplitSource`] adapter: a [`CorporateActionsQuery`]
+//! builder, the nested response types, and the paginated
+//! [`AlpacaRestClient::fetch_splits_raw`] stream. Only stock-split actions are requested
+//! (`types=forward_split,reverse_split`); each row is normalised into an [`AlpacaStockSplit`].
 //!
 //! # Date semantics
 //!
@@ -12,8 +11,8 @@
 //! re-bases and the price adjusts (observed equal to `process_date` across every sampled split).
 //! It is the field the [`StockSplitSource`] adapter maps onto the descriptor's `effective_date`.
 //! Alpaca also returns `payable_date`, which can fall a trading day *before* `ex_date` for forward
-//! splits and therefore must NOT be used as the effective date — see
-//! [`corporate_action`](super::corporate_action) for the full rationale.
+//! splits and therefore must NOT be used as the effective date: an effective date earlier than the
+//! true ex-date would re-base a position before the market actually did.
 //!
 //! [`StockSplitSource`]: rustrade_integration::corporate_action::StockSplitSource
 
@@ -64,7 +63,7 @@ pub struct CorporateActionsQuery {
     pub start: Option<NaiveDate>,
     /// Inclusive upper bound on the action's effective date.
     pub end: Option<NaiveDate>,
-    /// Results per page (clamped to [`MAX_LIMIT`]).
+    /// Results per page (clamped to 1000, the API maximum).
     pub limit: Option<u16>,
 }
 
@@ -214,7 +213,7 @@ impl AlpacaRestClient {
     ///
     /// Returns a stream that handles `page_token` pagination automatically, yielding each
     /// forward/reverse split as a normalised [`AlpacaStockSplit`]. The stream stops after
-    /// [`MAX_PAGES`] pages as a safety bound and logs a warning if that limit is hit.
+    /// 1000 pages as a safety bound and logs a warning if that limit is hit.
     ///
     /// # Example
     ///
@@ -311,6 +310,17 @@ mod tests {
     fn query_limit_clamped_to_max() {
         let params = CorporateActionsQuery::new().limit(5000).to_query_params();
         assert!(params.iter().any(|(k, v)| *k == "limit" && v == "1000"));
+    }
+
+    #[test]
+    fn documented_limits_match_their_constants() {
+        // Pinned against literals because the public rustdoc states both bounds in prose ("clamped
+        // to 1000", "1000 pages") — it cannot link these private constants under
+        // `deny(rustdoc::private_intra_doc_links)`. Without this, changing a constant would leave
+        // the documented contract silently wrong. `MAX_LIMIT` is also covered indirectly by the
+        // wire-param assertions above; `MAX_PAGES` has no other pin.
+        assert_eq!(MAX_LIMIT, 1000);
+        assert_eq!(MAX_PAGES, 1000);
     }
 
     #[test]

--- a/rustrade-data/src/exchange/alpaca/rest.rs
+++ b/rustrade-data/src/exchange/alpaca/rest.rs
@@ -79,9 +79,7 @@ pub enum AlpacaRestError {
 ///
 /// Holds the configured [`reqwest::Client`] (with auth headers + timeout) plus the broker and data
 /// API base URLs. Endpoint-family wrappers (`AlpacaOptionsClient`, the corporate-action source, …)
-/// build requests against these bases and drive them through [`request_with_retry`].
-///
-/// [`request_with_retry`]: AlpacaRestClient::request_with_retry
+/// build requests against these bases and drive them through a shared retrying request helper.
 #[derive(Clone)]
 pub struct AlpacaRestClient {
     http: reqwest::Client,

--- a/rustrade-data/src/exchange/binance/historical.rs
+++ b/rustrade-data/src/exchange/binance/historical.rs
@@ -59,6 +59,7 @@
 //! case rarely trips a `429` in the first place.
 
 use super::error::BinanceDataError;
+use crate::exchange::http::{MAX_ERROR_BODY_DOWNLOAD_BYTES, read_body_capped, truncate_str};
 use crate::subscription::candle::{
     Candle, CandleInterval, close_time_from_open, open_time_from_close,
 };
@@ -420,19 +421,23 @@ impl BinanceHistoricalClient {
             return Err(BinanceDataError::RateLimited { retry_after });
         }
 
-        let body = response.text().await?;
-
+        // A non-success body is only a diagnostic that `truncate_str` caps for the error message, so
+        // read it under a bound: a pathological proxy/CDN error page must not be buffered in full.
+        // The success body is the real kline JSON and is read whole below.
         if !status.is_success() {
+            let body = read_body_capped(response, MAX_ERROR_BODY_DOWNLOAD_BYTES).await?;
             return Err(BinanceDataError::Api {
                 status: status.as_u16(),
-                message: truncate_body(&body),
+                message: truncate_str(&body, ERROR_MESSAGE_BODY_BYTES),
             });
         }
+
+        let body = response.text().await?;
 
         serde_json::from_str::<Vec<BinanceKlineRow>>(&body).map_err(|e| {
             BinanceDataError::Deserialize {
                 message: e.to_string(),
-                payload: truncate_body(&body),
+                payload: truncate_str(&body, ERROR_MESSAGE_BODY_BYTES),
             }
         })
     }
@@ -458,11 +463,8 @@ fn validate_symbol(symbol: &str) -> Result<String, BinanceDataError> {
     Ok(symbol.to_uppercase())
 }
 
-/// Truncate a response body for error messages (max 512 chars, UTF-8 safe).
-fn truncate_body(body: &str) -> String {
-    let boundary = body.floor_char_boundary(512);
-    body[..boundary].to_owned()
-}
+/// Byte cap applied to a response body before it is stored in a [`BinanceDataError`] message.
+const ERROR_MESSAGE_BODY_BYTES: usize = 512;
 
 /// One Binance kline, as the wire's positional array-of-arrays row.
 ///
@@ -959,6 +961,45 @@ mod tests {
             stream.next().await.is_none(),
             "the stream must end after RateLimited"
         );
+        server.join().expect("mock server panicked");
+    }
+
+    #[tokio::test]
+    async fn non_success_status_yields_api_error_carrying_the_body() {
+        // The generic non-2xx branch had no coverage — only the 429/418 short-circuit above did — so
+        // nothing pinned that a plain error status surfaces as `Api` at all, that it is reached
+        // *after* the rate-limit check rather than swallowing 429, or that the server's diagnostic
+        // body survives into the message where an operator can read it.
+        //
+        // Deliberately a *small* body. The download cap that `read_body_capped` applies is 64 KiB
+        // while `ERROR_MESSAGE_BODY_BYTES` retains 512, so the outer truncation always dominates and
+        // an oversized body here would prove nothing about the cap — the assertion would hold
+        // identically against an unbounded `response.text()`. The cap is covered where it is
+        // observable, against a real chunk stream: see `read_body_capped`'s tests in `exchange::http`.
+        let (url, server) = spawn_mock(vec![MockResponse {
+            status: 400,
+            retry_after_secs: None,
+            body: r#"{"code":-1121,"msg":"Invalid symbol."}"#.to_owned(),
+        }]);
+
+        let client = BinanceHistoricalClient::spot()
+            .with_base_url(url)
+            .with_pace(Duration::ZERO);
+        let err = client
+            .collect_candles("BTCUSDT", CandleInterval::Min1, ms(0), ms(MIN_MS))
+            .await
+            .unwrap_err();
+
+        match err {
+            BinanceDataError::Api { status, message } => {
+                assert_eq!(status, 400);
+                assert!(
+                    message.contains("Invalid symbol."),
+                    "the diagnostic body must survive into the error, got: {message}"
+                );
+            }
+            other => panic!("expected Api, got {other:?}"),
+        }
         server.join().expect("mock server panicked");
     }
 }

--- a/rustrade-data/src/exchange/http.rs
+++ b/rustrade-data/src/exchange/http.rs
@@ -1,0 +1,107 @@
+//! Small HTTP helpers shared by the REST-based exchange integrations.
+
+/// Cap for error-path body reads (see [`read_body_capped`]).
+///
+/// Generous relative to any real diagnostic envelope — so it never truncates a legitimate error or
+/// status response the caller still needs to parse — while bounding a pathological proxy/CDN error
+/// page that would otherwise be buffered without limit.
+pub(crate) const MAX_ERROR_BODY_DOWNLOAD_BYTES: usize = 64 * 1024;
+
+/// Read a response body, stopping after at most `cap` bytes and discarding the rest of the stream.
+///
+/// Intended for **error paths only**. A non-success response body is a human-facing diagnostic that
+/// callers truncate further for storage anyway, so a pathological proxy/CDN error page must not be
+/// buffered in full just to extract a short message. Success bodies are real payload and should
+/// still be read in full via [`reqwest::Response::text`].
+///
+/// `cap` should be chosen well above any legitimate error/status envelope the caller may still need
+/// to parse, yet far below an unbounded page — its purpose is to bound the pathological case, not to
+/// trim normal responses (see [`MAX_ERROR_BODY_DOWNLOAD_BYTES`]). A byte cap can land mid-character,
+/// so an invalid trailing sequence is decoded lossily (`U+FFFD`), which is acceptable for a
+/// diagnostic string. Reaching the cap drops the response, aborting the remainder of the download.
+///
+/// Any `reqwest::Error` from the underlying stream is propagated unchanged, so a caller whose
+/// `From<reqwest::Error>` conversion strips the URL (e.g. to avoid leaking a token in the query
+/// string) keeps that protection.
+pub(crate) async fn read_body_capped(
+    mut response: reqwest::Response,
+    cap: usize,
+) -> Result<String, reqwest::Error> {
+    let mut buf: Vec<u8> = Vec::new();
+    while buf.len() < cap {
+        let Some(chunk) = response.chunk().await? else {
+            break;
+        };
+        let remaining = cap - buf.len();
+        if chunk.len() <= remaining {
+            buf.extend_from_slice(&chunk);
+        } else {
+            buf.extend_from_slice(&chunk[..remaining]);
+            break;
+        }
+    }
+    // `from_utf8` consumes `buf` without copying on the valid-UTF-8 path (the overwhelmingly common
+    // case for a JSON/XML diagnostic); the lossy re-decode only pays for a second buffer when the cap
+    // actually split a multi-byte character.
+    Ok(String::from_utf8(buf)
+        .unwrap_or_else(|error| String::from_utf8_lossy(error.as_bytes()).into_owned()))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Tests should panic on unexpected values.
+mod tests {
+    use super::*;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Serve `body` under a non-success status and read it back through [`read_body_capped`] at `cap`,
+    /// exercising the real `reqwest` chunk stream rather than an in-memory buffer.
+    async fn read_capped(body: impl Into<String>, cap: usize) -> String {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500).set_body_string(body.into()))
+            .mount(&server)
+            .await;
+        let response = reqwest::Client::new()
+            .get(server.uri())
+            .send()
+            .await
+            .unwrap();
+        read_body_capped(response, cap).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn body_under_cap_is_returned_whole() {
+        // The common case: a real diagnostic envelope is far below the cap and must survive intact.
+        assert_eq!(
+            read_capped("{\"error\":\"not found\"}", 1024).await,
+            "{\"error\":\"not found\"}"
+        );
+    }
+
+    #[tokio::test]
+    async fn body_over_cap_is_truncated_at_the_exact_byte() {
+        assert_eq!(read_capped("0123456789", 4).await, "0123");
+    }
+
+    #[tokio::test]
+    async fn cap_landing_mid_character_decodes_lossily_instead_of_panicking() {
+        // `é` is 0xC3 0xA9, so a cap of 1 splits it. A byte cap has no obligation to respect char
+        // boundaries — the contract is a valid `String` out, with the partial sequence as U+FFFD.
+        assert_eq!(read_capped("é", 1).await, "\u{FFFD}");
+    }
+
+    #[tokio::test]
+    async fn empty_body_is_read_as_empty_rather_than_erroring() {
+        assert_eq!(read_capped("", 1024).await, "");
+    }
+
+    #[tokio::test]
+    async fn pathological_body_is_bounded_to_the_shared_download_cap() {
+        // The case the helper exists for: a body far larger than the cap, delivered over multiple
+        // chunks, is bounded to exactly `MAX_ERROR_BODY_DOWNLOAD_BYTES` instead of being buffered whole.
+        let oversized = "a".repeat(MAX_ERROR_BODY_DOWNLOAD_BYTES * 4);
+        let read = read_capped(oversized, MAX_ERROR_BODY_DOWNLOAD_BYTES).await;
+        assert_eq!(read.len(), MAX_ERROR_BODY_DOWNLOAD_BYTES);
+    }
+}

--- a/rustrade-data/src/exchange/http.rs
+++ b/rustrade-data/src/exchange/http.rs
@@ -1,5 +1,20 @@
 //! Small HTTP helpers shared by the REST-based exchange integrations.
 
+/// Truncate `s` to at most `max_bytes` bytes, rounding down to a UTF-8 char boundary.
+///
+/// A byte budget can land mid-character, which `String::truncate` and a naive `&s[..n]` both
+/// reject (panicking on a non-boundary index). [`str::floor_char_boundary`] rounds down to the
+/// nearest boundary — one always exists at or below any index — so the result is always a valid
+/// `str`, at the cost of dropping the straddling character.
+///
+/// The cap is a parameter rather than a constant because callers budget differently for different
+/// contexts: a full error message, a short inline snippet, and a proxy/CDN error page are not the
+/// same size problem. Sharing the *function* keeps the boundary-safety logic in one place; sharing
+/// one *constant* across those contexts would be false consistency.
+pub(crate) fn truncate_str(s: &str, max_bytes: usize) -> String {
+    s[..s.floor_char_boundary(max_bytes)].to_owned()
+}
+
 /// Cap for error-path body reads (see [`read_body_capped`]).
 ///
 /// Generous relative to any real diagnostic envelope — so it never truncates a legitimate error or
@@ -45,6 +60,37 @@ pub(crate) async fn read_body_capped(
     // actually split a multi-byte character.
     Ok(String::from_utf8(buf)
         .unwrap_or_else(|error| String::from_utf8_lossy(error.as_bytes()).into_owned()))
+}
+
+#[cfg(test)]
+mod truncate_str_tests {
+    use super::*;
+
+    #[test]
+    fn shorter_than_the_cap_is_returned_whole() {
+        assert_eq!(truncate_str("abc", 512), "abc");
+    }
+
+    #[test]
+    fn longer_than_the_cap_is_cut_at_the_exact_byte() {
+        assert_eq!(truncate_str("0123456789", 4), "0123");
+    }
+
+    #[test]
+    fn a_cap_splitting_a_multi_byte_char_rounds_down_instead_of_panicking() {
+        // `€` is 3 bytes, so a cap of 2 lands inside it. Rounding down drops the whole character
+        // rather than slicing it into an invalid `str` (which would panic).
+        assert_eq!(truncate_str("€", 2), "");
+        assert_eq!(truncate_str("a€", 3), "a");
+        assert_eq!(truncate_str("a€", 4), "a€");
+    }
+
+    #[test]
+    fn a_cap_beyond_the_string_is_not_out_of_bounds() {
+        // `floor_char_boundary` saturates at `len`, so an over-large cap is a no-op rather than a
+        // panicking slice.
+        assert_eq!(truncate_str("abc", usize::MAX), "abc");
+    }
 }
 
 #[cfg(test)]

--- a/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/corporate_action.rs
@@ -29,13 +29,25 @@ use serde::Deserialize;
 use smol_str::SmolStr;
 use tracing::warn;
 
-use super::{IbkrFlexError, nonempty};
+use super::{IbkrFlexError, finish_parse_error, nonempty};
 
 /// A single corporate-action row from an IBKR Flex statement, surfaced verbatim.
 ///
 /// Every field mirrors a Flex `<CorporateAction>` attribute with no interpretation applied beyond
 /// type coercion (string → `Decimal`/`NaiveDate`) and treating absent/empty attributes as `None`.
-/// See the [module docs](self) for why this is a reconciliation record and not a split-ratio source.
+///
+/// This is a **reconciliation** record, not a split-ratio source, and three limitations follow from
+/// that:
+///
+/// - **No ratio is derived.** Flex carries no standardised split-ratio field, only an action type
+///   plus an account-scoped share delta. Deriving a ratio would mean parsing the unstable free-text
+///   `action_description` or dividing post- by pre-event holdings (account state this library does
+///   not own) — both silent-failure risks, so ratio derivation is left to the caller.
+/// - **These records cannot drive a live split.** A Flex statement is *post-hoc*: `report_date` is
+///   when the broker booked the action (typically T+1 or later), not the market execution date a
+///   backtest or live engine needs.
+/// - **Records are account-scoped.** `quantity_delta` is the change to *this account's* position,
+///   not a market-wide quantity; two accounts see different deltas for the same action.
 ///
 /// `#[non_exhaustive]`: IBKR may add attributes to the Flex schema; new fields are surfaced
 /// additively without a breaking change. Construct instances via [`parse_corporate_actions`], not a
@@ -168,6 +180,25 @@ impl From<&str> for IbkrReorgType {
 /// Returns [`IbkrFlexError::Parse`] if the document is not well-formed XML or does not match the
 /// expected Flex statement shape.
 pub fn parse_corporate_actions(xml: &str) -> Result<Vec<IbkrFlexCorporateAction>, IbkrFlexError> {
+    parse_corporate_actions_scrubbed(xml, None)
+}
+
+/// [`parse_corporate_actions`], additionally redacting `token` from any error message.
+///
+/// Exists because the two callers differ in what they are able to protect. Called directly, this
+/// parser has no credential in scope and can only *bound* its messages. Called from
+/// [`IbkrFlexClient::fetch_corporate_actions`](super::IbkrFlexClient::fetch_corporate_actions) a
+/// token does exist, and the message must be redacted as well as bounded.
+///
+/// The token is threaded in *here*, rather than the caller scrubbing the returned message, because
+/// the two operations do not commute. Redaction matches the full token, so it has to run while the
+/// message is still unbounded: bounding first can leave a straddling credential present only as a
+/// prefix fragment, which a subsequent full-token match would miss. See
+/// [`sanitize_error_body`](super::sanitize_error_body), which enforces the same ordering internally.
+pub(super) fn parse_corporate_actions_scrubbed(
+    xml: &str,
+    token: Option<&str>,
+) -> Result<Vec<IbkrFlexCorporateAction>, IbkrFlexError> {
     // Assert the document is actually a `<FlexQueryResponse>` statement BEFORE deserializing.
     // quick-xml's serde path does not verify the root element, and the raw structs use
     // `#[serde(default)]`, so an IBKR error/status envelope (`<FlexStatementResponse>`, e.g. an
@@ -179,19 +210,34 @@ pub fn parse_corporate_actions(xml: &str) -> Result<Vec<IbkrFlexCorporateAction>
     match super::root_element_name(xml).as_deref() {
         Some("FlexQueryResponse") => {}
         Some(other) => {
-            return Err(IbkrFlexError::Parse(format!(
-                "expected Flex statement root <FlexQueryResponse>, found <{other}>"
-            )));
+            // `other` is a tag name lifted verbatim out of the supplied document, so an adversarial
+            // or corrupt statement could otherwise inflate the error to the size of the input.
+            // `finish_parse_error` applies the same cap the fetch-response parse path applies —
+            // after redaction, never before it.
+            return Err(finish_parse_error(
+                format!("expected Flex statement root <FlexQueryResponse>, found <{other}>"),
+                token,
+            ));
         }
         None => {
-            return Err(IbkrFlexError::Parse(
+            // Routed through the same finaliser as the branches above even though this message is a
+            // fixed literal with nothing to redact or bound. Uniformity is the point: "every `Parse`
+            // is built by `finish_parse_error`" is a property a reader can check locally, whereas
+            // "every `Parse` that *could* carry a credential is" requires re-auditing each branch
+            // whenever a message gains an interpolated value.
+            return Err(finish_parse_error(
                 "empty or unreadable Flex statement document".to_owned(),
+                token,
             ));
         }
     }
 
-    let response: RawFlexQueryResponse = quick_xml::de::from_str(xml)
-        .map_err(|e| IbkrFlexError::Parse(format!("failed to parse Flex statement XML: {e}")))?;
+    // Bounded for the same reason: a `DeError` embeds the deserialiser's rendering of the offending
+    // input (quick-xml's `UnexpectedStart` carries the raw tag bytes it choked on), so the message
+    // length tracks the document, not the failure.
+    let response: RawFlexQueryResponse = quick_xml::de::from_str(xml).map_err(|e| {
+        finish_parse_error(format!("failed to parse Flex statement XML: {e}"), token)
+    })?;
 
     Ok(response
         .flex_statements
@@ -353,6 +399,53 @@ fn opt_date(value: Option<String>) -> Option<NaiveDate> {
 #[allow(clippy::unwrap_used, clippy::expect_used)] // Tests should panic on unexpected values.
 mod tests {
     use super::*;
+    // Only the assertions below reference the cap directly — `finish_parse_error` applies it.
+    use super::super::MAX_ERROR_BODY_BYTES;
+
+    #[test]
+    fn parse_errors_are_bounded() {
+        // These messages embed the offending document, so their length must track the cap rather
+        // than the input. Both input-reflecting branches are covered: the root-element mismatch and
+        // the deserialiser failure. The short "empty or unreadable" branch is a fixed literal.
+        let huge_root = format!("<{}/>", "a".repeat(8192));
+        match parse_corporate_actions(&huge_root) {
+            Err(IbkrFlexError::Parse(message)) => {
+                assert!(
+                    message.starts_with("expected Flex statement root"),
+                    "must reach the root-element branch, got: {message}"
+                );
+                assert!(
+                    message.len() <= MAX_ERROR_BODY_BYTES,
+                    "bounded to the cap, got {} bytes",
+                    message.len()
+                );
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+
+        // A correct root that then fails to deserialize, driving the `DeError` branch. The inner
+        // tag is left unclosed so quick-xml reports a mismatched end tag, embedding the long name.
+        // (A malformed *attribute* would not do: `quantity` is `Option<String>` and an unparseable
+        // value is coerced to `0` with a warn, so it returns `Ok` and would test nothing.)
+        let huge_body = format!(
+            "<FlexQueryResponse><{}></FlexQueryResponse>",
+            "a".repeat(8192)
+        );
+        match parse_corporate_actions(&huge_body) {
+            Err(IbkrFlexError::Parse(message)) => {
+                assert!(
+                    message.starts_with("failed to parse Flex statement XML"),
+                    "must reach the deserialiser branch, got: {message}"
+                );
+                assert!(
+                    message.len() <= MAX_ERROR_BODY_BYTES,
+                    "bounded to the cap, got {} bytes",
+                    message.len()
+                );
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
 
     const ACTIVITY_FIXTURE: &str =
         include_str!("../../../../tests/fixtures/ibkr_flex/activity_corporate_actions.xml");

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -85,6 +85,28 @@ const GENERATION_IN_PROGRESS_CODE: &str = "1019";
 /// and IBKR error envelopes are tiny; this only bounds an unexpectedly large proxy/CDN error page.
 const MAX_ERROR_BODY_BYTES: usize = 1024;
 
+// The redact-before-bound ordering in `sanitize_error_body` is only safe while the *gap* between the
+// download and retained caps exceeds the token length. A token straddling the coarse
+// `MAX_ERROR_BODY_DOWNLOAD_BYTES` pre-bound survives redaction as an unmatched prefix fragment pinned
+// to the tail of the pre-bounded slice: it ends at the download cap, so a fragment of length `f`
+// starts at `MAX_ERROR_BODY_DOWNLOAD_BYTES - f`. The final `MAX_ERROR_BODY_BYTES` truncation discards
+// it when that start lands at or past the retained cap — i.e. when `f` is at most the gap
+// `MAX_ERROR_BODY_DOWNLOAD_BYTES - MAX_ERROR_BODY_BYTES`. A straddling fragment is always shorter than
+// the whole token, so once the gap exceeds the longest possible token every such fragment is
+// truncated away. That is the invariant.
+//
+// The assert below is a proportional proxy for that gap, not a proof for arbitrary token lengths: a
+// 4x ratio keeps the gap at a floor of 3 * MAX_ERROR_BODY_BYTES (3 KiB at the current retained cap;
+// the actual current gap is far larger), which dwarfs any real Flex token (a short opaque string).
+// Its job is to fail the build — the two constants live in different modules — if a future edit
+// collapses the caps close enough together to shrink that margin below a plausible token, silently
+// reopening the straddling leak.
+const _: () = assert!(
+    MAX_ERROR_BODY_DOWNLOAD_BYTES >= MAX_ERROR_BODY_BYTES * 4,
+    "MAX_ERROR_BODY_DOWNLOAD_BYTES must stay well above MAX_ERROR_BODY_BYTES so a token straddling \
+     the download-cap boundary is truncated away by the retained-cap bound (see sanitize_error_body)"
+);
+
 /// Errors from IBKR Flex Web Service operations.
 ///
 /// `#[non_exhaustive]`: the Flex service may introduce new failure conditions over time, so new
@@ -143,11 +165,18 @@ pub enum IbkrFlexError {
     },
 
     /// The Flex service returned a non-success status (e.g. invalid token, throttled, expired).
+    ///
+    /// `message` is the `<ErrorMessage>` element lifted from a server-supplied body, so — like
+    /// [`IbkrFlexError::HttpStatus`] and [`IbkrFlexError::Parse`] — both fields are bounded to 1 KiB
+    /// and **token-scrubbed** before storage: a proxy that reflected the request line into its
+    /// `<ErrorMessage>` could otherwise carry the `t=` Flex token into it. The scrub is a no-op for a
+    /// real numeric Flex code/message that does not contain the token.
     #[error("Flex service error ({code}): {message}")]
     Flex {
-        /// The Flex `ErrorCode` (empty if the response carried none).
+        /// The Flex `ErrorCode` (empty if the response carried none), bounded and token-scrubbed
+        /// like `message`.
         code: String,
-        /// The Flex `ErrorMessage` (or a synthesised description).
+        /// The Flex `ErrorMessage` (or a synthesised description), bounded and token-scrubbed.
         message: String,
     },
 
@@ -737,6 +766,23 @@ fn flex_error(resp: FlexStatementResponse, stage: &str) -> IbkrFlexError {
     }
 }
 
+/// Scrub the Flex `token` from, and bound, a terminal [`IbkrFlexError::Flex`]'s fields.
+///
+/// A `Flex` error's `message` is the `<ErrorMessage>` element lifted verbatim from a server-supplied
+/// body — the same untrusted source [`IbkrFlexError::HttpStatus`] and [`IbkrFlexError::Parse`]
+/// scrub. A body that reflected the request line (a misconfigured proxy echoing `?t=<TOKEN>` into
+/// its `<ErrorMessage>`) could otherwise carry the credential into the stored error, and an
+/// oversized element could bloat it. `code` is a short structured field in practice, but running it
+/// through the same [`sanitize_error_body`] (redact-before-bound, capped at [`MAX_ERROR_BODY_BYTES`])
+/// costs nothing on this error path and closes the gap uniformly — the scrub is a no-op for a real
+/// numeric Flex code that does not contain the token.
+fn scrub_flex_error(code: String, message: String, token: &str) -> IbkrFlexError {
+    IbkrFlexError::Flex {
+        code: sanitize_error_body(&code, token),
+        message: sanitize_error_body(&message, token),
+    }
+}
+
 /// Interpret a SendRequest response given its HTTP `status` and `body`.
 ///
 /// The body is parsed as a Flex envelope **first**, so an IBKR application error that arrives under
@@ -744,7 +790,9 @@ fn flex_error(resp: FlexStatementResponse, stage: &str) -> IbkrFlexError {
 /// token). A body that is *not* a recognizable Flex envelope under a non-success status becomes
 /// [`IbkrFlexError::HttpStatus`] (a proxy/CDN error page) rather than a misleading XML parse error;
 /// the same malformed body under a 2xx status stays a genuine [`IbkrFlexError::Parse`] — with its
-/// message token-scrubbed, since an XML deserialiser embeds fragments of the offending input.
+/// message token-scrubbed, since an XML deserialiser embeds fragments of the offending input. A
+/// genuine Flex error envelope surfaces as [`IbkrFlexError::Flex`], its fields likewise scrubbed and
+/// bounded ([`scrub_flex_error`]), since `<ErrorMessage>` is server-supplied free text.
 fn interpret_send_response(
     status: reqwest::StatusCode,
     body: &str,
@@ -755,6 +803,7 @@ fn interpret_send_response(
             Err(http_status_error(status, body, token))
         }
         Err(IbkrFlexError::Parse(message)) => Err(finish_parse_error(message, Some(token))),
+        Err(IbkrFlexError::Flex { code, message }) => Err(scrub_flex_error(code, message, token)),
         other => other,
     }
 }
@@ -765,7 +814,8 @@ fn interpret_send_response(
 /// non-2xx status is still recognized as retryable — previously `error_for_status` aborted the poll
 /// before the body was classified. A body that is not a recognizable Flex envelope under a
 /// non-success status becomes [`IbkrFlexError::HttpStatus`]; a terminal Flex error envelope under a
-/// non-2xx status stays the richer [`IbkrFlexError::Flex`].
+/// non-2xx status stays the richer [`IbkrFlexError::Flex`], its fields scrubbed and bounded
+/// ([`scrub_flex_error`]) since `<ErrorMessage>` is server-supplied free text.
 fn interpret_poll_response(
     status: reqwest::StatusCode,
     body: &str,
@@ -776,6 +826,7 @@ fn interpret_poll_response(
             Err(http_status_error(status, body, token))
         }
         Err(IbkrFlexError::Parse(message)) => Err(finish_parse_error(message, Some(token))),
+        Err(IbkrFlexError::Flex { code, message }) => Err(scrub_flex_error(code, message, token)),
         other => other,
     }
 }
@@ -789,11 +840,22 @@ fn interpret_poll_response(
 /// therefore carry the credential into the stored error, which [`IbkrFlexError::HttpStatus`] is
 /// already protected against but this variant was not.
 ///
-/// **Every** `Parse` in this module is constructed here, including the token-less case, so that the
-/// redact-before-bound ordering exists in exactly one place. That ordering is a security invariant,
-/// not an implementation detail: redaction matches the full token, so bounding first can leave a
-/// credential straddling the cap present only as an unmatched prefix fragment. Two helpers that had
-/// to be kept in step would be one edit away from diverging on it.
+/// This is the single **finaliser** for a `Parse` that leaves the module — not the single
+/// construction point. The raw parsers [`parse_send_request_response`] and [`classify_get_statement`]
+/// build *unbounded, unscrubbed* `Parse` values directly, but they are private and every production
+/// caller routes their `Err(Parse(_))` back through here (or, for a non-2xx non-envelope body,
+/// through [`http_status_error`]): see [`interpret_send_response`]/[`interpret_poll_response`], and
+/// [`parse_corporate_actions_scrubbed`](corporate_action::parse_corporate_actions_scrubbed) for the
+/// statement re-parse. Keeping the redact-before-bound ordering in exactly one place is what makes
+/// that safe: it is a security invariant, not an implementation detail — redaction matches the full
+/// token, so bounding first can leave a credential straddling the cap present only as an unmatched
+/// prefix fragment. A finaliser duplicated across callers would be one edit away from diverging on
+/// it.
+///
+/// Maintainer corollary: the guarantee is caller discipline over two private parsers, **not** a
+/// property the type system enforces. A *new* call site for either raw parser must route its `Parse`
+/// through this function (or `http_status_error`) too, or it reintroduces the unbounded/unscrubbed
+/// leak this exists to prevent.
 ///
 /// `message` must therefore arrive unbounded — a caller that has already truncated at
 /// [`MAX_ERROR_BODY_BYTES`] has already lost the guarantee, and passing it here cannot recover it.
@@ -1290,6 +1352,98 @@ mod tests {
         match interpret_poll_response(reqwest::StatusCode::BAD_REQUEST, GET_FAIL, "tok") {
             Err(IbkrFlexError::Flex { code, .. }) => assert_eq!(code, "1020"),
             other => panic!("expected Flex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpret_send_response_flex_error_message_is_token_scrubbed() {
+        // A genuine Flex error envelope's <ErrorMessage> is server-supplied free text — a
+        // misconfigured proxy could reflect the request line (with the `t=` token) into it. The
+        // stored Flex error must never carry the credential, the same protection HttpStatus/Parse
+        // already have. The Flex code is still preserved so consumers can match on it.
+        let token = "super-secret-token";
+        let body = format!(
+            "<FlexStatementResponse><Status>Fail</Status><ErrorCode>1003</ErrorCode>\
+             <ErrorMessage>invalid token for GET /SendRequest?t={token}&amp;q=1&amp;v=3</ErrorMessage>\
+             </FlexStatementResponse>"
+        );
+        match interpret_send_response(reqwest::StatusCode::OK, &body, token) {
+            Err(IbkrFlexError::Flex { code, message }) => {
+                assert_eq!(code, "1003", "the Flex code is preserved for matching");
+                assert!(
+                    !message.contains(token),
+                    "token must be redacted, got: {message}"
+                );
+                assert!(message.contains("[REDACTED]"));
+            }
+            other => panic!("expected Flex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpret_poll_response_flex_error_message_is_token_scrubbed() {
+        // Sibling of the SendRequest case above, for the GetStatement poll path.
+        let token = "super-secret-token";
+        let body = format!(
+            "<FlexStatementResponse><Status>Fail</Status><ErrorCode>1020</ErrorCode>\
+             <ErrorMessage>bad reference for GET /GetStatement?t={token}&amp;q=1&amp;v=3</ErrorMessage>\
+             </FlexStatementResponse>"
+        );
+        match interpret_poll_response(reqwest::StatusCode::OK, &body, token) {
+            Err(IbkrFlexError::Flex { code, message }) => {
+                assert_eq!(code, "1020");
+                assert!(
+                    !message.contains(token),
+                    "token must be redacted, got: {message}"
+                );
+                assert!(message.contains("[REDACTED]"));
+            }
+            other => panic!("expected Flex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpret_send_response_flex_error_code_is_token_scrubbed() {
+        // `scrub_flex_error` runs `code` through the same redact-before-bound path as `message`, so a
+        // token reflected into a `<ErrorCode>` (a no-op for the real numeric codes IBKR returns, but
+        // the field is still server-supplied) must not survive into the stored error either.
+        let token = "super-secret-token";
+        let body = format!(
+            "<FlexStatementResponse><Status>Fail</Status>\
+             <ErrorCode>bogus t={token}</ErrorCode>\
+             <ErrorMessage>rejected</ErrorMessage></FlexStatementResponse>"
+        );
+        match interpret_send_response(reqwest::StatusCode::OK, &body, token) {
+            Err(IbkrFlexError::Flex { code, message }) => {
+                assert!(
+                    !code.contains(token),
+                    "token must be redacted from code, got: {code}"
+                );
+                assert!(code.contains("[REDACTED]"));
+                assert_eq!(message, "rejected");
+            }
+            other => panic!("expected Flex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flex_error_message_is_bounded() {
+        // A `Flex` message derives from an unbounded 2xx `response.text()` read, so an adversarial or
+        // buggy server returning a well-formed Flex error envelope with a huge <ErrorMessage> must be
+        // bounded like HttpStatus/Parse, not stored whole. Multi-byte chars confirm the cap lands on
+        // a char boundary rather than panicking.
+        let body = format!(
+            "<FlexStatementResponse><Status>Fail</Status><ErrorCode>1003</ErrorCode>\
+             <ErrorMessage>{}</ErrorMessage></FlexStatementResponse>",
+            "€".repeat(1000) // 3000 bytes, exceeds the 1024-byte cap
+        );
+        match interpret_send_response(reqwest::StatusCode::OK, &body, "tok") {
+            Err(IbkrFlexError::Flex { message, .. }) => assert!(
+                message.len() <= MAX_ERROR_BODY_BYTES,
+                "message bounded to the cap, got {} bytes",
+                message.len()
+            ),
+            other => panic!("expected Flex, got {other:?}"),
         }
     }
 

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -17,7 +17,9 @@
 //!    until it returns the `<FlexQueryResponse>` statement (or a terminal error).
 //!
 //! Non-success statuses (e.g. `1003` invalid token, `1018` throttled, token-expired) surface as
-//! [`IbkrFlexError::Flex`]; exhausting the poll budget surfaces as [`IbkrFlexError::PollTimeout`].
+//! [`IbkrFlexError::Flex`]; a non-success HTTP status whose body is *not* a recognizable Flex
+//! envelope (e.g. a proxy/CDN error page) surfaces as [`IbkrFlexError::HttpStatus`]; exhausting the
+//! poll budget surfaces as [`IbkrFlexError::PollTimeout`].
 //!
 //! This service uses an HTTPS token + saved-query id — it does **not** use IB Gateway / TWS, so it
 //! is entirely independent of the socket [`IbkrStreamConfig`](crate::exchange::ibkr::IbkrStreamConfig).
@@ -68,9 +70,19 @@ const POLL_MAX_ATTEMPTS: u32 = 12;
 /// Delay between GetStatement poll attempts while the statement is still generating.
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 
+/// Delay before the *first* GetStatement poll. The statement is generated asynchronously, so the
+/// first poll almost always reports [`GENERATION_IN_PROGRESS_CODE`]; waiting once up front keeps
+/// that near-certain miss from consuming one of the bounded poll attempts. Overridable via
+/// [`FlexPollPolicy`].
+const POLL_INITIAL_DELAY: Duration = Duration::from_secs(5);
+
 /// Flex `ErrorCode` meaning "statement generation in progress, try again shortly" — the only
 /// non-success status that should be retried rather than surfaced as an error.
 const GENERATION_IN_PROGRESS_CODE: &str = "1019";
+
+/// Maximum number of bytes of a non-Flex error body retained in [`IbkrFlexError::HttpStatus`]. Flex
+/// and IBKR error envelopes are tiny; this only bounds an unexpectedly large proxy/CDN error page.
+const MAX_ERROR_BODY_BYTES: usize = 1024;
 
 /// Errors from IBKR Flex Web Service operations.
 ///
@@ -90,20 +102,42 @@ pub enum IbkrFlexError {
     #[error("invalid credential: {0}")]
     InvalidCredential(String),
 
-    /// Transport-level HTTP error (connection, timeout, or non-2xx status).
+    /// Transport-level HTTP error (connection, timeout, or body-decode failure).
+    ///
+    /// A non-2xx HTTP *status* no longer surfaces here: the client reads the response body **before**
+    /// branching on status and reports a non-success status as [`IbkrFlexError::HttpStatus`] (or the
+    /// richer [`IbkrFlexError::Flex`] when the body is a Flex error envelope). This variant is now
+    /// purely a connection/timeout/decode failure.
     ///
     /// The inner [`reqwest::Error`] **never carries the request URL.** The Flex token is
     /// transmitted as `t=<TOKEN>` in every request URL, and `reqwest::Error`'s `Display` and
     /// `Debug` both embed that URL verbatim when present. The `From<reqwest::Error>` conversion
     /// for this type always strips it via [`reqwest::Error::without_url`] before the error is
-    /// stored, covering every reqwest site that attaches a URL (`send`, `error_for_status`, body
-    /// decode); `Client::build()` errors carry no URL, so the strip is a no-op for them. The
-    /// `source()` chain (hyper/IO transport errors) is preserved and does not independently carry
-    /// the URL.
+    /// stored, covering every reqwest site that attaches a URL (`send`, body decode);
+    /// `Client::build()` errors carry no URL, so the strip is a no-op for them. The `source()`
+    /// chain (hyper/IO transport errors) is preserved and does not independently carry the URL.
     ///
     /// Safe to log or display without credential scrubbing.
     #[error("HTTP error: {0}")]
     Http(reqwest::Error),
+
+    /// The service returned a non-success HTTP status whose body was **not** a recognizable Flex
+    /// envelope — e.g. a proxy/CDN/WAF error page or a gateway timeout served in front of the Flex
+    /// Web Service.
+    ///
+    /// The body is read before the status is inspected (so the diagnostic is preserved rather than
+    /// discarded by `error_for_status`), then bounded to [`MAX_ERROR_BODY_BYTES`] and
+    /// **token-scrubbed** before storage: the Flex token rides in the request URL's `t=` parameter,
+    /// so a proxy that echoes the request line into its error page could otherwise reflect the
+    /// credential into this body. An IBKR *application* error that arrives under a non-2xx status is
+    /// still surfaced as the richer [`IbkrFlexError::Flex`], not here.
+    #[error("HTTP status {status}: {body}")]
+    HttpStatus {
+        /// The non-success HTTP status code.
+        status: u16,
+        /// A bounded, token-scrubbed slice of the response body.
+        body: String,
+    },
 
     /// The Flex service returned a non-success status (e.g. invalid token, throttled, expired).
     #[error("Flex service error ({code}): {message}")]
@@ -114,11 +148,12 @@ pub enum IbkrFlexError {
         message: String,
     },
 
-    /// The statement was still generating after [`POLL_MAX_ATTEMPTS`] poll attempts.
+    /// The statement was still generating after the configured poll budget was exhausted.
     #[error("Flex statement not ready after {attempts} poll attempts")]
     PollTimeout {
-        /// Number of poll attempts made before giving up. Currently always [`POLL_MAX_ATTEMPTS`],
-        /// since this error fires only after every attempt reported the statement still generating.
+        /// Number of poll attempts made before giving up — the configured
+        /// [`FlexPollPolicy::max_attempts`] ([`POLL_MAX_ATTEMPTS`] by default), since this error
+        /// fires only after every attempt reported the statement still generating.
         attempts: u32,
     },
 
@@ -137,12 +172,49 @@ pub enum IbkrFlexError {
 ///
 /// Stripping lives in this single conversion rather than per-call-site discipline so the
 /// "[`IbkrFlexError::Http`] never carries the URL" invariant is enforced by the type system: every
-/// `?` on a `reqwest::Error` — at the request sites *and* any path added later — routes through here.
+/// `?` on a `reqwest::Error` — at the request sites (`send`, body decode) *and* any path added later
+/// — routes through here.
 /// [`reqwest::Error::without_url`] sets the stored URL to `None` (a no-op for `Client::build()`
 /// errors, which carry none) while preserving the diagnostic kind/status and `source()` chain.
 impl From<reqwest::Error> for IbkrFlexError {
     fn from(error: reqwest::Error) -> Self {
         IbkrFlexError::Http(error.without_url())
+    }
+}
+
+/// Poll timing for the GetStatement stage of [`IbkrFlexClient::fetch_statement_xml`].
+///
+/// The Flex Web Service generates statements asynchronously, so a fetch polls GetStatement until the
+/// statement is ready. This policy controls that polling:
+///
+/// - `initial_delay` — waited **once** before the first poll. The statement is created
+///   asynchronously, so the first GetStatement almost always reports `1019` ("still generating"); an
+///   initial delay keeps that near-certain miss from consuming one of the bounded attempts.
+/// - `interval` — waited between subsequent polls.
+/// - `max_attempts` — the number of GetStatement polls before giving up with
+///   [`IbkrFlexError::PollTimeout`].
+///
+/// The [`Default`] budget (`initial_delay` 5 s, `interval` 5 s, `max_attempts` 12) suits a typical
+/// small activity statement. A caller fetching a large statement — which takes longer to generate —
+/// can widen the budget via [`IbkrFlexClient::with_poll_policy`]. A `max_attempts` of `0` yields an
+/// immediate [`IbkrFlexError::PollTimeout`] (an observable "no polling requested" outcome).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlexPollPolicy {
+    /// Delay before the first GetStatement poll.
+    pub initial_delay: Duration,
+    /// Delay between subsequent GetStatement polls.
+    pub interval: Duration,
+    /// Maximum number of GetStatement poll attempts before [`IbkrFlexError::PollTimeout`].
+    pub max_attempts: u32,
+}
+
+impl Default for FlexPollPolicy {
+    fn default() -> Self {
+        Self {
+            initial_delay: POLL_INITIAL_DELAY,
+            interval: POLL_INTERVAL,
+            max_attempts: POLL_MAX_ATTEMPTS,
+        }
     }
 }
 
@@ -252,6 +324,7 @@ pub struct IbkrFlexClient {
     token: String,
     query_id: String,
     base_url: String,
+    poll_policy: FlexPollPolicy,
 }
 
 impl fmt::Debug for IbkrFlexClient {
@@ -260,6 +333,7 @@ impl fmt::Debug for IbkrFlexClient {
         f.debug_struct("IbkrFlexClient")
             .field("query_id", &self.query_id)
             .field("base_url", &self.base_url)
+            .field("poll_policy", &self.poll_policy)
             .finish_non_exhaustive()
     }
 }
@@ -280,8 +354,9 @@ impl IbkrFlexClient {
             // `https_only(true)` rejects any request whose own URL is not `https`, catching a
             // misconfigured `http://` base URL before the token reaches the wire. This client issues
             // two GETs to known HTTPS endpoints and expects no redirects, so an unexpected 3xx is
-            // returned unfollowed and surfaces downstream as a body-parse error — never as a silent
-            // scheme downgrade. (The content-layer scheme check on the SendRequest poll URL cannot
+            // returned unfollowed and surfaces downstream as an `IbkrFlexError::HttpStatus` (a
+            // non-success status with a non-Flex body) — never as a silent scheme downgrade. (The
+            // content-layer scheme check on the SendRequest poll URL cannot
             // intercept redirects reqwest would otherwise follow, which is why these guards exist.)
             .https_only(true)
             .redirect(reqwest::redirect::Policy::none())
@@ -291,7 +366,31 @@ impl IbkrFlexClient {
             token: config.token,
             query_id: config.query_id,
             base_url: FLEX_BASE_URL.to_owned(),
+            poll_policy: FlexPollPolicy::default(),
         })
+    }
+
+    /// Override the GetStatement [`FlexPollPolicy`] (poll timing / budget).
+    ///
+    /// Builder-style; defaults to [`FlexPollPolicy::default`]. Widen the budget for a large
+    /// statement (which takes longer to generate):
+    ///
+    /// ```no_run
+    /// # use std::time::Duration;
+    /// # use rustrade_data::exchange::ibkr::{IbkrFlexClient, FlexPollPolicy};
+    /// # fn f() -> Result<(), Box<dyn std::error::Error>> {
+    /// let _client = IbkrFlexClient::from_env()?.with_poll_policy(FlexPollPolicy {
+    ///     initial_delay: Duration::from_secs(10),
+    ///     interval: Duration::from_secs(10),
+    ///     max_attempts: 30,
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn with_poll_policy(mut self, policy: FlexPollPolicy) -> Self {
+        self.poll_policy = policy;
+        self
     }
 
     /// Create a client from environment variables (see [`IbkrFlexConfig::from_env`]).
@@ -306,8 +405,10 @@ impl IbkrFlexClient {
 
     /// Run the full 2-call Flex flow and return the raw `<FlexQueryResponse>` statement XML.
     ///
-    /// Issues SendRequest, then polls GetStatement (up to [`POLL_MAX_ATTEMPTS`] times, sleeping
-    /// [`POLL_INTERVAL`] between attempts) until the statement is ready.
+    /// Issues SendRequest, then polls GetStatement until the statement is ready, governed by this
+    /// client's [`FlexPollPolicy`] (an `initial_delay` before the first poll, `interval` between
+    /// subsequent polls, and a `max_attempts` budget). Defaults to [`FlexPollPolicy::default`];
+    /// override with [`with_poll_policy`](Self::with_poll_policy).
     ///
     /// # Security
     ///
@@ -334,67 +435,80 @@ impl IbkrFlexClient {
     ///
     /// - [`IbkrFlexError::Http`] on a transport failure.
     /// - [`IbkrFlexError::Flex`] if the service reports a terminal non-success status.
+    /// - [`IbkrFlexError::HttpStatus`] if a non-success HTTP status carries a body that is not a
+    ///   recognizable Flex envelope (e.g. a proxy/CDN error page).
     /// - [`IbkrFlexError::PollTimeout`] if the statement is still generating after the poll budget.
     /// - [`IbkrFlexError::Parse`] if a response cannot be parsed.
     pub async fn fetch_statement_xml(&self) -> Result<String, IbkrFlexError> {
         let send_url = format!("{}/SendRequest", self.base_url);
         debug!("Requesting IBKR Flex statement generation");
 
-        // Plain `?` is safe: `IbkrFlexError`'s `From<reqwest::Error>` strips the token-bearing
-        // request URL from every error (see the impl above).
-        let body = self
-            .http
-            .get(&send_url)
-            .query(&[
-                ("t", self.token.as_str()),
-                ("q", self.query_id.as_str()),
-                ("v", FLEX_VERSION),
-            ])
-            .send()
-            .await?
-            .error_for_status()?
-            .text()
+        let (status, body) = self
+            .get_with_query(&send_url, self.query_id.as_str())
             .await?;
-
         let SendRequestOk {
             reference_code,
             url,
-        } = parse_send_request_response(&body)?;
+        } = interpret_send_response(status, &body, &self.token)?;
 
-        for attempt in 1..=POLL_MAX_ATTEMPTS {
-            // Plain `?` as above: the `From` impl strips the token-bearing URL from any reqwest error.
-            let body = self
-                .http
-                .get(&url)
-                .query(&[
-                    ("t", self.token.as_str()),
-                    ("q", reference_code.as_str()),
-                    ("v", FLEX_VERSION),
-                ])
-                .send()
-                .await?
-                .error_for_status()?
-                .text()
-                .await?;
+        // A short initial delay before the first poll: the statement is generated asynchronously, so
+        // an immediate GetStatement almost always reports 1019 ("still generating") and would burn
+        // one of the bounded attempts on a near-certain miss. Skipped when no polls are budgeted
+        // (`max_attempts == 0`), so that documented "no polling requested" case fails over immediately
+        // rather than sleeping before an empty loop.
+        if self.poll_policy.max_attempts > 0 {
+            tokio::time::sleep(self.poll_policy.initial_delay).await;
+        }
 
-            match classify_get_statement(&body)? {
+        for attempt in 1..=self.poll_policy.max_attempts {
+            let (status, body) = self.get_with_query(&url, reference_code.as_str()).await?;
+
+            match interpret_poll_response(status, &body, &self.token)? {
                 GetStatementOutcome::Ready => return Ok(body),
                 GetStatementOutcome::InProgress => {
                     debug!(
                         attempt,
-                        max = POLL_MAX_ATTEMPTS,
+                        max = self.poll_policy.max_attempts,
                         "Flex statement still generating"
                     );
-                    if attempt < POLL_MAX_ATTEMPTS {
-                        tokio::time::sleep(POLL_INTERVAL).await;
+                    if attempt < self.poll_policy.max_attempts {
+                        tokio::time::sleep(self.poll_policy.interval).await;
                     }
                 }
             }
         }
 
         Err(IbkrFlexError::PollTimeout {
-            attempts: POLL_MAX_ATTEMPTS,
+            attempts: self.poll_policy.max_attempts,
         })
+    }
+
+    /// Issue a GET to `url` with the standard Flex query parameters (`t`/`q`/`v`) and read the full
+    /// response body **regardless of HTTP status**, returning the status alongside the body.
+    ///
+    /// Reading the body before branching on status is deliberate: `error_for_status` discards the
+    /// body, but IBKR/proxy diagnostic bodies — and Flex application errors that arrive under a
+    /// non-2xx status — are exactly what a caller needs to diagnose a failure. The status is
+    /// returned so the caller ([`interpret_send_response`] / [`interpret_poll_response`]) can decide
+    /// whether an unrecognized body under a non-success status is a transport error
+    /// ([`IbkrFlexError::HttpStatus`]) versus a genuine Flex-envelope error.
+    ///
+    /// The `?` on `send`/`text` still routes any `reqwest::Error` through the URL-stripping
+    /// `From<reqwest::Error>` impl, so the token never leaks into an error.
+    async fn get_with_query(
+        &self,
+        url: &str,
+        q: &str,
+    ) -> Result<(reqwest::StatusCode, String), IbkrFlexError> {
+        let response = self
+            .http
+            .get(url)
+            .query(&[("t", self.token.as_str()), ("q", q), ("v", FLEX_VERSION)])
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.text().await?;
+        Ok((status, body))
     }
 
     /// Fetch the statement and parse its Corporate Actions section into faithful records.
@@ -454,6 +568,26 @@ struct FlexStatementResponse {
 /// Parse a SendRequest response: success yields the reference code + poll URL; any other status
 /// becomes an [`IbkrFlexError::Flex`].
 fn parse_send_request_response(xml: &str) -> Result<SendRequestOk, IbkrFlexError> {
+    // A SendRequest response is always a `<FlexStatementResponse>` envelope. Reject any other root
+    // element as a parse error up front — otherwise quick_xml's lenient, all-`#[serde(default)]`
+    // deserialization coerces a non-Flex body (e.g. a proxy/CDN HTML error page) into an
+    // empty-status envelope, which would surface as a confusing `Flex { code: "" }`. Mirrors the
+    // root-element check `classify_get_statement` already does, and lets `interpret_send_response`
+    // distinguish a non-Flex body (→ `HttpStatus` under a non-2xx status) from a genuine Flex error.
+    match root_element_name(xml).as_deref() {
+        Some("FlexStatementResponse") => {}
+        Some(other) => {
+            return Err(IbkrFlexError::Parse(format!(
+                "unexpected Flex SendRequest root element <{other}>"
+            )));
+        }
+        None => {
+            return Err(IbkrFlexError::Parse(
+                "empty or unreadable Flex SendRequest response".to_owned(),
+            ));
+        }
+    }
+
     let resp: FlexStatementResponse = quick_xml::de::from_str(xml).map_err(|e| {
         IbkrFlexError::Parse(format!("failed to parse Flex SendRequest response: {e}"))
     })?;
@@ -525,6 +659,87 @@ fn flex_error(resp: FlexStatementResponse, stage: &str) -> IbkrFlexError {
             .error_message
             .unwrap_or_else(|| format!("Flex {stage} returned non-success status {}", resp.status)),
     }
+}
+
+/// Interpret a SendRequest response given its HTTP `status` and `body`.
+///
+/// The body is parsed as a Flex envelope **first**, so an IBKR application error that arrives under
+/// a non-2xx status still surfaces as the richer [`IbkrFlexError::Flex`] (e.g. `1003` invalid
+/// token). A body that is *not* a recognizable Flex envelope under a non-success status becomes
+/// [`IbkrFlexError::HttpStatus`] (a proxy/CDN error page) rather than a misleading XML parse error;
+/// the same malformed body under a 2xx status stays a genuine [`IbkrFlexError::Parse`].
+fn interpret_send_response(
+    status: reqwest::StatusCode,
+    body: &str,
+    token: &str,
+) -> Result<SendRequestOk, IbkrFlexError> {
+    match parse_send_request_response(body) {
+        Err(IbkrFlexError::Parse(_)) if !status.is_success() => {
+            Err(http_status_error(status, body, token))
+        }
+        other => other,
+    }
+}
+
+/// Interpret a GetStatement poll response given its HTTP `status` and `body`.
+///
+/// The body is classified **first**, so a `1019` "still generating" that IBKR returns under a
+/// non-2xx status is still recognized as retryable — previously `error_for_status` aborted the poll
+/// before the body was classified. A body that is not a recognizable Flex envelope under a
+/// non-success status becomes [`IbkrFlexError::HttpStatus`]; a terminal Flex error envelope under a
+/// non-2xx status stays the richer [`IbkrFlexError::Flex`].
+fn interpret_poll_response(
+    status: reqwest::StatusCode,
+    body: &str,
+    token: &str,
+) -> Result<GetStatementOutcome, IbkrFlexError> {
+    match classify_get_statement(body) {
+        Err(IbkrFlexError::Parse(_)) if !status.is_success() => {
+            Err(http_status_error(status, body, token))
+        }
+        other => other,
+    }
+}
+
+/// Build an [`IbkrFlexError::HttpStatus`] from a non-success response, bounding and token-scrubbing
+/// the body.
+fn http_status_error(status: reqwest::StatusCode, body: &str, token: &str) -> IbkrFlexError {
+    IbkrFlexError::HttpStatus {
+        status: status.as_u16(),
+        body: sanitize_error_body(body, token),
+    }
+}
+
+/// Redact the Flex `token` from `body`, then bound the result to [`MAX_ERROR_BODY_BYTES`] (on a
+/// UTF-8 char boundary).
+///
+/// The token rides in the request URL's `t=` query parameter, so a misconfigured proxy or WAF that
+/// echoes the request line into its error page could reflect the credential into the body. Redacting
+/// it upholds the "token never appears in an error" invariant this module enforces for
+/// `reqwest::Error` URLs. Redaction runs over the full body **before** bounding so a token that
+/// straddles the byte cap can't survive as an unredacted fragment.
+fn sanitize_error_body(body: &str, token: &str) -> String {
+    // Redact the token over the FULL body first (order matters for correctness, not just cost):
+    // bounding first could leave a credential that straddles the byte cap present only as a prefix,
+    // which the full-token `contains`/`replace` would then miss, and redacting after bounding could
+    // also push the result back over the cap (`[REDACTED]` is longer than a short token). Scanning
+    // the whole body only runs on the error path, so the extra pass is acceptable.
+    let mut scrubbed = if !token.is_empty() && body.contains(token) {
+        body.replace(token, "[REDACTED]")
+    } else {
+        body.to_owned()
+    };
+    // Then bound to MAX_ERROR_BODY_BYTES so a large proxy/CDN error page can't bloat the error.
+    // `is_char_boundary` keeps the truncated string valid UTF-8 (there is always a boundary at or
+    // below the cap), which `String::truncate` requires.
+    if scrubbed.len() > MAX_ERROR_BODY_BYTES {
+        let mut end = MAX_ERROR_BODY_BYTES;
+        while !scrubbed.is_char_boundary(end) {
+            end -= 1;
+        }
+        scrubbed.truncate(end);
+    }
+    scrubbed
 }
 
 /// Read the name of the first (root) element of an XML document, ignoring the prolog/comments.
@@ -639,6 +854,27 @@ mod tests {
             parse_send_request_response(xml),
             Err(IbkrFlexError::Parse(_))
         ));
+    }
+
+    #[test]
+    fn send_request_non_envelope_root_is_a_parse_error() {
+        // A non-<FlexStatementResponse> body (e.g. a proxy/CDN HTML error page) must be a parse
+        // error, not coerced by lenient all-`#[serde(default)]` deserialization into a confusing
+        // empty-status `Flex` error. This is what lets `interpret_send_response` treat it as an
+        // HttpStatus under a non-2xx status.
+        for body in [
+            "<html><body>502 Bad Gateway</body></html>",
+            "<not-flex/>",
+            "",
+        ] {
+            assert!(
+                matches!(
+                    parse_send_request_response(body),
+                    Err(IbkrFlexError::Parse(_))
+                ),
+                "expected Parse for body {body:?}"
+            );
+        }
     }
 
     #[test]
@@ -811,6 +1047,177 @@ mod tests {
         assert!(
             !debug.contains("  987654"),
             "surrounding whitespace should not survive into the stored query_id, got: {debug}"
+        );
+    }
+
+    // ----- status/body interpretation (part (a): read body before branching on status) -----
+
+    #[test]
+    fn interpret_send_response_success_parses() {
+        let ok = interpret_send_response(reqwest::StatusCode::OK, SEND_SUCCESS, "tok").unwrap();
+        assert_eq!(ok.reference_code, "1234567890");
+    }
+
+    #[test]
+    fn interpret_send_response_flex_error_preserved_under_non_2xx() {
+        // An IBKR application error (Fail/1003) that arrives under a non-success HTTP status must
+        // still surface as the richer Flex error, not be masked as a raw transport status.
+        match interpret_send_response(reqwest::StatusCode::UNAUTHORIZED, SEND_FAIL, "tok") {
+            Err(IbkrFlexError::Flex { code, .. }) => assert_eq!(code, "1003"),
+            other => panic!("expected Flex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpret_send_response_non_flex_body_under_non_2xx_is_http_status() {
+        // A proxy/CDN error page (not a Flex envelope) under a non-2xx status becomes HttpStatus,
+        // carrying the status + body rather than being discarded (as `error_for_status` did) or
+        // surfacing as a misleading XML parse error.
+        let body = "<html><body>502 Bad Gateway</body></html>";
+        match interpret_send_response(reqwest::StatusCode::BAD_GATEWAY, body, "tok") {
+            Err(IbkrFlexError::HttpStatus { status, body }) => {
+                assert_eq!(status, 502);
+                assert!(body.contains("Bad Gateway"), "diagnostic body preserved");
+            }
+            other => panic!("expected HttpStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpret_send_response_garbage_under_2xx_is_parse_error() {
+        // A malformed body under a *success* status is a genuine parse failure, not a transport
+        // status — the HttpStatus fallback must fire only on non-success statuses.
+        assert!(matches!(
+            interpret_send_response(reqwest::StatusCode::OK, "<not-flex/>", "tok"),
+            Err(IbkrFlexError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn interpret_poll_response_ready_and_in_progress() {
+        assert_eq!(
+            interpret_poll_response(reqwest::StatusCode::OK, GET_READY, "tok").unwrap(),
+            GetStatementOutcome::Ready
+        );
+        assert_eq!(
+            interpret_poll_response(reqwest::StatusCode::OK, GET_IN_PROGRESS, "tok").unwrap(),
+            GetStatementOutcome::InProgress
+        );
+    }
+
+    #[test]
+    fn interpret_poll_response_1019_under_non_2xx_is_still_retryable() {
+        // R9 retry-path fix: a 1019 "still generating" that IBKR returns under a non-success HTTP
+        // status must remain retryable. Previously `error_for_status` aborted the poll before the
+        // body was ever classified, turning a transient generation delay into a hard failure.
+        assert_eq!(
+            interpret_poll_response(
+                reqwest::StatusCode::SERVICE_UNAVAILABLE,
+                GET_IN_PROGRESS,
+                "tok"
+            )
+            .unwrap(),
+            GetStatementOutcome::InProgress
+        );
+    }
+
+    #[test]
+    fn interpret_poll_response_terminal_flex_error_preserved_under_non_2xx() {
+        match interpret_poll_response(reqwest::StatusCode::BAD_REQUEST, GET_FAIL, "tok") {
+            Err(IbkrFlexError::Flex { code, .. }) => assert_eq!(code, "1020"),
+            other => panic!("expected Flex error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpret_poll_response_non_flex_body_under_non_2xx_is_http_status() {
+        match interpret_poll_response(
+            reqwest::StatusCode::GATEWAY_TIMEOUT,
+            "upstream request timed out",
+            "tok",
+        ) {
+            Err(IbkrFlexError::HttpStatus { status, body }) => {
+                assert_eq!(status, 504);
+                assert!(body.contains("timed out"));
+            }
+            other => panic!("expected HttpStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn http_status_body_is_token_scrubbed() {
+        // A misconfigured proxy could reflect the request URL (with the `t=` token) into its error
+        // page; the stored HttpStatus body must never carry the credential.
+        let token = "super-secret-token";
+        let body = format!("400 Bad Request: GET /SendRequest?t={token}&q=1&v=3");
+        match interpret_send_response(reqwest::StatusCode::BAD_REQUEST, &body, token) {
+            Err(IbkrFlexError::HttpStatus { body, .. }) => {
+                assert!(!body.contains(token), "token must be redacted, got: {body}");
+                assert!(body.contains("[REDACTED]"));
+            }
+            other => panic!("expected HttpStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn http_status_body_is_bounded_on_char_boundary() {
+        // A large body is truncated to the cap without splitting a multi-byte char (`€` is 3 bytes,
+        // 1024 is not a multiple of 3, so a naive byte-slice would panic on an invalid boundary).
+        let body = "€".repeat(1000); // 3000 bytes, exceeds the 1024-byte cap
+        match interpret_send_response(reqwest::StatusCode::BAD_GATEWAY, &body, "tok") {
+            Err(IbkrFlexError::HttpStatus { body, .. }) => {
+                assert!(
+                    body.len() <= MAX_ERROR_BODY_BYTES,
+                    "body bounded to the cap"
+                );
+                assert!(
+                    body.chars().all(|c| c == '€'),
+                    "truncation must land on a char boundary (valid UTF-8)"
+                );
+            }
+            other => panic!("expected HttpStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn http_status_body_scrubs_token_straddling_the_cap() {
+        // Regression: the token must be redacted even when it straddles the MAX_ERROR_BODY_BYTES cap
+        // in the *original* body. Redacting after bounding (the previous order) would leave only a
+        // prefix of the token in the bounded slice, which the full-token match then misses — leaking
+        // the fragment. Redacting first also keeps the result within the cap (`[REDACTED]` is longer
+        // than a short token, so replacing after bounding could overrun it).
+        let token = "SECRETTOKEN1234567890"; // 21 bytes
+        let prefix = "x".repeat(MAX_ERROR_BODY_BYTES - 9); // token starts 9 bytes before the cap
+        let body = format!("{prefix}{token}{}", "y".repeat(100)); // > cap; token spans the boundary
+        match interpret_send_response(reqwest::StatusCode::BAD_REQUEST, &body, token) {
+            Err(IbkrFlexError::HttpStatus { body, .. }) => {
+                assert!(
+                    !body.contains(token),
+                    "full token must be redacted, got: {body}"
+                );
+                assert!(
+                    !body.contains("SECRET"),
+                    "no token fragment may survive the boundary, got: {body}"
+                );
+                assert!(
+                    body.len() <= MAX_ERROR_BODY_BYTES,
+                    "redaction must not push the body back over the cap, len = {}",
+                    body.len()
+                );
+            }
+            other => panic!("expected HttpStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flex_poll_policy_default_matches_constants() {
+        assert_eq!(
+            FlexPollPolicy::default(),
+            FlexPollPolicy {
+                initial_delay: POLL_INITIAL_DELAY,
+                interval: POLL_INTERVAL,
+                max_attempts: POLL_MAX_ATTEMPTS,
+            }
         );
     }
 }

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -46,7 +46,7 @@ mod corporate_action;
 
 pub use corporate_action::{IbkrFlexCorporateAction, IbkrReorgType, parse_corporate_actions};
 
-use crate::exchange::http::{MAX_ERROR_BODY_DOWNLOAD_BYTES, read_body_capped};
+use crate::exchange::http::{MAX_ERROR_BODY_DOWNLOAD_BYTES, read_body_capped, truncate_str};
 use quick_xml::{Reader, events::Event};
 use serde::Deserialize;
 use smol_str::SmolStr;
@@ -127,11 +127,11 @@ pub enum IbkrFlexError {
     /// Web Service.
     ///
     /// The body is read before the status is inspected (so the diagnostic is preserved rather than
-    /// discarded by `error_for_status`), then bounded to [`MAX_ERROR_BODY_BYTES`] and
+    /// discarded by `error_for_status`), then bounded to 1 KiB and
     /// **token-scrubbed** before storage: the Flex token rides in the request URL's `t=` parameter,
     /// so a proxy that echoes the request line into its error page could otherwise reflect the
     /// credential into this body. The scrub is best-effort defense-in-depth — it redacts both the
-    /// raw token and the encoded form it takes on the wire (see [`sanitize_error_body`]). An IBKR
+    /// raw token and the encoded form it takes on the wire. An IBKR
     /// *application* error that arrives under a non-2xx status is still surfaced as the richer
     /// [`IbkrFlexError::Flex`], not here.
     #[error("HTTP status {status}: {body}")]
@@ -155,12 +155,24 @@ pub enum IbkrFlexError {
     #[error("Flex statement not ready after {attempts} poll attempts")]
     PollTimeout {
         /// Number of poll attempts made before giving up — the configured
-        /// [`FlexPollPolicy::max_attempts`] ([`POLL_MAX_ATTEMPTS`] by default), since this error
+        /// [`FlexPollPolicy::max_attempts`] (12 by default), since this error
         /// fires only after every attempt reported the statement still generating.
         attempts: u32,
     },
 
     /// The statement or status XML could not be parsed.
+    ///
+    /// A parse message embeds the deserialiser's own rendering of the offending input, so its
+    /// length tracks the *document* rather than the failure, and a document that reflected the
+    /// request line could carry the `t=` credential into it. This variant is therefore **always
+    /// bounded** to 1 KiB, and **token-scrubbed** on every path where a token is in scope — the
+    /// same protection [`IbkrFlexError::HttpStatus`] gets, for the same reason.
+    ///
+    /// Scrubbing covers every `Parse` returned by [`IbkrFlexClient::fetch_statement_xml`] and
+    /// [`IbkrFlexClient::fetch_corporate_actions`]. The one path it cannot cover is calling
+    /// [`parse_corporate_actions`] directly: there the caller supplies its own XML and no token
+    /// exists to redact. Such a message is still bounded — just not scrubbed, since there is
+    /// nothing to scrub against.
     #[error("Flex XML parse error: {0}")]
     Parse(String),
 }
@@ -490,20 +502,14 @@ impl IbkrFlexClient {
             .query(&[("t", self.token.as_str()), ("q", q), ("v", FLEX_VERSION)])
             .send()
             .await?;
-        let status = response.status();
-        let body = if status.is_success() {
-            response.text().await?
-        } else {
-            read_body_capped(response, MAX_ERROR_BODY_DOWNLOAD_BYTES).await?
-        };
-        Ok((status, body))
+        read_status_and_body(response).await
     }
 
     /// Fetch the statement and parse its Corporate Actions section into faithful records.
     ///
     /// Convenience over [`fetch_statement_xml`](Self::fetch_statement_xml) +
     /// [`parse_corporate_actions`]. Returns **all** reorg rows; filtering to splits is the caller's
-    /// job. See [`corporate_action`] for the record contract and limitations.
+    /// job. See [`IbkrFlexCorporateAction`] for the record contract and limitations.
     ///
     /// # Errors
     ///
@@ -512,8 +518,41 @@ impl IbkrFlexClient {
         &self,
     ) -> Result<Vec<IbkrFlexCorporateAction>, IbkrFlexError> {
         let xml = self.fetch_statement_xml().await?;
-        parse_corporate_actions(&xml)
+        // The token is threaded *into* the parse rather than scrubbed off its result: redaction
+        // matches the full token, so it must run before the message is bounded, and
+        // `parse_corporate_actions` bounds before returning. Scrubbing afterwards would leave a
+        // credential straddling the cap present only as an unmatched prefix fragment. This re-parses
+        // a body that already crossed the network, and a misconfigured proxy that echoed the request
+        // line into it would have put `t=<TOKEN>` in reach of a deserialiser message.
+        corporate_action::parse_corporate_actions_scrubbed(&xml, Some(&self.token))
     }
+}
+
+/// Read a response's HTTP status and body, bounding the read on the error path.
+///
+/// Split out of [`IbkrFlexClient::get_with_query`] so this contract can be exercised against a
+/// synthetic [`reqwest::Response`] with no live socket (reqwest exposes
+/// `From<http::Response<_>>`), which the caller's `send()` cannot be. That matters because the
+/// ordering here is the load-bearing part: the body is read **before** the status is judged, so a
+/// Flex envelope arriving under a non-2xx status — notably the retryable `1019` "still generating"
+/// — survives to be classified. `error_for_status()?.text().await?` would discard it and abort the
+/// poll, and every test that drives [`interpret_poll_response`] with a synthetic `(status, body)`
+/// tuple would still pass. See `read_status_and_body_*` in this module's tests.
+///
+/// A **success** body is the statement payload (a `<FlexQueryResponse>`, which can be large) and is
+/// read in full. A **non-success** body is only a small Flex status/error envelope or a proxy/CDN
+/// diagnostic page — never the statement — so it is capped at [`MAX_ERROR_BODY_DOWNLOAD_BYTES`],
+/// far above any real Flex envelope.
+async fn read_status_and_body(
+    response: reqwest::Response,
+) -> Result<(reqwest::StatusCode, String), IbkrFlexError> {
+    let status = response.status();
+    let body = if status.is_success() {
+        response.text().await?
+    } else {
+        read_body_capped(response, MAX_ERROR_BODY_DOWNLOAD_BYTES).await?
+    };
+    Ok((status, body))
 }
 
 /// Poll GetStatement until the statement is ready or `policy`'s attempt budget is exhausted,
@@ -704,7 +743,8 @@ fn flex_error(resp: FlexStatementResponse, stage: &str) -> IbkrFlexError {
 /// a non-2xx status still surfaces as the richer [`IbkrFlexError::Flex`] (e.g. `1003` invalid
 /// token). A body that is *not* a recognizable Flex envelope under a non-success status becomes
 /// [`IbkrFlexError::HttpStatus`] (a proxy/CDN error page) rather than a misleading XML parse error;
-/// the same malformed body under a 2xx status stays a genuine [`IbkrFlexError::Parse`].
+/// the same malformed body under a 2xx status stays a genuine [`IbkrFlexError::Parse`] — with its
+/// message token-scrubbed, since an XML deserialiser embeds fragments of the offending input.
 fn interpret_send_response(
     status: reqwest::StatusCode,
     body: &str,
@@ -714,6 +754,7 @@ fn interpret_send_response(
         Err(IbkrFlexError::Parse(_)) if !status.is_success() => {
             Err(http_status_error(status, body, token))
         }
+        Err(IbkrFlexError::Parse(message)) => Err(finish_parse_error(message, Some(token))),
         other => other,
     }
 }
@@ -734,8 +775,35 @@ fn interpret_poll_response(
         Err(IbkrFlexError::Parse(_)) if !status.is_success() => {
             Err(http_status_error(status, body, token))
         }
+        Err(IbkrFlexError::Parse(message)) => Err(finish_parse_error(message, Some(token))),
         other => other,
     }
+}
+
+/// Build an [`IbkrFlexError::Parse`] from an **unbounded** message: redact `token` when one is in
+/// scope, then bound the result to [`MAX_ERROR_BODY_BYTES`].
+///
+/// A parse failure message embeds the deserialiser's own rendering of the offending input —
+/// quick-xml's `DeError::UnexpectedStart`, for instance, carries the raw tag bytes it choked on. A
+/// body that reflected the request line (a misconfigured proxy echoing `?t=<TOKEN>`) could
+/// therefore carry the credential into the stored error, which [`IbkrFlexError::HttpStatus`] is
+/// already protected against but this variant was not.
+///
+/// **Every** `Parse` in this module is constructed here, including the token-less case, so that the
+/// redact-before-bound ordering exists in exactly one place. That ordering is a security invariant,
+/// not an implementation detail: redaction matches the full token, so bounding first can leave a
+/// credential straddling the cap present only as an unmatched prefix fragment. Two helpers that had
+/// to be kept in step would be one edit away from diverging on it.
+///
+/// `message` must therefore arrive unbounded — a caller that has already truncated at
+/// [`MAX_ERROR_BODY_BYTES`] has already lost the guarantee, and passing it here cannot recover it.
+/// Both branches end at the same cap and differ only in whether a redaction pass runs first, so the
+/// bound is applied exactly once either way.
+fn finish_parse_error(message: String, token: Option<&str>) -> IbkrFlexError {
+    IbkrFlexError::Parse(match token {
+        Some(token) => sanitize_error_body(&message, token),
+        None => truncate_str(&message, MAX_ERROR_BODY_BYTES),
+    })
 }
 
 /// Build an [`IbkrFlexError::HttpStatus`] from a non-success response, bounding and token-scrubbing
@@ -765,14 +833,43 @@ fn http_status_error(status: reqwest::StatusCode, body: &str, token: &str) -> Ib
 /// HTML-entity escaping, or truncation that splits the token). For a real IBKR token — a numeric
 /// string that encodes to itself — the raw scrub already covers it and the wire-form pass is a no-op.
 ///
-/// `body` arrives already bounded: [`IbkrFlexClient::get_with_query`] reads a non-success response
-/// through [`read_body_capped`] at [`MAX_ERROR_BODY_DOWNLOAD_BYTES`] (64 KiB) before it ever reaches
-/// this function. The two caps are complementary, not redundant — the outer one bounds memory during
-/// the network read itself, this one bounds what is retained in the stored error. The 64× gap between
-/// them also means a token fragment straddling the *download* boundary cannot survive into the final
-/// message: the trailing partial token sits far past [`MAX_ERROR_BODY_BYTES`] and is truncated away.
+/// How `body` is bounded depends on the caller, and only one of the two arrives pre-bounded:
+///
+/// - Via [`http_status_error`] (non-success status), `body` has already passed through
+///   [`read_body_capped`] at [`MAX_ERROR_BODY_DOWNLOAD_BYTES`] (64 KiB) in
+///   [`IbkrFlexClient::get_with_query`]. The two caps are complementary, not redundant — the outer
+///   one bounds memory during the network read itself, this one bounds what is retained in the
+///   stored error. The 64× gap between them also means a token fragment straddling the *download*
+///   boundary cannot survive into the final message: the trailing partial token sits far past
+///   [`MAX_ERROR_BODY_BYTES`] and is truncated away.
+/// - Via [`finish_parse_error`] (2xx status), `body` is a deserialiser message — raised either
+///   while interpreting a SendRequest/GetStatement response or while re-parsing a statement in
+///   [`parse_corporate_actions_scrubbed`](corporate_action::parse_corporate_actions_scrubbed) —
+///   derived from an **unbounded** `response.text()` read,
+///   so no download-level cap applies to it. This function therefore applies the coarse
+///   [`MAX_ERROR_BODY_DOWNLOAD_BYTES`] bound itself, on entry, reproducing the same 64× gap the
+///   non-success path gets for free — wide enough that it cannot split a token whose fragment would
+///   then survive into the retained message, but narrow enough that the redaction passes below do
+///   not scan an unbounded string.
+///
+/// Callers must pass a message that has **not** already been truncated at
+/// [`MAX_ERROR_BODY_BYTES`]: redaction matches the full token, so a caller-side cut at the same
+/// width this function retains could leave a straddling credential as an unmatched prefix. Both 2xx
+/// callers hand over their message unbounded for exactly this reason.
 fn sanitize_error_body(body: &str, token: &str) -> String {
-    // Redact the token over the FULL body first (order matters for correctness, not just cost):
+    // Bound the input before the redaction passes. `redact` allocates a full copy per pass even when
+    // the needle is absent, and a 2xx `Parse` message derives from an unbounded read, so without
+    // this an oversized message is copied twice before the trailing truncate discards nearly all of
+    // it. Slicing (rather than `truncate_str`) keeps the common under-cap case allocation-free, and
+    // the cap sits 64× above what is retained, so it cannot create the straddling-fragment problem
+    // the redact-then-bound ordering below exists to avoid.
+    let body = if body.len() > MAX_ERROR_BODY_DOWNLOAD_BYTES {
+        &body[..body.floor_char_boundary(MAX_ERROR_BODY_DOWNLOAD_BYTES)]
+    } else {
+        body
+    };
+    // Redact the token over the (coarsely bounded) body first — order matters for correctness, not
+    // just cost:
     // bounding first could leave a credential that straddles the byte cap present only as a prefix,
     // which the full-token `contains`/`replace` would then miss, and redacting after bounding could
     // also push the result back over the cap (`[REDACTED]` is longer than a short token). Scanning
@@ -1211,6 +1308,49 @@ mod tests {
         }
     }
 
+    /// Build a `reqwest::Response` directly, with no socket and no mock server, via reqwest's
+    /// `From<http::Response<_>>` impl. This is what makes the transport-layer read testable without
+    /// relaxing the client's `https_only(true)` guard — the Flex token rides in the request URL, so
+    /// a plaintext test server would mean building a client that is not the production one.
+    fn synthetic_response(status: u16, body: &'static str) -> reqwest::Response {
+        reqwest::Response::from(
+            http::Response::builder()
+                .status(status)
+                .body(body)
+                .expect("status and body are valid"),
+        )
+    }
+
+    #[tokio::test]
+    async fn read_status_and_body_keeps_a_1019_body_under_a_non_2xx_status() {
+        // The regression this pins, and the one no `interpret_*` test can catch: reverting
+        // `get_with_query` to `error_for_status()?.text().await?` discards the body on a non-2xx,
+        // so the retryable 1019 envelope never reaches `interpret_poll_response` and the poll
+        // aborts instead of retrying. Here the body must survive the non-success status intact.
+        let (status, body) = read_status_and_body(synthetic_response(503, GET_IN_PROGRESS))
+            .await
+            .expect("a non-success status must still yield its body");
+
+        assert_eq!(status, reqwest::StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            classify_get_statement(&body).expect("body is a Flex envelope"),
+            GetStatementOutcome::InProgress,
+            "a 1019 arriving under a non-2xx status must still classify as retryable"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_status_and_body_reads_a_success_body_in_full() {
+        // The success path is the statement payload and must not be routed through the error-path
+        // cap, which would silently truncate a large `<FlexQueryResponse>`.
+        let (status, body) = read_status_and_body(synthetic_response(200, GET_READY))
+            .await
+            .expect("success body reads");
+
+        assert_eq!(status, reqwest::StatusCode::OK);
+        assert_eq!(body, GET_READY);
+    }
+
     #[test]
     fn http_status_body_is_token_scrubbed() {
         // A misconfigured proxy could reflect the request URL (with the `t=` token) into its error
@@ -1223,6 +1363,65 @@ mod tests {
                 assert!(body.contains("[REDACTED]"));
             }
             other => panic!("expected HttpStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_is_token_scrubbed_under_2xx() {
+        // The `HttpStatus` path is covered above; this pins the sibling `Parse` path, which is only
+        // reachable under a *success* status and so never passes through `http_status_error`. A
+        // deserialiser message embeds fragments of the offending input, so a body that reflected the
+        // request line must not carry the credential into the stored error either. Both interpreters
+        // route their `Parse` arm through `finish_parse_error`; assert both.
+        let token = "super-secret-token";
+        // The root-element check formats the tag name verbatim into the message, so naming the root
+        // after the token is the shortest body that reflects it into a `Parse`.
+        let body = format!("<{token}/>");
+
+        match interpret_send_response(reqwest::StatusCode::OK, &body, token) {
+            Err(IbkrFlexError::Parse(message)) => {
+                assert!(
+                    !message.contains(token),
+                    "token must be redacted, got: {message}"
+                );
+                assert!(message.contains("[REDACTED]"));
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+
+        match interpret_poll_response(reqwest::StatusCode::OK, &body, token) {
+            Err(IbkrFlexError::Parse(message)) => {
+                assert!(
+                    !message.contains(token),
+                    "token must be redacted, got: {message}"
+                );
+                assert!(message.contains("[REDACTED]"));
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_message_is_bounded_under_2xx() {
+        // `Parse` messages derive from an unbounded 2xx `response.text()` read, so — unlike the
+        // `HttpStatus` path — `sanitize_error_body`'s trailing truncate is the *only* thing bounding
+        // them. Multi-byte chars confirm the cap lands on a char boundary rather than panicking.
+        let body = format!("<{}/>", "€".repeat(1000)); // 3000 bytes of tag name, exceeds the cap
+        match interpret_send_response(reqwest::StatusCode::OK, &body, "tok") {
+            Err(IbkrFlexError::Parse(message)) => {
+                // Guard against a vacuous pass: the short "empty or unreadable" fallback is under
+                // the cap regardless, so confirm this really is the input-reflecting message.
+                assert!(
+                    message.starts_with("unexpected"),
+                    "fixture must reach the root-element path, got: {message}"
+                );
+                assert!(
+                    message.len() <= MAX_ERROR_BODY_BYTES,
+                    "message bounded to the cap, got {} bytes",
+                    message.len()
+                );
+            }
+            other => panic!("expected Parse, got {other:?}"),
         }
     }
 
@@ -1277,13 +1476,102 @@ mod tests {
     }
 
     #[test]
-    fn flex_poll_policy_default_matches_constants() {
+    fn corporate_action_parse_scrubs_token_straddling_the_cap() {
+        // Sibling of `http_status_body_scrubs_token_straddling_the_cap`, for the path that reaches
+        // `Parse` through `fetch_corporate_actions`. Regression: `parse_corporate_actions` bounds its
+        // own message, so scrubbing its *result* (the previous shape) redacted an already-truncated
+        // string — a token straddling the cap survived as an unmatched prefix fragment, because both
+        // truncations used MAX_ERROR_BODY_BYTES and left no protective gap. The token is now threaded
+        // into the parse so redaction runs while the message is still unbounded.
+        let token = "SECRETTOKEN1234567890"; // 21 bytes
+        // Sweep the token across the cap rather than pinning one offset: the straddling position
+        // depends on the byte length of the message's fixed prefix, which is not a contract and
+        // shifts if the wording is ever edited. `straddled` guards against that drift silently
+        // emptying this test — without it, a reworded message could move the boundary outside the
+        // swept range and every assertion below would pass vacuously, losing the coverage that is
+        // the entire reason this test exists.
+        let mut straddled = false;
+        for pad in (MAX_ERROR_BODY_BYTES - 80)..(MAX_ERROR_BODY_BYTES - 40) {
+            let xml = format!("<{}{token}/>", "x".repeat(pad));
+            // The unscrubbed message the same input would produce. A genuine straddle shows up as a
+            // non-empty *proper prefix* of the token left at its end — distinct from the token
+            // landing entirely past the cap (nothing of it remains) or entirely before it (all of it
+            // remains), neither of which exercises the boundary.
+            let Err(IbkrFlexError::Parse(plain)) =
+                corporate_action::parse_corporate_actions_scrubbed(&xml, None)
+            else {
+                panic!("expected Parse from the token-less parse at pad {pad}");
+            };
+            straddled |= (1..token.len()).any(|cut| plain.ends_with(&token[..cut]));
+
+            match corporate_action::parse_corporate_actions_scrubbed(&xml, Some(token)) {
+                Err(IbkrFlexError::Parse(message)) => {
+                    assert!(
+                        !message.contains(token),
+                        "full token must be redacted at pad {pad}"
+                    );
+                    // A straddling leak surfaces as a token *prefix* left at the truncation
+                    // boundary, so check every prefix length rather than one fixed substring — a
+                    // 5-byte fragment is as much a credential leak as a 6-byte one.
+                    for cut in 1..token.len() {
+                        assert!(
+                            !message.ends_with(&token[..cut]),
+                            "a {cut}-byte token fragment survived the boundary at pad {pad}, got: {message}"
+                        );
+                    }
+                    assert!(
+                        message.len() <= MAX_ERROR_BODY_BYTES,
+                        "redaction must not push the message over the cap at pad {pad}, len = {}",
+                        message.len()
+                    );
+                }
+                other => panic!("expected Parse, got {other:?}"),
+            }
+        }
+        assert!(
+            straddled,
+            "the swept range no longer places the token across the {MAX_ERROR_BODY_BYTES}-byte cap \
+             — widen it, or this test proves nothing"
+        );
+    }
+
+    #[test]
+    fn corporate_action_parse_without_a_token_is_still_bounded() {
+        // The public `parse_corporate_actions` has no credential in scope, so it only bounds. Pins
+        // that routing both callers through one finaliser did not drop the bound on the `None` arm.
+        let xml = format!("<{}/>", "€".repeat(1000)); // 3000 bytes of tag name, exceeds the cap
+        match parse_corporate_actions(&xml) {
+            Err(IbkrFlexError::Parse(message)) => assert!(
+                message.len() <= MAX_ERROR_BODY_BYTES,
+                "len = {}",
+                message.len()
+            ),
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn max_error_body_bytes_is_the_documented_cap() {
+        // Pinned against a literal because the public rustdoc on `IbkrFlexError` states this bound as
+        // "1 KiB" in prose (it cannot link a private constant under
+        // `deny(rustdoc::private_intra_doc_links)`). Changing the constant without the docs would
+        // otherwise drift silently.
+        assert_eq!(MAX_ERROR_BODY_BYTES, 1024);
+    }
+
+    #[test]
+    fn flex_poll_policy_default_is_the_documented_budget() {
+        // Asserted against literals, not against the constants the impl already reads: comparing
+        // `Default::default()` to a struct built from those same constants is a tautology that
+        // holds for any value, and — since `POLL_INITIAL_DELAY` and `POLL_INTERVAL` are both 5s —
+        // would not even catch the two being transposed. These literals are the budget the public
+        // rustdoc promises (~65s total), so a change here is a deliberate, visible contract change.
         assert_eq!(
             FlexPollPolicy::default(),
             FlexPollPolicy {
-                initial_delay: POLL_INITIAL_DELAY,
-                interval: POLL_INTERVAL,
-                max_attempts: POLL_MAX_ATTEMPTS,
+                initial_delay: Duration::from_secs(5),
+                interval: Duration::from_secs(5),
+                max_attempts: 12,
             }
         );
     }

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -129,8 +129,10 @@ pub enum IbkrFlexError {
     /// discarded by `error_for_status`), then bounded to [`MAX_ERROR_BODY_BYTES`] and
     /// **token-scrubbed** before storage: the Flex token rides in the request URL's `t=` parameter,
     /// so a proxy that echoes the request line into its error page could otherwise reflect the
-    /// credential into this body. An IBKR *application* error that arrives under a non-2xx status is
-    /// still surfaced as the richer [`IbkrFlexError::Flex`], not here.
+    /// credential into this body. The scrub is best-effort defense-in-depth — it redacts both the
+    /// raw token and the encoded form it takes on the wire (see [`sanitize_error_body`]). An IBKR
+    /// *application* error that arrives under a non-2xx status is still surfaced as the richer
+    /// [`IbkrFlexError::Flex`], not here.
     #[error("HTTP status {status}: {body}")]
     HttpStatus {
         /// The non-success HTTP status code.
@@ -451,36 +453,10 @@ impl IbkrFlexClient {
             url,
         } = interpret_send_response(status, &body, &self.token)?;
 
-        // A short initial delay before the first poll: the statement is generated asynchronously, so
-        // an immediate GetStatement almost always reports 1019 ("still generating") and would burn
-        // one of the bounded attempts on a near-certain miss. Skipped when no polls are budgeted
-        // (`max_attempts == 0`), so that documented "no polling requested" case fails over immediately
-        // rather than sleeping before an empty loop.
-        if self.poll_policy.max_attempts > 0 {
-            tokio::time::sleep(self.poll_policy.initial_delay).await;
-        }
-
-        for attempt in 1..=self.poll_policy.max_attempts {
-            let (status, body) = self.get_with_query(&url, reference_code.as_str()).await?;
-
-            match interpret_poll_response(status, &body, &self.token)? {
-                GetStatementOutcome::Ready => return Ok(body),
-                GetStatementOutcome::InProgress => {
-                    debug!(
-                        attempt,
-                        max = self.poll_policy.max_attempts,
-                        "Flex statement still generating"
-                    );
-                    if attempt < self.poll_policy.max_attempts {
-                        tokio::time::sleep(self.poll_policy.interval).await;
-                    }
-                }
-            }
-        }
-
-        Err(IbkrFlexError::PollTimeout {
-            attempts: self.poll_policy.max_attempts,
+        poll_until_ready(&self.poll_policy, &self.token, async || {
+            self.get_with_query(&url, reference_code.as_str()).await
         })
+        .await
     }
 
     /// Issue a GET to `url` with the standard Flex query parameters (`t`/`q`/`v`) and read the full
@@ -526,6 +502,55 @@ impl IbkrFlexClient {
         let xml = self.fetch_statement_xml().await?;
         parse_corporate_actions(&xml)
     }
+}
+
+/// Poll GetStatement until the statement is ready or `policy`'s attempt budget is exhausted,
+/// delegating each raw fetch to `poll_once`.
+///
+/// Isolating the loop from the transport keeps its orchestration deterministically testable without
+/// a network round trip: `poll_once` is any async producer of a `(status, body)` pair, so a scripted
+/// responder can drive the exact wiring — the `max_attempts == 0` immediate-timeout case, the
+/// `1..=max_attempts` bound, and the `attempt < max_attempts` inter-poll sleep guard — under
+/// zero-duration policies. (The live two-call round trip stays covered by the `#[ignore]`d network
+/// test.)
+///
+/// The `initial_delay` is waited once before the first poll: the statement is generated
+/// asynchronously, so an immediate GetStatement almost always reports `1019` ("still generating") and
+/// would burn one of the bounded attempts on a near-certain miss. It is skipped when no polls are
+/// budgeted (`max_attempts == 0`), so that documented "no polling requested" case fails over
+/// immediately with [`IbkrFlexError::PollTimeout`] rather than sleeping before an empty loop.
+async fn poll_until_ready<F>(
+    policy: &FlexPollPolicy,
+    token: &str,
+    mut poll_once: F,
+) -> Result<String, IbkrFlexError>
+where
+    F: AsyncFnMut() -> Result<(reqwest::StatusCode, String), IbkrFlexError>,
+{
+    if policy.max_attempts > 0 {
+        tokio::time::sleep(policy.initial_delay).await;
+    }
+
+    for attempt in 1..=policy.max_attempts {
+        let (status, body) = poll_once().await?;
+        match interpret_poll_response(status, &body, token)? {
+            GetStatementOutcome::Ready => return Ok(body),
+            GetStatementOutcome::InProgress => {
+                debug!(
+                    attempt,
+                    max = policy.max_attempts,
+                    "Flex statement still generating"
+                );
+                if attempt < policy.max_attempts {
+                    tokio::time::sleep(policy.interval).await;
+                }
+            }
+        }
+    }
+
+    Err(IbkrFlexError::PollTimeout {
+        attempts: policy.max_attempts,
+    })
 }
 
 // ============================================================================
@@ -710,25 +735,38 @@ fn http_status_error(status: reqwest::StatusCode, body: &str, token: &str) -> Ib
     }
 }
 
-/// Redact the Flex `token` from `body`, then bound the result to [`MAX_ERROR_BODY_BYTES`] (on a
-/// UTF-8 char boundary).
+/// Redact the Flex `token` — both its raw form and its `application/x-www-form-urlencoded` wire
+/// form — from `body`, then bound the result to [`MAX_ERROR_BODY_BYTES`] (on a UTF-8 char boundary).
 ///
-/// The token rides in the request URL's `t=` query parameter, so a misconfigured proxy or WAF that
-/// echoes the request line into its error page could reflect the credential into the body. Redacting
-/// it upholds the "token never appears in an error" invariant this module enforces for
-/// `reqwest::Error` URLs. Redaction runs over the full body **before** bounding so a token that
-/// straddles the byte cap can't survive as an unredacted fragment.
+/// The token rides in the request URL's `t=` query parameter, attached via reqwest's `.query(&[…])`,
+/// which serialises through [`url::Url::query_pairs_mut`] — WHATWG form-urlencoding, which escapes
+/// space as `+` and leaves a *narrower* byte set unescaped than RFC-3986 percent-encoding (e.g. `~`
+/// is escaped here). A misconfigured proxy or WAF that echoes the request line into its error page
+/// would reflect *that* wire form, not the raw token, so both are scrubbed. The wire form is computed
+/// with [`url::form_urlencoded::byte_serialize`] — the same primitive `url`'s serializer (and thus
+/// reqwest's `.query()`) uses internally, not a hand-rolled percent-encoding table — so it cannot
+/// drift from what is actually sent (`sanitize_error_body_scrubs_reqwests_wire_encoded_token` pins
+/// this against reqwest's real request encoding).
+///
+/// This is **best-effort defense-in-depth, not an absolute guarantee**: an intermediary could still
+/// transform the reflected value in a way this scrub does not anticipate (further re-encoding,
+/// HTML-entity escaping, or truncation that splits the token). For a real IBKR token — a numeric
+/// string that encodes to itself — the raw scrub already covers it and the wire-form pass is a no-op.
 fn sanitize_error_body(body: &str, token: &str) -> String {
     // Redact the token over the FULL body first (order matters for correctness, not just cost):
     // bounding first could leave a credential that straddles the byte cap present only as a prefix,
     // which the full-token `contains`/`replace` would then miss, and redacting after bounding could
     // also push the result back over the cap (`[REDACTED]` is longer than a short token). Scanning
     // the whole body only runs on the error path, so the extra pass is acceptable.
-    let mut scrubbed = if !token.is_empty() && body.contains(token) {
-        body.replace(token, "[REDACTED]")
-    } else {
-        body.to_owned()
-    };
+    let mut scrubbed = redact(body, token);
+    // Also scrub the encoded form the token actually takes on the wire, so a reflected request line
+    // is covered too — but only when it differs from the raw token (a no-op for numeric tokens).
+    if !token.is_empty() {
+        let wire_form: String = url::form_urlencoded::byte_serialize(token.as_bytes()).collect();
+        if wire_form.as_str() != token {
+            scrubbed = redact(&scrubbed, &wire_form);
+        }
+    }
     // Then bound to MAX_ERROR_BODY_BYTES so a large proxy/CDN error page can't bloat the error.
     // `is_char_boundary` keeps the truncated string valid UTF-8 (there is always a boundary at or
     // below the cap), which `String::truncate` requires.
@@ -740,6 +778,19 @@ fn sanitize_error_body(body: &str, token: &str) -> String {
         scrubbed.truncate(end);
     }
     scrubbed
+}
+
+/// Replace every occurrence of `needle` in `body` with `[REDACTED]`, always returning an owned
+/// `String` (the caller chains two redaction passes over the result, so a borrowing return would not
+/// help). The `contains` guard skips only the `replace` scan when `needle` is absent — it does not
+/// avoid the allocation. An empty `needle` is never treated as a match: `str::replace` with an empty
+/// pattern would splice the replacement between every character.
+fn redact(body: &str, needle: &str) -> String {
+    if !needle.is_empty() && body.contains(needle) {
+        body.replace(needle, "[REDACTED]")
+    } else {
+        body.to_owned()
+    }
 }
 
 /// Read the name of the first (root) element of an XML document, ignoring the prolog/comments.
@@ -1219,5 +1270,113 @@ mod tests {
                 max_attempts: POLL_MAX_ATTEMPTS,
             }
         );
+    }
+
+    #[test]
+    fn sanitize_error_body_scrubs_reqwests_wire_encoded_token() {
+        // A token with characters that encode differently on the wire (space -> `+`; `+ / ~` -> `%..`).
+        // If a proxy reflects the *encoded* request line into its error page, the raw-token scrub
+        // alone would miss it. This pins two properties: (1) `byte_serialize` produces exactly what
+        // reqwest's `.query()` puts on the wire — so the scrub can't silently drift from the real
+        // encoding if reqwest/url change — and (2) that encoded form is redacted from the body.
+        let token = "abc def+g/h~i";
+
+        // What reqwest actually serialises onto the query string (`build()` only — nothing is sent).
+        let request = reqwest::Client::new()
+            .get("https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/GetStatement")
+            .query(&[("t", token), ("q", "1234567890"), ("v", FLEX_VERSION)])
+            .build()
+            .expect("request builds without sending");
+        let wire_query = request.url().query().expect("query present");
+
+        let wire_form: String = url::form_urlencoded::byte_serialize(token.as_bytes()).collect();
+        assert_ne!(
+            wire_form, token,
+            "test token must actually encode to something different, else it proves nothing"
+        );
+        assert!(
+            wire_query.contains(&format!("t={wire_form}")),
+            "byte_serialize must match reqwest's actual query encoding, else the wire-form scrub \
+             silently stops matching; query = {wire_query}, wire_form = {wire_form}"
+        );
+
+        // A proxy that echoes the received request line into its error page reflects the encoded form.
+        let reflected = format!("502 Bad Gateway while proxying GET /GetStatement?{wire_query}");
+        let scrubbed = sanitize_error_body(&reflected, token);
+        assert!(
+            !scrubbed.contains(&wire_form),
+            "wire-encoded token must be redacted, got: {scrubbed}"
+        );
+        assert!(scrubbed.contains("[REDACTED]"));
+    }
+
+    #[tokio::test]
+    async fn poll_until_ready_zero_max_attempts_times_out_without_polling() {
+        // `max_attempts == 0` is the documented "no polling requested" case: it must return
+        // immediately with `PollTimeout { attempts: 0 }` and issue zero GetStatement calls (and skip
+        // the initial delay). Zero-duration policy keeps the test instant.
+        let policy = FlexPollPolicy {
+            initial_delay: Duration::ZERO,
+            interval: Duration::ZERO,
+            max_attempts: 0,
+        };
+        let calls = std::cell::Cell::new(0u32);
+        let result = poll_until_ready(&policy, "tok", async || {
+            calls.set(calls.get() + 1);
+            Ok((reqwest::StatusCode::OK, GET_READY.to_owned()))
+        })
+        .await;
+        assert_eq!(calls.get(), 0, "max_attempts == 0 must not issue any poll");
+        assert!(matches!(
+            result,
+            Err(IbkrFlexError::PollTimeout { attempts: 0 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn poll_until_ready_returns_as_soon_as_statement_is_ready() {
+        // The loop must stop at the first Ready response, not run the full budget.
+        let policy = FlexPollPolicy {
+            initial_delay: Duration::ZERO,
+            interval: Duration::ZERO,
+            max_attempts: 5,
+        };
+        let calls = std::cell::Cell::new(0u32);
+        let result = poll_until_ready(&policy, "tok", async || {
+            calls.set(calls.get() + 1);
+            // In progress on the first poll, ready on the second.
+            let body = if calls.get() < 2 {
+                GET_IN_PROGRESS
+            } else {
+                GET_READY
+            };
+            Ok((reqwest::StatusCode::OK, body.to_owned()))
+        })
+        .await;
+        assert_eq!(calls.get(), 2, "must stop polling once Ready is seen");
+        assert_eq!(result.expect("ready"), GET_READY);
+    }
+
+    #[tokio::test]
+    async fn poll_until_ready_exhausts_budget_and_reports_attempt_count() {
+        // Every poll reports in-progress: the loop must run exactly `max_attempts` times — proving
+        // the `1..=max_attempts` bound and the `attempt < max_attempts` sleep guard don't over- or
+        // under-run — and surface that count in `PollTimeout`.
+        let policy = FlexPollPolicy {
+            initial_delay: Duration::ZERO,
+            interval: Duration::ZERO,
+            max_attempts: 3,
+        };
+        let calls = std::cell::Cell::new(0u32);
+        let result = poll_until_ready(&policy, "tok", async || {
+            calls.set(calls.get() + 1);
+            Ok((reqwest::StatusCode::OK, GET_IN_PROGRESS.to_owned()))
+        })
+        .await;
+        assert_eq!(calls.get(), 3, "must poll exactly max_attempts times");
+        assert!(matches!(
+            result,
+            Err(IbkrFlexError::PollTimeout { attempts: 3 })
+        ));
     }
 }

--- a/rustrade-data/src/exchange/ibkr/flex/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/flex/mod.rs
@@ -46,6 +46,7 @@ mod corporate_action;
 
 pub use corporate_action::{IbkrFlexCorporateAction, IbkrReorgType, parse_corporate_actions};
 
+use crate::exchange::http::{MAX_ERROR_BODY_DOWNLOAD_BYTES, read_body_capped};
 use quick_xml::{Reader, events::Event};
 use serde::Deserialize;
 use smol_str::SmolStr;
@@ -459,17 +460,24 @@ impl IbkrFlexClient {
         .await
     }
 
-    /// Issue a GET to `url` with the standard Flex query parameters (`t`/`q`/`v`) and read the full
+    /// Issue a GET to `url` with the standard Flex query parameters (`t`/`q`/`v`) and read the
     /// response body **regardless of HTTP status**, returning the status alongside the body.
     ///
     /// Reading the body before branching on status is deliberate: `error_for_status` discards the
-    /// body, but IBKR/proxy diagnostic bodies — and Flex application errors that arrive under a
-    /// non-2xx status — are exactly what a caller needs to diagnose a failure. The status is
+    /// body, but IBKR/proxy diagnostic bodies — and Flex application errors (e.g. `1019`) that arrive
+    /// under a non-2xx status — are exactly what a caller needs to diagnose a failure. The status is
     /// returned so the caller ([`interpret_send_response`] / [`interpret_poll_response`]) can decide
     /// whether an unrecognized body under a non-success status is a transport error
     /// ([`IbkrFlexError::HttpStatus`]) versus a genuine Flex-envelope error.
     ///
-    /// The `?` on `send`/`text` still routes any `reqwest::Error` through the URL-stripping
+    /// A **success** body is the statement payload (a `<FlexQueryResponse>`, which can be large) and
+    /// is read in full. A **non-success** body is only a small Flex status/error envelope or a
+    /// proxy/CDN diagnostic page — never the statement — so it is read only up to
+    /// `MAX_ERROR_BODY_DOWNLOAD_BYTES`, bounding a pathological error page that would otherwise be
+    /// buffered without limit (it is truncated further for storage anyway). The cap is far above any
+    /// real Flex envelope, so a `1019`/error response the poll loop still parses is never truncated.
+    ///
+    /// The `?` on `send`/`chunk`/`text` still routes any `reqwest::Error` through the URL-stripping
     /// `From<reqwest::Error>` impl, so the token never leaks into an error.
     async fn get_with_query(
         &self,
@@ -483,7 +491,11 @@ impl IbkrFlexClient {
             .send()
             .await?;
         let status = response.status();
-        let body = response.text().await?;
+        let body = if status.is_success() {
+            response.text().await?
+        } else {
+            read_body_capped(response, MAX_ERROR_BODY_DOWNLOAD_BYTES).await?
+        };
         Ok((status, body))
     }
 
@@ -752,6 +764,13 @@ fn http_status_error(status: reqwest::StatusCode, body: &str, token: &str) -> Ib
 /// transform the reflected value in a way this scrub does not anticipate (further re-encoding,
 /// HTML-entity escaping, or truncation that splits the token). For a real IBKR token — a numeric
 /// string that encodes to itself — the raw scrub already covers it and the wire-form pass is a no-op.
+///
+/// `body` arrives already bounded: [`IbkrFlexClient::get_with_query`] reads a non-success response
+/// through [`read_body_capped`] at [`MAX_ERROR_BODY_DOWNLOAD_BYTES`] (64 KiB) before it ever reaches
+/// this function. The two caps are complementary, not redundant — the outer one bounds memory during
+/// the network read itself, this one bounds what is retained in the stored error. The 64× gap between
+/// them also means a token fragment straddling the *download* boundary cannot survive into the final
+/// message: the trailing partial token sits far past [`MAX_ERROR_BODY_BYTES`] and is truncated away.
 fn sanitize_error_body(body: &str, token: &str) -> String {
     // Redact the token over the FULL body first (order matters for correctness, not just cost):
     // bounding first could leave a credential that straddles the byte cap present only as a prefix,
@@ -768,14 +787,11 @@ fn sanitize_error_body(body: &str, token: &str) -> String {
         }
     }
     // Then bound to MAX_ERROR_BODY_BYTES so a large proxy/CDN error page can't bloat the error.
-    // `is_char_boundary` keeps the truncated string valid UTF-8 (there is always a boundary at or
-    // below the cap), which `String::truncate` requires.
+    // `floor_char_boundary` rounds the cap down to a UTF-8 char boundary (there is always one at or
+    // below it), keeping the truncated string valid — which `String::truncate` requires. Matches the
+    // idiom used across the crate (e.g. `massive::error`, `massive::rest`, `binance::error`).
     if scrubbed.len() > MAX_ERROR_BODY_BYTES {
-        let mut end = MAX_ERROR_BODY_BYTES;
-        while !scrubbed.is_char_boundary(end) {
-            end -= 1;
-        }
-        scrubbed.truncate(end);
+        scrubbed.truncate(scrubbed.floor_char_boundary(MAX_ERROR_BODY_BYTES));
     }
     scrubbed
 }
@@ -1378,5 +1394,43 @@ mod tests {
             result,
             Err(IbkrFlexError::PollTimeout { attempts: 3 })
         ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn poll_until_ready_sleeps_initial_delay_first_then_interval_between_polls() {
+        // The zero-duration tests above prove call counts and outcomes but not the *timing* wiring:
+        // that `initial_delay` is awaited **before** the first poll and `interval` between subsequent
+        // polls. Under `start_paused`, Tokio advances virtual time whenever the runtime is idle on a
+        // timer, so each `sleep` completes deterministically and we can record the clock at every poll
+        // without real sleeping.
+        let policy = FlexPollPolicy {
+            initial_delay: Duration::from_secs(5),
+            interval: Duration::from_secs(2),
+            max_attempts: 3,
+        };
+        let start = tokio::time::Instant::now();
+        let elapsed_at_poll = std::cell::RefCell::new(Vec::<Duration>::new());
+        let result = poll_until_ready(&policy, "tok", async || {
+            elapsed_at_poll.borrow_mut().push(start.elapsed());
+            // Always in-progress so the loop runs the full budget, exercising every inter-poll sleep.
+            Ok((reqwest::StatusCode::OK, GET_IN_PROGRESS.to_owned()))
+        })
+        .await;
+        assert!(matches!(
+            result,
+            Err(IbkrFlexError::PollTimeout { attempts: 3 })
+        ));
+
+        // Poll 1 at t=5s proves `initial_delay` elapsed *before* the first poll (not t=0); polls 2 and
+        // 3 one `interval` (2s) apart prove the between-poll sleep. A regression that polled before
+        // sleeping, or that dropped a sleep, would shift these timestamps.
+        assert_eq!(
+            *elapsed_at_poll.borrow(),
+            vec![
+                Duration::from_secs(5),
+                Duration::from_secs(7),
+                Duration::from_secs(9),
+            ],
+        );
     }
 }

--- a/rustrade-data/src/exchange/ibkr/historical.rs
+++ b/rustrade-data/src/exchange/ibkr/historical.rs
@@ -282,13 +282,13 @@ impl IbkrHistoricalData {
     ///   native unique identifier.
     /// - A mid-stream IB API error is surfaced two ways: ibapi 3.1+ yields it as
     ///   an `Err` on the tick iterator, so this method logs a `warn!`, ends
-    ///   iteration, and sets [`HistoricalTicks::truncated_by_error`] on the
+    ///   iteration, and sets [`HistoricalTicks::truncation_error`] on the
     ///   returned value (the ticks received before the error are still returned).
     ///   Separately, this method also emits a `warn!` when the number of raw ticks
     ///   received is less than `request.number_of_ticks`. Because a short batch is
     ///   also a normal end-of-data signal, treat that warning as a flag for
     ///   investigation (or a prompt to paginate), **not** as proof of an error;
-    ///   `truncated_by_error` is the authoritative signal for a confirmed error.
+    ///   `truncation_error.is_some()` is the authoritative signal for a confirmed error.
     pub async fn fetch_historical_ticks(
         &self,
         request: HistoricalTickRequest,
@@ -396,13 +396,13 @@ impl IbkrHistoricalData {
     /// - For larger ranges, paginate using last tick's timestamp as new `start`
     /// - A mid-stream IB API error is surfaced two ways: ibapi 3.1+ yields it as
     ///   an `Err` on the tick iterator, so this method logs a `warn!`, ends
-    ///   iteration, and sets [`HistoricalTicks::truncated_by_error`] on the
+    ///   iteration, and sets [`HistoricalTicks::truncation_error`] on the
     ///   returned value (the ticks received before the error are still returned).
     ///   Separately, this method also emits a `warn!` when the number of raw ticks
     ///   received is less than `request.number_of_ticks`. Because a short batch is
     ///   also a normal end-of-data signal, treat that warning as a flag for
     ///   investigation (or a prompt to paginate), **not** as proof of an error;
-    ///   `truncated_by_error` is the authoritative signal for a confirmed error.
+    ///   `truncation_error.is_some()` is the authoritative signal for a confirmed error.
     pub async fn fetch_historical_bid_ask(
         &self,
         request: HistoricalTickRequest,

--- a/rustrade-data/src/exchange/ibkr/mod.rs
+++ b/rustrade-data/src/exchange/ibkr/mod.rs
@@ -72,8 +72,8 @@ pub mod subscription;
 pub mod trades;
 
 pub use flex::{
-    IbkrFlexClient, IbkrFlexConfig, IbkrFlexCorporateAction, IbkrFlexError, IbkrReorgType,
-    parse_corporate_actions,
+    FlexPollPolicy, IbkrFlexClient, IbkrFlexConfig, IbkrFlexCorporateAction, IbkrFlexError,
+    IbkrReorgType, parse_corporate_actions,
 };
 
 use crate::{

--- a/rustrade-data/src/exchange/massive/error.rs
+++ b/rustrade-data/src/exchange/massive/error.rs
@@ -7,7 +7,11 @@ use std::time::Duration;
 ///
 /// The library returns these errors without automatic retry or reconnection.
 /// Consumers decide how to handle rate limits, disconnections, and auth failures.
+///
+/// `#[non_exhaustive]`: new variants may be added without a major-version bump, so
+/// downstream `match`es must include a wildcard arm.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum MassiveError {
     /// Rate limited by the API. Contains optional retry-after duration.
     ///
@@ -49,6 +53,25 @@ pub enum MassiveError {
     /// Returned when input parameters are invalid before making an API request
     /// (e.g., timestamp out of representable range).
     InvalidInput { message: String },
+
+    /// A paginated fetch exceeded the maximum number of pages before the API
+    /// reported the end of the result set.
+    ///
+    /// Yielded as a terminal error on the affected stream. For a market-data
+    /// client a silent truncation is indistinguishable from a genuinely small
+    /// result set, so pagination fails loudly rather than returning a partial
+    /// `Vec`. Hitting this limit indicates either an unexpectedly large query or
+    /// a server that never signals the final page — inspect the query before
+    /// retrying.
+    PaginationLimitExceeded { pages: usize, limit: usize },
+
+    /// A paginated fetch revisited a URL it had already fetched.
+    ///
+    /// Yielded as a terminal error on the affected stream. A `next_url` that
+    /// points back to an already-visited page would otherwise loop forever;
+    /// detecting the cycle turns silent non-termination into an observable
+    /// failure.
+    CyclicPagination { url: String },
 }
 
 impl std::fmt::Display for MassiveError {
@@ -88,6 +111,18 @@ impl std::fmt::Display for MassiveError {
             }
             MassiveError::InvalidInput { message } => {
                 write!(f, "Massive invalid input: {}", message)
+            }
+            MassiveError::PaginationLimitExceeded { pages, limit } => {
+                write!(
+                    f,
+                    "Massive pagination exceeded {limit}-page limit (fetched {pages} pages) — result may be incomplete"
+                )
+            }
+            MassiveError::CyclicPagination { url } => {
+                write!(
+                    f,
+                    "Massive pagination cycle detected: next_url revisits {url}"
+                )
             }
         }
     }

--- a/rustrade-data/src/exchange/massive/error.rs
+++ b/rustrade-data/src/exchange/massive/error.rs
@@ -77,11 +77,10 @@ pub enum MassiveError {
     /// origin (scheme + host + port), or one that failed to parse as a URL.
     ///
     /// Yielded as a terminal error *before* the request is issued. The client
-    /// attaches its API key as an `Authorization: Bearer` default header sent
-    /// with **every** request regardless of destination host, so following a
-    /// `next_url` that names an unexpected origin would leak the token to
-    /// whatever host it points at. A prefix check is insufficient — a look-alike
-    /// host such as `https://api.massive.com.evil.example` (or the
+    /// attaches its API key as an `Authorization: Bearer` header only after this
+    /// origin check passes, so a `next_url` that names an unexpected origin is
+    /// rejected before the token is ever attached. A prefix check is insufficient
+    /// — a look-alike host such as `https://api.massive.com.evil.example` (or the
     /// separator-less `https://api.massive.comevil.example`) shares the prefix
     /// yet is a different origin — so origins are parsed and compared, and a
     /// mismatched or unparseable `next_url` is rejected (fail-closed).

--- a/rustrade-data/src/exchange/massive/error.rs
+++ b/rustrade-data/src/exchange/massive/error.rs
@@ -72,6 +72,33 @@ pub enum MassiveError {
     /// detecting the cycle turns silent non-termination into an observable
     /// failure.
     CyclicPagination { url: String },
+
+    /// A paginated fetch received a `next_url` outside the client's configured
+    /// origin (scheme + host + port), or one that failed to parse as a URL.
+    ///
+    /// Yielded as a terminal error *before* the request is issued. The client
+    /// attaches its API key as an `Authorization: Bearer` default header sent
+    /// with **every** request regardless of destination host, so following a
+    /// `next_url` that names an unexpected origin would leak the token to
+    /// whatever host it points at. A prefix check is insufficient — a look-alike
+    /// host such as `https://api.massive.com.evil.example` (or the
+    /// separator-less `https://api.massive.comevil.example`) shares the prefix
+    /// yet is a different origin — so origins are parsed and compared, and a
+    /// mismatched or unparseable `next_url` is rejected (fail-closed).
+    ///
+    /// A well-behaved Massive API only ever returns a `next_url` under its own
+    /// origin (the path and `cursor` query differ; the origin is fixed). Hitting
+    /// this indicates a server-side bug, response tampering, or a misconfigured
+    /// base URL. Consumers may match on it to alert distinctly from ordinary
+    /// input-validation failures.
+    UntrustedNextUrl {
+        /// The rejected `next_url`, exactly as received (unparsed if it failed
+        /// to parse as a URL at all).
+        next_url: String,
+        /// ASCII-serialized origin (`scheme://host[:port]`) the client trusts,
+        /// derived from its configured base URL.
+        expected_origin: String,
+    },
 }
 
 impl std::fmt::Display for MassiveError {
@@ -122,6 +149,15 @@ impl std::fmt::Display for MassiveError {
                 write!(
                     f,
                     "Massive pagination cycle detected: next_url revisits {url}"
+                )
+            }
+            MassiveError::UntrustedNextUrl {
+                next_url,
+                expected_origin,
+            } => {
+                write!(
+                    f,
+                    "Massive rejected next_url outside trusted origin {expected_origin}: {next_url}"
                 )
             }
         }

--- a/rustrade-data/src/exchange/massive/error.rs
+++ b/rustrade-data/src/exchange/massive/error.rs
@@ -3,6 +3,31 @@
 use crate::error::DataError;
 use std::time::Duration;
 
+/// Byte cap applied to a URL when rendering it into an error message.
+///
+/// URLs in these variants are stored in full — the value is often exactly what a
+/// caller needs to debug a misbehaving server — but a server-supplied URL can be
+/// long, and every `Display` of the error would otherwise carry it whole into a
+/// log line. Matches the 512-byte budget the `Api`/`Auth` messages use; the
+/// tighter 100-byte cap on `Deserialize` is for an inline snippet inside an
+/// already-descriptive message, a different context.
+const DISPLAY_URL_BYTES: usize = 512;
+
+/// Truncate `s` to at most `max_bytes` for rendering, returning the kept prefix and an ellipsis
+/// marker that is non-empty only when bytes were actually dropped.
+///
+/// A *silent* cut is worse than a visible one: a reader who cannot tell the value was shortened may
+/// chase a URL whose informative `cursor=...` tail is simply missing. Every truncating `Display` arm
+/// in this file goes through here so they all mark truncation the same way.
+///
+/// Borrows rather than reusing [`truncate_str`](crate::exchange::http::truncate_str) — that helper
+/// returns an owned `String` for values a caller *stores*, whereas a `Display` arm only needs to
+/// write the prefix straight out.
+fn truncate_for_display(s: &str, max_bytes: usize) -> (&str, &'static str) {
+    let boundary = s.floor_char_boundary(max_bytes);
+    (&s[..boundary], if boundary < s.len() { "..." } else { "" })
+}
+
 /// Massive-specific errors.
 ///
 /// The library returns these errors without automatic retry or reconnection.
@@ -73,6 +98,34 @@ pub enum MassiveError {
     /// failure.
     CyclicPagination { url: String },
 
+    /// A paginated fetch encountered a URL longer than the paginator will follow.
+    ///
+    /// Yielded as a terminal error *before* the URL is recorded for cycle
+    /// detection or requested. A page's `next_url` is server-controlled and
+    /// success bodies are read unbounded, so without this bound a misbehaving
+    /// origin could hand back arbitrarily long URLs — one retained per page, for
+    /// the life of the stream.
+    ///
+    /// A real Massive cursor URL is a few hundred bytes, so hitting this
+    /// indicates response tampering, a server-side bug, or (far less likely, but
+    /// covered by the same check) a caller query that expands into an
+    /// unreasonable first-page URL.
+    PaginationUrlTooLong {
+        /// Length of the rejected URL, in bytes.
+        len: usize,
+        /// The byte limit that was exceeded.
+        limit: usize,
+        /// A bounded prefix of the rejected URL, for diagnosis. Unlike
+        /// [`UntrustedNextUrl::next_url`](MassiveError::UntrustedNextUrl) this is
+        /// truncated by construction — retaining the value in full is the very
+        /// thing the variant exists to prevent.
+        ///
+        /// [`Display`](std::fmt::Display) marks the value as truncated only when
+        /// `prefix` is actually shorter than `len`, so a prefix that happens to
+        /// be complete does not render a misleading trailing `...`.
+        prefix: String,
+    },
+
     /// A paginated fetch received a `next_url` outside the client's configured
     /// origin (scheme + host + port), or one that failed to parse as a URL.
     ///
@@ -93,6 +146,9 @@ pub enum MassiveError {
     UntrustedNextUrl {
         /// The rejected `next_url`, exactly as received (unparsed if it failed
         /// to parse as a URL at all).
+        ///
+        /// Stored in full; [`Display`](std::fmt::Display) bounds the *rendered*
+        /// form so an oversized value cannot flood a log line.
         next_url: String,
         /// ASCII-serialized origin (`scheme://host[:port]`) the client trusts,
         /// derived from its configured base URL.
@@ -123,9 +179,7 @@ impl std::fmt::Display for MassiveError {
                 write!(f, "Massive HTTP error: {}", message)
             }
             MassiveError::Deserialize { message, payload } => {
-                let boundary = payload.floor_char_boundary(100);
-                let truncated = &payload[..boundary];
-                let ellipsis = if boundary < payload.len() { "..." } else { "" };
+                let (truncated, ellipsis) = truncate_for_display(payload, 100);
                 write!(
                     f,
                     "Massive deserialize error: {} (payload: {truncated}{ellipsis})",
@@ -144,19 +198,33 @@ impl std::fmt::Display for MassiveError {
                     "Massive pagination exceeded {limit}-page limit (fetched {pages} pages) — result may be incomplete"
                 )
             }
-            MassiveError::CyclicPagination { url } => {
+            MassiveError::PaginationUrlTooLong { len, limit, prefix } => {
+                // Derive the ellipsis from the data rather than assuming the cut happened. The
+                // internal constructor always truncates, but `#[non_exhaustive]` sits on the enum,
+                // not this variant, so it does not stop downstream code from building one with a
+                // whole `prefix` — which the unconditional `...` would then misreport as truncated.
+                // Comparing against `len` (the full URL's length) is exact and needs no cap constant.
+                let ellipsis = if prefix.len() < *len { "..." } else { "" };
                 write!(
                     f,
-                    "Massive pagination cycle detected: next_url revisits {url}"
+                    "Massive pagination URL exceeds the {limit}-byte limit ({len} bytes): {prefix}{ellipsis}"
+                )
+            }
+            MassiveError::CyclicPagination { url } => {
+                let (url, ellipsis) = truncate_for_display(url, DISPLAY_URL_BYTES);
+                write!(
+                    f,
+                    "Massive pagination cycle detected: next_url revisits {url}{ellipsis}"
                 )
             }
             MassiveError::UntrustedNextUrl {
                 next_url,
                 expected_origin,
             } => {
+                let (next_url, ellipsis) = truncate_for_display(next_url, DISPLAY_URL_BYTES);
                 write!(
                     f,
-                    "Massive rejected next_url outside trusted origin {expected_origin}: {next_url}"
+                    "Massive rejected next_url outside trusted origin {expected_origin}: {next_url}{ellipsis}"
                 )
             }
         }
@@ -183,6 +251,179 @@ impl From<tokio_tungstenite::tungstenite::Error> for MassiveError {
     fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
         MassiveError::Disconnected {
             reason: err.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A URL long enough to exceed [`DISPLAY_URL_BYTES`], built from a repeated ASCII byte so
+    /// `len()` and char count coincide.
+    fn oversized_url() -> String {
+        format!("https://api.massive.com/v3/x?cursor={}", "a".repeat(4096))
+    }
+
+    #[test]
+    fn cyclic_pagination_display_is_bounded() {
+        let url = oversized_url();
+        let rendered = MassiveError::CyclicPagination { url: url.clone() }.to_string();
+
+        assert!(
+            rendered.len() < url.len(),
+            "an oversized URL must not reach the log line in full"
+        );
+        assert!(rendered.contains("cycle detected"));
+        // The bounded prefix is still the real URL, so the message stays diagnostic.
+        assert!(rendered.contains("https://api.massive.com/v3/x?cursor=aaa"));
+        // A cut must be visible: an unmarked prefix reads as a complete URL, sending a reader
+        // after a `cursor` value that was silently dropped.
+        assert!(rendered.ends_with("..."), "an elided URL is marked");
+    }
+
+    #[test]
+    fn untrusted_next_url_display_is_bounded_but_stores_the_url_in_full() {
+        let next_url = oversized_url();
+        let error = MassiveError::UntrustedNextUrl {
+            next_url: next_url.clone(),
+            expected_origin: "https://api.massive.com".to_owned(),
+        };
+        let rendered = error.to_string();
+
+        assert!(rendered.len() < next_url.len(), "Display must be bounded");
+        assert!(rendered.contains("https://api.massive.com"));
+        assert!(rendered.ends_with("..."), "an elided URL is marked");
+        // The field keeps the value exactly as received — only rendering is capped, so a consumer
+        // matching on the variant can still inspect the whole URL.
+        match error {
+            MassiveError::UntrustedNextUrl {
+                next_url: stored, ..
+            } => {
+                assert_eq!(stored, next_url)
+            }
+            other => panic!("expected UntrustedNextUrl, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn display_of_a_short_url_is_not_truncated() {
+        // The bound must be invisible in the overwhelmingly common case.
+        let url = "https://api.massive.com/v3/reference/tickers?cursor=abc";
+        let rendered = MassiveError::CyclicPagination {
+            url: url.to_owned(),
+        }
+        .to_string();
+
+        assert!(rendered.ends_with(url), "got: {rendered}");
+    }
+
+    #[test]
+    fn pagination_url_too_long_display_reports_both_sizes() {
+        let rendered = MassiveError::PaginationUrlTooLong {
+            len: 9000,
+            limit: 8192,
+            prefix: "https://api.massive.com/v3/x".to_owned(),
+        }
+        .to_string();
+
+        assert!(rendered.contains("9000"), "got: {rendered}");
+        assert!(rendered.contains("8192"), "got: {rendered}");
+        assert!(rendered.contains("https://api.massive.com/v3/x"));
+        assert!(
+            rendered.ends_with("..."),
+            "a prefix shorter than `len` is truncated and must say so, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn pagination_url_too_long_display_omits_the_ellipsis_when_nothing_was_cut() {
+        // `#[non_exhaustive]` is on the enum, not this variant, so downstream code can build one
+        // with a complete `prefix`. The ellipsis is derived from `prefix.len() < len` rather than
+        // assumed from the internal constructor's behaviour, so a whole URL is not misreported as
+        // truncated.
+        let url = "https://api.massive.com/v3/x";
+        let rendered = MassiveError::PaginationUrlTooLong {
+            len: url.len(),
+            limit: 8192,
+            prefix: url.to_owned(),
+        }
+        .to_string();
+
+        assert!(rendered.contains(url), "got: {rendered}");
+        assert!(
+            !rendered.ends_with("..."),
+            "an untruncated prefix must not be marked as cut, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn deserialize_display_truncates_its_payload_snippet() {
+        let rendered = MassiveError::Deserialize {
+            message: "expected `,`".to_owned(),
+            payload: "x".repeat(500),
+        }
+        .to_string();
+
+        assert!(rendered.contains("expected `,`"));
+        assert!(rendered.contains("..."), "an elided payload is marked");
+        assert!(rendered.len() < 500);
+    }
+
+    #[test]
+    fn display_covers_every_variant_without_panicking() {
+        // `Display` slices strings by byte index, so a multi-byte payload in any variant is a
+        // panic risk; this walks all of them at once.
+        let multibyte = "€".repeat(400);
+        let variants = [
+            MassiveError::RateLimited {
+                retry_after: Some(Duration::from_secs(5)),
+            },
+            MassiveError::RateLimited { retry_after: None },
+            MassiveError::Disconnected {
+                reason: multibyte.clone(),
+            },
+            MassiveError::Auth {
+                message: multibyte.clone(),
+            },
+            MassiveError::Api {
+                status: 500,
+                message: multibyte.clone(),
+            },
+            MassiveError::Http {
+                message: multibyte.clone(),
+            },
+            MassiveError::Deserialize {
+                message: "bad".to_owned(),
+                payload: multibyte.clone(),
+            },
+            MassiveError::EnvVar { var: "MASSIVE_KEY" },
+            MassiveError::InvalidInput {
+                message: multibyte.clone(),
+            },
+            MassiveError::PaginationLimitExceeded {
+                pages: 10_001,
+                limit: 10_000,
+            },
+            MassiveError::CyclicPagination {
+                url: multibyte.clone(),
+            },
+            MassiveError::PaginationUrlTooLong {
+                len: 9000,
+                limit: 8192,
+                prefix: multibyte.clone(),
+            },
+            MassiveError::UntrustedNextUrl {
+                next_url: multibyte.clone(),
+                expected_origin: "https://api.massive.com".to_owned(),
+            },
+        ];
+
+        for variant in variants {
+            assert!(
+                !variant.to_string().is_empty(),
+                "every variant renders something: {variant:?}"
+            );
         }
     }
 }

--- a/rustrade-data/src/exchange/massive/mod.rs
+++ b/rustrade-data/src/exchange/massive/mod.rs
@@ -82,6 +82,7 @@ mod corporate_action;
 mod error;
 pub(crate) mod live;
 pub(crate) mod options;
+mod pagination;
 pub(crate) mod reference;
 pub(crate) mod rest;
 pub(crate) mod transformer;

--- a/rustrade-data/src/exchange/massive/options.rs
+++ b/rustrade-data/src/exchange/massive/options.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use super::error::MassiveError;
+use super::pagination::PaginationGuard;
 use super::reference::SortOrder;
 use super::rest::MassiveRestClient;
 use crate::subscription::greeks::OptionGreeks;
@@ -954,8 +955,10 @@ impl MassiveRestClient {
         let mut contracts: Vec<MassiveOptionContract> =
             Vec::with_capacity(query.limit.unwrap_or(100) as usize);
         let mut next_url: Option<String> = Some(initial_url);
+        let mut guard = PaginationGuard::default();
 
         while let Some(url) = next_url.take() {
+            guard.observe(&url)?;
             debug!(url = %url, "Fetching option contracts page");
 
             let body = self.fetch_page_body(&url).await?;
@@ -1032,8 +1035,10 @@ impl MassiveRestClient {
         let mut snapshots: Vec<MassiveOptionSnapshot> =
             Vec::with_capacity(query.limit.unwrap_or(50) as usize);
         let mut next_url: Option<String> = Some(initial_url);
+        let mut guard = PaginationGuard::default();
 
         while let Some(url) = next_url.take() {
+            guard.observe(&url)?;
             debug!(url = %url, "Fetching option chain snapshot page");
 
             let body = self.fetch_page_body(&url).await?;

--- a/rustrade-data/src/exchange/massive/options.rs
+++ b/rustrade-data/src/exchange/massive/options.rs
@@ -974,9 +974,6 @@ impl MassiveRestClient {
                 }
             }
 
-            if let Some(ref url) = parsed.next_url {
-                Self::validate_next_url(url, base_url)?;
-            }
             next_url = parsed.next_url;
         }
 
@@ -1054,9 +1051,6 @@ impl MassiveRestClient {
                 }
             }
 
-            if let Some(ref url) = parsed.next_url {
-                Self::validate_next_url(url, base_url)?;
-            }
             next_url = parsed.next_url;
         }
 

--- a/rustrade-data/src/exchange/massive/pagination.rs
+++ b/rustrade-data/src/exchange/massive/pagination.rs
@@ -1,0 +1,141 @@
+//! Bounded, cycle-safe pagination for Massive REST streams.
+//!
+//! Every Massive REST endpoint follows the same `next_url` cursor protocol: a
+//! page carries an optional `next_url` pointing at the following page, and the
+//! stream terminates when a page omits it. Two failure modes make that loop
+//! unsafe if followed unconditionally:
+//!
+//! - a server (or proxy) that never stops returning a `next_url` would page
+//!   forever, and
+//! - a `next_url` that points back to an already-fetched page would loop over
+//!   the same responses indefinitely.
+//!
+//! [`PaginationGuard`] makes both observable: it caps the page count at
+//! [`MAX_PAGES`] and records visited URLs to detect cycles, returning a terminal
+//! [`MassiveError`] instead of looping. It intentionally does **not** truncate
+//! silently — for a market-data client a short `Vec` is indistinguishable from a
+//! genuinely small result set, so incomplete pagination must fail loudly.
+
+use super::error::MassiveError;
+use std::collections::HashSet;
+
+/// Maximum number of pages a single paginated fetch will follow.
+///
+/// This is a runaway backstop, not a business limit: it is set well above the
+/// largest legitimate paginated response (e.g. the full reference-ticker
+/// universe), so reaching it signals a pathological query or a misbehaving
+/// server rather than normal operation.
+pub(super) const MAX_PAGES: usize = 10_000;
+
+/// Tracks pagination progress across a single Massive REST stream, enforcing a
+/// page-count cap and detecting `next_url` cycles.
+///
+/// Construct once per stream (via [`Default`]) and call [`observe`] once per page
+/// with the URL about to be fetched. The guard borrows nothing and is reset by
+/// simply creating a new instance.
+///
+/// [`observe`]: PaginationGuard::observe
+#[derive(Debug, Default)]
+pub(super) struct PaginationGuard {
+    pages: usize,
+    /// URLs already fetched, for cycle detection. Bounded by [`MAX_PAGES`]
+    /// entries: [`observe`] checks the page cap before inserting, so growth
+    /// cannot exceed the cap before the stream terminates.
+    ///
+    /// [`observe`]: PaginationGuard::observe
+    visited: HashSet<String>,
+}
+
+impl PaginationGuard {
+    /// Record that `url` is about to be fetched as the next page.
+    ///
+    /// Returns:
+    /// - [`MassiveError::PaginationLimitExceeded`] once more than [`MAX_PAGES`]
+    ///   pages have been observed, and
+    /// - [`MassiveError::CyclicPagination`] if `url` was already observed.
+    ///
+    /// Both are terminal: propagate them to end the stream rather than continuing
+    /// to page.
+    pub(super) fn observe(&mut self, url: &str) -> Result<(), MassiveError> {
+        self.pages += 1;
+        if self.pages > MAX_PAGES {
+            return Err(MassiveError::PaginationLimitExceeded {
+                pages: self.pages,
+                limit: MAX_PAGES,
+            });
+        }
+        if !self.visited.insert(url.to_owned()) {
+            return Err(MassiveError::CyclicPagination {
+                url: url.to_owned(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)] // Test code: panics on unexpected values are acceptable
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distinct_urls_under_the_cap_are_accepted() {
+        let mut guard = PaginationGuard::default();
+        for i in 0..MAX_PAGES {
+            assert!(
+                guard
+                    .observe(&format!("https://api.massive.com/page/{i}"))
+                    .is_ok(),
+                "page {i} within the cap should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn exceeding_the_page_cap_is_a_terminal_error() {
+        let mut guard = PaginationGuard::default();
+        // Exactly MAX_PAGES distinct pages are allowed.
+        for i in 0..MAX_PAGES {
+            guard
+                .observe(&format!("https://api.massive.com/page/{i}"))
+                .expect("within cap");
+        }
+        // The next distinct page trips the backstop.
+        let err = guard
+            .observe("https://api.massive.com/page/over")
+            .expect_err("page MAX_PAGES + 1 must be rejected");
+        assert_eq!(
+            err,
+            MassiveError::PaginationLimitExceeded {
+                pages: MAX_PAGES + 1,
+                limit: MAX_PAGES,
+            }
+        );
+    }
+
+    #[test]
+    fn revisiting_a_url_is_detected_as_a_cycle() {
+        let mut guard = PaginationGuard::default();
+        let url = "https://api.massive.com/v2/aggs/ticker/X:BTCUSD/range/1/minute/0/1?cursor=abc";
+        guard.observe(url).expect("first visit is fine");
+        let err = guard.observe(url).expect_err("second visit is a cycle");
+        assert_eq!(
+            err,
+            MassiveError::CyclicPagination {
+                url: url.to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn cycle_detection_is_url_exact() {
+        // URLs differing by cursor are distinct pages, not a cycle.
+        let mut guard = PaginationGuard::default();
+        guard
+            .observe("https://api.massive.com/x?cursor=a")
+            .expect("page 1");
+        guard
+            .observe("https://api.massive.com/x?cursor=b")
+            .expect("page 2 is a different URL");
+    }
+}

--- a/rustrade-data/src/exchange/massive/pagination.rs
+++ b/rustrade-data/src/exchange/massive/pagination.rs
@@ -17,7 +17,10 @@
 //! genuinely small result set, so incomplete pagination must fail loudly.
 
 use super::error::MassiveError;
+use crate::exchange::http::truncate_str;
 use std::collections::HashSet;
+use std::collections::hash_map::RandomState;
+use std::hash::BuildHasher;
 
 /// Maximum number of pages a single paginated fetch will follow.
 ///
@@ -26,6 +29,21 @@ use std::collections::HashSet;
 /// universe), so reaching it signals a pathological query or a misbehaving
 /// server rather than normal operation.
 pub(super) const MAX_PAGES: usize = 10_000;
+
+/// Maximum byte length of a URL this paginator will follow.
+///
+/// Like [`MAX_PAGES`], a runaway backstop rather than a business limit: a real
+/// Massive cursor URL is a few hundred bytes, and no mainstream HTTP stack
+/// accepts a request line beyond a few KiB, so this only rejects pathological
+/// input. It matters because a page's `next_url` is server-controlled and
+/// success bodies are read unbounded — without a cap, a misbehaving origin
+/// could hand back arbitrarily long URLs, and the guard would retain one per
+/// page for the life of the stream.
+pub(super) const MAX_URL_BYTES: usize = 8 * 1024;
+
+/// Bytes of a rejected URL retained for diagnosis (see
+/// [`MassiveError::PaginationUrlTooLong`]).
+const URL_PREFIX_BYTES: usize = 200;
 
 /// Tracks pagination progress across a single Massive REST stream, enforcing a
 /// page-count cap and detecting `next_url` cycles.
@@ -38,12 +56,31 @@ pub(super) const MAX_PAGES: usize = 10_000;
 #[derive(Debug, Default)]
 pub(super) struct PaginationGuard {
     pages: usize,
-    /// URLs already fetched, for cycle detection. Bounded by [`MAX_PAGES`]
-    /// entries: [`observe`] checks the page cap before inserting, so growth
-    /// cannot exceed the cap before the stream terminates.
+    /// Fixed-size fingerprints of the URLs already fetched, for cycle detection.
+    /// Bounded by [`MAX_PAGES`] entries: [`observe`] checks the page cap before
+    /// inserting, so growth cannot exceed the cap before the stream terminates.
+    ///
+    /// Fingerprints rather than the URLs themselves so each entry costs a
+    /// constant 8 bytes regardless of URL length — the URLs are server-supplied
+    /// and would otherwise be retained in full, up to [`MAX_PAGES`] of them.
+    /// Storing a *truncated* URL would not work: two distinct URLs sharing a
+    /// long prefix would compare equal and be reported as a false cycle, whereas
+    /// a hash is computed over the whole string.
     ///
     /// [`observe`]: PaginationGuard::observe
-    visited: HashSet<String>,
+    visited: HashSet<u64>,
+    /// Per-guard (and therefore per-stream) hash key.
+    ///
+    /// Deliberately [`RandomState`] rather than [`DefaultHasher::new`], whose
+    /// SipHash key is a fixed `(0, 0)` published in std's source. With a known
+    /// key, a misbehaving origin could precompute two distinct, well-formed
+    /// `next_url`s that collide and so force a spurious
+    /// [`MassiveError::CyclicPagination`] on a legitimate stream. A key the
+    /// server cannot know removes that possibility — which is precisely the
+    /// hash-flooding threat model SipHash was designed for.
+    ///
+    /// [`DefaultHasher::new`]: std::hash::DefaultHasher::new
+    hasher: RandomState,
 }
 
 impl PaginationGuard {
@@ -51,11 +88,20 @@ impl PaginationGuard {
     ///
     /// Returns:
     /// - [`MassiveError::PaginationLimitExceeded`] once more than [`MAX_PAGES`]
-    ///   pages have been observed, and
+    ///   pages have been observed,
+    /// - [`MassiveError::PaginationUrlTooLong`] if `url` exceeds
+    ///   [`MAX_URL_BYTES`], and
     /// - [`MassiveError::CyclicPagination`] if `url` was already observed.
     ///
-    /// Both are terminal: propagate them to end the stream rather than continuing
-    /// to page.
+    /// All three are terminal: propagate them to end the stream rather than
+    /// continuing to page.
+    ///
+    /// The length check runs before the URL is hashed or requested, so a
+    /// pathological value is rejected without being retained. It applies to
+    /// every URL the paginator follows — in practice always a server-supplied
+    /// `next_url`, but the first page's URL (built by this client from the
+    /// caller's query) passes through the same check, which is why the error is
+    /// named for the paginator rather than for `next_url`.
     pub(super) fn observe(&mut self, url: &str) -> Result<(), MassiveError> {
         self.pages += 1;
         if self.pages > MAX_PAGES {
@@ -64,7 +110,14 @@ impl PaginationGuard {
                 limit: MAX_PAGES,
             });
         }
-        if !self.visited.insert(url.to_owned()) {
+        if url.len() > MAX_URL_BYTES {
+            return Err(MassiveError::PaginationUrlTooLong {
+                len: url.len(),
+                limit: MAX_URL_BYTES,
+                prefix: truncate_str(url, URL_PREFIX_BYTES),
+            });
+        }
+        if !self.visited.insert(self.hasher.hash_one(url)) {
             return Err(MassiveError::CyclicPagination {
                 url: url.to_owned(),
             });
@@ -137,5 +190,58 @@ mod tests {
         guard
             .observe("https://api.massive.com/x?cursor=b")
             .expect("page 2 is a different URL");
+    }
+
+    #[test]
+    fn long_urls_sharing_a_prefix_are_not_a_false_cycle() {
+        // The property that rules out storing a *truncated* URL as the dedup key: these two differ
+        // only in their final byte, far beyond any sane truncation point, yet are distinct pages.
+        // Hashing the whole string keeps them distinct; a truncating key would report a cycle and
+        // kill a legitimate stream.
+        let mut guard = PaginationGuard::default();
+        let base = format!("https://api.massive.com/x?cursor={}", "a".repeat(2048));
+        guard.observe(&format!("{base}1")).expect("page 1");
+        guard
+            .observe(&format!("{base}2"))
+            .expect("page 2 differs only in its last byte but is a different URL");
+    }
+
+    #[test]
+    fn a_url_at_the_byte_cap_is_accepted() {
+        let mut guard = PaginationGuard::default();
+        let url = "a".repeat(MAX_URL_BYTES);
+        guard.observe(&url).expect("exactly at the cap is allowed");
+    }
+
+    #[test]
+    fn a_url_over_the_byte_cap_is_rejected_with_a_bounded_prefix() {
+        let mut guard = PaginationGuard::default();
+        let url = format!("https://api.massive.com/{}", "a".repeat(MAX_URL_BYTES));
+        let err = guard
+            .observe(&url)
+            .expect_err("past the cap must be rejected");
+
+        match err {
+            MassiveError::PaginationUrlTooLong { len, limit, prefix } => {
+                assert_eq!(len, url.len());
+                assert_eq!(limit, MAX_URL_BYTES);
+                assert_eq!(prefix.len(), URL_PREFIX_BYTES);
+                assert!(prefix.starts_with("https://api.massive.com/"));
+            }
+            other => panic!("expected PaginationUrlTooLong, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_oversized_url_is_rejected_before_being_recorded() {
+        // The point of checking length *before* insertion: the guard must not retain the very value
+        // it just refused, or the bound would be pointless.
+        let mut guard = PaginationGuard::default();
+        let url = "a".repeat(MAX_URL_BYTES + 1);
+        guard.observe(&url).expect_err("rejected");
+        assert!(
+            guard.visited.is_empty(),
+            "a rejected URL must leave no trace in the visited set"
+        );
     }
 }

--- a/rustrade-data/src/exchange/massive/reference.rs
+++ b/rustrade-data/src/exchange/massive/reference.rs
@@ -1166,9 +1166,6 @@ impl MassiveRestClient {
                     }
                 }
 
-                if let Some(ref url) = parsed.next_url {
-                    Self::validate_next_url(url, base_url)?;
-                }
                 next_url = parsed.next_url;
             }
         }
@@ -1360,9 +1357,6 @@ impl MassiveRestClient {
                     }
                 }
 
-                if let Some(ref url) = parsed.next_url {
-                    Self::validate_next_url(url, base_url)?;
-                }
                 next_url = parsed.next_url;
             }
         }
@@ -1416,9 +1410,6 @@ impl MassiveRestClient {
                     }
                 }
 
-                if let Some(ref url) = parsed.next_url {
-                    Self::validate_next_url(url, base_url)?;
-                }
                 next_url = parsed.next_url;
             }
         }

--- a/rustrade-data/src/exchange/massive/reference.rs
+++ b/rustrade-data/src/exchange/massive/reference.rs
@@ -3,6 +3,7 @@
 //! Provides access to ticker information, exchanges, market status, and holidays.
 
 use super::error::MassiveError;
+use super::pagination::PaginationGuard;
 use super::rest::MassiveRestClient;
 use async_stream::try_stream;
 use chrono::{DateTime, NaiveDate, Utc};
@@ -1145,8 +1146,10 @@ impl MassiveRestClient {
             );
 
             let mut next_url: Option<String> = Some(initial_url);
+            let mut guard = PaginationGuard::default();
 
             while let Some(url) = next_url.take() {
+                guard.observe(&url)?;
                 debug!(url = %url, "Fetching tickers page");
 
                 let body = self.fetch_page_body(&url).await?;
@@ -1337,8 +1340,10 @@ impl MassiveRestClient {
             );
 
             let mut next_url: Option<String> = Some(initial_url);
+            let mut guard = PaginationGuard::default();
 
             while let Some(url) = next_url.take() {
+                guard.observe(&url)?;
                 debug!(url = %url, "Fetching dividends page");
 
                 let body = self.fetch_page_body(&url).await?;
@@ -1391,8 +1396,10 @@ impl MassiveRestClient {
             );
 
             let mut next_url: Option<String> = Some(initial_url);
+            let mut guard = PaginationGuard::default();
 
             while let Some(url) = next_url.take() {
+                guard.observe(&url)?;
                 debug!(url = %url, "Fetching splits page");
 
                 let body = self.fetch_page_body(&url).await?;

--- a/rustrade-data/src/exchange/massive/rest.rs
+++ b/rustrade-data/src/exchange/massive/rest.rs
@@ -19,6 +19,7 @@ use reqwest::{Client, StatusCode, header};
 use std::env;
 use std::time::Duration;
 use tracing::debug;
+use url::Url;
 
 const BASE_URL: &str = "https://api.massive.com";
 const ENV_API_KEY: &str = "MASSIVE_API_KEY";
@@ -69,6 +70,16 @@ impl MassiveRestClient {
     /// # Arguments
     ///
     /// * `api_key` - Massive API key from <https://massive.com/dashboard/api-keys>
+    ///
+    /// # Redirects
+    ///
+    /// The client does **not** follow HTTP redirects. The API key is sent as an
+    /// `Authorization: Bearer` header on every request, so auto-following a
+    /// server-issued 3xx could carry it off the trusted origin. Massive uses
+    /// explicit `next_url` cursor pagination and is not expected to redirect, so
+    /// an unexpected 3xx surfaces as [`MassiveError::Api`] rather than being
+    /// followed. A base URL set via [`Self::with_base_url`] must therefore serve
+    /// responses directly, without redirect indirection.
     pub fn new(api_key: impl Into<String>) -> Result<Self, MassiveError> {
         let api_key = api_key.into();
         let mut headers = header::HeaderMap::new();
@@ -83,6 +94,17 @@ impl MassiveRestClient {
         let client = Client::builder()
             .default_headers(headers)
             .timeout(Duration::from_secs(30))
+            // Transport-layer companion to the `validate_next_url` origin guard. The API key rides in
+            // an `Authorization: Bearer` default header on every request, so a server-issued 3xx must
+            // not be allowed to bounce an origin-validated request to another host: `Policy::none()`
+            // stops reqwest auto-following any redirect, so an unexpected 3xx is returned unfollowed
+            // and surfaces as a `MassiveError::Api` instead of silently carrying the token off-origin.
+            // This makes the "token never leaves the trusted origin" guarantee structural rather than
+            // relying on reqwest's internal cross-origin header stripping. (`https_only` is deliberately
+            // NOT set: it would reject the `http://` base URL that `with_base_url` accepts for local
+            // testing, while adding nothing against the leak — the origin check already rejects any
+            // `http://` `next_url` under an `https` base, since scheme is part of the compared origin.)
+            .redirect(reqwest::redirect::Policy::none())
             .build()?;
 
         Ok(Self {
@@ -100,6 +122,10 @@ impl MassiveRestClient {
     }
 
     /// Override the base URL (useful for testing or legacy polygon.io endpoint).
+    ///
+    /// The base URL defines the trusted origin: a paginated `next_url` is followed
+    /// only when it shares this scheme, host, and port, and redirects are never
+    /// followed (see the "Redirects" note on [`Self::new`]).
     #[must_use]
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
@@ -126,22 +152,56 @@ impl MassiveRestClient {
         Ok(())
     }
 
-    /// Validate next_url is from the expected origin to prevent token leakage.
-    pub(super) fn validate_next_url(next_url: &str, base_url: &str) -> Result<(), MassiveError> {
-        if !next_url.starts_with(base_url) {
-            return Err(MassiveError::InvalidInput {
-                message: format!(
-                    "next_url origin mismatch: expected {}, got {}",
-                    base_url, next_url
-                ),
-            });
+    /// Validate that `url` shares the client's configured origin before a request
+    /// is issued, so the API token is never sent to an untrusted host.
+    ///
+    /// The client attaches `Authorization: Bearer <key>` as a reqwest default
+    /// header, sent with **every** request this client issues regardless of
+    /// destination host, so a URL naming a different origin would leak the token.
+    /// A `starts_with(base_url)` prefix check is insufficient — a look-alike host
+    /// such as `https://api.massive.com.evil.example` (or the separator-less
+    /// `https://api.massive.comevil.example`) shares the prefix yet is a
+    /// different origin. Both URLs are parsed and their
+    /// [origins](url::Url::origin) (scheme + host + port) compared; a `url` that
+    /// fails to parse or whose origin differs is rejected (fail-closed) with
+    /// [`MassiveError::UntrustedNextUrl`].
+    ///
+    /// A `base_url` that fails to parse is a client-side misconfiguration
+    /// (reachable only via [`Self::with_base_url`], since [`BASE_URL`] is a valid
+    /// constant) and surfaces as [`MassiveError::InvalidInput`], not as a
+    /// security event.
+    ///
+    /// On success returns the parsed [`Url`] so the caller can issue the request
+    /// without re-parsing the string.
+    fn validate_next_url(next_url: &str, base_url: &str) -> Result<Url, MassiveError> {
+        let base_origin = Url::parse(base_url)
+            .map_err(|e| MassiveError::InvalidInput {
+                message: format!("base_url is not a valid URL ({e}): {base_url}"),
+            })?
+            .origin();
+
+        let untrusted = || MassiveError::UntrustedNextUrl {
+            next_url: next_url.to_owned(),
+            expected_origin: base_origin.ascii_serialization(),
+        };
+
+        let parsed = Url::parse(next_url).map_err(|_| untrusted())?;
+        if parsed.origin() != base_origin {
+            return Err(untrusted());
         }
-        Ok(())
+        Ok(parsed)
     }
 
     /// Fetch a page body from the given URL with standard error handling.
+    ///
+    /// Every URL is [origin-validated](Self::validate_next_url) against the
+    /// client's base URL before the request is sent — this is the single
+    /// chokepoint that issues an authenticated request, so validating here (not
+    /// at each pagination call site) makes the token-leak guard structural: a new
+    /// paginated fetch cannot bypass it by forgetting to call the validator.
     pub(super) async fn fetch_page_body(&self, url: &str) -> Result<String, MassiveError> {
-        let response = self.client.get(url).send().await?;
+        let validated_url = Self::validate_next_url(url, &self.base_url)?;
+        let response = self.client.get(validated_url).send().await?;
         let status = response.status();
 
         // Extract retry-after before consuming response
@@ -272,10 +332,6 @@ impl MassiveRestClient {
                     }
                 }
 
-                // Validate next_url origin before following
-                if let Some(ref url) = parsed.next_url {
-                    Self::validate_next_url(url, &self.base_url)?;
-                }
                 next_url = parsed.next_url;
             }
         }
@@ -332,10 +388,6 @@ impl MassiveRestClient {
                     }
                 }
 
-                // Validate next_url origin before following
-                if let Some(ref url) = parsed.next_url {
-                    Self::validate_next_url(url, &self.base_url)?;
-                }
                 next_url = parsed.next_url;
             }
         }
@@ -398,10 +450,6 @@ impl MassiveRestClient {
                     }
                 }
 
-                // Validate next_url origin before following
-                if let Some(ref url) = parsed.next_url {
-                    Self::validate_next_url(url, &self.base_url)?;
-                }
                 next_url = parsed.next_url;
             }
         }
@@ -430,5 +478,96 @@ mod tests {
             let result = MassiveRestClient::from_env();
             assert!(matches!(result, Err(MassiveError::EnvVar { .. })));
         });
+    }
+
+    // --- validate_next_url (#182: token-leak guard) ---------------------------
+
+    const BASE: &str = "https://api.massive.com";
+
+    fn assert_untrusted(next_url: &str) {
+        match MassiveRestClient::validate_next_url(next_url, BASE) {
+            Err(MassiveError::UntrustedNextUrl {
+                next_url: got,
+                expected_origin,
+            }) => {
+                assert_eq!(got, next_url);
+                assert_eq!(expected_origin, "https://api.massive.com");
+            }
+            other => panic!("expected UntrustedNextUrl for {next_url:?}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_next_url_accepts_same_origin_different_path() {
+        // The documented shape: same origin, path + `cursor` query differ.
+        assert!(
+            MassiveRestClient::validate_next_url(
+                "https://api.massive.com/v3/reference/tickers?cursor=YWN0aXZlPXRydWU",
+                BASE,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_next_url_accepts_explicit_default_port() {
+        // `:443` is the default for https, so origins are equal.
+        assert!(
+            MassiveRestClient::validate_next_url("https://api.massive.com:443/v2/aggs", BASE)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_next_url_rejects_lookalike_subdomain() {
+        // The reported #182 vector: shares the base URL as a string prefix
+        // (so `starts_with` passed) but is a different host.
+        assert_untrusted("https://api.massive.com.attacker.example/v2/aggs?cursor=abc");
+    }
+
+    #[test]
+    fn validate_next_url_rejects_no_dot_suffix_host() {
+        // Proves the fix closes the separator-less bypass, not just subdomains:
+        // `api.massive.comevil.example` also `starts_with("https://api.massive.com")`.
+        assert_untrusted("https://api.massive.comevil.example/v2/aggs");
+    }
+
+    #[test]
+    fn validate_next_url_rejects_scheme_downgrade() {
+        // https -> http would send the bearer token in cleartext.
+        assert_untrusted("http://api.massive.com/v2/aggs");
+    }
+
+    #[test]
+    fn validate_next_url_rejects_port_mismatch() {
+        assert_untrusted("https://api.massive.com:8443/v2/aggs");
+    }
+
+    #[test]
+    fn validate_next_url_rejects_userinfo_confusion() {
+        // Host is `attacker.example`; `api.massive.com` is only userinfo.
+        assert_untrusted("https://api.massive.com@attacker.example/v2/aggs");
+    }
+
+    #[test]
+    fn validate_next_url_rejects_unparseable_next_url() {
+        // Fail-closed: an unverifiable URL must never receive the token.
+        assert_untrusted("not a url");
+    }
+
+    #[test]
+    fn validate_next_url_rejects_non_http_scheme() {
+        // Non-http(s) schemes yield opaque origins that never compare equal.
+        assert_untrusted("file:///etc/passwd");
+    }
+
+    #[test]
+    fn validate_next_url_unparseable_base_is_invalid_input_not_security() {
+        // A broken client-configured base URL is a misconfiguration, not a
+        // token-leak attempt — surfaces as InvalidInput.
+        assert!(matches!(
+            MassiveRestClient::validate_next_url("https://api.massive.com/v2/aggs", "not a url"),
+            Err(MassiveError::InvalidInput { .. })
+        ));
     }
 }

--- a/rustrade-data/src/exchange/massive/rest.rs
+++ b/rustrade-data/src/exchange/massive/rest.rs
@@ -8,7 +8,7 @@ use super::transformer::{
     AggregatesResponse, QuotesResponse, TradesResponse, parse_aggregates_response,
     parse_quotes_response, parse_trades_response, timespan_to_step,
 };
-use crate::exchange::http::{MAX_ERROR_BODY_DOWNLOAD_BYTES, read_body_capped};
+use crate::exchange::http::{MAX_ERROR_BODY_DOWNLOAD_BYTES, read_body_capped, truncate_str};
 use crate::subscription::{
     book::OrderBookL1,
     candle::{Candle, open_time_from_close},
@@ -25,11 +25,8 @@ use url::Url;
 const BASE_URL: &str = "https://api.massive.com";
 const ENV_API_KEY: &str = "MASSIVE_API_KEY";
 
-/// Truncate response body for error messages (max 512 chars, UTF-8 safe).
-fn truncate_body(body: &str) -> String {
-    let boundary = body.floor_char_boundary(512);
-    body[..boundary].to_owned()
-}
+/// Byte cap applied to a response body before it is stored in a [`MassiveError`] message.
+const ERROR_MESSAGE_BODY_BYTES: usize = 512;
 
 /// REST client for Massive historical and intraday market data.
 ///
@@ -82,8 +79,8 @@ impl MassiveRestClient {
     /// # Redirects
     ///
     /// The client does **not** follow HTTP redirects. The API key is attached as
-    /// an `Authorization: Bearer` header to each request (from the origin-validated
-    /// [`fetch_page_body`](Self::fetch_page_body) chokepoint), so auto-following a
+    /// an `Authorization: Bearer` header to each request, from a single
+    /// origin-validated chokepoint, so auto-following a
     /// server-issued 3xx could carry it off the trusted origin. Massive uses
     /// explicit `next_url` cursor pagination and is not expected to redirect, so
     /// an unexpected 3xx surfaces as [`MassiveError::Api`] rather than being
@@ -159,7 +156,10 @@ impl MassiveRestClient {
     ///
     /// # Errors
     ///
-    /// Returns [`MassiveError::InvalidInput`] if `base_url` does not parse as a URL.
+    /// Returns [`MassiveError::InvalidInput`] if `base_url` does not parse as a
+    /// URL, or if it parses but uses a scheme other than `http`/`https` — a
+    /// non-special scheme (e.g. `file:`) yields an opaque origin that would
+    /// reject every subsequent request, so it is refused up front.
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Result<Self, MassiveError> {
         let base_url = base_url.into();
         self.base_origin = Self::parse_base_origin(&base_url)?;
@@ -285,19 +285,19 @@ impl MassiveRestClient {
             return Err(MassiveError::RateLimited { retry_after });
         }
 
-        // A non-success body is only a diagnostic that `truncate_body` caps for the error message, so
+        // A non-success body is only a diagnostic that `truncate_str` caps for the error message, so
         // read it under a bound: a pathological proxy/CDN error page must not be buffered in full.
         // The success body is the real JSON page and is read whole below.
         if !status.is_success() {
             let body = read_body_capped(response, MAX_ERROR_BODY_DOWNLOAD_BYTES).await?;
             if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
                 return Err(MassiveError::Auth {
-                    message: truncate_body(&body),
+                    message: truncate_str(&body, ERROR_MESSAGE_BODY_BYTES),
                 });
             }
             return Err(MassiveError::Api {
                 status: status.as_u16(),
-                message: truncate_body(&body),
+                message: truncate_str(&body, ERROR_MESSAGE_BODY_BYTES),
             });
         }
 

--- a/rustrade-data/src/exchange/massive/rest.rs
+++ b/rustrade-data/src/exchange/massive/rest.rs
@@ -3,6 +3,7 @@
 //! Provides access to aggregates (OHLCV), trades, and quotes across all asset classes.
 
 use super::error::MassiveError;
+use super::pagination::PaginationGuard;
 use super::transformer::{
     AggregatesResponse, QuotesResponse, TradesResponse, parse_aggregates_response,
     parse_quotes_response, parse_trades_response, timespan_to_step,
@@ -248,8 +249,10 @@ impl MassiveRestClient {
             );
 
             let mut next_url: Option<String> = Some(initial_url);
+            let mut guard = PaginationGuard::default();
 
             while let Some(url) = next_url.take() {
+                guard.observe(&url)?;
                 debug!(url = %url, "Fetching aggregates page");
 
                 let parsed = self.fetch_aggregates_page(&url).await?;
@@ -309,8 +312,10 @@ impl MassiveRestClient {
             );
 
             let mut next_url: Option<String> = Some(initial_url);
+            let mut guard = PaginationGuard::default();
 
             while let Some(url) = next_url.take() {
+                guard.observe(&url)?;
                 debug!(url = %url, "Fetching trades page");
 
                 let parsed = self.fetch_trades_page(&url).await?;
@@ -373,8 +378,10 @@ impl MassiveRestClient {
             );
 
             let mut next_url: Option<String> = Some(initial_url);
+            let mut guard = PaginationGuard::default();
 
             while let Some(url) = next_url.take() {
+                guard.observe(&url)?;
                 debug!(url = %url, "Fetching quotes page");
 
                 let parsed = self.fetch_quotes_page(&url).await?;

--- a/rustrade-data/src/exchange/massive/rest.rs
+++ b/rustrade-data/src/exchange/massive/rest.rs
@@ -51,9 +51,9 @@ fn truncate_body(body: &str) -> String {
 pub struct MassiveRestClient {
     client: Client,
     // Attached per-request as an `Authorization: Bearer` header from the
-    // origin-validated `fetch_page_body` chokepoint (and used for WebSocket auth),
-    // never as a client-wide default header — so the token can only ever ride a
-    // request whose destination origin has already been validated. See #198.
+    // origin-validated `fetch_page_body` chokepoint, never as a client-wide
+    // default header — so the token can only ever ride a request whose
+    // destination origin has already been validated. See #198.
     api_key: String,
     base_url: String,
     // Trusted origin (scheme + host + port) derived from `base_url`, parsed once at
@@ -155,14 +155,31 @@ impl MassiveRestClient {
     }
 
     /// Parse `base_url` into the trusted [origin](url::Origin) used to vet every
-    /// `next_url`. A base URL that fails to parse is a client-side misconfiguration
-    /// (surfaced as [`MassiveError::InvalidInput`]), not a security event.
+    /// `next_url`. A base URL that fails to parse — or that uses a non-`http(s)`
+    /// scheme — is a client-side misconfiguration (surfaced as
+    /// [`MassiveError::InvalidInput`]), not a security event.
+    ///
+    /// The scheme is restricted to `http`/`https` deliberately: a non-special
+    /// scheme (e.g. `file:`) parses fine but its [origin](url::Url::origin) is a
+    /// fresh [`url::Origin::Opaque`] that never compares equal to any other —
+    /// even one parsed from the identical string — so every subsequent
+    /// [`validate_next_url`](Self::validate_next_url) check (including the very
+    /// first request, built from `base_url` itself) would fail with a misleading
+    /// [`MassiveError::UntrustedNextUrl`]. Rejecting it here fails the build fast
+    /// with a clear message instead of self-bricking every request.
     fn parse_base_origin(base_url: &str) -> Result<url::Origin, MassiveError> {
-        Ok(Url::parse(base_url)
-            .map_err(|e| MassiveError::InvalidInput {
-                message: format!("base_url is not a valid URL ({e}): {base_url}"),
-            })?
-            .origin())
+        let url = Url::parse(base_url).map_err(|e| MassiveError::InvalidInput {
+            message: format!("base_url is not a valid URL ({e}): {base_url}"),
+        })?;
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err(MassiveError::InvalidInput {
+                message: format!(
+                    "base_url must use the http or https scheme, got `{}`: {base_url}",
+                    url.scheme()
+                ),
+            });
+        }
+        Ok(url.origin())
     }
 
     /// Get the base URL.
@@ -615,6 +632,20 @@ mod tests {
         let result = MassiveRestClient::new("test_api_key")
             .expect("client builds")
             .with_base_url("not a url");
+        assert!(matches!(result, Err(MassiveError::InvalidInput { .. })));
+    }
+
+    #[test]
+    fn with_base_url_rejects_non_http_scheme() {
+        // A base URL that *parses* but uses a non-http(s) scheme (e.g. `file:`)
+        // yields an opaque origin that never compares equal — which would brick
+        // every subsequent request with a misleading UntrustedNextUrl. It must
+        // instead fail fast at construction as InvalidInput (#198). Distinct from
+        // the parse-failure path above: `file:///data` parses successfully, so
+        // this exercises the scheme check specifically, not `Url::parse` erroring.
+        let result = MassiveRestClient::new("test_api_key")
+            .expect("client builds")
+            .with_base_url("file:///data");
         assert!(matches!(result, Err(MassiveError::InvalidInput { .. })));
     }
 }

--- a/rustrade-data/src/exchange/massive/rest.rs
+++ b/rustrade-data/src/exchange/massive/rest.rs
@@ -8,6 +8,7 @@ use super::transformer::{
     AggregatesResponse, QuotesResponse, TradesResponse, parse_aggregates_response,
     parse_quotes_response, parse_trades_response, timespan_to_step,
 };
+use crate::exchange::http::{MAX_ERROR_BODY_DOWNLOAD_BYTES, read_body_capped};
 use crate::subscription::{
     book::OrderBookL1,
     candle::{Candle, open_time_from_close},
@@ -88,6 +89,18 @@ impl MassiveRestClient {
     /// an unexpected 3xx surfaces as [`MassiveError::Api`] rather than being
     /// followed. A base URL set via [`Self::with_base_url`] must therefore serve
     /// responses directly, without redirect indirection.
+    ///
+    /// # Known limitation
+    ///
+    /// Redirect-following is disabled *wholesale* (`reqwest::redirect::Policy::none()`),
+    /// so this applies to **same-origin** redirects too: even a same-origin 301/308
+    /// — e.g. trailing-slash normalization by a load balancer or CDN — is surfaced
+    /// as a terminal [`MassiveError::Api`] with the 3xx status rather than being
+    /// transparently followed. This is a deliberate trade-off: a wholesale block
+    /// keeps the "token never leaves the trusted origin" guarantee structural
+    /// rather than dependent on reqwest's cross-origin header-stripping. It relies
+    /// on Massive serving `next_url` pages directly; a deployment fronted by a
+    /// redirecting proxy is not supported.
     pub fn new(api_key: impl Into<String>) -> Result<Self, MassiveError> {
         let api_key = api_key.into();
         // Validate the key forms a well-formed `Authorization` header value now, so a
@@ -272,21 +285,23 @@ impl MassiveRestClient {
             return Err(MassiveError::RateLimited { retry_after });
         }
 
-        let body = response.text().await?;
-
-        if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
-            return Err(MassiveError::Auth {
-                message: truncate_body(&body),
-            });
-        }
-
+        // A non-success body is only a diagnostic that `truncate_body` caps for the error message, so
+        // read it under a bound: a pathological proxy/CDN error page must not be buffered in full.
+        // The success body is the real JSON page and is read whole below.
         if !status.is_success() {
+            let body = read_body_capped(response, MAX_ERROR_BODY_DOWNLOAD_BYTES).await?;
+            if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+                return Err(MassiveError::Auth {
+                    message: truncate_body(&body),
+                });
+            }
             return Err(MassiveError::Api {
                 status: status.as_u16(),
                 message: truncate_body(&body),
             });
         }
 
+        let body = response.text().await?;
         Ok(body)
     }
 

--- a/rustrade-data/src/exchange/massive/rest.rs
+++ b/rustrade-data/src/exchange/massive/rest.rs
@@ -50,9 +50,16 @@ fn truncate_body(body: &str) -> String {
 #[derive(Clone)]
 pub struct MassiveRestClient {
     client: Client,
-    #[allow(dead_code)] // Retained for WebSocket auth; HTTP auth is in client headers
+    // Attached per-request as an `Authorization: Bearer` header from the
+    // origin-validated `fetch_page_body` chokepoint (and used for WebSocket auth),
+    // never as a client-wide default header — so the token can only ever ride a
+    // request whose destination origin has already been validated. See #198.
     api_key: String,
     base_url: String,
+    // Trusted origin (scheme + host + port) derived from `base_url`, parsed once at
+    // construction so each `next_url` check compares against cached state and a
+    // malformed base URL fails fast rather than on the first request. See #198.
+    base_origin: url::Origin,
 }
 
 impl std::fmt::Debug for MassiveRestClient {
@@ -73,8 +80,9 @@ impl MassiveRestClient {
     ///
     /// # Redirects
     ///
-    /// The client does **not** follow HTTP redirects. The API key is sent as an
-    /// `Authorization: Bearer` header on every request, so auto-following a
+    /// The client does **not** follow HTTP redirects. The API key is attached as
+    /// an `Authorization: Bearer` header to each request (from the origin-validated
+    /// [`fetch_page_body`](Self::fetch_page_body) chokepoint), so auto-following a
     /// server-issued 3xx could carry it off the trusted origin. Massive uses
     /// explicit `next_url` cursor pagination and is not expected to redirect, so
     /// an unexpected 3xx surfaces as [`MassiveError::Api`] rather than being
@@ -82,28 +90,33 @@ impl MassiveRestClient {
     /// responses directly, without redirect indirection.
     pub fn new(api_key: impl Into<String>) -> Result<Self, MassiveError> {
         let api_key = api_key.into();
-        let mut headers = header::HeaderMap::new();
-        let auth_value =
-            header::HeaderValue::from_str(&format!("Bearer {}", api_key)).map_err(|e| {
-                MassiveError::Auth {
-                    message: format!("Invalid API key format: {}", e),
-                }
-            })?;
-        headers.insert(header::AUTHORIZATION, auth_value);
+        // Validate the key forms a well-formed `Authorization` header value now, so a
+        // malformed key fails fast at construction (as `Auth`) instead of as a confusing
+        // per-request error. The token is deliberately NOT installed as a client-wide
+        // default header — that would ride every request regardless of host. It is attached
+        // per-request in `fetch_page_body`, only after the destination origin is validated,
+        // so the credential is coupled to the origin check by construction. See #198.
+        header::HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|e| {
+            MassiveError::Auth {
+                message: format!("Invalid API key format: {e}"),
+            }
+        })?;
+
+        let base_origin = Self::parse_base_origin(BASE_URL)?;
 
         let client = Client::builder()
-            .default_headers(headers)
             .timeout(Duration::from_secs(30))
-            // Transport-layer companion to the `validate_next_url` origin guard. The API key rides in
-            // an `Authorization: Bearer` default header on every request, so a server-issued 3xx must
-            // not be allowed to bounce an origin-validated request to another host: `Policy::none()`
-            // stops reqwest auto-following any redirect, so an unexpected 3xx is returned unfollowed
-            // and surfaces as a `MassiveError::Api` instead of silently carrying the token off-origin.
-            // This makes the "token never leaves the trusted origin" guarantee structural rather than
-            // relying on reqwest's internal cross-origin header stripping. (`https_only` is deliberately
-            // NOT set: it would reject the `http://` base URL that `with_base_url` accepts for local
-            // testing, while adding nothing against the leak — the origin check already rejects any
-            // `http://` `next_url` under an `https` base, since scheme is part of the compared origin.)
+            // Transport-layer companion to the `validate_next_url` origin guard. The API key is
+            // attached per-request (see `fetch_page_body`), so a server-issued 3xx must not be allowed
+            // to bounce an origin-validated request to another host: `Policy::none()` stops reqwest
+            // auto-following any redirect, so an unexpected 3xx is returned unfollowed and surfaces as
+            // a `MassiveError::Api` instead of the client re-issuing the request against the redirect
+            // target. This makes the "token never leaves the trusted origin" guarantee structural
+            // rather than relying on reqwest's internal cross-origin header stripping. (`https_only` is
+            // deliberately NOT set: it would reject the `http://` base URL that `with_base_url` accepts
+            // for local testing, while adding nothing against the leak — the origin check already
+            // rejects any `http://` `next_url` under an `https` base, since scheme is part of the
+            // compared origin.)
             .redirect(reqwest::redirect::Policy::none())
             .build()?;
 
@@ -111,6 +124,7 @@ impl MassiveRestClient {
             client,
             api_key,
             base_url: BASE_URL.to_string(),
+            base_origin,
         })
     }
 
@@ -125,11 +139,30 @@ impl MassiveRestClient {
     ///
     /// The base URL defines the trusted origin: a paginated `next_url` is followed
     /// only when it shares this scheme, host, and port, and redirects are never
-    /// followed (see the "Redirects" note on [`Self::new`]).
-    #[must_use]
-    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
-        self.base_url = base_url.into();
-        self
+    /// followed (see the "Redirects" note on [`Self::new`]). The origin is parsed
+    /// and cached here, so a `base_url` that is not a valid URL is rejected up
+    /// front with [`MassiveError::InvalidInput`] rather than deferred to the first
+    /// request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MassiveError::InvalidInput`] if `base_url` does not parse as a URL.
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Result<Self, MassiveError> {
+        let base_url = base_url.into();
+        self.base_origin = Self::parse_base_origin(&base_url)?;
+        self.base_url = base_url;
+        Ok(self)
+    }
+
+    /// Parse `base_url` into the trusted [origin](url::Origin) used to vet every
+    /// `next_url`. A base URL that fails to parse is a client-side misconfiguration
+    /// (surfaced as [`MassiveError::InvalidInput`]), not a security event.
+    fn parse_base_origin(base_url: &str) -> Result<url::Origin, MassiveError> {
+        Ok(Url::parse(base_url)
+            .map_err(|e| MassiveError::InvalidInput {
+                message: format!("base_url is not a valid URL ({e}): {base_url}"),
+            })?
+            .origin())
     }
 
     /// Get the base URL.
@@ -152,41 +185,35 @@ impl MassiveRestClient {
         Ok(())
     }
 
-    /// Validate that `url` shares the client's configured origin before a request
+    /// Validate that `next_url` shares the client's trusted origin before a request
     /// is issued, so the API token is never sent to an untrusted host.
     ///
-    /// The client attaches `Authorization: Bearer <key>` as a reqwest default
-    /// header, sent with **every** request this client issues regardless of
-    /// destination host, so a URL naming a different origin would leak the token.
-    /// A `starts_with(base_url)` prefix check is insufficient — a look-alike host
-    /// such as `https://api.massive.com.evil.example` (or the separator-less
-    /// `https://api.massive.comevil.example`) shares the prefix yet is a
-    /// different origin. Both URLs are parsed and their
-    /// [origins](url::Url::origin) (scheme + host + port) compared; a `url` that
-    /// fails to parse or whose origin differs is rejected (fail-closed) with
+    /// The client attaches `Authorization: Bearer <key>` to each request from the
+    /// [`fetch_page_body`](Self::fetch_page_body) chokepoint, *after* this check
+    /// passes — so a URL naming a different origin is rejected before the token is
+    /// ever attached. A `starts_with(base_url)` prefix check is insufficient — a
+    /// look-alike host such as `https://api.massive.com.evil.example` (or the
+    /// separator-less `https://api.massive.comevil.example`) shares the prefix yet
+    /// is a different origin. `next_url` is parsed and its
+    /// [origin](url::Url::origin) (scheme + host + port) compared against the
+    /// client's cached `base_origin`; a `next_url` that fails to parse or whose
+    /// origin differs is rejected (fail-closed) with
     /// [`MassiveError::UntrustedNextUrl`].
     ///
-    /// A `base_url` that fails to parse is a client-side misconfiguration
-    /// (reachable only via [`Self::with_base_url`], since [`BASE_URL`] is a valid
-    /// constant) and surfaces as [`MassiveError::InvalidInput`], not as a
-    /// security event.
+    /// The trusted `base_origin` is parsed once at construction (see
+    /// [`Self::parse_base_origin`]), so a malformed base URL is rejected there —
+    /// it can never reach this check.
     ///
     /// On success returns the parsed [`Url`] so the caller can issue the request
     /// without re-parsing the string.
-    fn validate_next_url(next_url: &str, base_url: &str) -> Result<Url, MassiveError> {
-        let base_origin = Url::parse(base_url)
-            .map_err(|e| MassiveError::InvalidInput {
-                message: format!("base_url is not a valid URL ({e}): {base_url}"),
-            })?
-            .origin();
-
+    fn validate_next_url(next_url: &str, base_origin: &url::Origin) -> Result<Url, MassiveError> {
         let untrusted = || MassiveError::UntrustedNextUrl {
             next_url: next_url.to_owned(),
             expected_origin: base_origin.ascii_serialization(),
         };
 
         let parsed = Url::parse(next_url).map_err(|_| untrusted())?;
-        if parsed.origin() != base_origin {
+        if &parsed.origin() != base_origin {
             return Err(untrusted());
         }
         Ok(parsed)
@@ -194,14 +221,25 @@ impl MassiveRestClient {
 
     /// Fetch a page body from the given URL with standard error handling.
     ///
-    /// Every URL is [origin-validated](Self::validate_next_url) against the
-    /// client's base URL before the request is sent — this is the single
-    /// chokepoint that issues an authenticated request, so validating here (not
-    /// at each pagination call site) makes the token-leak guard structural: a new
-    /// paginated fetch cannot bypass it by forgetting to call the validator.
+    /// This is the single chokepoint that issues an authenticated request: every
+    /// URL is [origin-validated](Self::validate_next_url) against the client's
+    /// cached origin *before* the request is sent, and the `Authorization: Bearer`
+    /// token is attached here per-request only after that check passes. Doing both
+    /// in one place (not at each pagination call site) makes the token-leak guard
+    /// structural — a new paginated fetch cannot leak the credential by forgetting
+    /// to call the validator, because the token lives on this path alone. See #198.
     pub(super) async fn fetch_page_body(&self, url: &str) -> Result<String, MassiveError> {
-        let validated_url = Self::validate_next_url(url, &self.base_url)?;
-        let response = self.client.get(validated_url).send().await?;
+        let validated_url = Self::validate_next_url(url, &self.base_origin)?;
+        // Attach the bearer token only now, after the destination origin has been validated —
+        // the token is not a client-wide default header, so it can never accompany an
+        // unvalidated URL. `bearer_auth` also marks the header sensitive (redacted in reqwest
+        // logs). See #198.
+        let response = self
+            .client
+            .get(validated_url)
+            .bearer_auth(&self.api_key)
+            .send()
+            .await?;
         let status = response.status();
 
         // Extract retry-after before consuming response
@@ -463,6 +501,7 @@ impl MassiveRestClient {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)] // Test code: panics on unexpected values are acceptable
 mod tests {
     use super::*;
 
@@ -484,8 +523,12 @@ mod tests {
 
     const BASE: &str = "https://api.massive.com";
 
+    fn base_origin() -> url::Origin {
+        Url::parse(BASE).expect("BASE is a valid URL").origin()
+    }
+
     fn assert_untrusted(next_url: &str) {
-        match MassiveRestClient::validate_next_url(next_url, BASE) {
+        match MassiveRestClient::validate_next_url(next_url, &base_origin()) {
             Err(MassiveError::UntrustedNextUrl {
                 next_url: got,
                 expected_origin,
@@ -503,7 +546,7 @@ mod tests {
         assert!(
             MassiveRestClient::validate_next_url(
                 "https://api.massive.com/v3/reference/tickers?cursor=YWN0aXZlPXRydWU",
-                BASE,
+                &base_origin(),
             )
             .is_ok()
         );
@@ -513,8 +556,11 @@ mod tests {
     fn validate_next_url_accepts_explicit_default_port() {
         // `:443` is the default for https, so origins are equal.
         assert!(
-            MassiveRestClient::validate_next_url("https://api.massive.com:443/v2/aggs", BASE)
-                .is_ok()
+            MassiveRestClient::validate_next_url(
+                "https://api.massive.com:443/v2/aggs",
+                &base_origin()
+            )
+            .is_ok()
         );
     }
 
@@ -562,12 +608,13 @@ mod tests {
     }
 
     #[test]
-    fn validate_next_url_unparseable_base_is_invalid_input_not_security() {
+    fn with_base_url_rejects_unparseable_base_as_invalid_input() {
         // A broken client-configured base URL is a misconfiguration, not a
-        // token-leak attempt — surfaces as InvalidInput.
-        assert!(matches!(
-            MassiveRestClient::validate_next_url("https://api.massive.com/v2/aggs", "not a url"),
-            Err(MassiveError::InvalidInput { .. })
-        ));
+        // token-leak attempt — and it now fails fast at construction (#198),
+        // surfacing as InvalidInput rather than deferring to the first request.
+        let result = MassiveRestClient::new("test_api_key")
+            .expect("client builds")
+            .with_base_url("not a url");
+        assert!(matches!(result, Err(MassiveError::InvalidInput { .. })));
     }
 }

--- a/rustrade-data/src/exchange/mod.rs
+++ b/rustrade-data/src/exchange/mod.rs
@@ -60,6 +60,10 @@ pub mod massive;
 /// exchange [`Connector`] to build [`WsMessage`] subscription payloads.
 pub mod subscription;
 
+/// Internal HTTP helpers shared by the REST-based exchange integrations (Massive, IBKR Flex).
+#[cfg(any(feature = "massive", feature = "ibkr"))]
+pub(crate) mod http;
+
 /// Default [`Duration`] the [`Connector::SubValidator`] will wait to receive all success responses to actioned
 /// `Subscription` requests.
 pub const DEFAULT_SUBSCRIPTION_TIMEOUT: Duration = Duration::from_secs(10);

--- a/rustrade-data/src/exchange/mod.rs
+++ b/rustrade-data/src/exchange/mod.rs
@@ -60,8 +60,11 @@ pub mod massive;
 /// exchange [`Connector`] to build [`WsMessage`] subscription payloads.
 pub mod subscription;
 
-/// Internal HTTP helpers shared by the REST-based exchange integrations (Massive, IBKR Flex).
-#[cfg(any(feature = "massive", feature = "ibkr"))]
+/// Internal HTTP helpers shared by the REST-based exchange integrations (Massive, IBKR Flex,
+/// Binance).
+///
+/// Not feature-gated: the Binance surface is always compiled and uses every helper here, so all
+/// three REST clients bound their error-path body reads identically.
 pub(crate) mod http;
 
 /// Default [`Duration`] the [`Connector::SubValidator`] will wait to receive all success responses to actioned

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -109,10 +109,20 @@ use tracing_subscriber as _;
 // (tests/massive_integration.rs), which compile as separate units.
 #[cfg(test)]
 use serial_test as _;
-// wiremock is only referenced by the pagination integration tests under the
-// `massive` feature (tests/massive_pagination.rs), which compile as separate units.
+// wiremock is referenced by the pagination integration tests under the `massive` feature
+// (tests/massive_pagination.rs, a separate compilation unit) and by `exchange::http`'s unit tests,
+// which compile only under `massive`/`ibkr`. This stub covers the build where neither is enabled.
 #[cfg(test)]
 use wiremock as _;
+// time is only referenced by the integration tests under the `databento`/`ibkr` features
+// (tests/databento_integration.rs, tests/ibkr_integration.rs) and by a databento example, which
+// compile as separate units.
+#[cfg(test)]
+use time as _;
+// temp_env is only referenced by the in-tree unit tests under the `massive` feature
+// (exchange::massive::{live, rest}), so it is unused when that feature is off.
+#[cfg(test)]
+use temp_env as _;
 
 use crate::{
     error::DataError,

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -3,7 +3,12 @@
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::cast_possible_truncation,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    // A public item linking to a private one renders as dead, non-hyperlinked code on docs.rs — the
+    // reader is pointed at something they cannot open. Denied rather than warned because these
+    // accumulate silently: `cargo doc` is not part of the normal build or the pre-commit gate, so a
+    // warning here is one nobody sees. Fix by inlining the fact or linking a public item instead.
+    rustdoc::private_intra_doc_links
 )]
 #![warn(
     unused,
@@ -111,7 +116,9 @@ use tracing_subscriber as _;
 use serial_test as _;
 // wiremock is referenced by the pagination integration tests under the `massive` feature
 // (tests/massive_pagination.rs, a separate compilation unit) and by `exchange::http`'s unit tests,
-// which compile only under `massive`/`ibkr`. This stub covers the build where neither is enabled.
+// which are no longer feature-gated and so reference it in every `cfg(test)` build. This stub is
+// therefore redundant today; it is kept alongside its siblings so re-gating those tests cannot
+// silently reintroduce the warning.
 #[cfg(test)]
 use wiremock as _;
 // time is only referenced by the integration tests under the `databento`/`ibkr` features
@@ -123,6 +130,10 @@ use time as _;
 // (exchange::massive::{live, rest}), so it is unused when that feature is off.
 #[cfg(test)]
 use temp_env as _;
+// http is only referenced by the in-tree unit tests under the `ibkr` feature
+// (exchange::ibkr::flex), which build synthetic `reqwest::Response`s without a socket.
+#[cfg(test)]
+use http as _;
 
 use crate::{
     error::DataError,

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -109,6 +109,10 @@ use tracing_subscriber as _;
 // (tests/massive_integration.rs), which compile as separate units.
 #[cfg(test)]
 use serial_test as _;
+// wiremock is only referenced by the pagination integration tests under the
+// `massive` feature (tests/massive_pagination.rs), which compile as separate units.
+#[cfg(test)]
+use wiremock as _;
 
 use crate::{
     error::DataError,

--- a/rustrade-data/tests/massive_pagination.rs
+++ b/rustrade-data/tests/massive_pagination.rs
@@ -1,0 +1,178 @@
+//! Massive REST pagination robustness tests (mocked HTTP, no live API key).
+//!
+//! Unlike `massive_integration.rs` (which is `#[ignore]` and hits the real Massive
+//! API), these tests stand up a local `wiremock` server via
+//! [`MassiveRestClient::with_base_url`] and drive the full paginated stream against
+//! crafted `next_url` chains. They verify the [`PaginationGuard`] wiring end-to-end:
+//!
+//! - a server that keeps returning the same `next_url` is caught as a cycle
+//!   (terminal `MassiveError::CyclicPagination`), and
+//! - a normal finite `next_url` chain paginates to completion with no false
+//!   positive.
+//!
+//! The numeric page cap (`MAX_PAGES`) is covered by fast, deterministic unit tests
+//! in `massive::pagination`; exercising it here would mean serving thousands of
+//! pages, so it is intentionally not re-tested through HTTP.
+
+#![cfg(feature = "massive")]
+// Tests use unwrap/expect for concise failure messages; panics are the intended failure mode.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use chrono::{Duration, Utc};
+use futures_util::StreamExt;
+use rustrade_data::exchange::massive::{
+    MassiveError, MassiveRestClient, OptionContractQuery, TickerQuery,
+};
+use std::pin::pin;
+use std::sync::atomic::{AtomicU32, Ordering};
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+/// Serves pre-configured JSON pages in registration order.
+///
+/// Each request advances an atomic counter and returns the next page body,
+/// panicking if called more times than pages were supplied — so an unexpected
+/// extra request surfaces as an explicit test failure rather than a stale reply.
+struct Sequential {
+    call: AtomicU32,
+    pages: Vec<serde_json::Value>,
+}
+
+impl Sequential {
+    fn new(pages: Vec<serde_json::Value>) -> Self {
+        Self {
+            call: AtomicU32::new(0),
+            pages,
+        }
+    }
+}
+
+impl Respond for Sequential {
+    fn respond(&self, _: &Request) -> ResponseTemplate {
+        let i = self.call.fetch_add(1, Ordering::Relaxed) as usize;
+        let body = self.pages.get(i).unwrap_or_else(|| {
+            panic!(
+                "Sequential: request #{i} has no configured response (only {} page(s) supplied)",
+                self.pages.len()
+            )
+        });
+        ResponseTemplate::new(200).set_body_json(body)
+    }
+}
+
+fn client_for(server: &MockServer) -> MassiveRestClient {
+    MassiveRestClient::new("test_api_key")
+        .expect("client builds")
+        .with_base_url(server.uri())
+}
+
+/// A `next_url` that always points back to the same page must terminate the stream
+/// with `CyclicPagination` rather than looping forever.
+#[tokio::test]
+async fn aggregates_stream_detects_next_url_cycle() {
+    let server = MockServer::start().await;
+    // Every page reports no bars and a `next_url` that points at a single fixed
+    // page under the mock's origin — so following it revisits the same URL.
+    let loop_url = format!("{}/loop", server.uri());
+    let body = serde_json::json!({
+        "resultsCount": 0,
+        "results": [],
+        "next_url": loop_url,
+    });
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let to = Utc::now();
+    let from = to - Duration::minutes(5);
+    let mut stream = pin!(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to));
+
+    let mut terminal_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(_) => continue,
+            Err(e) => {
+                terminal_err = Some(e);
+                break;
+            }
+        }
+    }
+
+    assert!(
+        matches!(terminal_err, Some(MassiveError::CyclicPagination { .. })),
+        "expected CyclicPagination, got {terminal_err:?}"
+    );
+}
+
+/// The `Vec`-returning fetches (`fetch_option_contracts` / `fetch_option_chain_snapshot`)
+/// collect eagerly rather than streaming, so the guard error must propagate through the
+/// plain `async fn -> Result<Vec<_>>` return path. A self-referential `next_url` must fail
+/// with `CyclicPagination` instead of growing the `Vec` without bound.
+#[tokio::test]
+async fn option_contracts_detects_next_url_cycle() {
+    let server = MockServer::start().await;
+    // Empty results + a `next_url` that points back at a single fixed page under the
+    // mock's origin — so following it revisits the same URL.
+    let loop_url = format!("{}/loop", server.uri());
+    let body = serde_json::json!({
+        "results": [],
+        "next_url": loop_url,
+        "status": "OK",
+    });
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let query = OptionContractQuery::new();
+    let result = client.fetch_option_contracts(&query).await;
+
+    assert!(
+        matches!(result, Err(MassiveError::CyclicPagination { .. })),
+        "expected CyclicPagination, got {result:?}"
+    );
+}
+
+/// A normal finite `next_url` chain paginates to completion: every item is yielded,
+/// the stream ends cleanly (no error), and the guard does not false-positive on
+/// legitimately distinct page URLs.
+#[tokio::test]
+async fn tickers_stream_paginates_finite_chain_without_false_positive() {
+    let server = MockServer::start().await;
+    let page2_url = format!("{}/v3/reference/tickers?cursor=page2", server.uri());
+    Mock::given(method("GET"))
+        .respond_with(Sequential::new(vec![
+            serde_json::json!({
+                "results": [{ "ticker": "AAA" }],
+                "next_url": page2_url,
+                "status": "OK",
+            }),
+            serde_json::json!({
+                "results": [{ "ticker": "BBB" }],
+                "next_url": serde_json::Value::Null,
+                "status": "OK",
+            }),
+        ]))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let query = TickerQuery::new();
+    let mut stream = pin!(client.fetch_tickers(&query));
+
+    let mut tickers = Vec::new();
+    while let Some(item) = stream.next().await {
+        tickers.push(item.expect("no error on a well-formed finite chain"));
+    }
+
+    let symbols: Vec<_> = tickers.iter().map(|t| t.ticker.as_str()).collect();
+    assert_eq!(symbols, vec!["AAA", "BBB"]);
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        2,
+        "exactly two pages should have been fetched"
+    );
+}

--- a/rustrade-data/tests/massive_pagination.rs
+++ b/rustrade-data/tests/massive_pagination.rs
@@ -25,7 +25,7 @@ use rustrade_data::exchange::massive::{
 };
 use std::pin::pin;
 use std::sync::atomic::{AtomicU32, Ordering};
-use wiremock::matchers::method;
+use wiremock::matchers::{header, method};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
 /// Serves pre-configured JSON pages in registration order.
@@ -64,6 +64,7 @@ fn client_for(server: &MockServer) -> MassiveRestClient {
     MassiveRestClient::new("test_api_key")
         .expect("client builds")
         .with_base_url(server.uri())
+        .expect("mock server uri is a valid base url")
 }
 
 /// A `next_url` that always points back to the same page must terminate the stream
@@ -236,6 +237,41 @@ async fn aggregates_stream_rejects_cross_origin_next_url_without_leaking_token()
     assert!(
         attacker.received_requests().await.unwrap().is_empty(),
         "client must not issue any request to the untrusted origin (token would leak)"
+    );
+}
+
+/// The positive counterpart to the cross-origin test: on the trusted origin the
+/// client *must* attach the `Authorization: Bearer <key>` header (#198 moved it off
+/// the reqwest default headers to a per-request attachment). The mock only matches
+/// when that header is present, so a clean stream completion proves the token rode
+/// the request; had it not been attached, the request would miss the mock and come
+/// back as a `MassiveError::Api { status: 404 }`.
+#[tokio::test]
+async fn aggregates_request_attaches_bearer_token_to_trusted_origin() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(header("authorization", "Bearer test_api_key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resultsCount": 0,
+            "results": [],
+            "next_url": serde_json::Value::Null,
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let to = Utc::now();
+    let from = to - Duration::minutes(5);
+    let mut stream = pin!(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to));
+
+    while let Some(item) = stream.next().await {
+        item.expect("request with bearer token should be accepted by the trusted origin");
+    }
+
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        1,
+        "expected exactly one authenticated request to the trusted origin"
     );
 }
 

--- a/rustrade-data/tests/massive_pagination.rs
+++ b/rustrade-data/tests/massive_pagination.rs
@@ -10,6 +10,12 @@
 //! - a normal finite `next_url` chain paginates to completion with no false
 //!   positive.
 //!
+//! The cycle test is repeated across **every** paginated fetch rather than a
+//! representative one. The guard's own logic is covered by unit tests in
+//! `massive::pagination`; what these tests protect is the per-call-site *wiring* —
+//! a `guard.observe(&url)?` omitted from one loop is exactly the copy-paste slip a
+//! single representative test would miss, and each loop is hand-written.
+//!
 //! The numeric page cap (`MAX_PAGES`) is covered by fast, deterministic unit tests
 //! in `massive::pagination`; exercising it here would mean serving thousands of
 //! pages, so it is intentionally not re-tested through HTTP.
@@ -19,14 +25,28 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use chrono::{Duration, Utc};
-use futures_util::StreamExt;
+use futures_util::{Stream, StreamExt};
 use rustrade_data::exchange::massive::{
-    MassiveError, MassiveRestClient, OptionContractQuery, TickerQuery,
+    DividendQuery, MassiveError, MassiveRestClient, OptionContractQuery, OptionSnapshotQuery,
+    SplitQuery, TickerQuery,
 };
 use std::pin::pin;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration as StdDuration;
 use wiremock::matchers::{header, method};
 use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+/// How long a guarded fetch may run before the test declares it non-terminating.
+///
+/// The cycle tests mount a mock that answers a self-referential `next_url` *forever*, so a
+/// regression that drops the `guard.observe(&url)?` wiring from a pagination loop does not fail —
+/// it pages indefinitely. Without this bound such a regression would hang until CI's job timeout,
+/// an opaque failure far removed from its cause. This turns "the guard is gone" into an explicit,
+/// fast assertion.
+///
+/// Generous relative to a local wiremock round-trip (milliseconds), so it can only fire on genuine
+/// non-termination, never on a slow machine.
+const TERMINATION_TIMEOUT: StdDuration = StdDuration::from_secs(10);
 
 /// Serves pre-configured JSON pages in registration order.
 ///
@@ -67,44 +87,149 @@ fn client_for(server: &MockServer) -> MassiveRestClient {
         .expect("mock server uri is a valid base url")
 }
 
-/// A `next_url` that always points back to the same page must terminate the stream
-/// with `CyclicPagination` rather than looping forever.
-#[tokio::test]
-async fn aggregates_stream_detects_next_url_cycle() {
-    let server = MockServer::start().await;
-    // Every page reports no bars and a `next_url` that points at a single fixed
-    // page under the mock's origin — so following it revisits the same URL.
+/// Mount a catch-all mock that answers every request with an empty page whose `next_url`
+/// points at one fixed URL under the mock's own origin — so following it revisits the same
+/// URL and only the [`PaginationGuard`] can end the stream.
+///
+/// The body is a superset of the fields every Massive page response deserializes
+/// (`resultsCount`/`results`/`next_url`/`status`); each endpoint's response type takes
+/// `results` as an `Option<Vec<_>>` and ignores the fields it does not declare, so one shape
+/// serves all of them.
+async fn mount_self_referential_page(server: &MockServer) {
     let loop_url = format!("{}/loop", server.uri());
     let body = serde_json::json!({
         "resultsCount": 0,
         "results": [],
         "next_url": loop_url,
+        "status": "OK",
     });
     Mock::given(method("GET"))
         .respond_with(ResponseTemplate::new(200).set_body_json(body))
-        .mount(&server)
+        .mount(server)
         .await;
+}
+
+/// Drive `stream` to completion, returning its terminal error if it yielded one.
+///
+/// Fails the test if the stream has not terminated within [`TERMINATION_TIMEOUT`] — see that
+/// constant for why an unbounded drain would fail opaquely against the cycle mocks.
+async fn drain_to_terminal_error<T>(
+    stream: impl Stream<Item = Result<T, MassiveError>>,
+) -> Option<MassiveError> {
+    let drain = async {
+        let mut stream = pin!(stream);
+        while let Some(item) = stream.next().await {
+            if let Err(error) = item {
+                return Some(error);
+            }
+        }
+        None
+    };
+    tokio::time::timeout(TERMINATION_TIMEOUT, drain)
+        .await
+        .expect("stream must terminate — a hang means the PaginationGuard wiring is missing")
+}
+
+/// [`drain_to_terminal_error`]'s counterpart for the `Vec`-returning fetches, which collect
+/// eagerly instead of streaming and so have no terminal item to drain to.
+async fn await_bounded<T>(
+    fetch: impl Future<Output = Result<T, MassiveError>>,
+) -> Result<T, MassiveError> {
+    tokio::time::timeout(TERMINATION_TIMEOUT, fetch)
+        .await
+        .expect("fetch must terminate — a hang means the PaginationGuard wiring is missing")
+}
+
+/// Assert that `error` is the terminal cycle error, with the fetch's name in the failure message
+/// so a regression names the offending call site directly.
+#[track_caller]
+fn assert_cycle_detected(fetch: &str, error: Option<MassiveError>) {
+    assert!(
+        matches!(error, Some(MassiveError::CyclicPagination { .. })),
+        "{fetch}: expected CyclicPagination, got {error:?}"
+    );
+}
+
+// ============================================================================
+// Cycle detection — one test per paginated call site
+// ============================================================================
+
+/// A `next_url` that always points back to the same page must terminate the stream
+/// with `CyclicPagination` rather than looping forever.
+#[tokio::test]
+async fn aggregates_stream_detects_next_url_cycle() {
+    let server = MockServer::start().await;
+    mount_self_referential_page(&server).await;
 
     let client = client_for(&server);
     let to = Utc::now();
     let from = to - Duration::minutes(5);
-    let mut stream = pin!(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to));
+    let error =
+        drain_to_terminal_error(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to)).await;
 
-    let mut terminal_err = None;
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(_) => continue,
-            Err(e) => {
-                terminal_err = Some(e);
-                break;
-            }
-        }
-    }
+    assert_cycle_detected("fetch_aggregates", error);
+}
 
-    assert!(
-        matches!(terminal_err, Some(MassiveError::CyclicPagination { .. })),
-        "expected CyclicPagination, got {terminal_err:?}"
-    );
+#[tokio::test]
+async fn trades_stream_detects_next_url_cycle() {
+    let server = MockServer::start().await;
+    mount_self_referential_page(&server).await;
+
+    let client = client_for(&server);
+    let to = Utc::now();
+    let from = to - Duration::minutes(5);
+    let error = drain_to_terminal_error(client.fetch_trades("X:BTCUSD", from, to)).await;
+
+    assert_cycle_detected("fetch_trades", error);
+}
+
+#[tokio::test]
+async fn quotes_stream_detects_next_url_cycle() {
+    let server = MockServer::start().await;
+    mount_self_referential_page(&server).await;
+
+    let client = client_for(&server);
+    let to = Utc::now();
+    let from = to - Duration::minutes(5);
+    let error = drain_to_terminal_error(client.fetch_quotes("X:BTCUSD", from, to)).await;
+
+    assert_cycle_detected("fetch_quotes", error);
+}
+
+#[tokio::test]
+async fn dividends_stream_detects_next_url_cycle() {
+    let server = MockServer::start().await;
+    mount_self_referential_page(&server).await;
+
+    let client = client_for(&server);
+    let query = DividendQuery::new();
+    let error = drain_to_terminal_error(client.fetch_dividends(&query)).await;
+
+    assert_cycle_detected("fetch_dividends", error);
+}
+
+#[tokio::test]
+async fn splits_stream_detects_next_url_cycle() {
+    let server = MockServer::start().await;
+    mount_self_referential_page(&server).await;
+
+    let client = client_for(&server);
+    let query = SplitQuery::new();
+    let error = drain_to_terminal_error(client.fetch_splits_raw(&query)).await;
+
+    assert_cycle_detected("fetch_splits_raw", error);
+}
+
+#[tokio::test]
+async fn tickers_stream_detects_next_url_cycle() {
+    let server = MockServer::start().await;
+    mount_self_referential_page(&server).await;
+
+    let client = client_for(&server);
+    let query = TickerQuery::new();
+    let error = drain_to_terminal_error(client.fetch_tickers(&query)).await;
+
+    assert_cycle_detected("fetch_tickers", error);
 }
 
 /// The `Vec`-returning fetches (`fetch_option_contracts` / `fetch_option_chain_snapshot`)
@@ -114,28 +239,30 @@ async fn aggregates_stream_detects_next_url_cycle() {
 #[tokio::test]
 async fn option_contracts_detects_next_url_cycle() {
     let server = MockServer::start().await;
-    // Empty results + a `next_url` that points back at a single fixed page under the
-    // mock's origin — so following it revisits the same URL.
-    let loop_url = format!("{}/loop", server.uri());
-    let body = serde_json::json!({
-        "results": [],
-        "next_url": loop_url,
-        "status": "OK",
-    });
-    Mock::given(method("GET"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(body))
-        .mount(&server)
-        .await;
+    mount_self_referential_page(&server).await;
 
     let client = client_for(&server);
     let query = OptionContractQuery::new();
-    let result = client.fetch_option_contracts(&query).await;
+    let result = await_bounded(client.fetch_option_contracts(&query)).await;
 
-    assert!(
-        matches!(result, Err(MassiveError::CyclicPagination { .. })),
-        "expected CyclicPagination, got {result:?}"
-    );
+    assert_cycle_detected("fetch_option_contracts", result.err());
 }
+
+#[tokio::test]
+async fn option_chain_snapshot_detects_next_url_cycle() {
+    let server = MockServer::start().await;
+    mount_self_referential_page(&server).await;
+
+    let client = client_for(&server);
+    let query = OptionSnapshotQuery::new();
+    let result = await_bounded(client.fetch_option_chain_snapshot("AAPL", &query)).await;
+
+    assert_cycle_detected("fetch_option_chain_snapshot", result.err());
+}
+
+// ============================================================================
+// Origin validation, redirects, and the no-false-positive baseline
+// ============================================================================
 
 /// A normal finite `next_url` chain paginates to completion: every item is yielded,
 /// the stream ends cleanly (no error), and the guard does not false-positive on
@@ -217,18 +344,8 @@ async fn aggregates_stream_rejects_cross_origin_next_url_without_leaking_token()
     let client = client_for(&primary);
     let to = Utc::now();
     let from = to - Duration::minutes(5);
-    let mut stream = pin!(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to));
-
-    let mut terminal_err = None;
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(_) => continue,
-            Err(e) => {
-                terminal_err = Some(e);
-                break;
-            }
-        }
-    }
+    let terminal_err =
+        drain_to_terminal_error(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to)).await;
 
     assert!(
         matches!(terminal_err, Some(MassiveError::UntrustedNextUrl { .. })),
@@ -307,18 +424,8 @@ async fn aggregates_stream_does_not_follow_redirect_off_origin() {
     let client = client_for(&primary);
     let to = Utc::now();
     let from = to - Duration::minutes(5);
-    let mut stream = pin!(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to));
-
-    let mut terminal_err = None;
-    while let Some(item) = stream.next().await {
-        match item {
-            Ok(_) => continue,
-            Err(e) => {
-                terminal_err = Some(e);
-                break;
-            }
-        }
-    }
+    let terminal_err =
+        drain_to_terminal_error(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to)).await;
 
     assert!(
         matches!(terminal_err, Some(MassiveError::Api { status, .. }) if (300..400).contains(&status)),

--- a/rustrade-data/tests/massive_pagination.rs
+++ b/rustrade-data/tests/massive_pagination.rs
@@ -176,3 +176,120 @@ async fn tickers_stream_paginates_finite_chain_without_false_positive() {
         "exactly two pages should have been fetched"
     );
 }
+
+/// A `next_url` pointing at a *different origin* must terminate the stream with
+/// `UntrustedNextUrl` and — the load-bearing guarantee (#182) — the client must
+/// never issue a request to that origin, so the `Authorization: Bearer` token is
+/// never leaked.
+///
+/// The two mock servers share host `127.0.0.1` but bind different ports, so they
+/// are distinct origins (origin = scheme + host + port); the malicious page under
+/// the trusted origin hands back a `next_url` on the attacker's origin.
+#[tokio::test]
+async fn aggregates_stream_rejects_cross_origin_next_url_without_leaking_token() {
+    // The attacker-controlled origin. Its catch-all mock would happily answer
+    // (and thus would have received the bearer token) *if* the client ever
+    // fetched it — the test asserts it never does.
+    let attacker = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resultsCount": 0,
+            "results": [],
+            "next_url": serde_json::Value::Null,
+        })))
+        .mount(&attacker)
+        .await;
+
+    // The trusted origin returns one empty page whose `next_url` points off-origin
+    // at the attacker.
+    let primary = MockServer::start().await;
+    let evil_next = format!("{}/v2/aggs/steal?cursor=abc", attacker.uri());
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resultsCount": 0,
+            "results": [],
+            "next_url": evil_next,
+        })))
+        .mount(&primary)
+        .await;
+
+    let client = client_for(&primary);
+    let to = Utc::now();
+    let from = to - Duration::minutes(5);
+    let mut stream = pin!(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to));
+
+    let mut terminal_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(_) => continue,
+            Err(e) => {
+                terminal_err = Some(e);
+                break;
+            }
+        }
+    }
+
+    assert!(
+        matches!(terminal_err, Some(MassiveError::UntrustedNextUrl { .. })),
+        "expected UntrustedNextUrl, got {terminal_err:?}"
+    );
+    assert!(
+        attacker.received_requests().await.unwrap().is_empty(),
+        "client must not issue any request to the untrusted origin (token would leak)"
+    );
+}
+
+/// The origin guard vets the URL the client *requests*, but a trusted server could
+/// still answer with a 3xx redirect to another origin. The client disables redirect
+/// following (`redirect::Policy::none()`), so the token can never ride a
+/// server-issued redirect off-origin: the 3xx is returned unfollowed and surfaces
+/// as a terminal `MassiveError::Api`, and — the load-bearing guarantee — the
+/// attacker origin receives no request. This keeps the "token never leaves the
+/// trusted origin" property from depending on reqwest's internal header stripping.
+#[tokio::test]
+async fn aggregates_stream_does_not_follow_redirect_off_origin() {
+    // Same catch-all attacker origin as the cross-origin test — it would answer
+    // (and receive the bearer token) if the client ever followed the redirect.
+    let attacker = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resultsCount": 0,
+            "results": [],
+            "next_url": serde_json::Value::Null,
+        })))
+        .mount(&attacker)
+        .await;
+
+    // The trusted origin redirects the very first request off-origin at the attacker.
+    let primary = MockServer::start().await;
+    let evil_location = format!("{}/v2/aggs/steal", attacker.uri());
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(302).insert_header("location", evil_location.as_str()))
+        .mount(&primary)
+        .await;
+
+    let client = client_for(&primary);
+    let to = Utc::now();
+    let from = to - Duration::minutes(5);
+    let mut stream = pin!(client.fetch_aggregates("X:BTCUSD", 1, "minute", from, to));
+
+    let mut terminal_err = None;
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(_) => continue,
+            Err(e) => {
+                terminal_err = Some(e);
+                break;
+            }
+        }
+    }
+
+    assert!(
+        matches!(terminal_err, Some(MassiveError::Api { status, .. }) if (300..400).contains(&status)),
+        "expected an unfollowed 3xx as MassiveError::Api, got {terminal_err:?}"
+    );
+    assert!(
+        attacker.received_requests().await.unwrap().is_empty(),
+        "client must not follow the redirect to the untrusted origin (token would leak)"
+    );
+}


### PR DESCRIPTION
## Summary

Hardens the Massive REST client and the IBKR Flex client against real-world failure and abuse modes, and improves diagnostics. Three areas:

1. **Bounded, cycle-safe Massive REST pagination** — every `next_url`-paginated fetch now caps the pages it will follow and detects a `next_url` that revisits an already-fetched page, failing loudly instead of paginating without bound. A silently truncated result is indistinguishable from a genuinely small one for a market-data client, so incomplete pagination is a terminal error.
2. **Massive bearer-token leak prevention** — a server-supplied `next_url` was validated with a `starts_with(base_url)` prefix check, which a look-alike host (`https://api.massive.com.attacker.example`, or the separator-less `https://api.massive.comevil.example`) could pass and receive the API token. Origins are now parsed and compared (scheme + host + port), redirect-following is disabled, and the token is attached per-request only after origin validation passes in a single request chokepoint — so the credential is structurally coupled to the origin check.
3. **Richer IBKR Flex diagnostics + configurable poll budget** — the client now reads the HTTP body *before* branching on status (preserving proxy/CDN/gateway error pages instead of discarding them via `error_for_status`), surfaces non-Flex error bodies as a new token-scrubbed `IbkrFlexError::HttpStatus`, fixes a retry-path bypass where a `1019` ("still generating") under a non-2xx status aborted the poll, and adds a tunable `FlexPollPolicy`.

## Changes

- **`feat(massive)`**: bounded, cycle-safe pagination for all REST fetches via a shared `PaginationGuard` (page cap + cycle detection); new `MassiveError::PaginationLimitExceeded` and `CyclicPagination` variants.
- **`fix(massive)` (#182)**: origin-based `next_url` validation (parsed `url::Origin`, fail-closed), redirects disabled (`redirect::Policy::none()`), validation centralized in the `fetch_page_body` chokepoint; new `MassiveError::UntrustedNextUrl`.
- **`fix(massive)` (#198)**: bearer token moved off the client-wide default headers to a per-request attachment inside the origin-validated chokepoint; base URL parsed into its trusted origin once at construction.
- **`feat(ibkr-flex)` (#180)**: read body before branching on status; new `IbkrFlexError::HttpStatus { status, body }` (token-scrubbed, bounded to 1024 bytes); retry-path fix for `1019` under non-2xx; new `FlexPollPolicy { initial_delay, interval, max_attempts }` set via `IbkrFlexClient::with_poll_policy`.

## Breaking changes

All documented in CHANGELOG with migration notes:
- **`MassiveRestClient::with_base_url` now returns `Result<Self, MassiveError>`** — append `?` or `.expect(..)` at call sites. (#198)
- **`MassiveError` is now `#[non_exhaustive]`** — exhaustive `match`es need a wildcard arm.
- `IbkrFlexError` was already `#[non_exhaustive]`; the new `HttpStatus` variant is additive.

## Testing

- `cargo clippy --workspace --all-targets --all-features` with the project's strict lint set — clean.
- `cargo test -p rustrade-data --features massive,ibkr --test massive_pagination --lib` — **324 passed**.
- New coverage includes: `PaginationGuard` cap/cycle unit tests; origin-validation attack vectors (look-alike host, scheme downgrade, port mismatch, userinfo confusion, unparseable URL); a wiremock integration suite asserting cross-origin `next_url` rejection *and* that the untrusted origin receives zero requests (token never leaks), redirect non-following, and bearer-token attachment on the trusted origin; Flex status/body interpretation, token scrubbing (including a token straddling the byte cap), and poll-policy defaults.

https://claude.ai/code/session_01GUJLdX3sbhfTv1hRCYdSuF
