### PR TITLE
refactor: Remove Ord/PartialOrd derives from Timed<T> and containing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `OptionPositionsRequireIdentityChange` (non-standard, wrapper-handled). Relevant only to code
   tracking this unreleased development line, where both the old and new variants are pre-release.
 
+- **BREAKING**: **`Ord`/`PartialOrd` on `Timed<T>` — and transitively on
+  `DefaultInstrumentMarketData` (`Ord`/`PartialOrd`) and `AssetState` (`PartialOrd`)** (`rustrade`).
+  The derived `Timed` ordering compared `value` before `time`, so `Vec<Timed<_>>::sort()` silently
+  produced a value-sorted, non-chronological order — and a time-first ordering is no safer (it would
+  collapse same-instant entries in `BTreeSet`/`BinaryHeap` via the `Ord`/`Eq` contract). Ordering is
+  now intentionally not provided; sorting on a chosen field fails to compile instead of silently
+  misbehaving. Migration: `events.sort_by_key(|timed| timed.time)` for chronological order (the
+  in-tree practice already everywhere). The two containing types lose their (equally meaningless,
+  lexicographic field-order) derived orderings with it.
+
 ### Fixed
 
 - **Published rustdoc no longer points at items readers cannot open** (`rustrade-data`). Twelve

--- a/rustrade/src/engine/state/asset/mod.rs
+++ b/rustrade/src/engine/state/asset/mod.rs
@@ -138,7 +138,10 @@ impl AssetStates {
 /// When used in the context of [`AssetStates`], this state is for an exchange asset, but it could
 /// be used for a "global" asset that aggregates data for similar named assets on multiple
 /// exchanges.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Constructor)]
+///
+/// Does not implement `PartialOrd`: `balance` holds a [`Timed`] value, whose whole-struct
+/// ordering is intentionally not provided (see [`Timed`] docs).
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Constructor)]
 pub struct AssetState {
     /// `Asset` name data that details the internal and exchange names.
     pub asset: Asset,

--- a/rustrade/src/engine/state/instrument/data.rs
+++ b/rustrade/src/engine/state/instrument/data.rs
@@ -59,9 +59,10 @@ pub trait InstrumentDataState<
 /// This is a simple example of instrument level data. Trading strategies typically maintain more
 /// comprehensive data, such as candles, technical indicators, market depth (L2 book), volatility metrics,
 /// or strategy-specific state data.
-#[derive(
-    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize, Constructor,
-)]
+///
+/// Does not implement `Ord`/`PartialOrd`: `last_traded_price` holds a [`Timed`] value, whose
+/// whole-struct ordering is intentionally not provided (see [`Timed`] docs).
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Default, Deserialize, Serialize, Constructor)]
 pub struct DefaultInstrumentMarketData {
     pub l1: OrderBookL1,
     pub last_traded_price: Option<Timed<Decimal>>,

--- a/rustrade/src/lib.rs
+++ b/rustrade/src/lib.rs
@@ -124,20 +124,12 @@ pub mod backtest;
 pub mod shutdown;
 
 /// A timed value.
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Default,
-    Deserialize,
-    Serialize,
-    Constructor,
-)]
+///
+/// Ordering is intentionally not provided: a whole-struct order must compare either value-first
+/// (sorting `Vec<Timed<_>>` by value, not chronology) or time-first (collapsing same-instant
+/// entries in ordered collections despite differing values) — both are footguns. Sort explicitly
+/// on the field you mean, e.g. `events.sort_by_key(|timed| timed.time)`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, Deserialize, Serialize, Constructor)]
 pub struct Timed<T> {
     pub value: T,
     pub time: DateTime<Utc>,


### PR DESCRIPTION
## Summary

Derived ordering on `Timed<T>` compared `value` before `time`, causing `Vec::sort()` and `BTreeSet` to silently produce non-chronological (value-sorted) order — a footgun that fails silently. Removing the derives forces callers to sort explicitly on the field they mean, e.g. `sort_by_key(|timed| timed.time)`, so misuse now fails at compile time instead of silently misbehaving.

## Changes

- Remove `Ord`/`PartialOrd` derives from `Timed<T>` in `rustrade/src/lib.rs`
- Remove `PartialOrd` derive from `AssetState` (contains `Timed` field)
- Remove `Ord`/`PartialOrd` derives from `DefaultInstrumentMarketData` (contains `Timed` field)
- Add rustdoc on `Timed<T>` explaining the rationale and migration path
- Add rustdoc on `AssetState` and `DefaultInstrumentMarketData` noting no ordering
- Update CHANGELOG with breaking change entry

Closes #174