### PR TITLE
feat(alpaca): Bounded, cycle-safe pagination with terminal error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Bounded, cycle-safe pagination for Alpaca REST fetches** (`rustrade-data`, `alpaca` feature).
+  Every `page_token`-paginated Alpaca fetch (`fetch_splits_raw`, `fetch_contracts`,
+  `fetch_snapshots` / `fetch_chain_snapshots`) previously stopped at its page cap with only a
+  `warn!`, returning a silently truncated result — indistinguishable from a genuinely small one
+  for a market-data client. Each fetch now fails loudly instead, mirroring the Massive pagination
+  hardening: exceeding the page cap or receiving a `next_page_token` that repeats an already-used
+  cursor surfaces as a terminal error on the fetch. Two new `AlpacaRestError` variants carry the
+  diagnosis: `PaginationLimitExceeded { pages, limit }` and `CyclicPagination { page_token }`
+  (the retained token bounded to a diagnostic prefix, as it is server-supplied).
+  `AlpacaRestError` is `#[non_exhaustive]`, so the new variants are additive. Also new:
+  `AlpacaRestClient::with_base_urls` / `AlpacaOptionsClient::with_base_urls` to point a client at
+  API-compatible non-production endpoints (mock servers in tests, proxies).
+
 - **Richer IBKR Flex transport diagnostics + configurable poll budget** (`rustrade-data`, `ibkr`
   feature). `IbkrFlexClient` now reads the HTTP response body **before** branching on status, so a
   non-2xx response's diagnostic body (IBKR/proxy/CDN error pages) is preserved instead of being

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -31,7 +31,7 @@ rust_decimal_macros = { workspace = true }
 time = { version = "0.3", features = ["macros"] }  # For ibkr tests and databento examples
 temp-env = { workspace = true }
 serial_test = { workspace = true }  # For Massive WebSocket tests (1 connection limit)
-wiremock = { workspace = true }  # For Massive REST pagination tests (mock next_url chains)
+wiremock = { workspace = true }  # For Massive/Alpaca REST pagination tests (mock next_url/page_token chains) and http.rs unit tests
 http = { workspace = true }  # Builds synthetic `reqwest::Response`s (via reqwest's `From<http::Response<_>>`) for socket-free transport tests; already in the tree via reqwest
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }  # `test-util` = paused-clock poll-timing tests
 

--- a/rustrade-data/src/exchange/alpaca/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/mod.rs
@@ -86,6 +86,8 @@ pub mod trade;
 
 // `StockSplitSource` adapter for `AlpacaRestClient` (no public items of its own — just the impl).
 mod corporate_action;
+// Shared page-cap + `page_token` cycle guard for the paginated REST fetches.
+mod pagination;
 
 pub use reference::{AlpacaStockSplit, CorporateActionsQuery};
 pub use rest::{AlpacaRestClient, AlpacaRestError};

--- a/rustrade-data/src/exchange/alpaca/options/contracts.rs
+++ b/rustrade-data/src/exchange/alpaca/options/contracts.rs
@@ -2,6 +2,7 @@
 //!
 //! Implements `GET /v2/options/contracts` for querying available option contracts.
 
+use super::super::pagination::PaginationGuard;
 use super::{AlpacaOptionsClient, AlpacaOptionsError};
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
@@ -16,7 +17,8 @@ const MAX_PAGE_SIZE: usize = 10_000;
 /// Default page size for contract queries.
 const DEFAULT_PAGE_SIZE: usize = 1_000;
 
-/// Maximum pages to fetch before stopping (safety limit).
+/// Maximum pages a single fetch will follow before failing with a terminal
+/// `PaginationLimitExceeded` (a runaway backstop, not a business limit).
 const MAX_PAGES: usize = 100;
 
 /// Query parameters for option contract discovery.
@@ -265,7 +267,11 @@ struct ContractsResponse {
 impl AlpacaOptionsClient {
     /// Fetch option contracts matching the query.
     ///
-    /// Automatically paginates through all results up to the safety limit.
+    /// Automatically paginates through all results. Pagination is bounded: the fetch returns a
+    /// terminal [`AlpacaOptionsError::PaginationLimitExceeded`] if it exceeds 100 pages, and
+    /// [`AlpacaOptionsError::CyclicPagination`] if the server repeats a `page_token` — a
+    /// silently truncated result would be indistinguishable from a genuinely small one, so
+    /// incomplete pagination fails loudly instead.
     ///
     /// # Arguments
     ///
@@ -277,14 +283,15 @@ impl AlpacaOptionsClient {
     ///
     /// # Errors
     ///
-    /// Returns error on network failure, API error, or invalid response.
+    /// Returns error on network failure, API error, invalid response, or out-of-bounds
+    /// pagination (see above).
     pub async fn fetch_contracts(
         &self,
         query: &AlpacaOptionContractQuery,
     ) -> Result<Vec<AlpacaOptionContract>, AlpacaOptionsError> {
         let mut all_contracts = Vec::new();
         let mut page_token: Option<String> = None;
-        let mut pages = 0usize;
+        let mut guard = PaginationGuard::new(MAX_PAGES);
 
         // Warn once per logical query (not once per page) if the caller requested a style Alpaca
         // cannot filter on. `to_query_params` silently omits the `style` param in that case; this
@@ -298,15 +305,7 @@ impl AlpacaOptionsClient {
         }
 
         loop {
-            if pages >= MAX_PAGES {
-                warn!(
-                    pages,
-                    contracts = all_contracts.len(),
-                    "Alpaca option contracts hit the max-pages safety limit; returning truncated results"
-                );
-                break;
-            }
-            pages += 1;
+            guard.observe(page_token.as_deref())?;
 
             let mut params = query.to_query_params();
             if let Some(ref token) = page_token {
@@ -323,7 +322,7 @@ impl AlpacaOptionsClient {
             all_contracts.extend(contracts);
 
             debug!(
-                page = pages,
+                page = guard.pages(),
                 count,
                 total = all_contracts.len(),
                 "fetched contracts page"

--- a/rustrade-data/src/exchange/alpaca/options/mod.rs
+++ b/rustrade-data/src/exchange/alpaca/options/mod.rs
@@ -117,6 +117,21 @@ impl AlpacaOptionsClient {
             rest: AlpacaRestClient::from_env()?,
         })
     }
+
+    /// Override both API base URLs (broker and data) on the underlying transport.
+    ///
+    /// See [`AlpacaRestClient::with_base_urls`] — points the client at API-compatible
+    /// endpoints other than the production Alpaca hosts (a local mock server in tests, or a
+    /// proxy/gateway).
+    #[must_use]
+    pub fn with_base_urls(
+        mut self,
+        broker_base: impl Into<String>,
+        data_base: impl Into<String>,
+    ) -> Self {
+        self.rest = self.rest.with_base_urls(broker_base, data_base);
+        self
+    }
 }
 
 #[cfg(test)]

--- a/rustrade-data/src/exchange/alpaca/options/snapshots.rs
+++ b/rustrade-data/src/exchange/alpaca/options/snapshots.rs
@@ -2,18 +2,20 @@
 //!
 //! Implements `GET /v1beta1/options/snapshots` for fetching option snapshots with Greeks.
 
+use super::super::pagination::PaginationGuard;
 use super::{AlpacaOptionsClient, AlpacaOptionsError};
 use crate::subscription::greeks::OptionGreeks;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tracing::{debug, warn};
+use tracing::debug;
 
 /// Maximum symbols per snapshot request (Alpaca API limit).
 const MAX_SYMBOLS_PER_REQUEST: usize = 100;
 
-/// Maximum pages to fetch before stopping (safety limit).
+/// Maximum pages a single batch fetch will follow before failing with a terminal
+/// `PaginationLimitExceeded` (a runaway backstop, not a business limit).
 const MAX_PAGES: usize = 100;
 
 /// Alpaca options data feed.
@@ -165,7 +167,11 @@ impl AlpacaOptionsClient {
     /// Fetch option snapshots with Greeks for the given symbols.
     ///
     /// Automatically batches requests if more than 100 symbols are provided,
-    /// and paginates through all results.
+    /// and paginates through all results. Per-batch pagination is bounded: the fetch returns a
+    /// terminal [`AlpacaOptionsError::PaginationLimitExceeded`] if a batch exceeds 100 pages,
+    /// and [`AlpacaOptionsError::CyclicPagination`] if the server repeats a `page_token` — a
+    /// silently truncated result would be indistinguishable from a genuinely small one, so
+    /// incomplete pagination fails loudly instead.
     ///
     /// # Arguments
     ///
@@ -178,7 +184,8 @@ impl AlpacaOptionsClient {
     ///
     /// # Errors
     ///
-    /// Returns error on network failure, API error, or invalid response.
+    /// Returns error on network failure, API error, invalid response, or out-of-bounds
+    /// pagination (see above).
     ///
     /// # Note
     ///
@@ -212,20 +219,12 @@ impl AlpacaOptionsClient {
     ) -> Result<Vec<AlpacaOptionSnapshot>, AlpacaOptionsError> {
         let mut all_snapshots = Vec::new();
         let mut page_token: Option<String> = None;
-        let mut pages = 0usize;
+        let mut guard = PaginationGuard::new(MAX_PAGES);
 
         let symbols_param = symbols.join(",");
 
         loop {
-            if pages >= MAX_PAGES {
-                warn!(
-                    pages,
-                    snapshots = all_snapshots.len(),
-                    "Alpaca option snapshots hit the max-pages safety limit; returning truncated results"
-                );
-                break;
-            }
-            pages += 1;
+            guard.observe(page_token.as_deref())?;
 
             let mut params: Vec<(&str, &str)> =
                 vec![("symbols", &symbols_param), ("feed", feed.as_str())];
@@ -250,7 +249,7 @@ impl AlpacaOptionsClient {
                 }));
 
                 debug!(
-                    page = pages,
+                    page = guard.pages(),
                     count,
                     total = all_snapshots.len(),
                     "fetched snapshots page"

--- a/rustrade-data/src/exchange/alpaca/pagination.rs
+++ b/rustrade-data/src/exchange/alpaca/pagination.rs
@@ -1,0 +1,236 @@
+//! Bounded, cycle-safe pagination for Alpaca REST fetches.
+//!
+//! Every paginated Alpaca REST endpoint follows the same `page_token` cursor
+//! protocol: a page carries an optional `next_page_token` to be echoed back as
+//! the `page_token` query parameter of the following request, and pagination
+//! terminates when a page omits it. Two failure modes make that loop unsafe if
+//! followed unconditionally:
+//!
+//! - a server (or proxy) that never stops returning a `next_page_token` would
+//!   page forever, and
+//! - a token that repeats an already-used cursor would fetch the same pages
+//!   indefinitely.
+//!
+//! [`PaginationGuard`] makes both observable: it caps the page count and records
+//! used tokens to detect cycles, returning a terminal [`AlpacaRestError`] instead
+//! of looping. It intentionally does **not** truncate silently — for a
+//! market-data client a short result is indistinguishable from a genuinely small
+//! result set, so incomplete pagination must fail loudly. Mirrors the
+//! `PaginationGuard` of the Massive REST client, adapted from that client's
+//! server-supplied `next_url`s to Alpaca's opaque cursor tokens.
+
+use super::rest::AlpacaRestError;
+use crate::exchange::http::truncate_str;
+use std::collections::HashSet;
+use std::collections::hash_map::RandomState;
+use std::hash::BuildHasher;
+
+/// Bytes of a cycling `page_token` retained for diagnosis (see
+/// [`AlpacaRestError::CyclicPagination`]).
+///
+/// Real Alpaca tokens are well under this, so in practice the whole token is
+/// retained; the bound only trims a pathological server-supplied value.
+const TOKEN_PREFIX_BYTES: usize = 200;
+
+/// Tracks pagination progress across a single Alpaca REST fetch, enforcing a
+/// page-count cap and detecting `page_token` cycles.
+///
+/// Construct once per fetch with the call site's page limit and call [`observe`]
+/// once per page — before the request — with the `page_token` about to be sent
+/// (`None` for the first page, which has no cursor). The guard borrows nothing
+/// and is reset by simply creating a new instance.
+///
+/// [`observe`]: PaginationGuard::observe
+#[derive(Debug)]
+pub(super) struct PaginationGuard {
+    /// Maximum number of pages this fetch may follow. A runaway backstop rather
+    /// than a business limit — reaching it signals a pathological query or a
+    /// misbehaving server, not normal operation. Per call site because the
+    /// Alpaca endpoints carry different documented bounds.
+    limit: usize,
+    pages: usize,
+    /// Fixed-size fingerprints of the tokens already used, for cycle detection.
+    /// Bounded by `limit` entries: [`observe`] checks the page cap before
+    /// inserting, so growth cannot exceed the cap before the fetch terminates.
+    ///
+    /// Fingerprints rather than the tokens themselves so each entry costs a
+    /// constant 8 bytes regardless of token length — the tokens are
+    /// server-supplied and would otherwise be retained in full. Storing a
+    /// *truncated* token would not work: two distinct tokens sharing a long
+    /// prefix would compare equal and be reported as a false cycle, whereas a
+    /// hash is computed over the whole string.
+    ///
+    /// [`observe`]: PaginationGuard::observe
+    visited: HashSet<u64>,
+    /// Per-guard (and therefore per-fetch) hash key.
+    ///
+    /// Deliberately [`RandomState`] rather than [`DefaultHasher::new`], whose
+    /// SipHash key is a fixed `(0, 0)` published in std's source. With a known
+    /// key, a misbehaving origin could precompute two distinct tokens that
+    /// collide and so force a spurious [`AlpacaRestError::CyclicPagination`] on
+    /// a legitimate fetch. A key the server cannot know removes that
+    /// possibility — which is precisely the hash-flooding threat model SipHash
+    /// was designed for.
+    ///
+    /// [`DefaultHasher::new`]: std::hash::DefaultHasher::new
+    hasher: RandomState,
+}
+
+impl PaginationGuard {
+    /// Create a guard that allows at most `limit` pages.
+    pub(super) fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            pages: 0,
+            // Sized up front: `observe` inserts at most one fingerprint per page,
+            // so `limit` covers the fetch without rehashing.
+            visited: HashSet::with_capacity(limit),
+            hasher: RandomState::new(),
+        }
+    }
+
+    /// Record that a page is about to be fetched with `page_token` as its cursor
+    /// (`None` for the first page, which carries no cursor and therefore cannot
+    /// cycle).
+    ///
+    /// Returns:
+    /// - [`AlpacaRestError::PaginationLimitExceeded`] once more than `limit`
+    ///   pages have been observed, and
+    /// - [`AlpacaRestError::CyclicPagination`] if `page_token` was already used
+    ///   by an earlier page of this fetch.
+    ///
+    /// Both are terminal: propagate them to end the fetch rather than
+    /// continuing to page.
+    pub(super) fn observe(&mut self, page_token: Option<&str>) -> Result<(), AlpacaRestError> {
+        self.pages += 1;
+        if self.pages > self.limit {
+            return Err(AlpacaRestError::PaginationLimitExceeded {
+                pages: self.pages,
+                limit: self.limit,
+            });
+        }
+        if let Some(token) = page_token
+            && !self.visited.insert(self.hasher.hash_one(token))
+        {
+            return Err(AlpacaRestError::CyclicPagination {
+                page_token: truncate_str(token, TOKEN_PREFIX_BYTES),
+            });
+        }
+        Ok(())
+    }
+
+    /// Number of pages observed so far (1-based once the first page has been
+    /// observed) — for progress logging at the call sites.
+    pub(super) fn pages(&self) -> usize {
+        self.pages
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)] // Test code: panics on unexpected values are acceptable
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distinct_tokens_under_the_cap_are_accepted() {
+        let mut guard = PaginationGuard::new(5);
+        guard.observe(None).expect("first page has no token");
+        for i in 1..5 {
+            guard
+                .observe(Some(&format!("token-{i}")))
+                .unwrap_or_else(|_| panic!("page {} within the cap should be accepted", i + 1));
+        }
+    }
+
+    #[test]
+    fn exceeding_the_page_cap_is_a_terminal_error() {
+        let mut guard = PaginationGuard::new(3);
+        // Exactly `limit` pages are allowed.
+        guard.observe(None).expect("page 1 within cap");
+        guard.observe(Some("a")).expect("page 2 within cap");
+        guard.observe(Some("b")).expect("page 3 within cap");
+        // The next page trips the backstop — even before any cycle question arises.
+        let err = guard
+            .observe(Some("c"))
+            .expect_err("page limit + 1 must be rejected");
+        assert!(
+            matches!(
+                err,
+                AlpacaRestError::PaginationLimitExceeded { pages: 4, limit: 3 }
+            ),
+            "expected PaginationLimitExceeded {{ pages: 4, limit: 3 }}, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn reusing_a_token_is_detected_as_a_cycle() {
+        let mut guard = PaginationGuard::new(10);
+        guard.observe(None).expect("first page");
+        guard
+            .observe(Some("cursor-abc"))
+            .expect("first use is fine");
+        let err = guard
+            .observe(Some("cursor-abc"))
+            .expect_err("second use is a cycle");
+        assert!(
+            matches!(
+                &err,
+                AlpacaRestError::CyclicPagination { page_token } if page_token == "cursor-abc"
+            ),
+            "expected CyclicPagination for cursor-abc, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn cycle_detection_is_token_exact() {
+        // Tokens differing anywhere are distinct cursors, not a cycle.
+        let mut guard = PaginationGuard::new(10);
+        guard.observe(Some("cursor=a")).expect("page 1");
+        guard
+            .observe(Some("cursor=b"))
+            .expect("page 2 is a different token");
+    }
+
+    #[test]
+    fn tokenless_pages_never_cycle() {
+        // `None` marks a page with no cursor (the first page). It participates in
+        // the page count but not in cycle detection — there is no token to repeat.
+        let mut guard = PaginationGuard::new(10);
+        guard.observe(None).expect("page 1");
+        guard
+            .observe(None)
+            .expect("a second tokenless page is not a cycle");
+    }
+
+    #[test]
+    fn long_tokens_sharing_a_prefix_are_not_a_false_cycle() {
+        // The property that rules out storing a *truncated* token as the dedup key:
+        // these two differ only in their final byte, beyond the diagnostic-prefix
+        // bound, yet are distinct cursors. Hashing the whole string keeps them
+        // distinct; a truncating key would report a cycle and kill a legitimate fetch.
+        let mut guard = PaginationGuard::new(10);
+        let base = "a".repeat(2 * TOKEN_PREFIX_BYTES);
+        guard.observe(Some(&format!("{base}1"))).expect("page 1");
+        guard
+            .observe(Some(&format!("{base}2")))
+            .expect("page 2 differs only in its last byte but is a different token");
+    }
+
+    #[test]
+    fn a_cycling_oversized_token_is_reported_with_a_bounded_prefix() {
+        // The error must not retain a pathological server-supplied token in full.
+        let mut guard = PaginationGuard::new(10);
+        let token = "a".repeat(2 * TOKEN_PREFIX_BYTES);
+        guard.observe(Some(&token)).expect("first use is fine");
+        let err = guard
+            .observe(Some(&token))
+            .expect_err("second use is a cycle");
+        match err {
+            AlpacaRestError::CyclicPagination { page_token } => {
+                assert_eq!(page_token.len(), TOKEN_PREFIX_BYTES);
+                assert!(token.starts_with(&page_token));
+            }
+            other => panic!("expected CyclicPagination, got {other:?}"),
+        }
+    }
+}

--- a/rustrade-data/src/exchange/alpaca/reference.rs
+++ b/rustrade-data/src/exchange/alpaca/reference.rs
@@ -16,6 +16,7 @@
 //!
 //! [`StockSplitSource`]: rustrade_integration::corporate_action::StockSplitSource
 
+use super::pagination::PaginationGuard;
 use super::rest::{AlpacaRestClient, AlpacaRestError};
 use async_stream::try_stream;
 use chrono::NaiveDate;
@@ -23,12 +24,13 @@ use futures::Stream;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 use smol_str::SmolStr;
-use tracing::{debug, warn};
+use tracing::debug;
 
 /// Maximum results per page (Alpaca API limit).
 const MAX_LIMIT: u16 = 1000;
 
-/// Maximum pages to fetch before stopping (safety limit against an unbounded `page_token` loop).
+/// Maximum pages a single fetch will follow before failing with a terminal
+/// `PaginationLimitExceeded` (a runaway backstop, not a business limit).
 const MAX_PAGES: usize = 1000;
 
 /// The `types` filter value — this surface only fetches stock splits, never other action kinds.
@@ -212,8 +214,11 @@ impl AlpacaRestClient {
     /// Fetch stock splits matching `query` from `GET /v1beta1/corporate-actions`.
     ///
     /// Returns a stream that handles `page_token` pagination automatically, yielding each
-    /// forward/reverse split as a normalised [`AlpacaStockSplit`]. The stream stops after
-    /// 1000 pages as a safety bound and logs a warning if that limit is hit.
+    /// forward/reverse split as a normalised [`AlpacaStockSplit`]. Pagination is bounded: the
+    /// stream yields a terminal [`AlpacaRestError::PaginationLimitExceeded`] if it exceeds
+    /// 1000 pages, and [`AlpacaRestError::CyclicPagination`] if the server repeats a
+    /// `page_token` — a silently truncated result would be indistinguishable from a genuinely
+    /// small one, so incomplete pagination fails loudly instead.
     ///
     /// # Example
     ///
@@ -235,21 +240,17 @@ impl AlpacaRestClient {
         try_stream! {
             let url = format!("{}/v1beta1/corporate-actions", self.data_base());
             let mut page_token: Option<String> = None;
-            let mut pages = 0usize;
+            let mut guard = PaginationGuard::new(MAX_PAGES);
 
             loop {
-                if pages >= MAX_PAGES {
-                    warn!(pages, "Alpaca corporate-actions hit the max-pages safety limit; stopping");
-                    break;
-                }
-                pages += 1;
+                guard.observe(page_token.as_deref())?;
 
                 let mut params = query.to_query_params();
                 if let Some(ref token) = page_token {
                     params.push(("page_token", token.clone()));
                 }
 
-                debug!(url = %url, page = pages, "Fetching Alpaca corporate-actions page");
+                debug!(url = %url, page = guard.pages(), "Fetching Alpaca corporate-actions page");
                 let request = self.get(&url).query(&params);
                 let response: CorporateActionsResponse = self.request_with_retry(request).await?;
 

--- a/rustrade-data/src/exchange/alpaca/rest.rs
+++ b/rustrade-data/src/exchange/alpaca/rest.rs
@@ -73,6 +73,27 @@ pub enum AlpacaRestError {
     /// shared retry helper recovers instead of aborting the task.
     #[error("request body is not cloneable; cannot retry (streaming bodies are unsupported)")]
     NotCloneable,
+
+    /// A paginated fetch exceeded the maximum number of pages before the API reported the end of
+    /// the result set.
+    ///
+    /// Returned as a terminal error on the affected fetch. For a market-data client a silent
+    /// truncation is indistinguishable from a genuinely small result set, so pagination fails
+    /// loudly rather than returning a partial result. Hitting this limit indicates either an
+    /// unexpectedly large query or a server that never signals the final page — inspect the query
+    /// before retrying.
+    #[error("pagination exceeded the {limit}-page safety limit (attempted page {pages})")]
+    PaginationLimitExceeded { pages: usize, limit: usize },
+
+    /// A paginated fetch received a `next_page_token` it had already used as a cursor.
+    ///
+    /// Returned as a terminal error on the affected fetch. A repeated token would otherwise
+    /// re-fetch the same pages until the page cap ran out; detecting the cycle turns silent
+    /// non-termination into an observable failure after a single wasted round-trip. The token is
+    /// server-supplied, so the retained value is truncated to a bounded diagnostic prefix (real
+    /// Alpaca tokens are far shorter than the bound and are retained whole).
+    #[error("pagination cycle detected: page_token {page_token:?} was already used")]
+    CyclicPagination { page_token: String },
 }
 
 /// Authenticated Alpaca REST client.
@@ -164,6 +185,27 @@ impl AlpacaRestClient {
             .unwrap_or(false);
 
         Self::new(&api_key, &api_secret, paper)
+    }
+
+    /// Override both API base URLs (broker and data).
+    ///
+    /// Points the client at API-compatible endpoints other than the production Alpaca hosts —
+    /// a local mock server in tests, or a proxy/gateway. Credentials, timeouts and retry
+    /// behaviour are unchanged.
+    ///
+    /// Infallible by design: unlike a `next_url`-following client, this client only ever
+    /// requests URLs it builds itself from these bases (pagination advances via an opaque
+    /// `page_token` query parameter, never a server-supplied URL), so there is no trusted
+    /// origin to derive — and nothing to fail on — at construction.
+    #[must_use]
+    pub fn with_base_urls(
+        mut self,
+        broker_base: impl Into<String>,
+        data_base: impl Into<String>,
+    ) -> Self {
+        self.broker_base = broker_base.into();
+        self.data_base = data_base.into();
+        self
     }
 
     /// The broker API base URL (`https://api.alpaca.markets`, or the paper endpoint).

--- a/rustrade-data/tests/alpaca_pagination.rs
+++ b/rustrade-data/tests/alpaca_pagination.rs
@@ -1,0 +1,308 @@
+//! Alpaca REST pagination robustness tests (mocked HTTP, no live API key).
+//!
+//! Unlike `alpaca_corporate_actions.rs` (which is `#[ignore]` and hits the real
+//! Alpaca API), these tests stand up a local `wiremock` server via
+//! [`AlpacaRestClient::with_base_urls`] / [`AlpacaOptionsClient::with_base_urls`]
+//! and drive the full paginated fetches against crafted `page_token` chains. They
+//! verify the `PaginationGuard` wiring end-to-end:
+//!
+//! - a server that keeps returning the same `next_page_token` is caught as a
+//!   cycle (terminal `AlpacaRestError::CyclicPagination`), and
+//! - a normal finite `page_token` chain paginates to completion with no false
+//!   positive.
+//!
+//! The cycle test is repeated across **every** paginated fetch rather than a
+//! representative one. The guard's own logic is covered by unit tests in
+//! `alpaca::pagination`; what these tests protect is the per-call-site *wiring* —
+//! a `guard.observe(..)?` omitted from one loop is exactly the copy-paste slip a
+//! single representative test would miss, and each loop is hand-written.
+//!
+//! The numeric page cap (`MAX_PAGES`) is covered by fast, deterministic unit
+//! tests in `alpaca::pagination`; exercising it here would mean serving hundreds
+//! of pages, so it is intentionally not re-tested through HTTP.
+
+#![cfg(feature = "alpaca")]
+// Tests use unwrap/expect for concise failure messages; panics are the intended failure mode.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use futures::{Stream, StreamExt};
+use rustrade_data::exchange::alpaca::options::{
+    AlpacaOptionContractQuery, AlpacaOptionFeed, AlpacaOptionsClient,
+};
+use rustrade_data::exchange::alpaca::{AlpacaRestClient, AlpacaRestError, CorporateActionsQuery};
+use std::pin::pin;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration as StdDuration;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+/// How long a guarded fetch may run before the test declares it non-terminating.
+///
+/// The cycle tests mount a mock that answers with a self-repeating `next_page_token` *forever*, so
+/// a regression that drops the `guard.observe(..)?` wiring from a pagination loop does not fail —
+/// it pages until the (large) page cap instead of erroring on the second round-trip, and with the
+/// cap also gone it pages indefinitely. Without this bound such a regression would hang until CI's
+/// job timeout, an opaque failure far removed from its cause.
+///
+/// Generous relative to a local wiremock round-trip (milliseconds), so it can only fire on genuine
+/// non-termination, never on a slow machine.
+const TERMINATION_TIMEOUT: StdDuration = StdDuration::from_secs(10);
+
+/// Serves pre-configured JSON pages in registration order.
+///
+/// Each request advances an atomic counter and returns the next page body,
+/// panicking if called more times than pages were supplied — so an unexpected
+/// extra request surfaces as an explicit test failure rather than a stale reply.
+struct Sequential {
+    call: AtomicU32,
+    pages: Vec<serde_json::Value>,
+}
+
+impl Sequential {
+    fn new(pages: Vec<serde_json::Value>) -> Self {
+        Self {
+            call: AtomicU32::new(0),
+            pages,
+        }
+    }
+}
+
+impl Respond for Sequential {
+    fn respond(&self, _: &Request) -> ResponseTemplate {
+        let i = self.call.fetch_add(1, Ordering::Relaxed) as usize;
+        let body = self.pages.get(i).unwrap_or_else(|| {
+            panic!(
+                "Sequential: request #{i} has no configured response (only {} page(s) supplied)",
+                self.pages.len()
+            )
+        });
+        ResponseTemplate::new(200).set_body_json(body)
+    }
+}
+
+fn rest_client_for(server: &MockServer) -> AlpacaRestClient {
+    AlpacaRestClient::new("test-key-id", "test-secret", true)
+        .expect("client builds with ASCII credentials")
+        .with_base_urls(server.uri(), server.uri())
+}
+
+fn options_client_for(server: &MockServer) -> AlpacaOptionsClient {
+    AlpacaOptionsClient::new("test-key-id", "test-secret", true)
+        .expect("client builds with ASCII credentials")
+        .with_base_urls(server.uri(), server.uri())
+}
+
+/// Mount a catch-all mock whose page always advertises the same `next_page_token` —
+/// so echoing it back re-requests an already-used cursor and only the pagination
+/// guard can end the fetch.
+///
+/// The body is a superset of the fields every paginated Alpaca response
+/// deserializes (`corporate_actions` / `option_contracts` / `snapshots` /
+/// `next_page_token`); each response type takes its payload as defaulted/optional
+/// and ignores the fields it does not declare, so one shape serves all of them.
+async fn mount_self_repeating_page(server: &MockServer) {
+    let body = serde_json::json!({
+        "corporate_actions": {},
+        "option_contracts": [],
+        "snapshots": {},
+        "next_page_token": "repeated-cursor",
+    });
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// Drive `stream` to completion, returning its terminal error if it yielded one.
+///
+/// Fails the test if the stream has not terminated within [`TERMINATION_TIMEOUT`] — see that
+/// constant for why an unbounded drain would fail opaquely against the cycle mocks.
+async fn drain_to_terminal_error<T>(
+    stream: impl Stream<Item = Result<T, AlpacaRestError>>,
+) -> Option<AlpacaRestError> {
+    let drain = async {
+        let mut stream = pin!(stream);
+        while let Some(item) = stream.next().await {
+            if let Err(error) = item {
+                return Some(error);
+            }
+        }
+        None
+    };
+    tokio::time::timeout(TERMINATION_TIMEOUT, drain)
+        .await
+        .expect("stream must terminate — a hang means the PaginationGuard wiring is missing")
+}
+
+/// [`drain_to_terminal_error`]'s counterpart for the `Vec`-returning fetches, which collect
+/// eagerly instead of streaming and so have no terminal item to drain to.
+async fn await_bounded<T>(
+    fetch: impl Future<Output = Result<T, AlpacaRestError>>,
+) -> Result<T, AlpacaRestError> {
+    tokio::time::timeout(TERMINATION_TIMEOUT, fetch)
+        .await
+        .expect("fetch must terminate — a hang means the PaginationGuard wiring is missing")
+}
+
+/// Assert that `error` is the terminal cycle error, with the fetch's name in the failure message
+/// so a regression names the offending call site directly.
+#[track_caller]
+fn assert_cycle_detected(fetch: &str, error: Option<AlpacaRestError>) {
+    assert!(
+        matches!(error, Some(AlpacaRestError::CyclicPagination { .. })),
+        "{fetch}: expected CyclicPagination, got {error:?}"
+    );
+}
+
+// ============================================================================
+// Cycle detection — one test per paginated call site
+// ============================================================================
+
+/// A `next_page_token` that never changes must terminate the splits stream with
+/// `CyclicPagination` rather than paging until the cap.
+#[tokio::test]
+async fn splits_stream_detects_page_token_cycle() {
+    let server = MockServer::start().await;
+    mount_self_repeating_page(&server).await;
+
+    let client = rest_client_for(&server);
+    let query = CorporateActionsQuery::new().symbols(["NVDA"]);
+    let error = drain_to_terminal_error(client.fetch_splits_raw(&query)).await;
+
+    assert_cycle_detected("fetch_splits_raw", error);
+    // Page 1 (no cursor) + page 2 (cursor's first use) are fetched; the third
+    // request — the cursor's second use — is rejected before it is issued.
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        2,
+        "the cycle must be detected before a third request is issued"
+    );
+}
+
+#[tokio::test]
+async fn option_contracts_detects_page_token_cycle() {
+    let server = MockServer::start().await;
+    mount_self_repeating_page(&server).await;
+
+    let client = options_client_for(&server);
+    let query = AlpacaOptionContractQuery::new(vec!["AAPL".into()]);
+    let result = await_bounded(client.fetch_contracts(&query)).await;
+
+    assert_cycle_detected("fetch_contracts", result.err());
+}
+
+#[tokio::test]
+async fn option_snapshots_detects_page_token_cycle() {
+    let server = MockServer::start().await;
+    mount_self_repeating_page(&server).await;
+
+    let client = options_client_for(&server);
+    let symbols = vec!["AAPL240119C00150000".to_string()];
+    let result =
+        await_bounded(client.fetch_snapshots(&symbols, AlpacaOptionFeed::Indicative)).await;
+
+    assert_cycle_detected("fetch_snapshots", result.err());
+}
+
+// ============================================================================
+// No-false-positive baselines (also prove each base-URL override is honored)
+// ============================================================================
+
+/// A normal finite `page_token` chain paginates to completion: every item is yielded, the
+/// stream ends cleanly (no error), and the guard does not false-positive on legitimately
+/// distinct tokens. Also proves the `data_base` override routes `fetch_splits_raw`.
+#[tokio::test]
+async fn splits_stream_paginates_finite_chain_without_false_positive() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(Sequential::new(vec![
+            serde_json::json!({
+                "corporate_actions": {
+                    "forward_splits": [{
+                        "symbol": "NVDA", "new_rate": 10, "old_rate": 1,
+                        "ex_date": "2024-06-10",
+                    }]
+                },
+                "next_page_token": "page-2",
+            }),
+            serde_json::json!({
+                "corporate_actions": {
+                    "reverse_splits": [{
+                        "symbol": "ATRA", "new_rate": 1, "old_rate": 25,
+                        "ex_date": "2024-06-20",
+                    }]
+                },
+                "next_page_token": serde_json::Value::Null,
+            }),
+        ]))
+        .mount(&server)
+        .await;
+
+    let client = rest_client_for(&server);
+    let query = CorporateActionsQuery::new();
+    let mut stream = pin!(client.fetch_splits_raw(&query));
+
+    let mut splits = Vec::new();
+    while let Some(item) = stream.next().await {
+        splits.push(item.expect("no error on a well-formed finite chain"));
+    }
+
+    let symbols: Vec<_> = splits.iter().map(|s| s.symbol.as_str()).collect();
+    assert_eq!(symbols, vec!["NVDA", "ATRA"]);
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        2,
+        "exactly two pages should have been fetched"
+    );
+}
+
+/// The `Vec`-returning counterpart for the options side. Also proves the `broker_base`
+/// override routes `fetch_contracts` (the one paginated fetch on the broker API).
+#[tokio::test]
+async fn option_contracts_paginate_finite_chain_without_false_positive() {
+    let server = MockServer::start().await;
+    let contract = |symbol: &str| {
+        serde_json::json!({
+            "id": format!("id-{symbol}"),
+            "symbol": symbol,
+            "name": format!("{symbol} option"),
+            "status": "active",
+            "tradable": true,
+            "expiration_date": "2024-01-19",
+            "root_symbol": "AAPL",
+            "underlying_symbol": "AAPL",
+            "underlying_asset_id": "asset-1",
+            "type": "call",
+            "style": "american",
+            "strike_price": "150",
+            "size": "100",
+        })
+    };
+    Mock::given(method("GET"))
+        .respond_with(Sequential::new(vec![
+            serde_json::json!({
+                "option_contracts": [contract("AAPL240119C00150000")],
+                "next_page_token": "page-2",
+            }),
+            serde_json::json!({
+                "option_contracts": [contract("AAPL240119C00155000")],
+                "next_page_token": serde_json::Value::Null,
+            }),
+        ]))
+        .mount(&server)
+        .await;
+
+    let client = options_client_for(&server);
+    let query = AlpacaOptionContractQuery::new(vec!["AAPL".into()]);
+    let contracts = await_bounded(client.fetch_contracts(&query))
+        .await
+        .expect("no error on a well-formed finite chain");
+
+    let symbols: Vec<_> = contracts.iter().map(|c| c.symbol.as_str()).collect();
+    assert_eq!(symbols, vec!["AAPL240119C00150000", "AAPL240119C00155000"]);
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        2,
+        "exactly two pages should have been fetched"
+    );
+}


### PR DESCRIPTION
Closes #197

## Summary

Alpaca REST pagination was silent on failure — exceeding the page cap or detecting a cyclic token would truncate results indistinguishably from a genuinely small dataset. This makes pagination failures loud, mirroring the Massive client's pagination hardening (#178).

- New `pagination` module with `PaginationGuard` enforcing the page cap and detecting `page_token` cycles (FNV hashing over full tokens, randomized hasher per guard)
- Two additive `AlpacaRestError` variants (`#[non_exhaustive]`): `PaginationLimitExceeded { pages, limit }` and `CyclicPagination { page_token }` (token bounded to a diagnostic prefix)
- Guard integrated into all paginated fetches, replacing manual page-counting + `warn!`+`break`:
  - `fetch_splits_raw` (reference.rs) — yields terminal `Err` on the stream
  - `fetch_contracts` (options/contracts.rs) — returns `Err` instead of a silently short `Vec`
  - `fetch_snapshots` (options/snapshots.rs)
- `AlpacaRestClient::with_base_urls` / `AlpacaOptionsClient::with_base_urls` to override endpoints (test mocks, proxies, non-production hosts)

## Testing

New integration test file `alpaca_pagination.rs`:
- Cycle-detection wiring verified for each paginated call site (100% call-site coverage)
- Finite pagination baseline confirming no false positives
- Timeout guards so missing wiring surfaces as an explicit failure, not a CI hang
