### PR TITLE
feat(instrument)!: Support instruments priced on one venue and executed on another

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,40 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy --locked --workspace --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious -D clippy::style -W clippy::complexity -D clippy::perf
 
+  docs:
+    name: cargo doc
+    needs: [fmt, check]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install mold linker  # Required for proc-macro linking on cache miss
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
+        with:
+          mold-version: ${{ env.MOLD_VERSION }}
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: "rustrade-ci-check"
+
+      # Nothing else compiles rustdoc's link graph, so a doc link that stops resolving ships green
+      # and renders as dead text on docs.rs -- which is how four of them accumulated before this job
+      # existed. All three lints are warn-by-default, so denying them here is what makes them a gate.
+      # `--all-features` is load-bearing: `rustrade-execution` has `default = []` with every client
+      # feature-gated, so a bare `cargo doc` would document none of that code and pass vacuously.
+      - name: Check rustdoc links
+        env:
+          RUSTDOCFLAGS: >-
+            -D rustdoc::broken_intra_doc_links
+            -D rustdoc::private_intra_doc_links
+            -D rustdoc::redundant_explicit_links
+        run: cargo doc --locked --workspace --all-features --no-deps
+
   audit:
     name: cargo audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           shared-key: "rustrade-ci-check"
 
       # Nothing else compiles rustdoc's link graph, so a doc link that stops resolving ships green
-      # and renders as dead text on docs.rs -- which is how four of them accumulated before this job
+      # and renders as dead text on docs.rs -- which is how six of them accumulated before this job
       # existed. All three lints are warn-by-default, so denying them here is what makes them a gate.
       # `--all-features` is load-bearing: `rustrade-execution` has `default = []` with every client
       # feature-gated, so a bare `cargo doc` would document none of that code and pass vacuously.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1540,6 +1540,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is null). A transitive
   dependency (via `ibapi` and, in dev builds, `rayon`/`criterion`); the bump is a `Cargo.lock`-only
   patch within the existing `0.9` constraint.
+- Updated `lru` to 0.18.2 to clear RUSTSEC-2026-0253 (`LruCache::pop()` was not panic-safe: a
+  panicking key `Drop` skipped `detach()`, leaving a dangling pointer in the internal linked list
+  for a later eviction to write through — use-after-free and potential double-free). `lru` backs
+  the WebSocket event-deduplication cache behind the `alpaca` and `binance` features; reaching the
+  bug additionally requires `catch_unwind` around a panicking key `Drop`, and the cache is keyed on
+  plain owned data, so the workspace could not trigger it. The bump is a `Cargo.lock`-only patch
+  within the existing `0.18` constraint.
 
 ## [0.5.0] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -967,6 +967,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Twenty-one rustdoc link defects across the workspace** (`rustrade`, `rustrade-execution`,
+  `rustrade-integration`), each of which rendered as dead or misdirected text on docs.rs. **Six**
+  resolved to nothing: `EngineOutput::Commanded` and `EngineOutput::AlgoOrders` pointed at
+  `super::command::Command` / `super::audit::ProcessAudit`, but those docs live in `crate::engine`,
+  where `super::` is the crate root — both items are already imported in that module, so the bare
+  labels resolve; and `rustrade-integration`'s `corporate_action` module doc referenced `SmolStr`,
+  `StockSplitSource` and `CorporateAction` by bare name, which does not resolve there because that
+  module's documentation is split between the `pub mod` statement in `lib.rs` and the file's own
+  `//!` block. **Five** pointed public documentation at private items a reader cannot navigate to
+  (`DEFAULT_HTTP_REQUEST_TIMEOUT`, `ContractConfig::to_contract`, and the two `assert_aux_*` harness
+  checks named in `AuxEventSource`'s caller obligations), and are now plain code spans that still
+  name the mechanism. **Ten** carried an explicit target the label already implied. Documentation
+  only — no behaviour change.
+
+- **CI now gates rustdoc links.** No job ran `cargo doc` with denied lints, which is why the above
+  accumulated unnoticed — and why only `rustrade` had ever been checked at all, leaving the defects
+  in `rustrade-execution` and `rustrade-integration` invisible. A `cargo doc` job now denies
+  `broken_intra_doc_links`, `private_intra_doc_links` and `redundant_explicit_links` across the whole
+  workspace. It runs `--all-features` deliberately: `rustrade-execution` has `default = []` with
+  every client feature-gated, so a bare `cargo doc` documents none of that code and would pass
+  vacuously.
+
 - **`reconcile_venue_roles` now re-derives `ConnectivityStates::global` from the roles it
   corrected** (`rustrade`). `global` is a cached aggregate over `ConnectivityState::all_healthy`,
   which is a *function of* `ConnectivityState::role` — so correcting a role silently changes what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,9 +408,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before their execution clients exist — `backtest` builds one set of clients per run from a state
   supplied once — this corrects the roles after the fact instead of obliging the caller to declare
   venues it cannot yet know. Its one caller obligation — that `instruments` is the collection
-  `states` was built from — is `debug_assert!`ed by comparing the venue keys in `ExchangeIndex`
-  order, so a mismatched pair is caught in debug rather than silently assigning every venue a
-  plausible but wrong role. A pair holding the *same* venues with different instruments is not
+  `states` was built from — is `assert!`ed by comparing the venue keys in `ExchangeIndex`
+  order. **This panics in release builds too**, deliberately: the failure it guards is silent, in
+  the same way `assert_aux_events_sorted`'s is. Every venue would otherwise be handed a plausible
+  but wrong role, `global` is re-derived from those roles, and a strategy gated on global health
+  then trades against a link that never came up. A pair holding the *same* venues with different
+  instruments is not
   detectable this way, but also misaligns every `InstrumentIndex` in the engine, so venue roles are
   not the symptom that surfaces first.
 
@@ -1024,6 +1027,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   short-circuits on the cached aggregate and returns before writing, so a role error whose first
   market event arrives later is not observable through this field. Documentation only — no behaviour
   change.
+
+- **A disconnect on a dimension a venue does not provide no longer wedges global connectivity**
+  (`rustrade`). `ConnectivityStates::update_from_account_reconnecting` and
+  `update_from_market_reconnecting` checked only that the `ExchangeId` was *tracked*, then wrote
+  `ConnectivityStates::global = Health::Reconnecting` unconditionally, without consulting the
+  venue's `VenueRole`. In a split configuration both venues are single-dimension, so a
+  `MarketStreamEvent::Reconnecting` naming the **execution** venue — or an
+  `AccountStreamEvent::Reconnecting` naming the **data** venue — degraded global health over a
+  connection that venue never had, and nothing could then restore it: no event can arrive for a
+  dimension a venue does not provide, and `update_from_account_event` / `update_from_market_event`
+  each return early once their own dimension is already `Healthy`, so the convergence check never
+  re-ran. Every strategy gated on global health stayed gated for the remainder of the session, after
+  a single `warn!` line. Both paths now re-derive `global` through `ConnectivityState::all_healthy`,
+  which does not consult a dimension the role does not own, and `warn!` the role mismatch itself as
+  a misconfiguration in its own right. The market-side case is reachable without any wrong role at
+  all: a `SystemBuild`'s market stream is caller-supplied and forwarded verbatim, so one built per
+  `IndexedInstruments::exchanges()` rather than per *data* venue emits exactly this on its first
+  reconnect.
+  The aggregate is now derived in **one** place, shared by both disconnect paths, both event paths
+  and `reconcile_venue_roles`, so the cached value cannot disagree with the states it summarises.
+  One log change follows from that: a `global` transition is reported as
+  `"EngineState updating global connectivity"` with its previous and new value, in both directions,
+  replacing a message emitted only on the transition to `Healthy`.
 
 - **The three `UntrackedExchange` rejection paths now log** (`rustrade`). Each returned
   `Err(UntrackedExchange)` silently, while the *routine* disconnect on the adjacent line logged a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   token" at fetch time. A runnable example
   (`ibkr_flex_corporate_actions`, `--features ibkr`) sketches the wrapper-side reconcile.
 
+- **BREAKING**: **A distinct market-data venue on `Instrument`** (`rustrade-instrument`,
+  `rustrade-data`, `rustrade`). `Instrument` gains `data_venue: Option<DataVenue<ExchangeKey>>`, so
+  one instrument can be priced on one venue and executed on another — the single `exchange` field
+  could not express that at all, which made live trading on a third-party price feed structurally
+  impossible. Modelling it as two separate instruments is not equivalent: position and
+  `pnl_unrealised` are strictly `InstrumentIndex`-scoped, so the traded instrument would never
+  receive the price updates landing on the other index, and its PnL would sit permanently stale.
+  `DataVenue` carries the exchange **and** an optional `name_exchange`, because two venues routinely
+  spell one instrument differently — a venue-only field would subscribe under the execution venue's
+  symbol and silently receive nothing, or another instrument's prices. Read it through the new
+  `Instrument::data_exchange()` / `data_name_exchange()` accessors, which apply the
+  fall-back-to-the-execution-venue rule in one place, and set it with `with_data_venue()`.
+  `IndexedInstrumentsBuilder` now registers both venues into `exchanges` — but deliberately **not**
+  into `assets`, since a data-only venue holds no balances and registering it would seed balance
+  state for a venue that can never report one — and market-data subscription batching groups by
+  `data_exchange()`. Migration: `Instrument::new` / `Instrument::spot` are unchanged and set the
+  field to `None`, so only struct literals and destructuring patterns need touching. The field is
+  declared **last** deliberately: `Instrument` derives `Ord` and `IndexedInstrumentsBuilder` sorts
+  before assigning `InstrumentIndex`, so appending renumbers no existing configuration.
+  *Known limitation:* `index_market_data_subscription_batches` resolves assets and instrument against
+  the **execution** venue, so it cannot index a dual-venue instrument. It fails loudly (`IndexError`)
+  rather than mis-resolving, and its rustdoc states the gap.
+
+- **`VenueRole` — venues declare which connection dimensions they provide** (`rustrade`).
+  `ConnectivityState` gains `role: VenueRole { DataOnly, ExecutionOnly, Both }` and a
+  `ConnectivityState::new(role)` constructor; `all_healthy()` now consults only the dimensions a
+  venue actually has. Without this, any venue supplying market data without an account — which the
+  new `data_venue` makes ordinary — would hold its `account` at `Reconnecting` forever, so
+  `ConnectivityStates::global` could never reach `Healthy`, and everything gated on global health
+  would be permanently degraded. The role is derived per dimension rather than per provider, which
+  matters: marking only the data venue `DataOnly` fixes half the trap, leaving the *execution* venue
+  waiting on a market-data subscription that is never made. The field is `#[serde(default)]` to
+  `Both` — the semantics that predate it — so state persisted earlier deserialises unchanged.
+
+- **`EngineStateBuilder::execution_venues`** (`rustrade`) declares which venues have a registered
+  execution client, so only those are given an account connection to wait on. `SystemBuilder` calls
+  it automatically; provide it by hand when building an `EngineState` directly, as `backtest` does.
+  See the Fixed entry on the account connection dimension for what it corrects.
+
+- **`ExecutionClient::SUPPORTED_KINDS`** (`rustrade-execution`, `rustrade`), a required associated
+  const listing the `InstrumentKindDiscriminant`s a client can trade, alongside the existing
+  `const EXCHANGE`. `rustrade-execution` had no kind guard whatsoever, so an instrument of a kind a
+  venue cannot encode reached that venue as a silent wrong-symbol order. `ExecutionBuilder::add_execution`
+  now rejects the build naming the offending client and kind. The new
+  `InstrumentKindDiscriminant { Spot, Perpetual, Future, Option, Cfd }` in `rustrade-instrument`
+  (plus `InstrumentKind::discriminant()`) exists because `InstrumentKind` carries data on four of its
+  five variants and so cannot itself be declared against; `MarketDataInstrumentKind` is deliberately
+  not reused, as it answers a different question. Declared support: Binance spot and margin `Spot`;
+  Hyperliquid perpetual `Perpetual` and spot `Spot`; Alpaca `Spot, Option`; IBKR `Spot, Future,
+  Option`; mock `Spot, Cfd`. IBKR omits `Cfd` deliberately — the client builds no security type for
+  them, so accepting one would produce exactly the silent wrong-symbol order this guards against.
+  **BREAKING** for external `ExecutionClient` implementors: the const has no default.
+
+- **`ConnectivityDimension` and `UntrackedExchange`** (`rustrade`), the reported detail when a market
+  or account event names an exchange the engine does not track — see the Fixed entry below.
+
+- **`UnsupportedCorporateActionReason::AmbiguousSplitTarget`** (`rustrade`), rejecting a stock split
+  whose target is not the unique deliverable instrument on its `(base, quote, exchange)` — see the
+  Fixed entry below. Appended last to the (`#[non_exhaustive]`) enum, which derives `Ord`.
+
 ### Changed
 
 - **Silent assumptions in the new LSE and streaming code are now observable.** None of these change
@@ -813,6 +873,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TimedMergeStream` is now **fused** and implements `FusedStream`, without which the abort was not
   an abort: the next poll fell through to draining the aux stream, emitting events at instants the
   market data never reached.
+
+- **BREAKING**: **The `ExchangeId`-keyed connectivity updates are now fallible** (`rustrade`).
+  `ConnectivityStates::update_from_market_event`, `update_from_market_reconnecting` and
+  `update_from_account_reconnecting` return `Result<(), UntrackedExchange>`, and
+  `EngineState::update_from_market` propagates it — see the Fixed entry on the untracked-exchange
+  panic. The `ExchangeIndex`-keyed accessors stay panicking, deliberately: those keys are derived
+  from the same `IndexedInstruments` the collection was built from, so an out-of-range one is a
+  library bug rather than a misconfigured input, and is not something a caller could handle.
+  `UpdateFromMarketOutput` and `UpdateFromAccountOutput` each gain an `UntrackedExchange` variant and
+  are now `#[non_exhaustive]` (adding the variant was already breaking, so the future-proofing is
+  absorbed here rather than costing a second break later).
+
+- **BREAKING**: **`generate_empty_indexed_connectivity_states` takes the execution venues**
+  (`rustrade`), as `Option<&FnvHashSet<ExchangeId>>`. Pass `None` to keep the previous
+  instrument-derived behaviour. See the Fixed entry on the account connection dimension.
+
+- **BREAKING**: **`DataVenue::map_exchange_key` takes a lookup closure**, not a pre-resolved key
+  (`rustrade-instrument`). One key cannot serve two venues: the old shape could only stamp the
+  execution venue's key onto the data venue, which is wrong by construction once the two differ.
+
+- **`UnindexedAccountSnapshot`s omit data-only venues instead of reporting them empty** (`rustrade`).
+  `From<&EngineState> for FnvHashMap<ExchangeId, UnindexedAccountSnapshot>` iterated every tracked
+  exchange, so a venue that only supplies market data produced an **empty** snapshot. The two claims
+  are not the same: an empty snapshot asserts a known, drained account, which a caller cannot
+  distinguish from a real one that has gone to zero — and seeding a `MockExecutionConfig::initial_state`
+  from it would stand up a mock account at a venue nothing trades on. A missing `ExchangeId` now means
+  "no account here", so callers must not assume every tracked exchange appears as a key.
+
+- **`EngineOutput::CorporateActionAlreadyProcessed` has two emitters** (`rustrade`), distinguished by
+  its `instrument` field: the pre-existing target-level replay suppression, and the new per-option
+  one described in the Fixed entry below. Its rustdoc previously claimed no other observable
+  accompanies it, which is no longer true — a suppressed chain adjustment emits one per skipped
+  option alongside an aggregate warning.
 
 ### Removed
 
@@ -1268,6 +1361,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bench_backtests_concurrent` groups previously panicked during setup and could not run — meaning any
   prior `--save-baseline` numbers for those two groups are not comparable across this change (they
   never completed). Benchmark-only; no library behaviour changes.
+
+- **An event from an untracked exchange is reported instead of panicking the engine** (`rustrade`).
+  A market or account event naming an exchange with no `ConnectivityState` hit
+  `panic!("ConnectivityStates does not contain: {key}")`. Worse than a panic, it was an
+  *intermittent* one: the lookup sat behind a `global == Healthy` early-return, so a misconfigured
+  exchange was silently ignored for as long as everything else stayed healthy and only brought the
+  engine down once a reconnect dragged global health back down — hours into a run. The exchange is
+  now resolved on **every** market event, including the healthy fast path, so the report fires on the
+  first event from that exchange in every run; the early-return still skips the state mutation. An
+  untracked exchange mutates nothing — including `global`, which previously went to `Reconnecting`
+  immediately before the panic — and surfaces as a non-mutating `EngineOutput::UntrackedExchange`.
+  `EngineState::update_from_market` returns before the positional `instrument_index_mut` lookup,
+  which would otherwise panic or, worse, misattribute the print to whichever instrument occupied that
+  slot. Untracked reconnects also skip `Strategy::on_disconnect`, since the strategy has no link to
+  that venue to react to. The audit replica reaches the same verdict by replaying the event rather
+  than mirroring the output. Cost of the unconditional lookup, measured rather than assumed: below
+  the noise floor of a ~50,000-market-event backtest bench (127.28 ms → 126.66 ms, within the
+  criterion noise threshold).
+
+- **The account connection dimension is derived from execution clients, not the instrument model**
+  (`rustrade`). A venue that supplies prices without executing anything was assigned
+  `VenueRole::Both`, so it waited forever on an account connection nothing would ever establish and
+  held `ConnectivityStates::global` at `Reconnecting` for the life of the run. The two dimensions
+  have different sources of truth: market data is instrument-derived and exactly so, since
+  subscriptions are generated from the same `data_exchange` field, but account events reach the
+  engine only from a registered `ExecutionManager`, and `Instrument::exchange` names the venue an
+  instrument *would* trade on — not whether anything is wired up to trade there. `SystemBuilder`
+  now reads the registered venues from the `MultiExchangeTxMap` it has already built, so the live
+  path is correct without the caller doing anything. This matters for any configuration pricing one
+  instrument on a venue it never trades on, including a strategy that decides on one instrument and
+  trades another. A venue providing neither dimension — instruments priced elsewhere, no execution
+  client registered — is reachable for the first time as a result; it stays `Both`, withholding
+  health rather than granting it to a venue with no known connection, and is reported with a warning.
+
+- **A stock split no longer double-adjusts an option chain** (`rustrade`).
+  `prepare_corporate_action_split` derived `(base, quote, exchange)` from the split target and
+  adjusted every option matching it, with nothing verifying the target was the unique deliverable
+  instrument on that underlying. Two instruments sharing that identity each acted as a valid trigger
+  for adjusting the whole chain, and the second pass was silent *and* unrecorded: unheld options took
+  the strike correction with no position event, and `corporate_actions_processed` was consulted only
+  on the target, so the mutated options carried no record at all. A re-delivered action therefore
+  halved an already-halved strike, surfacing months later as mis-settlement at contract expiry. Both
+  doors are now closed, because they are different doors — the existing idempotency guard is keyed on
+  action `id` alone and read only from the target's set, so recording alone is defeated by a distinct
+  `id` per instrument, while uniqueness alone leaves a same-`id` replay unrecorded on the options it
+  mutated:
+  - the split is rejected with `UnsupportedCorporateActionReason::AmbiguousSplitTarget` if any other
+    registered instrument is split-eligible on the target's `(base, quote, exchange)`, checked before
+    any mutation and before the ratio arithmetic, so an ambiguous target is reported as such even
+    when the arithmetic would also fail;
+  - each adjusted option records the action `id` in its **own** `corporate_actions_processed`,
+    written before the unheld early-out so a silent registry fix leaves the same evidence a held
+    position does, and the prepare pass filters options already carrying the `id` out of the plan.
+  Suppressed options are reported, not silently skipped — one
+  `EngineOutput::CorporateActionAlreadyProcessed` each plus a single aggregate warning, since a full
+  chain can be large. Dropping them would have reproduced the defect's own signature. Both guards
+  live in the shared prepare pass rather than being hand-mirrored, so the live handler and the audit
+  replica agree by construction.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,27 +380,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into `assets`, since a data-only venue holds no balances and registering it would seed balance
   state for a venue that can never report one — and market-data subscription batching groups by
   `data_exchange()`. Migration: `Instrument::new` / `Instrument::spot` are unchanged and set the
-  field to `None`, so only struct literals and destructuring patterns need touching. The field is
-  declared **last** deliberately: `Instrument` derives `Ord` and `IndexedInstrumentsBuilder` sorts
+  field to `None`, so only struct literals and destructuring patterns need touching. The same field
+  is added to `system::config::InstrumentConfig`, which has no constructor to shield literals from
+  it — it is `#[serde(default)]`, so configs written before it existed still deserialise. The field
+  is declared **last** deliberately: `Instrument` derives `Ord` and `IndexedInstrumentsBuilder` sorts
   before assigning `InstrumentIndex`, so appending renumbers no existing configuration.
-  *Known limitation:* `index_market_data_subscription_batches` resolves assets and instrument against
-  the **execution** venue, so it cannot index a dual-venue instrument. It fails loudly (`IndexError`)
-  rather than mis-resolving, and its rustdoc states the gap.
+  *Known limitation:* `index_market_data_subscription_batches` resolves both the assets and the
+  instrument against the **execution** venue, so it cannot honour a `DataVenue`. Naming the data
+  venue fails loudly (`IndexError`), since that venue holds no registered assets. Naming the
+  execution venue **succeeds** — the returned `InstrumentIndex` is correct, but the subscription it
+  is attached to names the wrong feed, and the function has no way to tell that the instrument is
+  priced elsewhere. Its rustdoc states both cases, and a test pins each.
 
-- **`VenueRole` — venues declare which connection dimensions they provide** (`rustrade`).
-  `ConnectivityState` gains `role: VenueRole { DataOnly, ExecutionOnly, Both }` and a
-  `ConnectivityState::new(role)` constructor; `all_healthy()` now consults only the dimensions a
-  venue actually has. Without this, any venue supplying market data without an account — which the
-  new `data_venue` makes ordinary — would hold its `account` at `Reconnecting` forever, so
-  `ConnectivityStates::global` could never reach `Healthy`, and everything gated on global health
-  would be permanently degraded. The role is derived per dimension rather than per provider, which
-  matters: marking only the data venue `DataOnly` fixes half the trap, leaving the *execution* venue
-  waiting on a market-data subscription that is never made. The field is `#[serde(default)]` to
-  `Both` — the semantics that predate it — so state persisted earlier deserialises unchanged.
+- **`VenueRole { DataOnly, ExecutionOnly, Both }`** (`rustrade`), naming which connection dimensions
+  a venue provides, alongside a `ConnectivityState::new(role)` constructor. See the **BREAKING**
+  Changed entry on `ConnectivityState` gaining the field for why it exists and how to migrate.
 
 - **`EngineStateBuilder::execution_venues`** (`rustrade`) declares which venues have a registered
   execution client, so only those are given an account connection to wait on. `SystemBuilder` calls
-  it automatically; provide it by hand when building an `EngineState` directly, as `backtest` does.
+  it automatically; provide it by hand when building an `EngineState` directly — which a `backtest`
+  caller must, precisely because `backtest` takes a pre-built state it cannot reach into.
   See the Fixed entry on the account connection dimension for what it corrects.
 
 - **`ExecutionClient::SUPPORTED_KINDS`** (`rustrade-execution`, `rustrade`), a required associated
@@ -874,6 +873,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an abort: the next poll fell through to draining the aux stream, emitting events at instants the
   market data never reached.
 
+- **BREAKING**: **`ConnectivityState` gains a `role: VenueRole` field** (`rustrade`), and
+  `all_healthy()` now consults only the dimensions that role says the venue actually has. Without
+  this, any venue supplying market data without an account — which the new `data_venue` makes
+  ordinary — would hold its `account` at `Reconnecting` forever, so `ConnectivityStates::global`
+  could never reach `Healthy`, and everything gated on global health would be permanently degraded.
+  The role is derived per dimension rather than per provider, which matters: marking only the data
+  venue `DataOnly` fixes half the trap, leaving the *execution* venue waiting on a market-data
+  subscription that is never made. Migration: struct literals and exhaustive destructuring patterns
+  must supply the field — use the new `ConnectivityState::new(role)`, or `..Default::default()`,
+  which yields the pre-existing `VenueRole::Both` semantics. The field is `#[serde(default)]` to
+  `Both`, so state persisted before it existed deserialises unchanged.
+
+- **BREAKING**: **`ConnectivityStates::exchanges` is an `FnvIndexMap`** (`rustrade`), not a
+  SipHash-keyed `indexmap::IndexMap`. It is looked up by `ExchangeId` on **every** market event now
+  that resolution precedes the global-health short-circuit (see the Fixed entry on the
+  untracked-exchange panic), and a fieldless enum key is exactly the shape SipHash's fixed
+  per-call setup cost is worst for. This also matches every sibling per-event keyed structure —
+  `InstrumentStates`, `AssetStates`, `MultiExchangeTxMap`. Iteration order is unchanged: `IndexMap`
+  is insertion-ordered regardless of hasher. Migration: the field is public, so code naming its type
+  or building one directly needs `rustrade_integration::collection::FnvIndexMap`; `IndexMap`'s API is
+  otherwise identical.
+
 - **BREAKING**: **The `ExchangeId`-keyed connectivity updates are now fallible** (`rustrade`).
   `ConnectivityStates::update_from_market_event`, `update_from_market_reconnecting` and
   `update_from_account_reconnecting` return `Result<(), UntrackedExchange>`, and
@@ -889,9 +910,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`rustrade`), as `Option<&FnvHashSet<ExchangeId>>`. Pass `None` to keep the previous
   instrument-derived behaviour. See the Fixed entry on the account connection dimension.
 
-- **BREAKING**: **`DataVenue::map_exchange_key` takes a lookup closure**, not a pre-resolved key
-  (`rustrade-instrument`). One key cannot serve two venues: the old shape could only stamp the
-  execution venue's key onto the data venue, which is wrong by construction once the two differ.
+- **BREAKING**: **`Instrument::map_exchange_key` takes a lookup closure**, not a pre-resolved key
+  (`rustrade-instrument`): `(self, exchange: NewExchangeKey)` becomes
+  `(self, find_exchange: impl Fn(&ExchangeKey) -> NewExchangeKey)`. One key cannot serve two venues:
+  the old shape could only stamp the execution venue's key onto the data venue, which is wrong by
+  construction once the two differ. Migration: pass a closure returning the key you used to pass —
+  `instrument.map_exchange_key(|_| key.clone())` reproduces the old behaviour exactly for an
+  instrument with no `data_venue`. `DataVenue::map_exchange_key` takes the same closure shape, but is
+  new API rather than a change.
 
 - **`UnindexedAccountSnapshot`s omit data-only venues instead of reporting them empty** (`rustrade`).
   `From<&EngineState> for FnvHashMap<ExchangeId, UnindexedAccountSnapshot>` iterated every tracked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -967,6 +967,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`reconcile_venue_roles` now re-derives `ConnectivityStates::global` from the roles it
+  corrected** (`rustrade`). `global` is a cached aggregate over `ConnectivityState::all_healthy`,
+  which is a *function of* `ConnectivityState::role` — so correcting a role silently changes what
+  the cached value should already have been, and the event paths that normally maintain it cannot
+  repair the difference, because each short-circuits once its own dimension is `Health::Healthy`. On
+  a state whose connections had already reported in, a role change therefore stranded `global` wrong
+  in whichever direction it moved, permanently and with no warning: **stale-`Healthy`** when a role
+  widened, where a consumer gating on `global` trades on for the rest of the run against a link that
+  never came up, or **stuck-`Reconnecting`** when one narrowed, where every health-gated strategy
+  stays gated for the whole run — the same footgun the function was added to remove. Reachable
+  through public API: `BacktestArgsConstant::engine_state` is caller-supplied, and `backtest` returns
+  its terminal `engine_state` precisely so it can be inspected and reused, so chaining one window's
+  terminal state into the next window's args (a walk-forward sweep) hits it whenever the execution
+  client set differs between windows. The freshly-built path is unaffected — every connection starts
+  `Reconnecting`, so the re-derive is a no-op there. An **empty** `ConnectivityStates` re-derives to
+  `Reconnecting` whatever it arrived with — a convention on a degenerate input rather than a safety
+  property, since neither `Health` variant is honest over zero venues and a venue-less state holds no
+  instrument to protect. `Reconnecting` is chosen to agree with
+  `generate_empty_indexed_connectivity_states`, which already returns it for a zero-exchange
+  collection, and to leave the postcondition total: on return `global` is `Healthy` iff the state is
+  non-empty and every venue in it is healthy under its corrected role.
+
+- **`generate_empty_indexed_connectivity_states` now warns on an empty venue set** (`rustrade`). A
+  venue-less engine leaves `global` at `Reconnecting` forever, which a consumer gating on it cannot
+  distinguish from a routine reconnect — so an empty configuration presents as an indefinite wait
+  with nothing naming the cause. It now reports the misconfiguration directly, matching the existing
+  warning for a venue that provides neither market data nor execution.
+
+- **`ConnectivityState::market_data`'s rustdoc no longer overstates it as a role-mismatch detector**
+  (`rustrade`). It claimed that a market event arriving for a venue declared `ExecutionOnly` would
+  set the field `Healthy` and so surface the wrong role. That holds only before
+  `ConnectivityStates::global` reaches `Healthy`: after convergence `update_from_market_event`
+  short-circuits on the cached aggregate and returns before writing, so a role error whose first
+  market event arrives later is not observable through this field. Documentation only — no behaviour
+  change.
+
+- **The three `UntrackedExchange` rejection paths now log** (`rustrade`). Each returned
+  `Err(UntrackedExchange)` silently, while the *routine* disconnect on the adjacent line logged a
+  `warn!` — so the anomaly was quieter than the ordinary event it replaced. The structured
+  observable (`EngineOutput::UntrackedExchange`) rides the audit stream, but only the
+  `*_with_audit` runners retain per-event ticks: a consumer on `sync_run`/`async_run` got **no**
+  signal at all, which is a differently-shaped version of the intermittent blind spot this release
+  set out to close. The level is chosen by how often each path can fire: `warn!` on
+  `update_from_account_reconnecting` and `update_from_market_reconnecting`, which are bounded by the
+  disconnect rate and now match the level of their tracked-venue counterparts, and `debug!` on
+  `update_from_market_event`, which fires once per market event and at `warn!` would emit at tick
+  rate for a stream wired to an unconfigured exchange. A consumer that must not miss this on a
+  non-audit runner should enable `debug!` for `rustrade::engine::state::connectivity` or run an
+  `*_with_audit` variant and count the output.
+
 - **`backtest` now derives venue roles from the execution clients it builds** (`rustrade`), instead
   of requiring the caller to declare them on the state it is handed. A backtest that priced an
   instrument on one venue and executed on another had that pricing venue approximated as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,9 +398,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`EngineStateBuilder::execution_venues`** (`rustrade`) declares which venues have a registered
   execution client, so only those are given an account connection to wait on. `SystemBuilder` calls
-  it automatically; provide it by hand when building an `EngineState` directly — which a `backtest`
-  caller must, precisely because `backtest` takes a pre-built state it cannot reach into.
+  it automatically, and `backtest` reconciles the roles itself (see the entry below); provide it by
+  hand when building an `EngineState` for an engine you drive directly.
   See the Fixed entry on the account connection dimension for what it corrects.
+
+- **`connectivity::reconcile_venue_roles`** (`rustrade`) re-derives every tracked venue's
+  `VenueRole` from the venues that have a registered execution client, leaving connection `Health`
+  and the positional `ExchangeIndex` order untouched. For callers that must build an `EngineState`
+  before their execution clients exist — `backtest` builds one set of clients per run from a state
+  supplied once — this corrects the roles after the fact instead of obliging the caller to declare
+  venues it cannot yet know.
 
 - **`ExecutionClient::SUPPORTED_KINDS`** (`rustrade-execution`, `rustrade`), a required associated
   const listing the `InstrumentKindDiscriminant`s a client can trade, alongside the existing
@@ -413,7 +420,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not reused, as it answers a different question. Declared support: Binance spot and margin `Spot`;
   Hyperliquid perpetual `Perpetual` and spot `Spot`; Alpaca `Spot, Option`; IBKR `Spot, Future,
   Option`; mock `Spot, Cfd`. IBKR omits `Cfd` deliberately — the client builds no security type for
-  them, so accepting one would produce exactly the silent wrong-symbol order this guards against.
+  them, so a CFD could only ever reach that venue as some other contract. Scope: the guard is
+  checked against `Instrument::kind`, so it catches a kind a client can never represent; it does
+  **not** validate a client's own symbol registry against the instrument model — IBKR's
+  `ContractConfig.security_type`, for one, stays caller-supplied and unchecked.
   **BREAKING** for external `ExecutionClient` implementors: the const has no default.
 
 - **`ConnectivityDimension` and `UntrackedExchange`** (`rustrade`), the reported detail when a market
@@ -951,6 +961,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lexicographic field-order) derived orderings with it.
 
 ### Fixed
+
+- **`backtest` now derives venue roles from the execution clients it builds** (`rustrade`), instead
+  of requiring the caller to declare them on the state it is handed. A backtest that priced an
+  instrument on one venue and executed on another had that pricing venue approximated as
+  `VenueRole::Both` unless the caller passed `EngineStateBuilder::execution_venues`, so it waited
+  forever on an account connection nothing would establish, held `ConnectivityStates::global` at
+  `Health::Reconnecting`, and gated every strategy that consults global health for the entire run —
+  without erroring. `backtest` builds its own execution clients per run, so it now reconciles the
+  roles on its own clone of the state (see `reconcile_venue_roles`); the caller's `engine_state` is
+  still never modified, and declaring the venues upfront remains supported and reconciles to
+  itself. A venue that neither prices an instrument nor has an execution client still cannot
+  converge — it is now reported with a warning naming it, rather than left to be inferred from a
+  `global` that never leaves `Reconnecting`.
 
 - **LSE candle pages are now checked for ordering and resolution instead of assumed correct**
   (`rustrade-data`, `lse` feature). Two provider behaviours the module compensates for were pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,7 +407,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the positional `ExchangeIndex` order untouched. For callers that must build an `EngineState`
   before their execution clients exist — `backtest` builds one set of clients per run from a state
   supplied once — this corrects the roles after the fact instead of obliging the caller to declare
-  venues it cannot yet know.
+  venues it cannot yet know. Its one caller obligation — that `instruments` is the collection
+  `states` was built from — is `debug_assert!`ed by comparing the venue keys in `ExchangeIndex`
+  order, so a mismatched pair is caught in debug rather than silently assigning every venue a
+  plausible but wrong role. A pair holding the *same* venues with different instruments is not
+  detectable this way, but also misaligns every `InstrumentIndex` in the engine, so venue roles are
+  not the symptom that surfaces first.
 
 - **`ExecutionClient::SUPPORTED_KINDS`** (`rustrade-execution`, `rustrade`), a required associated
   const listing the `InstrumentKindDiscriminant`s a client can trade, alongside the existing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,9 +3097,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.0",
 ]

--- a/rustrade-data/src/instrument.rs
+++ b/rustrade-data/src/instrument.rs
@@ -96,7 +96,11 @@ where
     fn from(value: &Keyed<InstrumentKey, Instrument<ExchangeKey, AssetKey>>) -> Self {
         Self {
             key: value.key.clone(),
-            name_exchange: value.value.name_exchange.clone(),
+            // The DATA venue's symbol, not the execution venue's. These differ whenever the two
+            // venues spell one instrument differently (`BP.L` against `BP`), and subscribing under
+            // the execution venue's name would silently yield no ticks -- or another instrument's.
+            // Falls back to `name_exchange` for every single-venue instrument.
+            name_exchange: value.value.data_name_exchange().clone(),
             kind: MarketDataInstrumentKind::from(&value.value.kind),
         }
     }

--- a/rustrade-data/src/streams/builder/dynamic/indexed.rs
+++ b/rustrade-data/src/streams/builder/dynamic/indexed.rs
@@ -193,6 +193,7 @@ mod tests {
     use rustrade_instrument::{
         Underlying,
         asset::Asset,
+        index::error::IndexError,
         instrument::{
             Instrument, data_venue::DataVenue, market_data::kind::MarketDataInstrumentKind,
             name::InstrumentNameExchange,
@@ -322,8 +323,11 @@ mod tests {
 
         let result = index_market_data_subscription_batches(&instruments, [[subscription]]);
 
+        // The *variant* is the claim, not merely that it failed. Were assets later registered under
+        // the data venue, the instrument lookup would fail instead and a bare `is_err` would keep
+        // passing with the rationale above silently false.
         assert!(
-            result.is_err(),
+            matches!(result, Err(DataError::Index(IndexError::AssetIndex(_)))),
             "the data venue registers no assets, so neither leg can resolve: {result:?}"
         );
     }

--- a/rustrade-data/src/streams/builder/dynamic/indexed.rs
+++ b/rustrade-data/src/streams/builder/dynamic/indexed.rs
@@ -67,7 +67,10 @@ pub fn generate_indexed_market_data_subscription_batches(
 ) -> Vec<Vec<Subscription<ExchangeId, MarketInstrumentData<InstrumentIndex>, SubKind>>> {
     // Generate Iterator<Item = Keyed<ExchangeId, MarketInstrumentData<InstrumentIndex>>>
     let instruments = instruments.instruments().iter().map(|keyed| {
-        let exchange = keyed.value.exchange.value;
+        // The DATA venue, not the execution venue: a subscription asks whoever publishes the
+        // prices, which for a dual-venue instrument is not who fills its orders. Falls back to
+        // `exchange` for every single-venue instrument, so this is the correct read for both.
+        let exchange = keyed.value.data_exchange().value;
         let instrument = MarketInstrumentData::from(keyed);
         Keyed::new(exchange, instrument)
     });
@@ -109,6 +112,21 @@ pub fn generate_indexed_market_data_subscription_batches(
 /// # Arguments
 /// * `instruments` - Collection of `IndexedInstruments` used for indexing
 /// * `batches` - Iterator of `Subscription` batches to be indexed
+///
+/// # Limitation: instruments carrying a [`DataVenue`] are not indexable here
+/// Both lookups below resolve against `Subscription::exchange` as the instrument's **execution**
+/// venue — its assets via `find_asset_index`, and the instrument itself via `exchange.value ==
+/// exchange`. An instrument with a
+/// [`DataVenue`](rustrade_instrument::instrument::data_venue::DataVenue) is priced by one venue and
+/// executed on another, and its assets are registered only under the latter, so neither lookup can
+/// match it: naming the data venue fails to resolve the assets, and naming the execution venue
+/// finds an instrument the caller did not mean to subscribe to on that feed.
+///
+/// This returns [`DataError`] rather than mis-indexing — a caller cannot get the wrong
+/// `InstrumentIndex` out of it — but it does mean **hand-written subscriptions do not support
+/// dual-venue instruments**. Use
+/// [`generate_indexed_market_data_subscription_batches`] for those; it reads the data venue
+/// directly off each instrument and needs no name-based reverse lookup.
 pub fn index_market_data_subscription_batches<SubBatchIter, SubIter, Sub>(
     instruments: &IndexedInstruments,
     batches: SubBatchIter,
@@ -160,4 +178,147 @@ where
             .collect()
         )
         .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use rustrade_instrument::{
+        Underlying,
+        asset::Asset,
+        instrument::{
+            Instrument, data_venue::DataVenue, market_data::kind::MarketDataInstrumentKind,
+            name::InstrumentNameExchange,
+        },
+    };
+
+    /// `BP` executed on IBKR, priced by LSE — where the two venues disagree on the symbol.
+    fn bp_priced_by_lse() -> Instrument<ExchangeId, Asset> {
+        Instrument::spot(
+            ExchangeId::Ibkr,
+            "ibkr-bp",
+            "BP",
+            Underlying::new(
+                Asset::new_from_exchange("bp"),
+                Asset::new_from_exchange("usd"),
+            ),
+            None,
+        )
+        .with_data_venue(DataVenue::new(
+            ExchangeId::LseEquities,
+            Some(InstrumentNameExchange::new("BP.L")),
+        ))
+    }
+
+    #[test]
+    fn a_subscription_is_built_against_the_data_venue_and_its_symbol() {
+        // Both halves matter, and both fail silently if wrong: subscribing on IBKR asks a venue
+        // that was never meant to supply prices here, and subscribing as `BP` asks LSE for a
+        // symbol it does not publish. Neither errors -- they just never tick.
+        let instruments = IndexedInstruments::new([bp_priced_by_lse()]);
+
+        let batches = generate_indexed_market_data_subscription_batches(
+            &instruments,
+            &[SubKind::PublicTrades],
+        );
+
+        let subscriptions = batches.into_iter().flatten().collect::<Vec<_>>();
+        assert_eq!(subscriptions.len(), 1);
+
+        assert_eq!(subscriptions[0].exchange, ExchangeId::LseEquities);
+        assert_eq!(
+            subscriptions[0].instrument.name_exchange,
+            InstrumentNameExchange::new("BP.L")
+        );
+    }
+
+    #[test]
+    fn a_single_venue_subscription_is_unchanged_by_the_data_venue_fallback() {
+        // The control: every instrument in the tree today has no data venue, so the fallback must
+        // reproduce exactly the previous behaviour.
+        let instrument = Instrument::spot(
+            ExchangeId::BinanceSpot,
+            "binance_spot-btc_usdt",
+            "BTCUSDT",
+            Underlying::new(
+                Asset::new_from_exchange("btc"),
+                Asset::new_from_exchange("usdt"),
+            ),
+            None,
+        );
+        let instruments = IndexedInstruments::new([instrument]);
+
+        let batches = generate_indexed_market_data_subscription_batches(
+            &instruments,
+            &[SubKind::PublicTrades],
+        );
+
+        let subscriptions = batches.into_iter().flatten().collect::<Vec<_>>();
+        assert_eq!(subscriptions.len(), 1);
+
+        assert_eq!(subscriptions[0].exchange, ExchangeId::BinanceSpot);
+        assert_eq!(
+            subscriptions[0].instrument.name_exchange,
+            InstrumentNameExchange::new("BTCUSDT")
+        );
+    }
+
+    #[test]
+    fn instruments_are_batched_by_data_venue_not_execution_venue() {
+        // Batches are per-venue connections. Two instruments executed on different venues but
+        // priced by the same one belong on ONE connection -- batching by execution venue would
+        // open two connections to LSE and, on a capped feed, burn two subscription slots.
+        let aapl = Instrument::spot(
+            ExchangeId::AlpacaBroker,
+            "alpaca_broker-aapl",
+            "AAPL",
+            Underlying::new(
+                Asset::new_from_exchange("aapl"),
+                Asset::new_from_exchange("usd"),
+            ),
+            None,
+        )
+        .with_data_venue(DataVenue::new_same_name(ExchangeId::LseEquities));
+
+        let instruments = IndexedInstruments::new([aapl, bp_priced_by_lse()]);
+
+        let batches = generate_indexed_market_data_subscription_batches(
+            &instruments,
+            &[SubKind::PublicTrades],
+        );
+
+        assert_eq!(batches.len(), 1, "{batches:?}");
+        assert_eq!(batches[0].len(), 2);
+        assert!(
+            batches[0]
+                .iter()
+                .all(|sub| sub.exchange == ExchangeId::LseEquities),
+            "{:?}",
+            batches[0]
+        );
+    }
+
+    #[test]
+    fn hand_written_subscriptions_reject_a_dual_venue_instrument_rather_than_mis_indexing_it() {
+        // Pins the documented limitation. The value here is the *shape* of the failure: a caller
+        // must not be able to receive an `InstrumentIndex` that resolves to an instrument priced
+        // by a venue other than the one they subscribed to, because every downstream event would
+        // then be attributed to the wrong instrument's state. An error is the correct outcome
+        // until the reverse lookup is redesigned to understand data venues.
+        let instruments = IndexedInstruments::new([bp_priced_by_lse()]);
+
+        let subscription = Subscription::new(
+            ExchangeId::LseEquities,
+            MarketDataInstrument::new("bp", "usd", MarketDataInstrumentKind::Spot),
+            SubKind::PublicTrades,
+        );
+
+        let result = index_market_data_subscription_batches(&instruments, [[subscription]]);
+
+        assert!(
+            result.is_err(),
+            "a dual-venue instrument must not be indexable through the name-based path: {result:?}"
+        );
+    }
 }

--- a/rustrade-data/src/streams/builder/dynamic/indexed.rs
+++ b/rustrade-data/src/streams/builder/dynamic/indexed.rs
@@ -113,20 +113,26 @@ pub fn generate_indexed_market_data_subscription_batches(
 /// * `instruments` - Collection of `IndexedInstruments` used for indexing
 /// * `batches` - Iterator of `Subscription` batches to be indexed
 ///
-/// # Limitation: instruments carrying a [`DataVenue`] are not indexable here
+/// # Limitation: this function cannot honour a [`DataVenue`]
 /// Both lookups below resolve against `Subscription::exchange` as the instrument's **execution**
 /// venue — its assets via `find_asset_index`, and the instrument itself via `exchange.value ==
-/// exchange`. An instrument with a
-/// [`DataVenue`](rustrade_instrument::instrument::data_venue::DataVenue) is priced by one venue and
-/// executed on another, and its assets are registered only under the latter, so neither lookup can
-/// match it: naming the data venue fails to resolve the assets, and naming the execution venue
-/// finds an instrument the caller did not mean to subscribe to on that feed.
+/// exchange`. An instrument carrying a [`DataVenue`] is priced by one venue and executed on another,
+/// and its assets are registered only under the latter, so **hand-written subscriptions do not
+/// support dual-venue instruments**. The two spellings fail differently, and only one of them fails
+/// loudly:
 ///
-/// This returns [`DataError`] rather than mis-indexing — a caller cannot get the wrong
-/// `InstrumentIndex` out of it — but it does mean **hand-written subscriptions do not support
-/// dual-venue instruments**. Use
-/// [`generate_indexed_market_data_subscription_batches`] for those; it reads the data venue
+/// - Naming the **data venue** returns [`DataError`]: that venue has no registered assets, so
+///   `find_asset_index` cannot resolve the base or quote.
+/// - Naming the **execution venue** returns `Ok`. The `InstrumentIndex` is the right one for that
+///   instrument — a caller cannot get the *wrong* instrument out of this function — but the
+///   subscription it is attached to names the execution venue's feed and symbol, which is the venue
+///   the `DataVenue` exists to say the instrument is *not* priced on. Nothing here can detect that:
+///   the lookup is by `(exchange, kind, base, quote)` and every one of those matches.
+///
+/// Use [`generate_indexed_market_data_subscription_batches`] instead; it reads the data venue
 /// directly off each instrument and needs no name-based reverse lookup.
+///
+/// [`DataVenue`]: rustrade_instrument::instrument::data_venue::DataVenue
 pub fn index_market_data_subscription_batches<SubBatchIter, SubIter, Sub>(
     instruments: &IndexedInstruments,
     batches: SubBatchIter,
@@ -300,12 +306,12 @@ mod tests {
     }
 
     #[test]
-    fn hand_written_subscriptions_reject_a_dual_venue_instrument_rather_than_mis_indexing_it() {
-        // Pins the documented limitation. The value here is the *shape* of the failure: a caller
-        // must not be able to receive an `InstrumentIndex` that resolves to an instrument priced
-        // by a venue other than the one they subscribed to, because every downstream event would
-        // then be attributed to the wrong instrument's state. An error is the correct outcome
-        // until the reverse lookup is redesigned to understand data venues.
+    fn hand_written_subscription_naming_the_data_venue_is_rejected() {
+        // Half the documented limitation -- the half that fails loudly. Assets are registered under
+        // the execution venue only, so LSE resolves neither leg. The value here is the *shape* of
+        // the failure: a caller must not be able to receive an `InstrumentIndex` that resolves to an
+        // instrument priced by a venue other than the one they subscribed to, because every
+        // downstream event would then be attributed to the wrong instrument's state.
         let instruments = IndexedInstruments::new([bp_priced_by_lse()]);
 
         let subscription = Subscription::new(
@@ -318,7 +324,44 @@ mod tests {
 
         assert!(
             result.is_err(),
-            "a dual-venue instrument must not be indexable through the name-based path: {result:?}"
+            "the data venue registers no assets, so neither leg can resolve: {result:?}"
+        );
+    }
+
+    /// KNOWN GAP, pinned so that fixing it is a visible test change rather than a silent one.
+    ///
+    /// The other half of the limitation, and the half the rustdoc has to spell out because it does
+    /// *not* fail loudly: naming the execution venue matches on every component of the lookup key,
+    /// so the caller gets `Ok` and a subscription pointed at the venue the `DataVenue` exists to say
+    /// this instrument is not priced on. Rework this function to understand data venues and this
+    /// assertion should be inverted -- the caller cannot express "IBKR's feed for an LSE-priced
+    /// instrument" meaningfully, so `Err` is the defensible answer once the lookup can tell.
+    #[test]
+    fn hand_written_subscription_naming_the_execution_venue_succeeds_on_the_wrong_feed() {
+        let instruments = IndexedInstruments::new([bp_priced_by_lse()]);
+
+        let subscription = Subscription::new(
+            ExchangeId::Ibkr,
+            MarketDataInstrument::new("bp", "usd", MarketDataInstrumentKind::Spot),
+            SubKind::PublicTrades,
+        );
+
+        let batches = index_market_data_subscription_batches(&instruments, [[subscription]])
+            .expect(
+                "naming the execution venue resolves: its assets and instrument are registered",
+            );
+
+        let indexed = &batches[0][0];
+
+        // The instrument is the right one -- the documented guarantee that survives.
+        assert_eq!(indexed.instrument.key, InstrumentIndex(0));
+
+        // The feed is not. This is the wrong-feed subscription the rustdoc warns about.
+        assert_eq!(indexed.exchange, ExchangeId::Ibkr);
+        assert_ne!(
+            indexed.exchange,
+            instruments.instruments()[0].value.data_exchange().value,
+            "the subscription names a venue the instrument is explicitly not priced on"
         );
     }
 }

--- a/rustrade-execution/src/client/alpaca/mod.rs
+++ b/rustrade-execution/src/client/alpaca/mod.rs
@@ -62,8 +62,10 @@ use itertools::Itertools as _;
 use lru::LruCache;
 use rust_decimal::Decimal;
 use rustrade_instrument::{
-    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    Side,
+    asset::name::AssetNameExchange,
+    exchange::ExchangeId,
+    instrument::{kind::InstrumentKindDiscriminant, name::InstrumentNameExchange},
 };
 use rustrade_integration::protocol::websocket::{WebSocket, WsMessage};
 use serde::{Deserialize, Serialize};
@@ -1120,6 +1122,14 @@ async fn rest_delete_with_retry(
 
 impl ExecutionClient for AlpacaClient {
     const EXCHANGE: ExchangeId = ExchangeId::AlpacaBroker;
+
+    // Equities and crypto are both `Spot` here — Alpaca settles each as an outright holding, and
+    // the client separates them only by symbol shape. `Option` is genuinely routed: OCC symbols
+    // are detected to derive the `position_intent` that Alpaca requires on options orders.
+    const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant] = &[
+        InstrumentKindDiscriminant::Spot,
+        InstrumentKindDiscriminant::Option,
+    ];
     type Config = AlpacaConfig;
     type AccountStream = BoxStream<'static, UnindexedAccountEvent>;
 

--- a/rustrade-execution/src/client/alpaca/mod.rs
+++ b/rustrade-execution/src/client/alpaca/mod.rs
@@ -1124,8 +1124,11 @@ impl ExecutionClient for AlpacaClient {
     const EXCHANGE: ExchangeId = ExchangeId::AlpacaBroker;
 
     // Equities and crypto are both `Spot` here — Alpaca settles each as an outright holding, and
-    // the client separates them only by symbol shape. `Option` is genuinely routed: OCC symbols
-    // are detected to derive the `position_intent` that Alpaca requires on options orders.
+    // the client separates them only by symbol shape. `Option` is genuinely routed: the
+    // `position_intent` Alpaca requires on options orders is derived from that same shape test,
+    // which is `is_options_or_equity_symbol` — a not-a-crypto-pair check (`!symbol.contains('/')`),
+    // not OCC format validation. Equities take the branch too, harmlessly: `position_intent` is
+    // accepted on an equity order.
     const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant] = &[
         InstrumentKindDiscriminant::Spot,
         InstrumentKindDiscriminant::Option,

--- a/rustrade-execution/src/client/binance/margin.rs
+++ b/rustrade-execution/src/client/binance/margin.rs
@@ -90,8 +90,10 @@ use chrono::{DateTime, TimeZone, Utc};
 use futures::stream::BoxStream;
 use rust_decimal::Decimal;
 use rustrade_instrument::{
-    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    Side,
+    asset::name::AssetNameExchange,
+    exchange::ExchangeId,
+    instrument::{kind::InstrumentKindDiscriminant, name::InstrumentNameExchange},
 };
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, format_smolstr};
@@ -521,6 +523,11 @@ impl BinanceMargin {
 
 impl ExecutionClient for BinanceMargin {
     const EXCHANGE: ExchangeId = ExchangeId::BinanceMargin;
+
+    // Margin is leverage applied to spot pairs, not a distinct instrument kind: a cross or
+    // isolated margin order is still an order on a `Spot` symbol.
+    const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant] =
+        &[InstrumentKindDiscriminant::Spot];
     type Config = BinanceMarginConfig;
     type AccountStream = BoxStream<'static, UnindexedAccountEvent>;
 

--- a/rustrade-execution/src/client/binance/spot.rs
+++ b/rustrade-execution/src/client/binance/spot.rs
@@ -73,8 +73,10 @@ use chrono::{DateTime, TimeZone, Utc};
 use futures::stream::BoxStream;
 use rust_decimal::Decimal;
 use rustrade_instrument::{
-    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    Side,
+    asset::name::AssetNameExchange,
+    exchange::ExchangeId,
+    instrument::{kind::InstrumentKindDiscriminant, name::InstrumentNameExchange},
 };
 use serde::Deserialize;
 use smol_str::format_smolstr;
@@ -515,6 +517,11 @@ async fn paginate_my_trades(
 
 impl ExecutionClient for BinanceSpot {
     const EXCHANGE: ExchangeId = ExchangeId::BinanceSpot;
+
+    // Binance Spot trades spot pairs only; its derivatives live on separate USD-M/COIN-M venues
+    // with their own APIs, which this client does not speak.
+    const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant] =
+        &[InstrumentKindDiscriminant::Spot];
     type Config = BinanceSpotConfig;
     type AccountStream = BoxStream<'static, UnindexedAccountEvent>;
 

--- a/rustrade-execution/src/client/hyperliquid/mod.rs
+++ b/rustrade-execution/src/client/hyperliquid/mod.rs
@@ -98,8 +98,10 @@ use futures::{StreamExt, stream::BoxStream};
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, InfoClient, Message, Subscription};
 use rust_decimal::Decimal;
 use rustrade_instrument::{
-    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    Side,
+    asset::name::AssetNameExchange,
+    exchange::ExchangeId,
+    instrument::{kind::InstrumentKindDiscriminant, name::InstrumentNameExchange},
 };
 use rustrade_integration::collection::snapshot::Snapshot;
 use smol_str::{SmolStr, format_smolstr};
@@ -184,6 +186,11 @@ impl HyperliquidClient {
 
 impl ExecutionClient for HyperliquidClient {
     const EXCHANGE: ExchangeId = ExchangeId::HyperliquidPerp;
+
+    // Perpetuals only — spot is served by `HyperliquidSpotClient`, which uses different coin
+    // naming, asset indices and balance endpoints.
+    const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant] =
+        &[InstrumentKindDiscriminant::Perpetual];
 
     type Config = HyperliquidConfig;
     type AccountStream = BoxStream<'static, UnindexedAccountEvent>;

--- a/rustrade-execution/src/client/hyperliquid/spot.rs
+++ b/rustrade-execution/src/client/hyperliquid/spot.rs
@@ -66,8 +66,10 @@ use futures::{StreamExt, stream::BoxStream};
 use hyperliquid_rust_sdk::{BaseUrl, ExchangeClient, InfoClient, Message, Subscription};
 use rust_decimal::Decimal;
 use rustrade_instrument::{
-    Side, asset::name::AssetNameExchange, exchange::ExchangeId,
-    instrument::name::InstrumentNameExchange,
+    Side,
+    asset::name::AssetNameExchange,
+    exchange::ExchangeId,
+    instrument::{kind::InstrumentKindDiscriminant, name::InstrumentNameExchange},
 };
 use rustrade_integration::collection::snapshot::Snapshot;
 use smol_str::{SmolStr, format_smolstr};
@@ -149,6 +151,10 @@ impl HyperliquidSpotClient {
 
 impl ExecutionClient for HyperliquidSpotClient {
     const EXCHANGE: ExchangeId = ExchangeId::HyperliquidSpot;
+
+    // Spot only — the perpetual counterpart is `HyperliquidClient`.
+    const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant] =
+        &[InstrumentKindDiscriminant::Spot];
 
     type Config = HyperliquidConfig;
     type AccountStream = BoxStream<'static, UnindexedAccountEvent>;

--- a/rustrade-execution/src/client/ibkr/contract.rs
+++ b/rustrade-execution/src/client/ibkr/contract.rs
@@ -91,7 +91,7 @@ pub fn futures_contract(
 /// Only `right` is validated here. `last_trade_date` and `strike` are forwarded
 /// to the IBKR contract as-is; an empty date or a `0.0` strike will build a
 /// (quietly wrong) contract. Presence of those fields is checked one level up in
-/// [`ContractConfig::to_contract`](super::ContractConfig::to_contract), which is
+/// [`ContractConfig`](super::ContractConfig)'s `to_contract`, which is
 /// the intended entry point for config-driven construction.
 pub fn option_contract(
     symbol: &str,

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -103,8 +103,11 @@ use order::{
 use parking_lot::Mutex;
 use rust_decimal::Decimal;
 use rustrade_instrument::{
-    Side, asset::name::AssetNameExchange, exchange::ExchangeId, ibkr::ContractRegistry,
-    instrument::name::InstrumentNameExchange,
+    Side,
+    asset::name::AssetNameExchange,
+    exchange::ExchangeId,
+    ibkr::ContractRegistry,
+    instrument::{kind::InstrumentKindDiscriminant, name::InstrumentNameExchange},
 };
 use serde::{Deserialize, Serialize};
 use smol_str::format_smolstr;
@@ -982,6 +985,18 @@ fn make_all_inactive_bracket(
 
 impl ExecutionClient for IbkrClient {
     const EXCHANGE: ExchangeId = ExchangeId::Ibkr;
+
+    // Mirrors the security types `ContractConfig::to_contract` can build: `STK` and `CASH` (forex)
+    // are both outright holdings and so map to `Spot`, `FUT` to `Future`, `OPT` to `Option`.
+    //
+    // `Cfd` is absent deliberately. IBKR does offer CFDs, but this client builds no `SecurityType`
+    // for them, so a CFD instrument would fail `to_contract` with `UnrecognizedSecurityType` at
+    // registration rather than trade.
+    const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant] = &[
+        InstrumentKindDiscriminant::Spot,
+        InstrumentKindDiscriminant::Future,
+        InstrumentKindDiscriminant::Option,
+    ];
 
     type Config = IbkrConfig;
     type AccountStream = BoxStream<'static, UnindexedAccountEvent>;

--- a/rustrade-execution/src/client/ibkr/mod.rs
+++ b/rustrade-execution/src/client/ibkr/mod.rs
@@ -992,6 +992,13 @@ impl ExecutionClient for IbkrClient {
     // `Cfd` is absent deliberately. IBKR does offer CFDs, but this client builds no `SecurityType`
     // for them, so a CFD instrument would fail `to_contract` with `UnrecognizedSecurityType` at
     // registration rather than trade.
+    //
+    // Scope: this declares which `InstrumentKind`s the client can represent AT ALL, and is checked
+    // against `Instrument::kind`. It is NOT a check that a registered `ContractConfig` describes
+    // the instrument it is keyed to -- `security_type` is a caller-populated `String` registered
+    // independently into `ContractRegistry` and never compared against `Instrument::kind`. A
+    // registry entry naming `STK` for an instrument modelled as `Option` still builds a stock
+    // contract; this gate does not catch it.
     const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant] = &[
         InstrumentKindDiscriminant::Spot,
         InstrumentKindDiscriminant::Future,

--- a/rustrade-execution/src/client/mock/mod.rs
+++ b/rustrade-execution/src/client/mock/mod.rs
@@ -20,7 +20,9 @@ use chrono::{DateTime, Utc};
 use derive_more::Constructor;
 use futures::{StreamExt, stream::BoxStream};
 use rustrade_instrument::{
-    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange,
+    exchange::ExchangeId,
+    instrument::{kind::InstrumentKindDiscriminant, name::InstrumentNameExchange},
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -109,6 +111,15 @@ where
     FnTime: Fn() -> DateTime<Utc> + Clone + Send + Sync,
 {
     const EXCHANGE: ExchangeId = ExchangeId::Mock;
+
+    // `MockExchange` models no expiry, funding schedule or contract chain, so `Perpetual`, `Future`
+    // and `Option` have no faithful projection onto it. `Spot` and `Cfd` need none: both are
+    // positions in an instrument that the mock can open, close and mark without simulating a
+    // lifecycle. Kept in step with the projection in `generate_mock_exchange_instruments`.
+    const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant] = &[
+        InstrumentKindDiscriminant::Spot,
+        InstrumentKindDiscriminant::Cfd,
+    ];
     type Config = MockExecutionClientConfig<FnTime>;
     type AccountStream = BoxStream<'static, UnindexedAccountEvent>;
 

--- a/rustrade-execution/src/client/mod.rs
+++ b/rustrade-execution/src/client/mod.rs
@@ -303,3 +303,102 @@ pub trait BracketOrderClient: ExecutionClient {
         request: BracketOrderRequest<ExchangeId, &InstrumentNameExchange>,
     ) -> impl Future<Output = BracketOrderResult> + Send;
 }
+
+/// The capability table, pinned.
+///
+/// [`ExecutionClient::SUPPORTED_KINDS`] is a `const`: widening one, or adding a kind a client builds
+/// no request for, compiles and passes clippy. The only thing it changes is which instruments
+/// [`ExecutionBuilder`](https://docs.rs/rustrade/latest/rustrade/execution/builder/struct.ExecutionBuilder.html)
+/// admits — so the failure mode is not a broken build but an instrument reaching a venue that cannot
+/// encode it, as a silently wrong order. These assertions exist so that changing a client's declared
+/// capabilities is a deliberate edit to a test that says what the venue can route, rather than a
+/// one-word diff nothing observes.
+///
+/// The real-client cases are each gated on their own feature, matching the module gates above; the
+/// mock case is ungated, like its module. So with `default = []`, a bare
+/// `cargo test -p rustrade-execution` compiles only the mock assertion — pinning a real client's
+/// capabilities requires `--features <name>` or `--all-features`.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::mock::MockExecution;
+
+    #[test]
+    fn mock_supports_only_the_kinds_it_can_model() {
+        // No expiry, funding schedule or contract chain in `MockExchange`, so `Perpetual`, `Future`
+        // and `Option` have no faithful projection onto it. Kept in step with the projection in
+        // `generate_mock_exchange_instruments`, which panics on a kind it cannot project.
+        assert_eq!(
+            <MockExecution<fn() -> DateTime<Utc>> as ExecutionClient>::SUPPORTED_KINDS,
+            &[
+                InstrumentKindDiscriminant::Spot,
+                InstrumentKindDiscriminant::Cfd
+            ]
+        );
+    }
+
+    #[cfg(feature = "binance")]
+    #[test]
+    fn binance_spot_and_margin_are_spot_only() {
+        use crate::client::binance::{BinanceMargin, BinanceSpot};
+
+        assert_eq!(
+            BinanceSpot::SUPPORTED_KINDS,
+            &[InstrumentKindDiscriminant::Spot]
+        );
+        // Cross margin trades the same spot instruments on borrowed funds -- the leverage is in the
+        // account, not the instrument kind.
+        assert_eq!(
+            BinanceMargin::SUPPORTED_KINDS,
+            &[InstrumentKindDiscriminant::Spot]
+        );
+    }
+
+    #[cfg(feature = "hyperliquid")]
+    #[test]
+    fn hyperliquid_splits_perpetual_and_spot_across_two_clients() {
+        use crate::client::hyperliquid::{HyperliquidClient, spot::HyperliquidSpotClient};
+
+        assert_eq!(
+            HyperliquidClient::SUPPORTED_KINDS,
+            &[InstrumentKindDiscriminant::Perpetual]
+        );
+        assert_eq!(
+            HyperliquidSpotClient::SUPPORTED_KINDS,
+            &[InstrumentKindDiscriminant::Spot]
+        );
+    }
+
+    #[cfg(feature = "alpaca")]
+    #[test]
+    fn alpaca_trades_equities_and_options() {
+        use crate::client::alpaca::AlpacaClient;
+
+        assert_eq!(
+            AlpacaClient::SUPPORTED_KINDS,
+            &[
+                InstrumentKindDiscriminant::Spot,
+                InstrumentKindDiscriminant::Option
+            ]
+        );
+    }
+
+    #[cfg(feature = "ibkr")]
+    #[test]
+    fn ibkr_omits_cfd_because_it_builds_no_contract_for_one() {
+        use crate::client::ibkr::IbkrClient;
+
+        // `ContractConfig::to_contract` builds `STK`, `FUT`, `OPT` and `CASH` and nothing else, so a
+        // CFD routed here would be encoded as some other security type -- exactly the silent
+        // wrong-symbol order this const exists to reject. Adding `Cfd` to the list requires adding
+        // the arm first.
+        assert_eq!(
+            IbkrClient::SUPPORTED_KINDS,
+            &[
+                InstrumentKindDiscriminant::Spot,
+                InstrumentKindDiscriminant::Future,
+                InstrumentKindDiscriminant::Option
+            ]
+        );
+    }
+}

--- a/rustrade-execution/src/client/mod.rs
+++ b/rustrade-execution/src/client/mod.rs
@@ -90,6 +90,13 @@ where
     /// There is deliberately no default. A new client must state its capabilities rather than
     /// inherit a permissive set that would silently admit every kind.
     ///
+    /// It is a `const` and not a `fn supported_kinds(&self)` because [`ExecutionBuilder`] validates
+    /// the instrument set *before* [`Self::new`] is ever called — there is no instance to ask at the
+    /// point the answer is needed, and deferring validation until after construction would mean
+    /// standing up a client for a venue the engine is about to reject. A capability set that varies
+    /// with `Self::Config` therefore cannot be expressed here; it would need a separate
+    /// pre-construction hook on the config.
+    ///
     /// [`ExecutionBuilder`]: https://docs.rs/rustrade/latest/rustrade/execution/builder/struct.ExecutionBuilder.html
     const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant];
 

--- a/rustrade-execution/src/client/mod.rs
+++ b/rustrade-execution/src/client/mod.rs
@@ -42,7 +42,9 @@ use crate::{
 use chrono::{DateTime, Utc};
 use futures::Stream;
 use rustrade_instrument::{
-    asset::name::AssetNameExchange, exchange::ExchangeId, instrument::name::InstrumentNameExchange,
+    asset::name::AssetNameExchange,
+    exchange::ExchangeId,
+    instrument::{kind::InstrumentKindDiscriminant, name::InstrumentNameExchange},
 };
 use std::future::Future;
 
@@ -72,6 +74,24 @@ where
     Self: Clone,
 {
     const EXCHANGE: ExchangeId;
+
+    /// The [`InstrumentKindDiscriminant`]s this client can trade.
+    ///
+    /// A client works off [`InstrumentNameExchange`] strings and never inspects an instrument's
+    /// kind, so nothing downstream can infer this from the implementation — routing a `Future`
+    /// through a spot-only venue produces a rejected or, worse, misinterpreted order rather than a
+    /// type error. Declaring the set here lets [`ExecutionBuilder`] reject an unsupported
+    /// instrument set at build time, before any order is sent.
+    ///
+    /// Declare what the *venue and this implementation together* can actually route, not what the
+    /// exchange's product catalogue advertises. A kind the exchange offers but this client builds
+    /// no request for does not belong in the set.
+    ///
+    /// There is deliberately no default. A new client must state its capabilities rather than
+    /// inherit a permissive set that would silently admit every kind.
+    ///
+    /// [`ExecutionBuilder`]: https://docs.rs/rustrade/latest/rustrade/execution/builder/struct.ExecutionBuilder.html
+    const SUPPORTED_KINDS: &'static [InstrumentKindDiscriminant];
 
     type Config: Clone;
     // `+ Send` required so generic code (e.g. ExecutionManager) can pass

--- a/rustrade-execution/src/exchange/mock/mod.rs
+++ b/rustrade-execution/src/exchange/mock/mod.rs
@@ -762,6 +762,7 @@ mod tests {
                 quote: InstrumentQuoteAsset::UnderlyingQuote,
                 kind: InstrumentKind::Spot,
                 spec: None,
+                data_venue: None,
             },
         );
 
@@ -879,6 +880,7 @@ mod tests {
                     settlement_asset: AssetNameExchange::new("gbp"),
                 }),
                 spec: None,
+                data_venue: None,
             },
         );
 

--- a/rustrade-instrument/src/index/builder.rs
+++ b/rustrade-instrument/src/index/builder.rs
@@ -27,6 +27,21 @@ impl IndexedInstrumentsBuilder {
         // Add ExchangeId
         self.exchanges.push(instrument.exchange);
 
+        // Add the market-data venue, when the instrument is priced somewhere other than where it
+        // is executed. Registering it is what gives a data-only venue an `ExchangeIndex`, and
+        // therefore an entry in `ConnectivityStates` -- without which the first market event from
+        // that venue hits a missing-exchange lookup.
+        //
+        // Its ASSETS are deliberately NOT registered. An `ExchangeAsset` keys balance state
+        // (`generate_empty_indexed_asset_states`), and a data-only venue holds no balances: it
+        // publishes prices and has no account. Registering them would seed phantom balances for a
+        // venue that can never report one, and double the asset index space for every dual-venue
+        // instrument. The instrument's own asset keys resolve against its execution venue, which
+        // is where its balances actually live.
+        if let Some(data_venue) = &instrument.data_venue {
+            self.exchanges.push(data_venue.exchange);
+        }
+
         // Add Underlying base
         self.assets.push(ExchangeAsset::new(
             instrument.exchange,
@@ -175,12 +190,17 @@ impl IndexedInstrumentsBuilder {
             .enumerate()
             .map(|(index, instrument)| {
                 let exchange_id = instrument.exchange;
-                #[allow(clippy::expect_used)]
-                // Invariant: add_instrument populates exchanges alongside each instrument
-                let exchange_key = find_exchange_by_exchange_id(&exchanges, &exchange_id)
-                    .expect("every exchange related to every instrument has been added");
 
-                let instrument = instrument.map_exchange_key(Keyed::new(exchange_key, exchange_id));
+                // Applied to the execution venue AND to any `DataVenue`, so a data-only venue is
+                // indexed on the same terms. Holds because `add_instrument` registers both.
+                let instrument = instrument.map_exchange_key(|id| {
+                    #[allow(clippy::expect_used)]
+                    // Invariant: add_instrument populates exchanges alongside each instrument
+                    let exchange_key = find_exchange_by_exchange_id(&exchanges, id)
+                        .expect("every exchange related to every instrument has been added");
+
+                    Keyed::new(exchange_key, *id)
+                });
 
                 #[allow(clippy::expect_used)]
                 // Invariant: add_instrument populates assets alongside each instrument
@@ -213,6 +233,7 @@ mod tests {
     use crate::{
         Underlying,
         instrument::{
+            data_venue::DataVenue,
             kind::{InstrumentKind, cfd::CfdContract, perpetual::PerpetualContract},
             name::{InstrumentNameExchange, InstrumentNameInternal},
             quote::InstrumentQuoteAsset,
@@ -255,6 +276,7 @@ mod tests {
             indexed.instruments()[0].value,
             Instrument {
                 exchange: Keyed::new(ExchangeIndex(0), ExchangeId::BinanceSpot),
+                data_venue: None,
                 name_exchange: InstrumentNameExchange::new("btc_usdt"),
                 name_internal: InstrumentNameInternal::new("binance_spot-btc_usdt"),
                 underlying: Underlying {
@@ -593,6 +615,116 @@ mod tests {
         assert_eq!(indexed.instruments().len(), 1);
     }
 
+    /// An `AAPL` executed on Alpaca but priced by LSE — the same-kind data-venue substitution the
+    /// field exists for.
+    fn dual_venue_instrument() -> Instrument<ExchangeId, Asset> {
+        Instrument::spot(
+            ExchangeId::AlpacaBroker,
+            "alpaca_broker-aapl",
+            "AAPL",
+            Underlying::new(
+                Asset::new_from_exchange("aapl"),
+                Asset::new_from_exchange("usd"),
+            ),
+            None,
+        )
+        .with_data_venue(DataVenue::new_same_name(ExchangeId::LseEquities))
+    }
+
+    #[test]
+    fn a_data_only_venue_is_indexed_so_it_can_carry_connectivity_state() {
+        // The registration that makes a data-only venue expressible at all: it appears on no
+        // instrument's `exchange`, so without this it would have no `ExchangeIndex` and no
+        // `ConnectivityState`, and its first market event would hit a missing-exchange lookup.
+        let indexed = IndexedInstrumentsBuilder::default()
+            .add_instrument(dual_venue_instrument())
+            .try_build()
+            .expect("a dual-venue instrument is a valid collection");
+
+        let exchanges = indexed
+            .exchanges()
+            .iter()
+            .map(|keyed| keyed.value)
+            .collect::<Vec<_>>();
+
+        assert!(
+            exchanges.contains(&ExchangeId::AlpacaBroker),
+            "{exchanges:?}"
+        );
+        assert!(
+            exchanges.contains(&ExchangeId::LseEquities),
+            "{exchanges:?}"
+        );
+    }
+
+    #[test]
+    fn a_data_only_venue_contributes_no_assets() {
+        // A data-only venue holds no balances, and `ExchangeAsset` keys balance state. Registering
+        // its assets would seed balances for an account that does not exist, and double the asset
+        // index space for every dual-venue instrument.
+        let indexed = IndexedInstrumentsBuilder::default()
+            .add_instrument(dual_venue_instrument())
+            .try_build()
+            .expect("a dual-venue instrument is a valid collection");
+
+        // AAPL and USD, on the execution venue only.
+        assert_eq!(indexed.assets().len(), 2);
+        assert!(
+            indexed
+                .assets()
+                .iter()
+                .all(|keyed| keyed.value.exchange == ExchangeId::AlpacaBroker),
+            "{:?}",
+            indexed.assets()
+        );
+    }
+
+    #[test]
+    fn a_dual_venue_instrument_carries_the_data_venues_own_exchange_index() {
+        // The indexing must resolve the data venue against the data venue -- stamping the
+        // execution venue's key onto it would point market-data state at the wrong exchange, with
+        // nothing at runtime to signal it.
+        let indexed = IndexedInstrumentsBuilder::default()
+            .add_instrument(dual_venue_instrument())
+            .try_build()
+            .expect("a dual-venue instrument is a valid collection");
+
+        let instrument = &indexed.instruments()[0].value;
+
+        let data_venue = instrument
+            .data_venue
+            .as_ref()
+            .expect("the data venue survives indexing");
+
+        assert_eq!(data_venue.exchange.value, ExchangeId::LseEquities);
+        assert_ne!(data_venue.exchange.key, instrument.exchange.key);
+
+        // And the key is the one the exchange index actually assigned to LSE.
+        let expected = indexed
+            .exchanges()
+            .iter()
+            .find(|keyed| keyed.value == ExchangeId::LseEquities)
+            .expect("LSE is indexed")
+            .key;
+        assert_eq!(data_venue.exchange.key, expected);
+    }
+
+    #[test]
+    fn a_data_venue_pointing_at_the_execution_venue_does_not_duplicate_the_exchange() {
+        // Degenerate but legal: stating the data venue explicitly when it is the same venue. The
+        // exchange dedup must absorb it, or the venue would be indexed twice and every later
+        // ExchangeIndex would shift.
+        let indexed = IndexedInstrumentsBuilder::default()
+            .add_instrument(
+                instrument(ExchangeId::BinanceSpot, "btc", "usdt")
+                    .with_data_venue(DataVenue::new_same_name(ExchangeId::BinanceSpot)),
+            )
+            .try_build()
+            .expect("a self-referential data venue is valid, if redundant");
+
+        assert_eq!(indexed.exchanges().len(), 1);
+    }
+
     #[test]
     fn test_builder_multiple_exchanges() {
         // Add instruments from different exchanges
@@ -681,6 +813,7 @@ mod tests {
             indexed.instruments()[0].value,
             Instrument {
                 exchange: Keyed::new(ExchangeIndex(0), ExchangeId::BinanceSpot),
+                data_venue: None,
                 name_exchange: InstrumentNameExchange::new("BTC_USDT"),
                 name_internal: InstrumentNameInternal::new("binance_spot-btc_usdt"),
                 underlying: Underlying {
@@ -697,6 +830,7 @@ mod tests {
             indexed.instruments()[1].value,
             Instrument {
                 exchange: Keyed::new(ExchangeIndex(1), ExchangeId::Coinbase),
+                data_venue: None,
                 name_exchange: InstrumentNameExchange::new("ETH_USD"),
                 name_internal: InstrumentNameInternal::new("coinbase-eth_usd"),
                 underlying: Underlying {

--- a/rustrade-instrument/src/index/builder.rs
+++ b/rustrade-instrument/src/index/builder.rs
@@ -151,15 +151,13 @@ impl IndexedInstrumentsBuilder {
                 // colliding instruments frequently share that name: a spot and a CFD on one symbol
                 // is the collision this check most plausibly catches, and reporting it as
                 // "AAPL and AAPL" asserts they are distinct while printing nothing that
-                // distinguishes them. `kind` is what does.
+                // distinguishes them. `describe_collision` is what does.
                 return Err(IndexError::DuplicateInstrumentNameInternal(format!(
-                    "{} is shared by the distinct instruments {} ({:?}) and {} ({:?}) on {} - \
+                    "{} is shared by the distinct instruments {} and {} on {} - \
                      every Instrument requires a unique name_internal",
                     instrument.name_internal,
-                    previous.name_exchange,
-                    previous.kind,
-                    instrument.name_exchange,
-                    instrument.kind,
+                    describe_collision(previous),
+                    describe_collision(instrument),
                     // `as_str`, not `Display`: the canonical snake_case spelling users write in
                     // configs, rather than the bare variant name.
                     instrument.exchange.as_str(),
@@ -223,6 +221,25 @@ impl IndexedInstrumentsBuilder {
             instruments,
             assets,
         })
+    }
+}
+
+/// Renders the axes two `Instrument`s sharing a `name_internal` can legitimately differ on while
+/// still sharing a `name_exchange`: `kind` (a spot and a CFD on one symbol) and `data_venue` (one
+/// symbol priced on two venues). Both are compared by the full-equality dedup, so a pair differing
+/// only in one of them survives it and reaches the uniqueness check — where naming neither reads as
+/// "AAPL and AAPL".
+fn describe_collision(instrument: &Instrument<ExchangeId, Asset>) -> String {
+    match &instrument.data_venue {
+        // `as_str`, not `Display`: the canonical snake_case spelling users write in configs,
+        // rather than the bare variant name.
+        Some(data_venue) => format!(
+            "{} ({:?}, priced on {})",
+            instrument.name_exchange,
+            instrument.kind,
+            data_venue.exchange.as_str(),
+        ),
+        None => format!("{} ({:?})", instrument.name_exchange, instrument.kind),
     }
 }
 
@@ -385,6 +402,48 @@ mod tests {
         // actionable.
         assert!(message.contains("Spot"), "{message}");
         assert!(message.contains("Cfd"), "{message}");
+    }
+
+    #[test]
+    fn test_duplicate_name_internal_message_distinguishes_instruments_sharing_everything_but_a_data_venue()
+     {
+        // The other axis a colliding pair can differ on while sharing `name_exchange` AND `kind`:
+        // one symbol configured twice, priced on a different venue each time. `data_venue` is part
+        // of `Instrument`s equality, so the dedup does not collapse these either -- and a message
+        // built from `name_exchange` and `kind` alone would read "AAPL (Spot) and AAPL (Spot)".
+        let shared_name = "ibkr-aapl";
+
+        let build = |data_venue| {
+            Instrument::new(
+                ExchangeId::Ibkr,
+                shared_name,
+                "AAPL",
+                Underlying::new(
+                    Asset::new_from_exchange("aapl"),
+                    Asset::new_from_exchange("usd"),
+                ),
+                InstrumentQuoteAsset::UnderlyingQuote,
+                InstrumentKind::Spot,
+                None,
+            )
+            .with_data_venue(DataVenue::new_same_name(data_venue))
+        };
+
+        let error = IndexedInstrumentsBuilder::default()
+            .add_instrument(build(ExchangeId::LseEquities))
+            .add_instrument(build(ExchangeId::BinanceSpot))
+            .try_build()
+            .expect_err("duplicate name_internal must be rejected");
+
+        let IndexError::DuplicateInstrumentNameInternal(message) = &error else {
+            panic!("unexpected error variant: {error:?}")
+        };
+
+        assert!(message.contains(shared_name), "{message}");
+        // The data venue is the only field that differs, so naming both is the only thing that
+        // tells the operator which of the two configured entries to change.
+        assert!(message.contains("lse_equities"), "{message}");
+        assert!(message.contains("binance_spot"), "{message}");
     }
 
     /// Builds a one-instrument collection whose only variable is the CFD multiplier.
@@ -714,11 +773,22 @@ mod tests {
         // Degenerate but legal: stating the data venue explicitly when it is the same venue. The
         // exchange dedup must absorb it, or the venue would be indexed twice and every later
         // ExchangeIndex would shift.
-        let indexed = IndexedInstrumentsBuilder::default()
-            .add_instrument(
-                instrument(ExchangeId::BinanceSpot, "btc", "usdt")
-                    .with_data_venue(DataVenue::new_same_name(ExchangeId::BinanceSpot)),
-            )
+        let builder = IndexedInstrumentsBuilder::default().add_instrument(
+            instrument(ExchangeId::BinanceSpot, "btc", "usdt")
+                .with_data_venue(DataVenue::new_same_name(ExchangeId::BinanceSpot)),
+        );
+
+        // Asserted before the build, because the post-build count alone would also hold if
+        // `add_instrument` never registered the data venue at all -- which is the bug this test
+        // must not pass through. The registration is unconditional; the dedup is what makes the
+        // degenerate case harmless.
+        assert_eq!(
+            builder.exchanges,
+            vec![ExchangeId::BinanceSpot; 2],
+            "the data venue is registered unconditionally, whatever venue it names",
+        );
+
+        let indexed = builder
             .try_build()
             .expect("a self-referential data venue is valid, if redundant");
 

--- a/rustrade-instrument/src/index/builder.rs
+++ b/rustrade-instrument/src/index/builder.rs
@@ -23,6 +23,33 @@ impl IndexedInstrumentsBuilder {
         Self::default()
     }
 
+    /// Registers an [`Instrument`], together with the exchanges and assets it implies.
+    ///
+    /// Nothing is validated here — duplicates are tolerated and de-duplicated, and every invariant
+    /// (unique `name_internal`, positive contract multipliers, resolvable asset references) is
+    /// enforced by [`Self::try_build`].
+    ///
+    /// # What a `data_venue` registers, and what it deliberately does not
+    /// An instrument carrying a [`DataVenue`](crate::instrument::data_venue::DataVenue) registers
+    /// **two** exchanges — the one it executes on and the one it is priced on. So
+    /// [`IndexedInstruments::exchanges`] is wider than the set of `Instrument::exchange` values, and
+    /// a data-only venue receives the [`ExchangeIndex`] it needs in order to carry connectivity
+    /// state; without one, the first market event from that venue has no state to resolve.
+    ///
+    /// Its **assets are not registered**. Every asset an instrument implies — underlying base and
+    /// quote, settlement asset, and any `OrderQuantityUnits::Asset` — is registered against the
+    /// *execution* venue alone, so a data-only venue contributes zero entries to
+    /// [`IndexedInstruments::assets`]. An [`ExchangeAsset`] keys balance state, and a venue that
+    /// only publishes prices holds no balance to key.
+    ///
+    /// That asymmetry is load bearing in both directions, and worth knowing before relying on
+    /// either half:
+    /// - It is why a data-only venue seeds no phantom balances it could never report, and why the
+    ///   asset index space is not doubled for every dual-venue instrument.
+    /// - It is also why any lookup that reaches an instrument *through* its assets cannot honour a
+    ///   data venue. `index_market_data_subscription_batches` is the one in tree: asked for a data
+    ///   venue it fails with an asset-index error, and asked for the execution venue it succeeds
+    ///   with the correct instrument index against the wrong feed.
     pub fn add_instrument(mut self, instrument: Instrument<ExchangeId, Asset>) -> Self {
         // Add ExchangeId
         self.exchanges.push(instrument.exchange);

--- a/rustrade-instrument/src/index/mod.rs
+++ b/rustrade-instrument/src/index/mod.rs
@@ -285,6 +285,7 @@ mod tests {
             actual.instruments()[0].value,
             Instrument {
                 exchange: Keyed::new(ExchangeIndex(0), ExchangeId::BinanceSpot),
+                data_venue: None,
                 name_exchange: InstrumentNameExchange::new("btc_usdt"),
                 name_internal: InstrumentNameInternal::new("binance_spot-btc_usdt"),
                 underlying: Underlying {

--- a/rustrade-instrument/src/instrument/data_venue.rs
+++ b/rustrade-instrument/src/instrument/data_venue.rs
@@ -36,6 +36,37 @@ use serde::{Deserialize, Serialize};
 /// synthetic series (a CFD or index proxy) has no book at all. That basis mismatch is sound for
 /// research and paper trading, but for real capital it is a property the caller must opt into
 /// knowingly — the library cannot detect it.
+///
+/// # When a `DataVenue` is the wrong tool
+/// A `DataVenue` models **one** economic instrument that two venues both quote — the same shares,
+/// the same contract, the same pair — where all that differs is who publishes the prices and how
+/// they spell the symbol. It does not model *related but distinct* instruments: a spot-metal or
+/// index CFD against the corresponding future, a perpetual against its underlying spot, one
+/// maturity against another. Those have their own tick sizes, expiries, funding and basis;
+/// collapsing them onto one `Instrument` would mark a position against a series that is not that
+/// position's own market, and the resulting `pnl_unrealised` would be wrong rather than stale.
+///
+/// Trading one off the other is the **two-instrument pattern**, and it needs no library support:
+///
+/// 1. Register **both** as ordinary `Instrument`s — the one you price, and the one you trade. Each
+///    carries its own kind, its own underlying and its own venue. Only the traded instrument needs
+///    an execution client registered against its exchange.
+/// 2. Subscribe to market data for both, or for the priced one alone.
+/// 3. Read the priced instrument's state in the strategy, and emit orders keyed to the **traded**
+///    instrument. Nothing couples an order's instrument to the instrument whose prices motivated
+///    it — the order interface takes whatever instrument key you give it.
+/// 4. Own the conversion. Hedge ratio, contract multiplier, quantity and basis are a trading
+///    decision the library has no way to derive, and getting them wrong is silent.
+///
+/// The consequence to accept is the mirror image of the case this type exists for: the two
+/// instruments keep **separate** ledgers. Position and `pnl_unrealised` live on the traded
+/// instrument, which is correct, and the priced instrument holds no position at all. Reconciling
+/// them — treating an exposure opened against one as a hedge for a signal from the other — is the
+/// caller's, because only the caller knows the relationship.
+///
+/// This is also what makes a non-executable kind usable for live decisions. An instrument kind no
+/// execution client accepts can still price a strategy; it simply cannot be the instrument an order
+/// names.
 #[derive(
     Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
 )]

--- a/rustrade-instrument/src/instrument/data_venue.rs
+++ b/rustrade-instrument/src/instrument/data_venue.rs
@@ -1,0 +1,77 @@
+use crate::instrument::name::InstrumentNameExchange;
+use derive_more::Constructor;
+use serde::{Deserialize, Serialize};
+
+/// The venue an [`Instrument`](super::Instrument)s **market data** is sourced from, when that
+/// differs from the venue it is **executed** on.
+///
+/// # Why this exists
+/// Position and `pnl_unrealised` state is strictly `InstrumentIndex`-scoped: a position opened by a
+/// fill only receives live PnL from market events tagged with *that* index. Modelling "priced by
+/// venue A, traded on venue B" as two separate `Instrument`s would therefore leave the traded
+/// instrument's PnL permanently stale, because the price updates would land on the other index.
+/// A `DataVenue` keeps both roles on **one** instrument, and so on one ledger.
+///
+/// # Fallback
+/// Both fields fall back to the execution venue's equivalents, so a `DataVenue` only has to state
+/// what actually differs:
+/// - no `DataVenue` at all ⇒ market data is sourced from `Instrument::exchange` under
+///   `Instrument::name_exchange`, which is the behaviour of every single-venue instrument;
+/// - a `DataVenue` with `name_exchange: None` ⇒ the data venue spells the symbol exactly as the
+///   execution venue does.
+///
+/// Read them through [`Instrument::data_exchange`](super::Instrument::data_exchange) and
+/// [`Instrument::data_name_exchange`](super::Instrument::data_name_exchange) rather than reaching
+/// into the fields, so the fallback is applied in one place.
+///
+/// # `name_exchange` is not cosmetic
+/// Two venues routinely spell one economic instrument differently — London Strategic Edge quotes BP
+/// as `BP.L` while a US broker lists it as `BP` — so a data venue that could only carry an exchange
+/// identifier would subscribe under the *execution* venue's symbol and silently receive nothing, or
+/// worse, receive a different instrument's prices.
+///
+/// # Suitability (caller obligation)
+/// Sourcing prices from one venue and filling on another means **the decision price is not the fill
+/// price**: the two venues have separate books, and a data venue that publishes an aggregated or
+/// synthetic series (a CFD or index proxy) has no book at all. That basis mismatch is sound for
+/// research and paper trading, but for real capital it is a property the caller must opt into
+/// knowingly — the library cannot detect it.
+#[derive(
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
+)]
+pub struct DataVenue<ExchangeKey> {
+    /// Venue the market data is sourced from.
+    pub exchange: ExchangeKey,
+
+    /// Symbol the data venue uses for this instrument.
+    ///
+    /// `None` ⇒ the data venue spells it exactly as the execution venue does.
+    #[serde(default)]
+    pub name_exchange: Option<InstrumentNameExchange>,
+}
+
+impl<ExchangeKey> DataVenue<ExchangeKey> {
+    /// Construct a `DataVenue` that shares the execution venue's symbol.
+    pub fn new_same_name(exchange: ExchangeKey) -> Self {
+        Self {
+            exchange,
+            name_exchange: None,
+        }
+    }
+
+    /// Map this `DataVenue`s `ExchangeKey` to a new key, using the provided lookup closure.
+    pub fn map_exchange_key<FnFindExchange, NewExchangeKey>(
+        self,
+        find_exchange: FnFindExchange,
+    ) -> DataVenue<NewExchangeKey>
+    where
+        FnFindExchange: FnOnce(&ExchangeKey) -> NewExchangeKey,
+    {
+        let exchange = find_exchange(&self.exchange);
+
+        DataVenue {
+            exchange,
+            name_exchange: self.name_exchange,
+        }
+    }
+}

--- a/rustrade-instrument/src/instrument/data_venue.rs
+++ b/rustrade-instrument/src/instrument/data_venue.rs
@@ -106,3 +106,52 @@ impl<ExchangeKey> DataVenue<ExchangeKey> {
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::exchange::ExchangeId;
+
+    #[test]
+    fn new_same_name_defers_the_symbol_to_the_execution_venue() {
+        let data_venue = DataVenue::new_same_name(ExchangeId::LseEquities);
+
+        assert_eq!(data_venue.exchange, ExchangeId::LseEquities);
+        assert_eq!(
+            data_venue.name_exchange, None,
+            "None is what makes `Instrument::data_name_exchange` fall back, so it must not be \
+             filled in with the execution venue's symbol here"
+        );
+    }
+
+    #[test]
+    fn map_exchange_key_rewrites_the_venue_and_carries_the_symbol_through() {
+        let data_venue = DataVenue::new(
+            ExchangeId::LseEquities,
+            Some(InstrumentNameExchange::from("BP.L")),
+        );
+
+        let mapped = data_venue.map_exchange_key(|exchange| exchange.as_str().to_string());
+
+        assert_eq!(mapped.exchange, "lse_equities");
+        assert_eq!(
+            mapped.name_exchange,
+            Some(InstrumentNameExchange::from("BP.L")),
+            "the data venue's own symbol must survive indexing - re-resolving it against the \
+             execution venue is what silently subscribes to the wrong instrument"
+        );
+    }
+
+    #[test]
+    fn a_data_venue_without_a_symbol_deserialises_from_a_payload_that_omits_the_field() {
+        // `name_exchange` is `#[serde(default)]`, so a config naming only the venue is valid.
+        let data_venue: DataVenue<ExchangeId> =
+            serde_json::from_str(r#"{"exchange":"lse_equities"}"#).unwrap();
+
+        assert_eq!(
+            data_venue,
+            DataVenue::new_same_name(ExchangeId::LseEquities)
+        );
+    }
+}

--- a/rustrade-instrument/src/instrument/kind/mod.rs
+++ b/rustrade-instrument/src/instrument/kind/mod.rs
@@ -394,4 +394,25 @@ mod tests {
         let actual = serde_json::from_str::<InstrumentKind<&str>>(&json).unwrap();
         assert_eq!(actual, kind);
     }
+
+    #[test]
+    fn test_discriminant_names_each_variant() {
+        // The match in `discriminant` is exhaustive, so a *missing* arm cannot compile -- but a
+        // transposed one (`Future(_) => Discriminant::Option`) compiles, passes clippy, and silently
+        // inverts every `ExecutionClient::SUPPORTED_KINDS` guard built on it: an instrument of a kind
+        // a venue cannot encode would be admitted, and one it can would be rejected. Nothing but this
+        // test stands between a typo here and the wrong-symbol order the capability set exists to
+        // prevent, so each pairing is asserted individually rather than by round-tripping a list.
+        assert_eq!(spot().discriminant(), InstrumentKindDiscriminant::Spot);
+        assert_eq!(
+            perpetual().discriminant(),
+            InstrumentKindDiscriminant::Perpetual
+        );
+        assert_eq!(future(1).discriminant(), InstrumentKindDiscriminant::Future);
+        assert_eq!(
+            option(1, Decimal::ONE).discriminant(),
+            InstrumentKindDiscriminant::Option
+        );
+        assert_eq!(cfd().discriminant(), InstrumentKindDiscriminant::Cfd);
+    }
 }

--- a/rustrade-instrument/src/instrument/kind/mod.rs
+++ b/rustrade-instrument/src/instrument/kind/mod.rs
@@ -10,6 +10,7 @@ use crate::instrument::{
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 /// Defines an [`PerpetualContract`].
 pub mod perpetual;
@@ -42,7 +43,51 @@ pub enum InstrumentKind<AssetKey> {
     Cfd(CfdContract<AssetKey>),
 }
 
+/// Names an [`InstrumentKind`] variant without its contract payload.
+///
+/// [`InstrumentKind`] carries per-contract data (`contract_size`, `settlement_asset`, expiry,
+/// strike) and is generic over `AssetKey`, so it can be neither named in a `const` nor compared
+/// without first constructing a contract. This is the payload-free spelling of *which* kind, which
+/// is what a venue needs in order to declare the kinds it can trade as a `const` capability set —
+/// see `ExecutionClient::SUPPORTED_KINDS` in `rustrade-execution`.
+///
+/// Deliberately distinct from [`MarketDataInstrumentKind`], which is not payload-free: its `Future`
+/// and `Option` variants carry the expiry and strike that bind a subscription. That type answers
+/// "which contract is this stream for"; this one answers "which family is this instrument".
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstrumentKindDiscriminant {
+    Spot,
+    Perpetual,
+    Future,
+    Option,
+    Cfd,
+}
+
+impl Display for InstrumentKindDiscriminant {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            InstrumentKindDiscriminant::Spot => "spot",
+            InstrumentKindDiscriminant::Perpetual => "perpetual",
+            InstrumentKindDiscriminant::Future => "future",
+            InstrumentKindDiscriminant::Option => "option",
+            InstrumentKindDiscriminant::Cfd => "cfd",
+        })
+    }
+}
+
 impl<AssetKey> InstrumentKind<AssetKey> {
+    /// Returns the [`InstrumentKindDiscriminant`] naming this variant, discarding contract detail.
+    pub fn discriminant(&self) -> InstrumentKindDiscriminant {
+        match self {
+            InstrumentKind::Spot => InstrumentKindDiscriminant::Spot,
+            InstrumentKind::Perpetual(_) => InstrumentKindDiscriminant::Perpetual,
+            InstrumentKind::Future(_) => InstrumentKindDiscriminant::Future,
+            InstrumentKind::Option(_) => InstrumentKindDiscriminant::Option,
+            InstrumentKind::Cfd(_) => InstrumentKindDiscriminant::Cfd,
+        }
+    }
+
     /// Returns the `contract_size` value for the `InstrumentKind`.
     ///
     /// Note that `Spot` is always `Decimal::ONE`.

--- a/rustrade-instrument/src/instrument/mod.rs
+++ b/rustrade-instrument/src/instrument/mod.rs
@@ -94,6 +94,9 @@ pub struct Instrument<ExchangeKey, AssetKey> {
     /// an `ExchangeKey: Default` bound on the whole `Deserialize` impl, which `Keyed<ExchangeIndex,
     /// ExchangeId>` — the key every *indexed* `Instrument` carries — does not satisfy. Naming the
     /// path keeps the bound off.
+    ///
+    /// Enforced by the compiler rather than by a test: reverting to the bare form fails to *build*
+    /// wherever an indexed `Instrument` is deserialised, so no runtime test below pins it.
     #[serde(default = "Option::default")]
     pub data_venue: Option<DataVenue<ExchangeKey>>,
 }
@@ -335,7 +338,11 @@ impl<ExchangeKey> From<&Instrument<ExchangeKey, Asset>> for MarketDataInstrument
 #[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
-    use crate::exchange::ExchangeId;
+    use crate::{
+        exchange::ExchangeId,
+        instrument::spec::{InstrumentSpecNotional, InstrumentSpecPrice},
+    };
+    use rust_decimal::Decimal;
 
     /// An `AAPL` traded on one venue, optionally priced by another.
     fn instrument(data_venue: Option<DataVenue<ExchangeId>>) -> Instrument<ExchangeId, Asset> {
@@ -354,6 +361,37 @@ mod tests {
             Some(data_venue) => instrument.with_data_venue(data_venue),
             None => instrument,
         }
+    }
+
+    /// `data_venue` is declared **last**, and that is load-bearing rather than stylistic:
+    /// `Instrument` derives `Ord` from field order and `IndexedInstrumentsBuilder` sorts the
+    /// collection before assigning each `InstrumentIndex`, so the field's *position* is part of how
+    /// instruments are numbered. Move it above `spec` and this test fails while every existing
+    /// collection silently renumbers — indices that are serialized into engine state, the audit
+    /// replica and backtest replay streams.
+    #[test]
+    fn data_venue_sorts_last_so_it_renumbers_no_existing_collection() {
+        // Identical up to `spec`, which is declared BEFORE `data_venue`. `Option: None < Some`, so
+        // each field on its own would order these opposite ways: `spec` puts the specless
+        // instrument first, `data_venue` puts the venueless one first. Only one of them can decide,
+        // and it must be the earlier field.
+        let no_spec_with_data_venue =
+            instrument(Some(DataVenue::new_same_name(ExchangeId::LseEquities)));
+        let mut spec_without_data_venue = instrument(None);
+        spec_without_data_venue.spec = Some(InstrumentSpec::new(
+            InstrumentSpecPrice::new(Decimal::ONE, Decimal::ONE),
+            InstrumentSpecQuantity::new(OrderQuantityUnits::Quote, Decimal::ONE, Decimal::ONE),
+            InstrumentSpecNotional::new(Decimal::ONE),
+        ));
+
+        assert!(
+            no_spec_with_data_venue < spec_without_data_venue,
+            "an earlier field must decide the order, whatever `data_venue` says"
+        );
+
+        // And among instruments equal in every earlier field, it is the tie-break — so declaring it
+        // appends to the sort key rather than displacing any part of it.
+        assert!(instrument(None) < no_spec_with_data_venue);
     }
 
     #[test]

--- a/rustrade-instrument/src/instrument/mod.rs
+++ b/rustrade-instrument/src/instrument/mod.rs
@@ -84,11 +84,17 @@ pub struct Instrument<ExchangeKey, AssetKey> {
     /// [`Self::data_name_exchange`] so the fallback to `exchange`/`name_exchange` is applied in
     /// one place.
     ///
-    /// Declared **last** deliberately. `Instrument` derives `Ord`, and `IndexedInstrumentsBuilder`
-    /// sorts the collection before assigning each `InstrumentIndex` — so field order is part of
-    /// how indices are numbered. Appending keeps the sort key's prefix identical to what it was
-    /// before this field existed, which means adding it renumbers nothing for the existing
-    /// (`None`) instruments that make up every collection built to date.
+    /// Declared **last** by convention, not by necessity — worth stating precisely so a future
+    /// maintainer does not infer a tighter constraint than exists. `Instrument` derives `Ord` and
+    /// `IndexedInstrumentsBuilder` sorts the collection before assigning each `InstrumentIndex`, so
+    /// field order is in principle part of how indices are numbered; this field is nonetheless
+    /// unreachable as a sort key in both of the cases that matter. A collection whose instruments
+    /// all carry `None` — every collection built before this field existed — compares `Equal` here
+    /// wherever the field sits, so adding it renumbers nothing regardless of position. And
+    /// `IndexedInstrumentsBuilder::try_build` rejects a duplicate `name_internal`, so in any
+    /// collection that builds at all, `Ord` between two distinct instruments is already decided by
+    /// an earlier field and never reaches this one to break a tie. Last is simply the least
+    /// surprising place for it.
     ///
     /// `default = "Option::default"` rather than a bare `default`: the bare form makes serde infer
     /// an `ExchangeKey: Default` bound on the whole `Deserialize` impl, which `Keyed<ExchangeIndex,

--- a/rustrade-instrument/src/instrument/mod.rs
+++ b/rustrade-instrument/src/instrument/mod.rs
@@ -2,6 +2,7 @@ use crate::{
     Underlying,
     asset::Asset,
     instrument::{
+        data_venue::DataVenue,
         kind::{
             InstrumentKind, cfd::CfdContract, future::FutureContract, option::OptionContract,
             perpetual::PerpetualContract,
@@ -18,6 +19,10 @@ use std::fmt::Formatter;
 
 /// Defines an [`Instrument`]s [`InstrumentKind`] (eg/ Spot, Perpetual, etc).
 pub mod kind;
+
+/// Defines the [`DataVenue`] an [`Instrument`]s market data is sourced from, when that differs
+/// from the venue it is executed on.
+pub mod data_venue;
 
 /// Defines the [`InstrumentNameExchange`] and [`InstrumentNameExchange`] types, used as
 /// `SmolStr` identifiers for an [`Instrument`].
@@ -73,6 +78,24 @@ pub struct Instrument<ExchangeKey, AssetKey> {
     #[serde(alias = "instrument_kind")]
     pub kind: InstrumentKind<AssetKey>,
     pub spec: Option<InstrumentSpec<AssetKey>>,
+
+    /// Venue this `Instrument`s **market data** is sourced from, when that differs from
+    /// `exchange` — see [`DataVenue`], and read it via [`Self::data_exchange`] /
+    /// [`Self::data_name_exchange`] so the fallback to `exchange`/`name_exchange` is applied in
+    /// one place.
+    ///
+    /// Declared **last** deliberately. `Instrument` derives `Ord`, and `IndexedInstrumentsBuilder`
+    /// sorts the collection before assigning each `InstrumentIndex` — so field order is part of
+    /// how indices are numbered. Appending keeps the sort key's prefix identical to what it was
+    /// before this field existed, which means adding it renumbers nothing for the existing
+    /// (`None`) instruments that make up every collection built to date.
+    ///
+    /// `default = "Option::default"` rather than a bare `default`: the bare form makes serde infer
+    /// an `ExchangeKey: Default` bound on the whole `Deserialize` impl, which `Keyed<ExchangeIndex,
+    /// ExchangeId>` — the key every *indexed* `Instrument` carries — does not satisfy. Naming the
+    /// path keeps the bound off.
+    #[serde(default = "Option::default")]
+    pub data_venue: Option<DataVenue<ExchangeKey>>,
 }
 
 impl<ExchangeKey, AssetKey> Instrument<ExchangeKey, AssetKey> {
@@ -101,6 +124,7 @@ impl<ExchangeKey, AssetKey> Instrument<ExchangeKey, AssetKey> {
             underlying,
             kind,
             spec,
+            data_venue: None,
         }
     }
 
@@ -127,25 +151,55 @@ impl<ExchangeKey, AssetKey> Instrument<ExchangeKey, AssetKey> {
             underlying,
             kind: InstrumentKind::Spot,
             spec,
+            data_venue: None,
         }
     }
 
-    /// Map this Instruments `ExchangeKey` to a new key.
-    pub fn map_exchange_key<NewExchangeKey>(
-        self,
-        exchange: NewExchangeKey,
-    ) -> Instrument<NewExchangeKey, AssetKey> {
-        let Instrument {
-            exchange: _,
-            name_internal,
-            name_exchange,
-            underlying,
-            quote,
-            kind,
-            spec,
-        } = self;
+    /// Source this `Instrument`s market data from a different venue than it is executed on.
+    ///
+    /// See [`DataVenue`] for the fallback semantics and — importantly — the suitability obligation
+    /// that comes with deciding on one venue's prices and filling on another.
+    pub fn with_data_venue(mut self, data_venue: DataVenue<ExchangeKey>) -> Self {
+        self.data_venue = Some(data_venue);
+        self
+    }
 
-        Instrument {
+    /// Venue this `Instrument`s market data is sourced from.
+    ///
+    /// Falls back to `exchange` when no [`DataVenue`] is set, so this is the correct accessor for
+    /// every instrument, single-venue or not.
+    pub fn data_exchange(&self) -> &ExchangeKey {
+        self.data_venue
+            .as_ref()
+            .map_or(&self.exchange, |data_venue| &data_venue.exchange)
+    }
+
+    /// Symbol the market data venue uses for this `Instrument`.
+    ///
+    /// Falls back to `name_exchange` when the data venue spells it the same way, or when there is
+    /// no [`DataVenue`] at all.
+    pub fn data_name_exchange(&self) -> &InstrumentNameExchange {
+        self.data_venue
+            .as_ref()
+            .and_then(|data_venue| data_venue.name_exchange.as_ref())
+            .unwrap_or(&self.name_exchange)
+    }
+
+    /// Map this Instruments `ExchangeKey` to a new key, using the provided lookup closure.
+    ///
+    /// The closure is applied to the execution `exchange` **and** to any [`DataVenue`]s exchange,
+    /// which is why it takes a lookup rather than a single pre-resolved key: those are two
+    /// different venues, so one key cannot serve both. A signature that accepted one key could
+    /// only stamp the execution venue's key onto the data venue — silently pointing market-data
+    /// state at the wrong exchange.
+    pub fn map_exchange_key<FnFindExchange, NewExchangeKey>(
+        self,
+        find_exchange: FnFindExchange,
+    ) -> Instrument<NewExchangeKey, AssetKey>
+    where
+        FnFindExchange: Fn(&ExchangeKey) -> NewExchangeKey,
+    {
+        let Instrument {
             exchange,
             name_internal,
             name_exchange,
@@ -153,6 +207,21 @@ impl<ExchangeKey, AssetKey> Instrument<ExchangeKey, AssetKey> {
             quote,
             kind,
             spec,
+            data_venue,
+        } = self;
+
+        let data_venue =
+            data_venue.map(|data_venue| data_venue.map_exchange_key(|key| find_exchange(key)));
+
+        Instrument {
+            exchange: find_exchange(&exchange),
+            name_internal,
+            name_exchange,
+            underlying,
+            quote,
+            kind,
+            spec,
+            data_venue,
         }
     }
 
@@ -172,6 +241,7 @@ impl<ExchangeKey, AssetKey> Instrument<ExchangeKey, AssetKey> {
             quote,
             kind,
             spec,
+            data_venue,
         } = self;
 
         let base_new_key = find_asset(&underlying.base)?;
@@ -244,6 +314,9 @@ impl<ExchangeKey, AssetKey> Instrument<ExchangeKey, AssetKey> {
             quote,
             kind,
             spec,
+            // The `DataVenue` holds no `AssetKey` — it names a venue and a symbol, and the
+            // underlying assets are the instrument's own regardless of who prices it.
+            data_venue,
         })
     }
 }
@@ -255,5 +328,150 @@ impl<ExchangeKey> From<&Instrument<ExchangeKey, Asset>> for MarketDataInstrument
             quote: value.underlying.quote.name_internal.clone(),
             kind: MarketDataInstrumentKind::from(&value.kind),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::exchange::ExchangeId;
+
+    /// An `AAPL` traded on one venue, optionally priced by another.
+    fn instrument(data_venue: Option<DataVenue<ExchangeId>>) -> Instrument<ExchangeId, Asset> {
+        let instrument = Instrument::spot(
+            ExchangeId::AlpacaBroker,
+            "alpaca_broker-aapl",
+            "AAPL",
+            Underlying::new(
+                Asset::new_from_exchange("aapl"),
+                Asset::new_from_exchange("usd"),
+            ),
+            None,
+        );
+
+        match data_venue {
+            Some(data_venue) => instrument.with_data_venue(data_venue),
+            None => instrument,
+        }
+    }
+
+    #[test]
+    fn a_single_venue_instrument_reports_its_execution_venue_as_its_data_venue() {
+        // The fallback is what lets every caller read `data_exchange()` unconditionally, rather
+        // than each one re-deriving `data_venue.unwrap_or(exchange)` and one of them getting it
+        // wrong.
+        let instrument = instrument(None);
+
+        assert_eq!(instrument.data_exchange(), &ExchangeId::AlpacaBroker);
+        assert_eq!(
+            instrument.data_name_exchange(),
+            &InstrumentNameExchange::new("AAPL")
+        );
+    }
+
+    #[test]
+    fn a_data_venue_without_a_symbol_overrides_the_venue_but_keeps_the_execution_symbol() {
+        // The common case: both venues spell it the same way, so only the venue is stated.
+        let instrument = instrument(Some(DataVenue::new_same_name(ExchangeId::LseEquities)));
+
+        assert_eq!(instrument.data_exchange(), &ExchangeId::LseEquities);
+        assert_eq!(
+            instrument.data_name_exchange(),
+            &InstrumentNameExchange::new("AAPL")
+        );
+        // The execution side is untouched — this is one instrument on one ledger, not two.
+        assert_eq!(instrument.exchange, ExchangeId::AlpacaBroker);
+        assert_eq!(
+            instrument.name_exchange,
+            InstrumentNameExchange::new("AAPL")
+        );
+    }
+
+    #[test]
+    fn a_data_venue_symbol_overrides_the_execution_symbol() {
+        // The case the field exists for: LSE quotes BP as `BP.L`, a US broker as `BP`. Subscribing
+        // under the execution symbol would silently receive nothing, or another instrument's
+        // prices.
+        let instrument = instrument(Some(DataVenue::new(
+            ExchangeId::LseEquities,
+            Some(InstrumentNameExchange::new("BP.L")),
+        )));
+
+        assert_eq!(instrument.data_exchange(), &ExchangeId::LseEquities);
+        assert_eq!(
+            instrument.data_name_exchange(),
+            &InstrumentNameExchange::new("BP.L")
+        );
+        assert_eq!(
+            instrument.name_exchange,
+            InstrumentNameExchange::new("AAPL")
+        );
+    }
+
+    #[test]
+    fn map_exchange_key_maps_the_data_venue_too() {
+        // The whole reason `map_exchange_key` takes a lookup rather than one pre-resolved key: the
+        // two venues are different exchanges, so a single key cannot serve both. Were the data
+        // venue left unmapped (or stamped with the execution venue's key), market-data state would
+        // point at the wrong exchange with nothing to signal it.
+        let instrument = instrument(Some(DataVenue::new(
+            ExchangeId::LseEquities,
+            Some(InstrumentNameExchange::new("BP.L")),
+        )));
+
+        let mapped = instrument.map_exchange_key(|exchange| exchange.as_str().to_owned());
+
+        assert_eq!(mapped.exchange, "alpaca_broker");
+        assert_eq!(
+            mapped
+                .data_venue
+                .as_ref()
+                .map(|venue| venue.exchange.as_str()),
+            Some("lse_equities")
+        );
+        // The symbol rides along unchanged — only the key is mapped.
+        assert_eq!(
+            mapped.data_name_exchange(),
+            &InstrumentNameExchange::new("BP.L")
+        );
+    }
+
+    #[test]
+    fn an_instrument_without_a_data_venue_deserialises_from_a_config_that_predates_the_field() {
+        // `data_venue` is additive, so every config written before it existed must still load. If
+        // this breaks, the field is a breaking change to on-disk configs rather than to source.
+        let json = r#"{
+            "exchange": "binance_spot",
+            "name_internal": "binance_spot-btc_usdt",
+            "name_exchange": "BTCUSDT",
+            "underlying": {
+                "base": { "name_internal": "btc", "name_exchange": "BTC" },
+                "quote": { "name_internal": "usdt", "name_exchange": "USDT" }
+            },
+            "quote": "underlying_quote",
+            "kind": "spot",
+            "spec": null
+        }"#;
+
+        let instrument =
+            serde_json::from_str::<Instrument<ExchangeId, Asset>>(json).expect("must deserialise");
+
+        assert_eq!(instrument.data_venue, None);
+        assert_eq!(instrument.data_exchange(), &ExchangeId::BinanceSpot);
+    }
+
+    #[test]
+    fn a_data_venue_round_trips_through_serde() {
+        let instrument = instrument(Some(DataVenue::new(
+            ExchangeId::LseEquities,
+            Some(InstrumentNameExchange::new("BP.L")),
+        )));
+
+        let json = serde_json::to_string(&instrument).expect("must serialise");
+        let round_tripped =
+            serde_json::from_str::<Instrument<ExchangeId, Asset>>(&json).expect("must deserialise");
+
+        assert_eq!(round_tripped, instrument);
     }
 }

--- a/rustrade-integration/src/corporate_action.rs
+++ b/rustrade-integration/src/corporate_action.rs
@@ -4,16 +4,17 @@
 //! Massive/Polygon and Alpaca: query a provider by symbol + effective-date range and receive a
 //! stream of corporate-action facts. The yielded fact is the
 //! [`CorporateAction`](rustrade_instrument::corporate_action::CorporateAction) descriptor
-//! (re-exported here), keyed by an unresolved provider symbol ([`SmolStr`]); a wrapper resolves the
-//! symbol to its engine instrument key and supplies the rounding policy + stamping instant before
-//! injecting an engine event.
+//! (re-exported here), keyed by an unresolved provider symbol ([`SmolStr`](smol_str::SmolStr)); a
+//! wrapper resolves the symbol to its engine instrument key and supplies the rounding policy +
+//! stamping instant before injecting an engine event.
 //!
 //! # The kind lives in the trait name, not a filter
 //!
 //! There is deliberately **no unified `CorporateActionSource` with a `kinds` filter**. Reference
 //! providers expose a *separate endpoint per action type* (splits vs dividends), so the action kind
-//! is encoded in the trait itself: [`StockSplitSource`] fetches splits. A `DividendSource` sibling
-//! trait is the natural future addition when dividends are needed — each fully typed, with no
+//! is encoded in the trait itself: [`StockSplitSource`](crate::corporate_action::StockSplitSource)
+//! fetches splits. A `DividendSource` sibling trait is the natural future addition when dividends
+//! are needed — each fully typed, with no
 //! discriminant enum to keep in lockstep with
 //! [`CorporateActionKind`](rustrade_instrument::corporate_action::CorporateActionKind).
 //!
@@ -21,7 +22,9 @@
 //!
 //! Account-scoped or push-based sources (e.g. Interactive Brokers' WSH / Flex Query feeds) do not
 //! fit the global-by-symbol PULL model and are **intentionally not** expressed through this trait.
-//! Such a source maps its data onto the same [`CorporateAction`] descriptor via its own adapter.
+//! Such a source maps its data onto the same
+//! [`CorporateAction`](rustrade_instrument::corporate_action::CorporateAction) descriptor via its
+//! own adapter.
 
 use chrono::NaiveDate;
 use derive_more::Constructor;

--- a/rustrade-integration/src/protocol/http/rest/mod.rs
+++ b/rustrade-integration/src/protocol/http/rest/mod.rs
@@ -39,7 +39,7 @@ pub trait RestRequest {
     ///
     /// Takes `&self` so an implementation may derive the timeout from per-instance/config state
     /// (e.g. an operator-tunable timeout captured at construction). The default returns the
-    /// compile-time [`DEFAULT_HTTP_REQUEST_TIMEOUT`] and ignores `self`.
+    /// compile-time `DEFAULT_HTTP_REQUEST_TIMEOUT` and ignores `self`.
     fn timeout(&self) -> Duration {
         DEFAULT_HTTP_REQUEST_TIMEOUT
     }

--- a/rustrade/examples/engine_sync_with_live_market_data_and_mock_execution_and_audit.rs
+++ b/rustrade/examples/engine_sync_with_live_market_data_and_mock_execution_and_audit.rs
@@ -1,5 +1,34 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
 
+//! Live market data driving a `MockExecution` system, with an audit stream.
+//!
+//! Every instrument here is priced and traded on the same venue. Two variations on that come up
+//! often enough to be worth knowing before adapting this example, and they are different things:
+//!
+//! # One instrument, priced somewhere other than where it trades
+//!
+//! The same shares, contract or pair, quoted by a data provider and executed at a broker. Give the
+//! `Instrument` a `DataVenue` — market data is then sourced from the data venue (under that venue's
+//! own symbol, if it spells it differently) while orders still route to the execution venue, and
+//! both roles stay on one instrument, so one position and one `pnl_unrealised`.
+//!
+//! # Two instruments, one priced and one traded
+//!
+//! A CFD or index proxy driving orders on the corresponding future, say. These are *different*
+//! economic instruments, with their own expiries, multipliers and basis, so they are registered as
+//! two ordinary `Instrument`s — not collapsed onto one with a `DataVenue`. The strategy reads the
+//! priced instrument's state and emits orders naming the traded one; nothing in `AlgoStrategy`
+//! couples the two. They keep separate ledgers: the position lives on the traded instrument, the
+//! priced instrument holds none, and the conversion between them (hedge ratio, quantity, basis) is
+//! yours to own.
+//!
+//! This is how an instrument kind no execution client accepts can still drive live trading: it
+//! prices the decision, and a different, executable instrument carries the order.
+//!
+//! Register execution clients only for the venues actually traded on. A venue that only supplies
+//! prices has no account to connect to, and `SystemBuilder` derives that from the execution clients
+//! registered here — so a data-only venue does not hold global connectivity at `Reconnecting`.
+
 use futures::StreamExt;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;

--- a/rustrade/src/backtest/aux_events.rs
+++ b/rustrade/src/backtest/aux_events.rs
@@ -23,26 +23,26 @@ use std::sync::Arc;
 ///   merge with the market stream is a two-way merge that relies on both inputs already being
 ///   sorted; out-of-order aux events produce an out-of-order engine feed (and, in backtest, a
 ///   non-monotonic [`HistoricalClock`](crate::engine::clock::HistoricalClock)).
-/// - For an [`EngineEvent::CorporateAction`](crate::EngineEvent::CorporateAction), the wrapping
-///   [`Timed::time`] MUST equal the action's `effective_time`. These are two independent knobs: the
+/// - For an [`EngineEvent::CorporateAction`], the wrapping [`Timed::time`] MUST equal the action's
+///   `effective_time`. These are two independent knobs: the
 ///   merge **positions** the event in the stream by `Timed::time`, while the handler advances the
 ///   [`HistoricalClock`](crate::engine::clock::HistoricalClock) to `effective_time` and stamps the
 ///   adjustment there. A mismatch would *order* the action at one instant but make it *take effect*
 ///   at another. The backtest harness **enforces** this pre-merge via
-///   [`assert_aux_corporate_action_effective_times`] (a hard panic naming the offending event) — the
+///   `assert_aux_corporate_action_effective_times` (a hard panic naming the offending event) — the
 ///   handler itself cannot see the wrapping `Timed`, so keep the two equal to pass the check.
-/// - For an [`EngineEvent::ContractExpiry`](crate::EngineEvent::ContractExpiry), the wrapping
-///   [`Timed::time`] MUST equal the target instrument's own `expiry` (engine-side ground truth on
+/// - For an [`EngineEvent::ContractExpiry`], the wrapping [`Timed::time`] MUST equal the target
+///   instrument's own `expiry` (engine-side ground truth on
 ///   its `InstrumentKind`). Unlike `CorporateAction`, the instant is not on the payload — the merge
 ///   positions the event by `Timed::time`, while the handler advances the clock to the instrument's
 ///   `expiry` (see below). A mismatch would *order* the expiry at one instant but *settle* it at
-///   another. Enforced pre-merge via [`assert_aux_contract_expiry_times`] (a hard panic naming the
+///   another. Enforced pre-merge via `assert_aux_contract_expiry_times` (a hard panic naming the
 ///   offending event); non-expiring or unregistered targets are skipped.
 ///
 /// # `ContractExpiry` clock advance
-/// [`EngineEvent::ContractExpiry`](crate::EngineEvent::ContractExpiry) carries no timestamp on its
-/// payload (unlike [`EngineEvent::CorporateAction`](crate::EngineEvent::CorporateAction), which
-/// carries `effective_time`). Its effective instant is instead engine-side ground truth: the
+/// [`EngineEvent::ContractExpiry`] carries no timestamp on its payload (unlike
+/// [`EngineEvent::CorporateAction`], which carries `effective_time`). Its effective instant is
+/// instead engine-side ground truth: the
 /// handler resolves the expiring instrument's `expiry` from its `InstrumentKind` and advances the
 /// [`HistoricalClock`](crate::engine::clock::HistoricalClock) to it via
 /// [`EngineClock::advance_to`](crate::engine::clock::EngineClock::advance_to), so the synthetic
@@ -51,7 +51,7 @@ use std::sync::Arc;
 /// handler always settles at the instrument's own `expiry`, so keep the wrapping `Timed::time` equal
 /// to that `expiry` (a mismatch would *order* the expiry at one instant but *settle* it at another).
 /// The harness enforces this equality pre-merge — see the caller obligation above and
-/// [`assert_aux_contract_expiry_times`].
+/// `assert_aux_contract_expiry_times`.
 pub trait AuxEventSource<
     MarketKind = DataKind,
     ExchangeKey = ExchangeIndex,

--- a/rustrade/src/backtest/market_data.rs
+++ b/rustrade/src/backtest/market_data.rs
@@ -205,10 +205,10 @@ impl<Kind> MarketDataInMemory<Kind> {
 ///
 /// A violation is nonetheless **observable rather than silent**: the harness's merge checks each
 /// event against the last as it passes, in release as well as debug, and a backwards step aborts
-/// the run with a [`BarterError::BacktestMarketData`](crate::error::BarterError::BacktestMarketData)
-/// instead of producing statistics over a non-monotonic clock. That is a backstop, not a licence to
-/// hand this an unsorted source: it reports the first violation and stops, so it tells the factory
-/// it is wrong rather than repairing anything.
+/// the run with a [`BarterError::BacktestMarketData`] instead of producing statistics over a
+/// non-monotonic clock. That is a backstop, not a licence to hand this an unsorted source: it
+/// reports the first violation and stops, so it tells the factory it is wrong rather than repairing
+/// anything.
 #[derive(Debug, Clone)]
 pub struct MarketDataStreamed<Factory, Kind> {
     time_first_event: DateTime<Utc>,

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -53,9 +53,8 @@ use std::{
 };
 use tracing::error;
 
-/// Defines the [`AuxEventSource`](aux_events::AuxEventSource) interface for interleaving non-market
-/// `EngineEvent`s (e.g. corporate actions, contract expiries) into a backtest in simulated-time
-/// order.
+/// Defines the [`AuxEventSource`] interface for interleaving non-market `EngineEvent`s (e.g.
+/// corporate actions, contract expiries) into a backtest in simulated-time order.
 pub mod aux_events;
 
 /// Defines the interface and implementations for different types of market data sources

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -16,7 +16,9 @@ use crate::{
         Processor,
         clock::HistoricalClock,
         execution_tx::MultiExchangeTxMap,
-        state::{EngineState, instrument::data::InstrumentDataState},
+        state::{
+            EngineState, connectivity::reconcile_venue_roles, instrument::data::InstrumentDataState,
+        },
     },
     error::BarterError,
     risk::RiskManager,
@@ -33,6 +35,7 @@ use crate::{
     system::builder::{AuditMode, SystemBuild},
 };
 use chrono::{DateTime, Utc};
+use fnv::FnvHashSet;
 use futures::{Stream, StreamExt, future::try_join_all, stream::FusedStream};
 use rust_decimal::Decimal;
 use rustrade_data::{event::MarketEvent, streams::consumer::MarketStreamEvent};
@@ -78,8 +81,8 @@ pub struct BacktestArgsConstant<MarketData, SummaryInterval, State, AuxEvents = 
     pub summary_interval: SummaryInterval,
     /// The [`EngineState`] every backtest in the batch starts from.
     ///
-    /// Built by the caller, and never modified here — see the `# Connectivity` section on
-    /// [`backtest`] for the one declaration this shifts onto the caller.
+    /// Built by the caller, and never modified here: each run reconciles venue roles on its own
+    /// clone — see the `# Connectivity` section on [`backtest`].
     pub engine_state: State,
     /// Source of auxiliary (non-market) `EngineEvent`s to interleave with the market data in
     /// simulated-time order (e.g. corporate actions, contract expiries).
@@ -264,19 +267,26 @@ where
 /// place of a result. No partial [`BacktestSummary`] is ever produced, because statistics computed
 /// over a prefix of the dataset are indistinguishable from statistics over all of it.
 ///
-/// # Connectivity: a caller obligation
-/// `backtest` takes a **pre-built** [`EngineState`] it cannot reach into, so it cannot declare which
-/// venues have an execution client — unlike [`SystemBuilder`], which does it for you. Build the state
-/// with [`EngineStateBuilder::execution_venues`] whenever some venue in the instrument collection is
-/// not traded on: an instrument registered purely so its prices are available, with nothing executing
-/// there, otherwise has that venue approximated as [`VenueRole::Both`] and waits forever on an account
-/// connection nothing will establish. `ConnectivityStates::global` then never leaves
-/// [`Health::Reconnecting`], and anything a strategy gates on global health stays gated for the whole
-/// run. Nothing errors — the run completes, having done nothing.
+/// # Connectivity: derived, not declared
+/// Each venue's [`VenueRole`] is re-derived from the execution clients this function builds, on the
+/// clone it runs against — see [`reconcile_venue_roles`]. A venue registered purely so its prices
+/// are available, with nothing executing there, is therefore marked [`VenueRole::DataOnly`] and is
+/// never waited on for an account connection nothing would establish, whether or not the caller
+/// declared anything.
+///
+/// The supplied `engine_state` is not modified, and declaring the venues upfront with
+/// [`EngineStateBuilder::execution_venues`] remains supported: both derive the same roles from the
+/// same inputs, so a state built that way reconciles to itself.
+///
+/// One configuration still cannot converge, and is reported rather than inferred: a venue that
+/// neither prices an instrument nor has an execution client provides no connection that could
+/// report healthy, so `ConnectivityStates::global` stays [`Health::Reconnecting`] for the whole
+/// run. `reconcile_venue_roles` logs a warning naming it.
 ///
 /// [`SystemBuilder`]: crate::system::builder::SystemBuilder
 /// [`EngineStateBuilder::execution_venues`]: crate::engine::state::builder::EngineStateBuilder::execution_venues
-/// [`VenueRole::Both`]: crate::engine::state::connectivity::VenueRole::Both
+/// [`VenueRole`]: crate::engine::state::connectivity::VenueRole
+/// [`VenueRole::DataOnly`]: crate::engine::state::connectivity::VenueRole::DataOnly
 /// [`Health::Reconnecting`]: crate::engine::state::connectivity::Health::Reconnecting
 pub async fn backtest<
     MarketData,
@@ -395,9 +405,24 @@ where
         )?
         .build();
 
+    // The same derivation `SystemBuilder` performs when it builds the state itself. Read before
+    // `execution_tx_map` is moved into the Engine below.
+    let execution_venues = execution_tx_map
+        .execution_venues()
+        .collect::<FnvHashSet<_>>();
+
+    // Applied to the clone, so the caller's own `engine_state` is left untouched and every backtest
+    // in a sweep derives its roles from the clients IT was built with.
+    let mut engine_state = args_constant.engine_state.clone();
+    reconcile_venue_roles(
+        &mut engine_state.connectivity,
+        &args_constant.instruments,
+        &execution_venues,
+    );
+
     let engine = Engine::new(
         clock,
-        args_constant.engine_state.clone(),
+        engine_state,
         execution_tx_map,
         args_dynamic.strategy,
         args_dynamic.risk,

--- a/rustrade/src/backtest/mod.rs
+++ b/rustrade/src/backtest/mod.rs
@@ -76,7 +76,10 @@ pub struct BacktestArgsConstant<MarketData, SummaryInterval, State, AuxEvents = 
     pub market_data: MarketData,
     /// Time interval for aggregating and reporting summary statistics.
     pub summary_interval: SummaryInterval,
-    /// EngineState.
+    /// The [`EngineState`] every backtest in the batch starts from.
+    ///
+    /// Built by the caller, and never modified here — see the `# Connectivity` section on
+    /// [`backtest`] for the one declaration this shifts onto the caller.
     pub engine_state: State,
     /// Source of auxiliary (non-market) `EngineEvent`s to interleave with the market data in
     /// simulated-time order (e.g. corporate actions, contract expiries).
@@ -260,6 +263,21 @@ where
 /// failed page fetch — **aborts the run**: the engine is shut down and that error is returned in
 /// place of a result. No partial [`BacktestSummary`] is ever produced, because statistics computed
 /// over a prefix of the dataset are indistinguishable from statistics over all of it.
+///
+/// # Connectivity: a caller obligation
+/// `backtest` takes a **pre-built** [`EngineState`] it cannot reach into, so it cannot declare which
+/// venues have an execution client — unlike [`SystemBuilder`], which does it for you. Build the state
+/// with [`EngineStateBuilder::execution_venues`] whenever some venue in the instrument collection is
+/// not traded on: an instrument registered purely so its prices are available, with nothing executing
+/// there, otherwise has that venue approximated as [`VenueRole::Both`] and waits forever on an account
+/// connection nothing will establish. `ConnectivityStates::global` then never leaves
+/// [`Health::Reconnecting`], and anything a strategy gates on global health stays gated for the whole
+/// run. Nothing errors — the run completes, having done nothing.
+///
+/// [`SystemBuilder`]: crate::system::builder::SystemBuilder
+/// [`EngineStateBuilder::execution_venues`]: crate::engine::state::builder::EngineStateBuilder::execution_venues
+/// [`VenueRole::Both`]: crate::engine::state::connectivity::VenueRole::Both
+/// [`Health::Reconnecting`]: crate::engine::state::connectivity::Health::Reconnecting
 pub async fn backtest<
     MarketData,
     SummaryInterval,

--- a/rustrade/src/engine/audit/mod.rs
+++ b/rustrade/src/engine/audit/mod.rs
@@ -229,6 +229,9 @@ impl<Event, OnTradingDisabled, OnDisconnect>
                 Self::with_output(event, EngineOutput::AccountDisconnect(disconnect))
             }
             UpdateFromAccountOutput::PositionExit(position) => Self::with_output(event, position),
+            UpdateFromAccountOutput::UntrackedExchange(untracked) => {
+                Self::with_output(event, EngineOutput::UntrackedExchange(untracked))
+            }
         }
     }
 
@@ -240,6 +243,9 @@ impl<Event, OnTradingDisabled, OnDisconnect>
             UpdateFromMarketOutput::None => Self::with_event(event),
             UpdateFromMarketOutput::OnDisconnect(disconnect) => {
                 Self::with_output(event, EngineOutput::MarketDisconnect(disconnect))
+            }
+            UpdateFromMarketOutput::UntrackedExchange(untracked) => {
+                Self::with_output(event, EngineOutput::UntrackedExchange(untracked))
             }
         }
     }

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -143,7 +143,8 @@ where
     /// - **`CorporateAction`**: a *hybrid*. `Position::apply_split` is deterministic, so the
     ///   adjustment (quantity / basis / unrealised PnL) is **event-replayed** for every position
     ///   from the payload — after re-running the same guards (idempotency / non-`Spot` /
-    ///   unsupported-kind, all of which skip without mutating). The Floor-to-zero **close** is
+    ///   unsupported-kind, plus the ambiguous-target and pre-validation guards inside the shared
+    ///   prepare pass, all of which skip without mutating). The Floor-to-zero **close** is
     ///   **output-mirrored** (like `ContractExpiry`): the live handler stamps the closing
     ///   `PositionExit.time_exit` with `self.time()`, which is wall-clock-derived on
     ///   `HistoricalClock` and therefore cannot be reproduced from the payload, so the replica
@@ -311,17 +312,19 @@ where
                 let adjust_options_in_place = classify_option_split(&kind).unwrap_or(false);
 
                 // Pre-compute the whole action BEFORE mutating anything, mirroring the live
-                // handler's Step 2c: if the live engine rejected it (Decimal overflow — equity,
-                // option strike, or option position — or a corrupted option contract count) it
-                // recorded no `id` and mutated nothing, so the replica must do the same or state
-                // parity drifts. Single-sourced via the same `prepare_corporate_action_split` the
-                // live handler calls, so both reach the identical accept/reject decision AND the
-                // identical committed values. No output emitted — the replica mirrors state, and the
-                // live engine already logged the rejection.
+                // handler's Step 2c: if the live engine rejected it (an ambiguous split target, a
+                // Decimal overflow — equity, option strike, or option position — or a corrupted
+                // option contract count) it recorded no `id` and mutated nothing, so the replica
+                // must do the same or state parity drifts. Single-sourced via the same
+                // `prepare_corporate_action_split` the live handler calls, so both reach the
+                // identical accept/reject decision AND the identical committed values — including
+                // which options are excluded as already-adjusted by this `id`. No output emitted —
+                // the replica mirrors state, and the live engine already logged the rejection.
                 let split_plan = match self
                     .replica_engine_state()
                     .instruments
                     .prepare_corporate_action_split(
+                        &id,
                         &instrument,
                         ratio,
                         policy,
@@ -429,6 +432,14 @@ where
                             );
                         };
                         contract.strike = opt_plan.strike_post_split;
+
+                        // Record `id` on the OPTION's own set (mirrors the live handler): the
+                        // replica's `InstrumentState` is asserted field-for-field against the live
+                        // engine's, and this set now gates whether a later delivery of the same
+                        // action re-adjusts the option — so omitting it would both fail parity and
+                        // let the replica double-divide a strike the live engine skipped. Written
+                        // before the unheld early-out, exactly as the live handler does.
+                        option_state.corporate_actions_processed.insert(id.clone());
 
                         // Unheld option: strike correction is the whole job (silent registry fix),
                         // mirroring the live handler.

--- a/rustrade/src/engine/audit/state_replica.rs
+++ b/rustrade/src/engine/audit/state_replica.rs
@@ -169,9 +169,16 @@ where
                     .trading
                     .update(trading_state);
             }
+            // The three `UntrackedExchange` results below are event-replayed, not output-mirrored:
+            // the replica's `ConnectivityStates` is a clone of the live engine's, so the same
+            // lookup against the same map reaches the same verdict from the event alone. On `Err`
+            // the live engine mutated nothing, and so does the replica — discarding the result
+            // *is* the mirror. (The live engine already emitted the observable and logged it; the
+            // replica mirrors state, not outputs.)
             EngineEvent::Account(event) => match event {
                 AccountStreamEvent::Reconnecting(exchange) => {
-                    self.replica_engine_state_mut()
+                    let _untracked = self
+                        .replica_engine_state_mut()
                         .connectivity
                         .update_from_account_reconnecting(&exchange);
                 }
@@ -181,12 +188,13 @@ where
             },
             EngineEvent::Market(event) => match event {
                 MarketStreamEvent::Reconnecting(exchange) => {
-                    self.replica_engine_state_mut()
+                    let _untracked = self
+                        .replica_engine_state_mut()
                         .connectivity
                         .update_from_market_reconnecting(&exchange);
                 }
                 MarketStreamEvent::Item(event) => {
-                    self.replica_engine_state_mut().update_from_market(&event);
+                    let _untracked = self.replica_engine_state_mut().update_from_market(&event);
                 }
             },
             EngineEvent::ContractExpiry(key) => {

--- a/rustrade/src/engine/clock.rs
+++ b/rustrade/src/engine/clock.rs
@@ -28,8 +28,7 @@ pub trait EngineClock {
     /// backtest stamps the synthetic settlement fill at the expiry instant rather than the prior
     /// market tick. Events that already carry their instant on the payload (e.g.
     /// [`EngineEvent::CorporateAction`]'s `effective_time`) advance the clock via the normal
-    /// [`TimeExchange`] path in [`Processor::process`](crate::engine::Processor::process) and do
-    /// not use this method.
+    /// [`TimeExchange`] path in [`Processor::process`] and do not use this method.
     ///
     /// The default implementation is a no-op, correct for clocks that derive time externally
     /// (e.g. [`LiveClock`], which reads `Utc::now()`). [`HistoricalClock`] overrides it.

--- a/rustrade/src/engine/execution_tx.rs
+++ b/rustrade/src/engine/execution_tx.rs
@@ -42,6 +42,24 @@ pub struct MultiExchangeTxMap<Tx = UnboundedTx<ExecutionRequest>>(
     FnvIndexMap<ExchangeId, Option<Tx>>,
 );
 
+impl<Tx> MultiExchangeTxMap<Tx> {
+    /// Venues that actually have a registered execution client.
+    ///
+    /// A venue is present in this map but holds `None` when the system tracks instruments for it
+    /// without trading on them — see the type-level note above on why the slot must still exist.
+    /// Having a transmitter is therefore what decides whether the engine will ever receive an
+    /// `AccountStream` event from that venue, which is precisely the account dimension
+    /// [`VenueRole`](crate::engine::state::connectivity::VenueRole) is derived from.
+    ///
+    /// Borrows `self`, so collect the result before moving the map into an
+    /// [`Engine`](crate::engine::Engine).
+    pub(crate) fn execution_venues(&self) -> impl Iterator<Item = ExchangeId> + '_ {
+        self.0
+            .iter()
+            .filter_map(|(exchange, tx)| tx.as_ref().map(|_| *exchange))
+    }
+}
+
 impl<Tx> FromIterator<(ExchangeId, Option<Tx>)> for MultiExchangeTxMap<Tx> {
     fn from_iter<Iter>(iter: Iter) -> Self
     where

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -721,7 +721,10 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     ///    instrument, not the (supported) kind:
     ///    - target instrument is not `Spot` ⇒ [`UnsupportedCorporateActionReason::InstrumentKindNotSupported`];
     ///    - action kind is not a stock split ⇒ [`UnsupportedCorporateActionReason::ActionKindNotSupported`]
-    ///      (the compiler-mandated arm for the `#[non_exhaustive]` [`CorporateActionKind`]).
+    ///      (the compiler-mandated arm for the `#[non_exhaustive]` [`CorporateActionKind`]);
+    ///    - another registered instrument is also split-eligible on the target's
+    ///      `(base, quote, exchange)` ⇒ [`UnsupportedCorporateActionReason::AmbiguousSplitTarget`],
+    ///      because the option chain below is resolved by that identity alone.
     /// 3. Snapshot resting orders into [`EngineOutput::OpenOrdersAtSplit`] (no cancellation).
     /// 4. Apply the split to every open position — the same per-position rescale as
     ///    [`Position::apply_split`](crate::engine::state::position::Position::apply_split), but the
@@ -746,7 +749,13 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     ///      **cannot** adjust them (the OCC assigns a new contract identity), so it emits
     ///      [`EngineOutput::OptionPositionsRequireIdentityChange`] and leaves them at pre-split
     ///      terms. The equity split is applied and the `id` recorded **regardless**.
-    /// 6. Record `id` in `corporate_actions_processed`.
+    ///
+    ///    On the **standard** path `id` is recorded in each adjusted option's *own*
+    ///    `corporate_actions_processed`, so an option already carrying it is skipped rather than
+    ///    strike-divided twice — surfaced as a per-option
+    ///    [`EngineOutput::CorporateActionAlreadyProcessed`]. The non-standard path mutates no option
+    ///    state and therefore records nothing on the options.
+    /// 6. Record `id` in the **target's** `corporate_actions_processed`.
     ///
     /// # Missing last price
     /// If the instrument's last price is unavailable the split is **still applied** and the `id`
@@ -872,6 +881,7 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
         // below carry no overflow error path — the previous per-position `apply_split` `unreachable!`
         // arms are gone by construction.
         let split_plan = match self.state.instruments.prepare_corporate_action_split(
+            id,
             key,
             ratio,
             policy,
@@ -883,9 +893,10 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
                     %id,
                     instrument = ?key,
                     ?reason,
-                    "CorporateAction: split failed pre-validation (applying it would mutate \
-                     positions non-atomically) — emitting UnsupportedCorporateAction; id NOT \
-                     recorded (retryable once the blocking condition is resolved)."
+                    "CorporateAction rejected by pre-validation (an ambiguous target, or a \
+                     mutation that could not be applied atomically) — nothing was mutated. \
+                     Emitting UnsupportedCorporateAction; id NOT recorded (retryable once the \
+                     blocking condition is resolved)."
                 );
                 outputs.push(EngineOutput::UnsupportedCorporateAction {
                     instrument: *key,
@@ -1017,6 +1028,30 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
         // checked. `true` ⇒ adjust the options in place (standard split); `false` ⇒ signal a
         // downstream identity change (see [`option_split_adjust_in_place`]).
         if adjust_options_in_place {
+            // Surface every option this action had ALREADY adjusted (its own
+            // `corporate_actions_processed` carries `id`), which pre-validation excluded from the
+            // plan so the strike is not divided twice. Reported as the same non-mutating
+            // `CorporateActionAlreadyProcessed` the target-level guard emits — same meaning, per
+            // instrument — so a consumer watching only the stream can tell a suppressed re-adjust
+            // from an option that simply had nothing to adjust. One aggregate warning, not one per
+            // option: a full chain can be large.
+            if !split_plan.options_already_adjusted.is_empty() {
+                warn!(
+                    %id,
+                    instrument = ?key,
+                    count = split_plan.options_already_adjusted.len(),
+                    "CorporateAction: options on the splitting underlying already carry this id \
+                     and were skipped (idempotent) — they were adjusted by an earlier delivery of \
+                     this same action."
+                );
+                outputs.extend(split_plan.options_already_adjusted.into_iter().map(
+                    |option_instrument| EngineOutput::CorporateActionAlreadyProcessed {
+                        instrument: option_instrument,
+                        kind: kind.clone(),
+                        id: id.clone(),
+                    },
+                ));
+            }
             self.commit_standard_option_split(id, ratio, split_plan.options, &mut outputs);
         } else {
             self.emit_option_identity_change(id, key, ratio, &mut outputs);
@@ -1049,6 +1084,12 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     /// carrying the CHECKED post-split strike and a `PreparedSplit` for every held position. No
     /// re-scan and no in-place `strike /=` (that previously-unchecked division is overflow-checked
     /// while preparing the plan) — the plan is authoritative, so this commit phase is infallible.
+    /// Options this action had already adjusted are absent from the plan (see
+    /// [`SplitPlan::options_already_adjusted`](crate::engine::state::instrument::SplitPlan)), so
+    /// every entry reaching this loop is one to mutate.
+    ///
+    /// Each adjusted option records `id` in its **own** `corporate_actions_processed`, which is what
+    /// makes that exclusion possible on a later delivery of the same action.
     fn commit_standard_option_split<OnTradingDisabled, OnDisconnect>(
         &mut self,
         id: &SmolStr,
@@ -1074,6 +1115,13 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
             let strike_pre_split = contract.strike;
             contract.strike = opt_plan.strike_post_split;
             let strike_post_split = opt_plan.strike_post_split;
+
+            // Record `id` on the OPTION's own set, not just the target's: this option's strike has
+            // now been divided, and only its own record can stop a second trigger for the same
+            // action from dividing it again. Written here — before the unheld early-out below — so
+            // an unheld option, whose adjustment is otherwise a silent registry fix with no
+            // position event, carries the same evidence a held one does.
+            option_state.corporate_actions_processed.insert(id.clone());
 
             // Snapshot the option's resting orders as an observable BEFORE the unheld early-out
             // and before adjusting any positions — a broker price-adjusts them, so the engine
@@ -1582,12 +1630,21 @@ pub enum EngineOutput<
     /// correctly ignored" from "a successful split on an instrument with nothing to adjust" — both
     /// otherwise produce no mutation observables.
     ///
-    /// **No state was mutated** and no other observable accompanies this one. A consumer that folds
+    /// **`instrument` was not mutated.** A consumer that folds
     /// [`SplitRemainder`](Self::SplitRemainder) / [`PositionExit`](Self::PositionExit) /
     /// [`OptionPositionAdjustedForSplit`](Self::OptionPositionAdjustedForSplit) into a mutation
     /// tally must **not** count this variant.
+    ///
+    /// # Two emitters — read `instrument`, not the variant
+    /// - The **target** guard: the action named `instrument` and its `id` was already applied
+    ///   there. Nothing was mutated anywhere, and this is the only output of the event.
+    /// - The **per-option** guard on a standard split: `instrument` is an *option* on the splitting
+    ///   underlying that this same `id` had already adjusted, so its strike was not divided again.
+    ///   The rest of the action still proceeds, so this arrives **alongside** the target's mutation
+    ///   observables — one per suppressed option.
     CorporateActionAlreadyProcessed {
-        /// The instrument the duplicate action targeted.
+        /// The instrument that was skipped — the duplicate action's target, or an option on the
+        /// splitting underlying this action had already adjusted (see above).
         instrument: InstrumentKey,
         /// The re-submitted action's market-fact kind (carried verbatim for the consumer). This is
         /// the kind of the duplicate event, which — should a caller violate the idempotency contract
@@ -1661,6 +1718,22 @@ pub enum UnsupportedCorporateActionReason {
     /// read-only pre-validation pass, so **no** position was mutated. Indicates a corrupt or
     /// adversarial feed rather than a transient condition.
     ArithmeticOverflow,
+    /// The action's target is **not the unique split-eligible instrument** on its
+    /// `(base, quote, exchange)` underlying identity — at least one other registered instrument is
+    /// also split-eligible on the same identity.
+    ///
+    /// The option chain a split must adjust is resolved by that identity alone — every
+    /// [`InstrumentState`](crate::engine::state::instrument::InstrumentState) whose underlying pair
+    /// and exchange match the target's — so a second eligible instrument is an equally valid
+    /// trigger for adjusting the *same* chain:
+    /// nothing in the engine state can say which of the two the options are actually written on.
+    /// Applying the split anyway would divide every strike on the chain once per trigger, silently
+    /// for unheld options. The action is rejected before any mutation and the `id` is not recorded.
+    ///
+    /// **Not** self-healing on retry: the instrument set is fixed at construction, so resolving it
+    /// means constructing the engine with one deliverable instrument per underlying identity — the
+    /// registry is wrong, not the action.
+    AmbiguousSplitTarget,
 }
 
 /// Output produced by the [`Engine`] updating from an [`TradingState`], used to construct

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -1450,15 +1450,15 @@ pub enum EngineOutput<
     ExchangeKey = ExchangeIndex,
     InstrumentKey = InstrumentIndex,
 > {
-    /// Output of an actioned [`Command`](super::command::Command).
+    /// Output of an actioned [`Command`].
     ///
     /// **Inline.** [`ActionOutput`]'s inner order payloads are boxed at the root (#195), so
     /// `ActionOutput` is only ~96 B — well under the ~232 B [`PositionExit`](Self::PositionExit)
     /// variant that floors this enum's size. Carrying it inline therefore costs `EngineOutput`
-    /// nothing in stack size (and thus in the per-tick [`ProcessAudit`](super::audit::ProcessAudit)
-    /// copy), while avoiding a heap allocation and pointer indirection on the command path that an
-    /// outer `Box` would add. The audit wire format is unchanged (a newtype variant serializes its
-    /// payload identically whether boxed or not).
+    /// nothing in stack size (and thus in the per-tick [`ProcessAudit`] copy), while avoiding a
+    /// heap allocation and pointer indirection on the command path that an outer `Box` would add.
+    /// The audit wire format is unchanged (a newtype variant serializes its payload identically
+    /// whether boxed or not).
     Commanded(ActionOutput<ExchangeKey, InstrumentKey>),
     OnTradingDisabled(OnTradingDisabled),
     AccountDisconnect(OnDisconnect),
@@ -1471,11 +1471,11 @@ pub enum EngineOutput<
     /// **Inline.** `GenerateAlgoOrdersOutput`'s inner order payloads are boxed at the root (#195),
     /// so it is only ~144 B — under the ~232 B [`PositionExit`](Self::PositionExit) variant that
     /// floors this enum's size. Carrying it inline therefore costs `EngineOutput` nothing in stack
-    /// size (and thus in the per-tick [`ProcessAudit`](super::audit::ProcessAudit) copy). The
-    /// only allocation is the root boxing of the orders themselves, paid solely when the strategy
-    /// actually emits some — the empty no-order case short-circuits before this variant is even
-    /// constructed. The audit wire format is unchanged (a newtype variant serializes its payload
-    /// identically whether boxed or not).
+    /// size (and thus in the per-tick [`ProcessAudit`] copy). The only allocation is the root
+    /// boxing of the orders themselves, paid solely when the strategy actually emits some — the
+    /// empty no-order case short-circuits before this variant is even constructed. The audit wire
+    /// format is unchanged (a newtype variant serializes its payload identically whether boxed or
+    /// not).
     AlgoOrders(GenerateAlgoOrdersOutput<ExchangeKey, InstrumentKey>),
 
     /// Cash-in-lieu observable: a corporate-action split disposed a fractional share quantity
@@ -1582,8 +1582,8 @@ pub enum EngineOutput<
     /// a backtest replays *known* history: pre-declare **both** identities at construction (each with
     /// its own data series — the new identity naturally has prints only post-split), then inject BOTH
     /// the [`CorporateAction`](crate::EngineEvent::CorporateAction) and a flatten
-    /// [`Command::ClosePositions`](crate::engine::command::Command::ClosePositions) for the old
-    /// identity at the split boundary. **Caveat** (identical to the
+    /// [`Command::ClosePositions`] for the old identity at the split boundary. **Caveat**
+    /// (identical to the
     /// [`EngineOutput::OpenOrdersAtSplit`] backtest caveat): in backtest the close trigger is
     /// *pre-planned* (the split date is known ahead), not *reactive* from this observable — the
     /// backtest harness disables the audit stream, so this output is invisible there; the reactive

--- a/rustrade/src/engine/mod.rs
+++ b/rustrade/src/engine/mod.rs
@@ -14,6 +14,7 @@ use crate::{
         execution_tx::ExecutionTxMap,
         state::{
             EngineState,
+            connectivity::UntrackedExchange,
             instrument::{OptionSplitPlan, data::InstrumentDataState},
             order::{Orders, in_flight_recorder::InFlightRequestRecorder, manager::OrderManager},
             position::{Position, PositionExited, PositionId, SplitRoundingPolicy},
@@ -320,11 +321,19 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     {
         match event {
             AccountStreamEvent::Reconnecting(exchange) => {
-                self.state
+                // An untracked exchange skips `on_disconnect` as well as the state update: the
+                // strategy has no link to that venue to react to, and the engine's own health is
+                // unaffected by one it never tracked.
+                match self
+                    .state
                     .connectivity
-                    .update_from_account_reconnecting(exchange);
-
-                UpdateFromAccountOutput::OnDisconnect(Strategy::on_disconnect(self, *exchange))
+                    .update_from_account_reconnecting(exchange)
+                {
+                    Ok(()) => UpdateFromAccountOutput::OnDisconnect(Strategy::on_disconnect(
+                        self, *exchange,
+                    )),
+                    Err(untracked) => UpdateFromAccountOutput::UntrackedExchange(untracked),
+                }
             }
             AccountStreamEvent::Item(event) => self
                 .state
@@ -350,16 +359,23 @@ impl<Clock, GlobalData, InstrumentData, ExecutionTxs, Strategy, Risk>
     {
         match event {
             MarketStreamEvent::Reconnecting(exchange) => {
-                self.state
+                // An untracked exchange skips `on_disconnect` as well as the state update — see the
+                // equivalent account-stream arm above.
+                match self
+                    .state
                     .connectivity
-                    .update_from_market_reconnecting(exchange);
-
-                UpdateFromMarketOutput::OnDisconnect(Strategy::on_disconnect(self, *exchange))
+                    .update_from_market_reconnecting(exchange)
+                {
+                    Ok(()) => UpdateFromMarketOutput::OnDisconnect(Strategy::on_disconnect(
+                        self, *exchange,
+                    )),
+                    Err(untracked) => UpdateFromMarketOutput::UntrackedExchange(untracked),
+                }
             }
-            MarketStreamEvent::Item(event) => {
-                self.state.update_from_market(event);
-                UpdateFromMarketOutput::None
-            }
+            MarketStreamEvent::Item(event) => match self.state.update_from_market(event) {
+                Ok(()) => UpdateFromMarketOutput::None,
+                Err(untracked) => UpdateFromMarketOutput::UntrackedExchange(untracked),
+            },
         }
     }
 
@@ -1580,6 +1596,25 @@ pub enum EngineOutput<
         /// The already-processed action `id` that was skipped.
         id: SmolStr,
     },
+
+    /// Observable, **non-mutating** signal that a market or account stream event named an exchange
+    /// the engine was not built against, so it could not be routed and was dropped.
+    ///
+    /// Emitted in place of the panic this path used to take. The check is now performed on **every**
+    /// market event rather than only while global connectivity is degraded, so a misconfigured
+    /// exchange is reported on its first event instead of surfacing hours later on a reconnect —
+    /// see [`UntrackedExchange`] for the full rationale and for exactly what was left untouched.
+    ///
+    /// **No state was mutated**, including
+    /// [`ConnectivityStates::global`](crate::engine::state::connectivity::ConnectivityStates::global).
+    /// A consumer folding
+    /// observables into a mutation tally must not count this variant — the same treatment as
+    /// [`CorporateActionAlreadyProcessed`](Self::CorporateActionAlreadyProcessed).
+    ///
+    /// Repeats per offending event, not once per exchange: the engine holds no "already reported"
+    /// set for untracked venues, since by definition it has no state keyed on them. A consumer that
+    /// wants one alert per venue must deduplicate on `exchange` itself.
+    UntrackedExchange(UntrackedExchange),
 }
 
 /// A single resting order captured in an [`EngineOutput::OpenOrdersAtSplit`] observable.
@@ -1638,20 +1673,35 @@ pub enum UpdateTradingStateOutput<OnTradingDisabled> {
 
 /// Output produced by the [`Engine`] updating from an [`AccountStreamEvent`], used to construct
 /// an `Engine` [`EngineAudit`].
+///
+/// `#[non_exhaustive]`: matches [`EngineOutput`], which this feeds — engine-driven observables can
+/// be added without breaking downstream exhaustive matches.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)] // PositionExit is rare; avoiding Box keeps API simple
+#[non_exhaustive]
 pub enum UpdateFromAccountOutput<OnDisconnect, InstrumentKey = InstrumentIndex> {
     None,
     OnDisconnect(OnDisconnect),
     PositionExit(PositionExited<AssetIndex, InstrumentKey>),
+
+    /// The event named an exchange the engine does not track; nothing was updated, and
+    /// `on_disconnect` was **not** called. See [`UntrackedExchange`].
+    UntrackedExchange(UntrackedExchange),
 }
 
 /// Output produced by the [`Engine`] updating from an [`MarketStreamEvent`], used to construct
 /// an `Engine` [`EngineAudit`].
+///
+/// `#[non_exhaustive]`: see [`UpdateFromAccountOutput`].
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+#[non_exhaustive]
 pub enum UpdateFromMarketOutput<OnDisconnect> {
     None,
     OnDisconnect(OnDisconnect),
+
+    /// The event named an exchange the engine does not track; nothing was updated, and neither
+    /// `on_disconnect` nor any instrument state was touched. See [`UntrackedExchange`].
+    UntrackedExchange(UntrackedExchange),
 }
 
 impl<OnTradingDisabled, OnDisconnect, ExchangeKey, InstrumentKey>

--- a/rustrade/src/engine/state/builder.rs
+++ b/rustrade/src/engine/state/builder.rs
@@ -90,8 +90,9 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
     /// life of the run.
     ///
     /// [`SystemBuilder`](crate::system::builder::SystemBuilder) calls this for you from the
-    /// execution clients it registers. Provide it by hand when constructing an `EngineState`
-    /// directly — eg/ for [`backtest`](crate::backtest::backtest), which takes a pre-built state.
+    /// execution clients it registers, and [`backtest`](crate::backtest::backtest) reconciles the
+    /// roles itself against the clients it builds per run. Provide it by hand when constructing an
+    /// `EngineState` for an engine you drive directly, where neither of those applies.
     pub fn execution_venues<Iter>(mut self, venues: Iter) -> Self
     where
         Iter: IntoIterator<Item = ExchangeId>,
@@ -248,7 +249,7 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
 mod tests {
     use super::*;
     use crate::{
-        engine::state::EngineState,
+        engine::state::{EngineState, connectivity::VenueRole},
         statistic::{summary::TradingSummaryGenerator, time::Annual365},
     };
     use rust_decimal::Decimal;
@@ -284,5 +285,59 @@ mod tests {
         );
 
         assert_eq!(generator.generate(Annual365).basis, BalanceBasis::NetAsset);
+    }
+
+    /// End-to-end seam for [`EngineStateBuilder::execution_venues`]: the declared set has to reach
+    /// [`generate_empty_indexed_connectivity_states`] for the built state's roles to differ from
+    /// the instrument-model approximation. The generator is unit-tested at its own seam; this pins
+    /// the threading between the two, which is otherwise verified nowhere.
+    #[test]
+    fn declared_execution_venues_reach_the_built_connectivity_states() {
+        const DATA: ExchangeId = ExchangeId::BinanceSpot;
+        const EXECUTION: ExchangeId = ExchangeId::Coinbase;
+
+        // Two-instrument pattern: `DATA` prices an instrument that is never traded, `EXECUTION`
+        // trades a different one. Both are some instrument's `exchange`, so the instrument model
+        // alone claims both hold an account.
+        let instruments = IndexedInstruments::builder()
+            .add_instrument(Instrument::spot(
+                DATA,
+                "data_venue_xau_usd",
+                "XAUUSD",
+                Underlying::new("xau", "usd"),
+                None,
+            ))
+            .add_instrument(Instrument::spot(
+                EXECUTION,
+                "execution_venue_btc_usdt",
+                "BTCUSDT",
+                Underlying::new("btc", "usdt"),
+                None,
+            ))
+            .build();
+
+        let declared: EngineState<(), ()> = EngineState::builder(&instruments, (), |_| ())
+            .execution_venues([EXECUTION])
+            .build();
+
+        assert_eq!(
+            declared.connectivity.connectivity(&DATA).role,
+            VenueRole::DataOnly,
+            "the declared set is what says nothing executes on the pricing venue"
+        );
+        assert_eq!(
+            declared.connectivity.connectivity(&EXECUTION).role,
+            VenueRole::Both
+        );
+
+        // Non-vacuous: without the declaration the same collection approximates `DATA` as `Both`,
+        // so the assertion above can only pass if the set was actually threaded through.
+        let approximated: EngineState<(), ()> =
+            EngineState::builder(&instruments, (), |_| ()).build();
+
+        assert_eq!(
+            approximated.connectivity.connectivity(&DATA).role,
+            VenueRole::Both
+        );
     }
 }

--- a/rustrade/src/engine/state/builder.rs
+++ b/rustrade/src/engine/state/builder.rs
@@ -11,7 +11,7 @@ use crate::{
     statistic::summary::asset::BalanceBasis,
 };
 use chrono::{DateTime, Utc};
-use fnv::FnvHashMap;
+use fnv::{FnvHashMap, FnvHashSet};
 use rustrade_execution::balance::{AssetBalance, Balance};
 use rustrade_instrument::{
     Keyed,
@@ -43,6 +43,9 @@ pub struct EngineStateBuilder<'a, GlobalData, FnInstrumentData> {
     /// [`BalanceBasis::NetAsset`] to compute drawdown and end-of-session balance from net asset
     /// value on margin accounts — see its docs for the net-must-stay-positive precondition.
     balance_basis: BalanceBasis,
+    /// Venues with a registered execution client, if known — see
+    /// [`EngineStateBuilder::execution_venues`].
+    execution_venues: Option<FnvHashSet<ExchangeId>>,
 }
 
 impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInstrumentData> {
@@ -67,7 +70,34 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
             instrument_data_init,
             oms_mode: OmsMode::Netting,
             balance_basis: BalanceBasis::default(),
+            execution_venues: None,
         }
+    }
+
+    /// Declare which venues have a registered execution client.
+    ///
+    /// Only these venues are given an account connection to wait on. Without this, the account
+    /// dimension is approximated from the instrument model — "is the execution venue of at least one
+    /// instrument" — which is correct whenever every venue holding instruments is also traded on,
+    /// and wrong for a venue that supplies prices without executing anything.
+    ///
+    /// That distinction matters for any configuration that prices an instrument on one venue and
+    /// trades a *different* instrument on another: the pricing venue would otherwise be assigned
+    /// [`VenueRole::Both`](crate::engine::state::connectivity::VenueRole::Both), wait forever on an
+    /// account connection nothing will ever establish, and hold
+    /// [`ConnectivityStates::global`](crate::engine::state::connectivity::ConnectivityStates::global)
+    /// at [`Health::Reconnecting`](crate::engine::state::connectivity::Health::Reconnecting) for the
+    /// life of the run.
+    ///
+    /// [`SystemBuilder`](crate::system::builder::SystemBuilder) calls this for you from the
+    /// execution clients it registers. Provide it by hand when constructing an `EngineState`
+    /// directly — eg/ for [`backtest`](crate::backtest::backtest), which takes a pre-built state.
+    pub fn execution_venues<Iter>(mut self, venues: Iter) -> Self
+    where
+        Iter: IntoIterator<Item = ExchangeId>,
+    {
+        self.execution_venues = Some(venues.into_iter().collect());
+        self
     }
 
     /// Optionally provide the initial `TradingState`.
@@ -168,6 +198,7 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
             instrument_data_init,
             oms_mode,
             balance_basis,
+            execution_venues,
         } = self;
 
         // Default if not provided
@@ -178,7 +209,8 @@ impl<'a, GlobalData, FnInstrumentData> EngineStateBuilder<'a, GlobalData, FnInst
         let trading = trading_state.unwrap_or_default();
 
         // Construct empty ConnectivityStates
-        let connectivity = generate_empty_indexed_connectivity_states(instruments);
+        let connectivity =
+            generate_empty_indexed_connectivity_states(instruments, execution_venues.as_ref());
 
         // Update empty AssetStates from provided exchange asset Balances
         let mut assets = generate_empty_indexed_asset_states(instruments, balance_basis);

--- a/rustrade/src/engine/state/connectivity/mod.rs
+++ b/rustrade/src/engine/state/connectivity/mod.rs
@@ -6,7 +6,7 @@ use rustrade_instrument::{
 };
 use rustrade_integration::collection::FnvIndexMap;
 use serde::{Deserialize, Serialize};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Maintains a global connection [`Health`], as well as the connection status of market data
 /// and account connections for each exchange.
@@ -297,6 +297,14 @@ pub enum VenueRole {
     ///
     /// The default, and the strictest interpretation: it is the behaviour that predates this type,
     /// so it is what a `ConnectivityState` deserialised from an older payload assumes.
+    ///
+    /// Also the conservative fallback for a venue observed to provide **neither** dimension: a
+    /// misconfiguration, and health is withheld rather than granted to a venue with no known
+    /// connection. The two cases are indistinguishable once constructed — this variant
+    /// records what is demanded of a venue, not what it was found to have. Only a warning from
+    /// whichever site derived the role — [`generate_empty_indexed_connectivity_states`] at startup,
+    /// or [`reconcile_venue_roles`] once the execution clients are known — tells them apart, and
+    /// neither is persisted.
     #[default]
     Both,
 }
@@ -322,8 +330,8 @@ impl VenueRole {
             // venue whose every instrument is priced elsewhere, and which was never given an
             // execution client, provides neither dimension. `Both` is the conservative fallback — it
             // withholds `Healthy` until there is evidence, rather than declaring a venue with no
-            // known connections healthy. The caller reports it; see
-            // `generate_empty_indexed_connectivity_states`.
+            // known connections healthy. Every caller reports it; see
+            // `generate_empty_indexed_connectivity_states` and `reconcile_venue_roles`.
             (false, false) => Self::Both,
         }
     }
@@ -435,18 +443,8 @@ pub fn generate_empty_indexed_connectivity_states(
         .map(|exchange| {
             let exchange = exchange.value;
 
-            let has_market_data = instruments
-                .instruments()
-                .iter()
-                .any(|instrument| instrument.value.data_exchange().value == exchange);
-
-            let has_account = match execution_venues {
-                Some(venues) => venues.contains(&exchange),
-                None => instruments
-                    .instruments()
-                    .iter()
-                    .any(|instrument| instrument.value.exchange.value == exchange),
-            };
+            let (has_market_data, has_account) =
+                derive_venue_dimensions(instruments, exchange, execution_venues);
 
             let role = VenueRole::from_dimensions(has_market_data, has_account);
 
@@ -471,6 +469,95 @@ pub fn generate_empty_indexed_connectivity_states(
     ConnectivityStates {
         global: Health::Reconnecting,
         exchanges,
+    }
+}
+
+/// Which connection dimensions a venue provides, as `(has_market_data, has_account)`.
+///
+/// Shared by [`generate_empty_indexed_connectivity_states`] and [`reconcile_venue_roles`] so both
+/// answer the question the same way. See the former for what each dimension is derived from, and
+/// what `execution_venues: None` approximates.
+fn derive_venue_dimensions(
+    instruments: &IndexedInstruments,
+    exchange: ExchangeId,
+    execution_venues: Option<&FnvHashSet<ExchangeId>>,
+) -> (bool, bool) {
+    let has_market_data = instruments
+        .instruments()
+        .iter()
+        .any(|instrument| instrument.value.data_exchange().value == exchange);
+
+    let has_account = match execution_venues {
+        Some(venues) => venues.contains(&exchange),
+        None => instruments
+            .instruments()
+            .iter()
+            .any(|instrument| instrument.value.exchange.value == exchange),
+    };
+
+    (has_market_data, has_account)
+}
+
+/// Re-derives the [`VenueRole`] of every tracked venue from the venues that have a registered
+/// execution client, leaving connection [`Health`] untouched.
+///
+/// For callers that must build their [`EngineState`](super::EngineState) *before* their execution
+/// clients exist — [`backtest`](crate::backtest::backtest) does, since it builds one set of clients
+/// per run from a state supplied once — this corrects the roles after the fact, rather than
+/// obliging the caller to declare venues it cannot yet know. Callers that can declare them upfront
+/// should keep using
+/// [`EngineStateBuilder::execution_venues`](super::builder::EngineStateBuilder::execution_venues);
+/// running both is harmless, since the two derive the same roles from the same inputs.
+///
+/// Only venues already present in `states` are touched — none are added or removed. The collection
+/// is keyed positionally by [`ExchangeIndex`], so inserting one here would renumber every venue
+/// after it and silently re-point the instruments indexed against them.
+///
+/// # Caller obligation
+/// `instruments` must be the collection `states` was built from. A mismatched pair fails
+/// **silently**: the dimensions are derived against the wrong collection and every venue is
+/// assigned a plausible but wrong [`VenueRole`], with no panic and no report — the `warn!` below
+/// fires only for a venue left with neither dimension, not for one merely given the wrong role.
+///
+/// # Arguments
+/// * `states` - The [`ConnectivityStates`] to correct in place.
+/// * `instruments` - The collection `states` was built from.
+/// * `execution_venues` - Venues with a registered execution client.
+pub fn reconcile_venue_roles(
+    states: &mut ConnectivityStates,
+    instruments: &IndexedInstruments,
+    execution_venues: &FnvHashSet<ExchangeId>,
+) {
+    for (exchange, state) in &mut states.exchanges {
+        let (has_market_data, has_account) =
+            derive_venue_dimensions(instruments, *exchange, Some(execution_venues));
+
+        if !has_market_data && !has_account {
+            // See `generate_empty_indexed_connectivity_states` for why this is said out loud. It
+            // is reported here too because this is the first point at which the execution clients
+            // are known, and so the first point at which it is detectable at all.
+            warn!(
+                %exchange,
+                "EngineState tracking an exchange that provides neither market data nor \
+                 execution - global connectivity cannot reach Healthy while it is tracked"
+            );
+        }
+
+        let role = VenueRole::from_dimensions(has_market_data, has_account);
+        if role == state.role {
+            continue;
+        }
+
+        // `debug!`, not `info!`: a backtest sweep shares one `BacktestArgsConstant` across every
+        // run, so each run reconciles the same state from the same clients and this fires once per
+        // run with identical content. The genuinely-wrong case above stays at `warn!`.
+        debug!(
+            %exchange,
+            previous = ?state.role,
+            ?role,
+            "EngineState correcting venue role against the registered execution clients"
+        );
+        state.role = role;
     }
 }
 
@@ -595,11 +682,17 @@ mod tests {
         // client was registered for it. Reachable only once execution venues are declared. Health
         // is withheld rather than granted to a venue with no known connection.
         let instruments = split_venue_instruments();
-        let states =
+        let mut states =
             generate_empty_indexed_connectivity_states(&instruments, Some(&FnvHashSet::default()));
 
         assert_eq!(states.connectivity(&DATA).role, VenueRole::DataOnly);
         assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::Both);
+
+        // Satisfying one dimension is not enough: `Both` demands the account connection too, which
+        // nothing will ever report for a venue with no execution client. Asserting on the state as
+        // generated would pass for every role, since both dimensions start `Reconnecting`.
+        states.connectivity_mut(&EXECUTION).market_data = Health::Healthy;
+
         assert!(!states.connectivity(&EXECUTION).all_healthy());
     }
 
@@ -629,6 +722,18 @@ mod tests {
                 market_data: Health::Reconnecting,
                 account: Health::Healthy,
                 role: VenueRole::DataOnly,
+            }
+            .all_healthy()
+        );
+
+        // The mirror of the case above, and the one that pins `has_account` as actually consulted
+        // for this role: without it, ignoring the account dimension for everything but `Both`
+        // passes every other assertion here.
+        assert!(
+            !ConnectivityState {
+                market_data: Health::Healthy,
+                account: Health::Reconnecting,
+                role: VenueRole::ExecutionOnly,
             }
             .all_healthy()
         );
@@ -742,6 +847,104 @@ mod tests {
             states.connectivity(&EXECUTION).market_data,
             Health::Reconnecting
         );
+    }
+
+    #[test]
+    fn a_tracked_account_disconnect_degrades_the_account_dimension_and_global_health() {
+        // The account twin of `a_tracked_exchange_disconnect_still_degrades_global_health`. The two
+        // update functions are near-identical, so nothing but a test per dimension catches one
+        // written to touch the other's field.
+        let instruments = IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]);
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
+
+        let execution = instruments.find_exchange_index(EXECUTION).unwrap();
+        states.update_from_market_event(&EXECUTION).unwrap();
+        states.update_from_account_event(&execution);
+        assert_eq!(states.global, Health::Healthy);
+
+        states.update_from_account_reconnecting(&EXECUTION).unwrap();
+
+        assert_eq!(
+            states.connectivity(&EXECUTION).account,
+            Health::Reconnecting
+        );
+        assert_eq!(
+            states.connectivity(&EXECUTION).market_data,
+            Health::Healthy,
+            "an account disconnect says nothing about the market data connection"
+        );
+        assert_eq!(states.global, Health::Reconnecting);
+    }
+
+    #[test]
+    fn reconciling_roles_corrects_a_venue_that_prices_without_executing() {
+        // The `backtest` path: the state is built before the execution clients exist, so `DATA` is
+        // approximated as `Both` and waits forever on an account. Reconciling against the clients
+        // that were ultimately registered is what lets global health converge.
+        let instruments = two_instrument_pattern();
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::Both);
+
+        reconcile_venue_roles(
+            &mut states,
+            &instruments,
+            &FnvHashSet::from_iter([EXECUTION]),
+        );
+
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::DataOnly);
+        assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::Both);
+    }
+
+    #[test]
+    fn reconciling_roles_preserves_health_and_the_indexed_venue_order() {
+        // `ExchangeIndex` is positional into `exchanges`, so reconciliation must correct roles in
+        // place -- never insert, remove or reorder -- and must not reset a connection that has
+        // already reported in.
+        let instruments = two_instrument_pattern();
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
+        states.update_from_market_event(&DATA).unwrap();
+
+        let order_before = states.exchanges.keys().copied().collect::<Vec<_>>();
+
+        reconcile_venue_roles(
+            &mut states,
+            &instruments,
+            &FnvHashSet::from_iter([EXECUTION]),
+        );
+
+        assert_eq!(
+            states.exchanges.keys().copied().collect::<Vec<_>>(),
+            order_before
+        );
+        assert_eq!(states.connectivity(&DATA).market_data, Health::Healthy);
+    }
+
+    #[test]
+    fn reconciling_roles_is_a_no_op_when_the_venues_were_declared_upfront() {
+        // `SystemBuilder`-style construction already derives the roles, so running both paths must
+        // agree -- otherwise the two entry points would disagree about the same configuration.
+        let instruments = two_instrument_pattern();
+        let venues = FnvHashSet::from_iter([EXECUTION]);
+        let declared = generate_empty_indexed_connectivity_states(&instruments, Some(&venues));
+
+        let mut reconciled = declared.clone();
+        reconcile_venue_roles(&mut reconciled, &instruments, &venues);
+
+        assert_eq!(reconciled, declared);
+    }
+
+    #[test]
+    fn reconciling_roles_reports_a_venue_left_with_neither_dimension() {
+        // Misconfiguration: `EXECUTION` holds an instrument priced on `DATA`, and no execution
+        // client was registered anywhere. `Both` is the conservative answer, so health stays
+        // withheld rather than being granted to a venue with no connection at all.
+        let instruments = split_venue_instruments();
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
+
+        reconcile_venue_roles(&mut states, &instruments, &FnvHashSet::default());
+
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::DataOnly);
+        assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::Both);
     }
 
     #[test]

--- a/rustrade/src/engine/state/connectivity/mod.rs
+++ b/rustrade/src/engine/state/connectivity/mod.rs
@@ -1,3 +1,4 @@
+use derive_more::Constructor;
 use indexmap::IndexMap;
 use rustrade_instrument::{
     exchange::{ExchangeId, ExchangeIndex},
@@ -25,10 +26,26 @@ impl ConnectivityStates {
     ///
     /// Sets the account `ConnectivityState` for the provided `ExchangeId`
     /// to [`Health::Reconnecting`].
-    pub fn update_from_account_reconnecting(&mut self, exchange: &ExchangeId) {
+    ///
+    /// # Errors
+    /// Returns [`UntrackedExchange`] if the `ExchangeId` has no `ConnectivityState`, having mutated
+    /// nothing — including [`Self::global`].
+    pub fn update_from_account_reconnecting(
+        &mut self,
+        exchange: &ExchangeId,
+    ) -> Result<(), UntrackedExchange> {
+        let Some(state) = self.exchanges.get_mut(exchange) else {
+            return Err(UntrackedExchange::new(
+                *exchange,
+                ConnectivityDimension::Account,
+            ));
+        };
+
         warn!(%exchange, "EngineState received AccountStream disconnected event");
+        state.account = Health::Reconnecting;
         self.global = Health::Reconnecting;
-        self.connectivity_mut(exchange).account = Health::Reconnecting;
+
+        Ok(())
     }
 
     /// Updates from an exchange AccountStream event, setting the `ConnectivityState` account
@@ -62,10 +79,26 @@ impl ConnectivityStates {
     ///
     /// Sets the market data `ConnectivityState` for the provided `ExchangeId`
     /// to [`Health::Reconnecting`].
-    pub fn update_from_market_reconnecting(&mut self, exchange: &ExchangeId) {
+    ///
+    /// # Errors
+    /// Returns [`UntrackedExchange`] if the `ExchangeId` has no `ConnectivityState`, having mutated
+    /// nothing — including [`Self::global`].
+    pub fn update_from_market_reconnecting(
+        &mut self,
+        exchange: &ExchangeId,
+    ) -> Result<(), UntrackedExchange> {
+        let Some(state) = self.exchanges.get_mut(exchange) else {
+            return Err(UntrackedExchange::new(
+                *exchange,
+                ConnectivityDimension::MarketData,
+            ));
+        };
+
         warn!(%exchange, "EngineState received MarketStream disconnect event");
+        state.market_data = Health::Reconnecting;
         self.global = Health::Reconnecting;
-        self.connectivity_mut(exchange).market_data = Health::Reconnecting
+
+        Ok(())
     }
 
     /// Updates from an exchange MarketStream event, setting the `ConnectivityState` market data
@@ -73,14 +106,32 @@ impl ConnectivityStates {
     ///
     /// If after the update all `ConnectivityState`s are healthy, the global health is set to
     /// `Health::Healthy`.
-    pub fn update_from_market_event(&mut self, exchange: &ExchangeId) {
-        if self.global == Health::Healthy {
-            return;
-        }
+    ///
+    /// # Errors
+    /// Returns [`UntrackedExchange`] if the `ExchangeId` has no `ConnectivityState`. The exchange is
+    /// resolved on **every** call, including the already-globally-healthy fast path, so this is
+    /// reported deterministically on the first event from that exchange — see the note at the
+    /// lookup for why that matters.
+    pub fn update_from_market_event(
+        &mut self,
+        exchange: &ExchangeId,
+    ) -> Result<(), UntrackedExchange> {
+        // Resolved BEFORE the `global == Healthy` short-circuit below, deliberately. Skipping the
+        // lookup while global health held is what made an untracked exchange an *intermittent*
+        // fault: its events were silently ignored for as long as everything else was healthy, and
+        // the misconfiguration only surfaced once something dragged `global` back to `Reconnecting`
+        // -- in practice a reconnect, hours into a run. Resolving unconditionally costs one
+        // `IndexMap` get per market event and makes the report fire on the first event from that
+        // exchange, in every run.
+        let Some(state) = self.exchanges.get_mut(exchange) else {
+            return Err(UntrackedExchange::new(
+                *exchange,
+                ConnectivityDimension::MarketData,
+            ));
+        };
 
-        let state = self.connectivity_mut(exchange);
-        if state.market_data == Health::Healthy {
-            return;
+        if self.global == Health::Healthy || state.market_data == Health::Healthy {
+            return Ok(());
         }
 
         info!(
@@ -93,12 +144,19 @@ impl ConnectivityStates {
             info!("EngineState setting global connectivity to Healthy");
             self.global = Health::Healthy
         }
+
+        Ok(())
     }
 
     /// Returns a reference to the `ConnectivityState` associated with the
     /// provided `ExchangeIndex`.
     ///
     /// Panics if the `ConnectivityState` associated with the `ExchangeIndex` is not found.
+    ///
+    /// Unlike the `ExchangeId`-keyed update path — which reports an [`UntrackedExchange`] rather
+    /// than panicking — an `ExchangeIndex` is derived from the same [`IndexedInstruments`] this
+    /// collection was built from, so an out-of-range one is a library bug rather than a
+    /// misconfigured input, and is not something a caller could handle.
     pub fn connectivity_index(&self, key: &ExchangeIndex) -> &ConnectivityState {
         self.exchanges
             .get_index(key.index())
@@ -120,7 +178,9 @@ impl ConnectivityStates {
     /// Returns a reference to the `ConnectivityState` associated with the
     /// provided `ExchangeId`.
     ///
-    /// Panics if the `ConnectivityState` associated with the `ExchangeId` is not found.
+    /// Panics if the `ConnectivityState` associated with the `ExchangeId` is not found. This is an
+    /// assertive accessor for a key the caller already knows is tracked; event-driven code takes
+    /// the fallible path instead and reports an [`UntrackedExchange`].
     pub fn connectivity(&self, key: &ExchangeId) -> &ConnectivityState {
         self.exchanges
             .get(key)
@@ -146,6 +206,48 @@ impl ConnectivityStates {
     pub fn exchange_states(&self) -> impl Iterator<Item = &ConnectivityState> {
         self.exchanges.values()
     }
+}
+
+/// One half of a venue's connectivity — the axis a [`VenueRole`] declares membership of, and the
+/// one an [`UntrackedExchange`] report names.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+pub enum ConnectivityDimension {
+    /// The market data subscription.
+    MarketData,
+
+    /// The account and execution connection.
+    Account,
+}
+
+/// A stream event arrived tagged with an [`ExchangeId`] that has no [`ConnectivityState`] — an
+/// exchange that is neither the execution venue nor the data venue of any instrument the engine was
+/// built from.
+///
+/// # Why this is reported rather than panicked
+/// The engine cannot rule it out in advance. A `SystemBuild`'s market stream is a caller-supplied
+/// `Stream` forwarded verbatim, so the set of exchanges it will emit is unknowable at build time —
+/// there is no seam at which to reject the mismatch early. The only honest options at the point of
+/// discovery are to abort the engine or to report and continue, and a single stray event from a
+/// venue nothing was configured against is not grounds for taking down a trading session.
+///
+/// # Nothing was mutated
+/// In particular [`ConnectivityStates::global`] is left alone. An exchange the engine does not track
+/// has no bearing on the health of the ones it does, so a stray disconnect notice must not degrade
+/// global health — nor can it be repaired, since no later event for that exchange can restore a
+/// state that does not exist.
+///
+/// Market events additionally stop **before** instrument state is touched. `InstrumentIndex` lookups
+/// are positional, so continuing would either panic on an out-of-range index or, worse, silently
+/// attribute the print to whichever instrument happens to occupy that slot.
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
+)]
+pub struct UntrackedExchange {
+    /// The exchange the event was tagged with.
+    pub exchange: ExchangeId,
+
+    /// Which connection the event would have updated.
+    pub dimension: ConnectivityDimension,
 }
 
 /// Represents the `Health` status of a component or connection to an exchange endpoint.
@@ -436,7 +538,7 @@ mod tests {
             assert_eq!(states.global, Health::Reconnecting);
 
             if market_data_first {
-                states.update_from_market_event(&DATA);
+                states.update_from_market_event(&DATA).unwrap();
                 assert_eq!(
                     states.global,
                     Health::Reconnecting,
@@ -450,11 +552,79 @@ mod tests {
                     Health::Reconnecting,
                     "the data venue has not reported yet"
                 );
-                states.update_from_market_event(&DATA);
+                states.update_from_market_event(&DATA).unwrap();
             }
 
             assert_eq!(states.global, Health::Healthy, "{market_data_first}");
         }
+    }
+
+    #[test]
+    fn an_untracked_exchange_is_reported_even_while_global_health_holds() {
+        // The regression this locks: the lookup used to sit *after* a `global == Healthy`
+        // short-circuit, so a misconfigured exchange was silently ignored for as long as everything
+        // else was healthy, and only panicked once a reconnect dragged global back down. Reaching
+        // `Healthy` first is therefore the whole point of this setup.
+        let instruments = IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]);
+        let mut states = generate_empty_indexed_connectivity_states(&instruments);
+
+        let execution = instruments.find_exchange_index(EXECUTION).unwrap();
+        states.update_from_market_event(&EXECUTION).unwrap();
+        states.update_from_account_event(&execution);
+        assert_eq!(states.global, Health::Healthy);
+
+        let error = states.update_from_market_event(&DATA).unwrap_err();
+
+        assert_eq!(
+            error,
+            UntrackedExchange::new(DATA, ConnectivityDimension::MarketData)
+        );
+        assert_eq!(states.global, Health::Healthy, "the report must not mutate");
+        assert_eq!(states.exchanges.len(), 1, "no state may be created for it");
+    }
+
+    #[test]
+    fn an_untracked_exchange_disconnect_does_not_degrade_global_health() {
+        // A disconnect notice from a venue the engine never tracked is not evidence about the
+        // venues it does track -- and could never be repaired, since no later event for it can
+        // restore a `ConnectivityState` that does not exist.
+        let instruments = IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]);
+        let mut states = generate_empty_indexed_connectivity_states(&instruments);
+
+        let execution = instruments.find_exchange_index(EXECUTION).unwrap();
+        states.update_from_market_event(&EXECUTION).unwrap();
+        states.update_from_account_event(&execution);
+        assert_eq!(states.global, Health::Healthy);
+
+        assert_eq!(
+            states.update_from_market_reconnecting(&DATA).unwrap_err(),
+            UntrackedExchange::new(DATA, ConnectivityDimension::MarketData)
+        );
+        assert_eq!(
+            states.update_from_account_reconnecting(&DATA).unwrap_err(),
+            UntrackedExchange::new(DATA, ConnectivityDimension::Account)
+        );
+
+        assert_eq!(states.global, Health::Healthy);
+    }
+
+    #[test]
+    fn a_tracked_exchange_disconnect_still_degrades_global_health() {
+        let instruments = IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]);
+        let mut states = generate_empty_indexed_connectivity_states(&instruments);
+
+        let execution = instruments.find_exchange_index(EXECUTION).unwrap();
+        states.update_from_market_event(&EXECUTION).unwrap();
+        states.update_from_account_event(&execution);
+        assert_eq!(states.global, Health::Healthy);
+
+        states.update_from_market_reconnecting(&EXECUTION).unwrap();
+
+        assert_eq!(states.global, Health::Reconnecting);
+        assert_eq!(
+            states.connectivity(&EXECUTION).market_data,
+            Health::Reconnecting
+        );
     }
 
     #[test]

--- a/rustrade/src/engine/state/connectivity/mod.rs
+++ b/rustrade/src/engine/state/connectivity/mod.rs
@@ -514,10 +514,16 @@ fn derive_venue_dimensions(
 /// after it and silently re-point the instruments indexed against them.
 ///
 /// # Caller obligation
-/// `instruments` must be the collection `states` was built from. A mismatched pair fails
-/// **silently**: the dimensions are derived against the wrong collection and every venue is
-/// assigned a plausible but wrong [`VenueRole`], with no panic and no report — the `warn!` below
-/// fires only for a venue left with neither dimension, not for one merely given the wrong role.
+/// `instruments` must be the collection `states` was built from. A mismatched pair derives every
+/// dimension against the wrong collection and assigns every venue a plausible but wrong
+/// [`VenueRole`] — the `warn!` below fires only for a venue left with neither dimension, not for
+/// one merely given the wrong role.
+///
+/// A `debug_assert!` catches the detectable half of that: `states` holding a different venue set,
+/// or holding it in a different order. It cannot catch a collection carrying the *same* venues
+/// with different instruments, since the venue keys are then identical — but such a pair also
+/// misaligns every [`InstrumentIndex`](rustrade_instrument::index::InstrumentIndex) in the engine,
+/// so venue roles are not the symptom that surfaces first.
 ///
 /// # Arguments
 /// * `states` - The [`ConnectivityStates`] to correct in place.
@@ -528,6 +534,26 @@ pub fn reconcile_venue_roles(
     instruments: &IndexedInstruments,
     execution_venues: &FnvHashSet<ExchangeId>,
 ) {
+    // Compared in `ExchangeIndex` order — the order `states` is indexed by — rather than as sets,
+    // so a state whose venues were reordered or reindexed is caught too, not merely one holding a
+    // different venue set. `debug_assert!` and not a `Result`: passing a mismatched pair is a
+    // caller-contract violation (a library-usage bug) rather than a handleable input, and the
+    // comparison then costs nothing in release.
+    debug_assert!(
+        states.exchanges.keys().eq(instruments
+            .exchanges()
+            .iter()
+            .map(|exchange| &exchange.value)),
+        "reconcile_venue_roles: `states` was not built from `instruments` — states: {:?}, \
+         instruments: {:?}",
+        states.exchanges.keys().collect::<Vec<_>>(),
+        instruments
+            .exchanges()
+            .iter()
+            .map(|exchange| exchange.value)
+            .collect::<Vec<_>>(),
+    );
+
     for (exchange, state) in &mut states.exchanges {
         let (has_market_data, has_account) =
             derive_venue_dimensions(instruments, *exchange, Some(execution_venues));
@@ -945,6 +971,25 @@ mod tests {
 
         assert_eq!(states.connectivity(&DATA).role, VenueRole::DataOnly);
         assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::Both);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)] // The guard under test compiles out in release
+    #[should_panic(expected = "was not built from")]
+    fn reconciling_roles_rejects_a_state_built_from_a_different_collection() {
+        // The caller obligation, violated: `states` built from one instrument collection and
+        // reconciled against another. Every venue would otherwise be handed a plausible role
+        // derived from instruments it was never built from, with nothing reported.
+        let mut states = generate_empty_indexed_connectivity_states(
+            &IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]),
+            None,
+        );
+
+        reconcile_venue_roles(
+            &mut states,
+            &two_instrument_pattern(),
+            &FnvHashSet::from_iter([EXECUTION]),
+        );
     }
 
     #[test]

--- a/rustrade/src/engine/state/connectivity/mod.rs
+++ b/rustrade/src/engine/state/connectivity/mod.rs
@@ -29,7 +29,15 @@ impl ConnectivityStates {
     /// Updates from an exchange AccountStream disconnection.
     ///
     /// Sets the account `ConnectivityState` for the provided `ExchangeId`
-    /// to [`Health::Reconnecting`].
+    /// to [`Health::Reconnecting`], then re-derives [`Self::global`].
+    ///
+    /// # A venue whose role declares no account
+    /// Reaching this for a [`VenueRole::DataOnly`] venue means the role is wrong or the event is
+    /// misrouted, and it is `warn!`ed. [`Self::global`] is unaffected, because it is re-derived
+    /// through [`ConnectivityState::all_healthy`], which does not consult a dimension the venue does
+    /// not provide. Degrading it here would be **unrecoverable**: no account event can arrive for a
+    /// venue with no execution client, and every other update path short-circuits once its own
+    /// dimension is [`Health::Healthy`], so nothing would ever re-run the convergence check.
     ///
     /// # Errors
     /// Returns [`UntrackedExchange`] if the `ExchangeId` has no `ConnectivityState`, having mutated
@@ -57,7 +65,23 @@ impl ConnectivityStates {
 
         warn!(%exchange, "EngineState received AccountStream disconnected event");
         state.account = Health::Reconnecting;
-        self.global = Health::Reconnecting;
+        let role = state.role;
+
+        if !role.has_account() {
+            // A disconnect on a dimension this venue does not provide is evidence its role is
+            // wrong, not evidence about the venues that do provide one. Said out loud rather than
+            // absorbed, for the same reason the neither-dimension case is in
+            // `generate_empty_indexed_connectivity_states`: nothing else in the state names it.
+            warn!(
+                %exchange,
+                ?role,
+                dimension = ?ConnectivityDimension::Account,
+                "EngineState received an AccountStream disconnect for a venue whose role declares \
+                 no account connection - the role is wrong, or the event is misrouted"
+            );
+        }
+
+        self.re_derive_global();
 
         Ok(())
     }
@@ -83,16 +107,19 @@ impl ConnectivityStates {
         );
         state.account = Health::Healthy;
 
-        if self.exchange_states().all(ConnectivityState::all_healthy) {
-            info!("EngineState setting global connectivity to Healthy");
-            self.global = Health::Healthy
-        }
+        self.re_derive_global();
     }
 
     /// Updates from an exchange MarketStream disconnection.
     ///
     /// Sets the market data `ConnectivityState` for the provided `ExchangeId`
-    /// to [`Health::Reconnecting`].
+    /// to [`Health::Reconnecting`], then re-derives [`Self::global`].
+    ///
+    /// # A venue whose role declares no market data
+    /// The mirror of the account twin above: reaching this for a [`VenueRole::ExecutionOnly`] venue
+    /// is `warn!`ed and leaves [`Self::global`] alone. Unrecoverable for the same reason, and more
+    /// reachable — a `SystemBuild`'s market stream is caller-supplied, so one built per
+    /// [`IndexedInstruments::exchanges`] rather than per *data* venue emits exactly this.
     ///
     /// # Errors
     /// Returns [`UntrackedExchange`] if the `ExchangeId` has no `ConnectivityState`, having mutated
@@ -118,7 +145,20 @@ impl ConnectivityStates {
 
         warn!(%exchange, "EngineState received MarketStream disconnect event");
         state.market_data = Health::Reconnecting;
-        self.global = Health::Reconnecting;
+        let role = state.role;
+
+        if !role.has_market_data() {
+            // See the account twin above.
+            warn!(
+                %exchange,
+                ?role,
+                dimension = ?ConnectivityDimension::MarketData,
+                "EngineState received a MarketStream disconnect for a venue whose role declares no \
+                 market data connection - the role is wrong, or the event is misrouted"
+            );
+        }
+
+        self.re_derive_global();
 
         Ok(())
     }
@@ -175,12 +215,36 @@ impl ConnectivityStates {
         );
         state.market_data = Health::Healthy;
 
-        if self.exchange_states().all(ConnectivityState::all_healthy) {
-            info!("EngineState setting global connectivity to Healthy");
-            self.global = Health::Healthy
-        }
+        self.re_derive_global();
 
         Ok(())
+    }
+
+    /// Re-derives the cached [`Self::global`] aggregate from the per-venue states it summarises.
+    ///
+    /// `global` is [`Health::Healthy`] iff at least one venue is tracked and every tracked venue is
+    /// [`ConnectivityState::all_healthy`] under its own [`VenueRole`]. **Every** site that changes a
+    /// connection `Health` or a role goes through here, so the cached value cannot disagree with the
+    /// states it aggregates — which is what stops a disconnect on a dimension a venue does not
+    /// provide from degrading `global` into a state no later event could repair.
+    ///
+    /// The empty case fails closed, for the reason given in full on [`reconcile_venue_roles`]: `all`
+    /// is vacuously true over zero venues, and no connection backs that `Healthy`. It is
+    /// unreachable from the update paths, which resolve a venue before reaching here, and load
+    /// bearing for `reconcile_venue_roles`, which does not.
+    fn re_derive_global(&mut self) {
+        let global = if !self.exchanges.is_empty()
+            && self.exchange_states().all(ConnectivityState::all_healthy)
+        {
+            Health::Healthy
+        } else {
+            Health::Reconnecting
+        };
+
+        if global != self.global {
+            info!(previous = ?self.global, ?global, "EngineState updating global connectivity");
+            self.global = global;
+        }
     }
 
     /// Returns a reference to the `ConnectivityState` associated with the
@@ -615,8 +679,10 @@ fn derive_venue_dimensions(
 /// [`VenueRole`] — the `warn!` below fires only for a venue left with neither dimension, not for
 /// one merely given the wrong role.
 ///
-/// A `debug_assert!` catches the detectable half of that: `states` holding a different venue set,
-/// or holding it in a different order. It cannot catch a collection carrying the *same* venues
+/// # Panics
+/// Panics — in **all** builds, since the failure it guards is otherwise silent — on the detectable
+/// half of that: `states` holding a different venue set, or holding it in a different order. It
+/// cannot catch a collection carrying the *same* venues
 /// with different instruments, since the venue keys are then identical — but such a pair also
 /// misaligns every [`InstrumentIndex`](rustrade_instrument::instrument::InstrumentIndex) in the engine,
 /// so venue roles are not the symptom that surfaces first.
@@ -632,10 +698,14 @@ pub fn reconcile_venue_roles(
 ) {
     // Compared in `ExchangeIndex` order — the order `states` is indexed by — rather than as sets,
     // so a state whose venues were reordered or reindexed is caught too, not merely one holding a
-    // different venue set. `debug_assert!` and not a `Result`: passing a mismatched pair is a
-    // caller-contract violation (a library-usage bug) rather than a handleable input, and the
-    // comparison then costs nothing in release.
-    debug_assert!(
+    // different venue set. Not a `Result`: passing a mismatched pair is a caller-contract violation
+    // (a library-usage bug) rather than a handleable input. A hard panic in all builds — not
+    // `debug_assert!` — because the failure it guards is silent, exactly like the non-monotonic
+    // timeline `assert_aux_events_sorted` rejects: every venue is handed a plausible but wrong role
+    // in release, `global` is then re-derived from those roles, and a health-gated strategy trades
+    // against a link that never came up. The comparison is one pass over a handful of venues, off
+    // the event path, once per engine build.
+    assert!(
         states.exchanges.keys().eq(instruments
             .exchanges()
             .iter()
@@ -684,19 +754,11 @@ pub fn reconcile_venue_roles(
 
     // Re-derive the cached aggregate against the corrected roles — see `# global is re-derived, not
     // preserved`. Unconditional rather than gated on "did any role change", because the incoming
-    // `global` is a caller-supplied value that may disagree with the roles it arrived with. The
-    // empty set is a conjunct rather than an early-out for the same reason: skipping the write there
-    // would leave exactly one input on which this function does not establish its postcondition, and
-    // would answer a zero-venue collection differently from
-    // `generate_empty_indexed_connectivity_states`. Costs one pass over a handful of venues, once
-    // per engine build, off the event path.
-    states.global = if !states.exchanges.is_empty()
-        && states.exchange_states().all(ConnectivityState::all_healthy)
-    {
-        Health::Healthy
-    } else {
-        Health::Reconnecting
-    };
+    // `global` is a caller-supplied value that may disagree with the roles it arrived with. Shared
+    // with the update paths so there is exactly one definition of the aggregate; the empty-set
+    // conjunct it applies is load-bearing here and only here, since this is the one caller that can
+    // reach it. Costs one pass over a handful of venues, once per engine build, off the event path.
+    states.re_derive_global();
 }
 
 #[cfg(test)]
@@ -1019,6 +1081,77 @@ mod tests {
     }
 
     #[test]
+    fn a_disconnect_on_a_dimension_a_venues_role_does_not_own_leaves_global_healthy() {
+        // The wedge this guards: `global` used to be written `Reconnecting` by ANY tracked
+        // exchange's disconnect, role notwithstanding -- and nothing could then restore it.
+        // `update_from_account_event` and `update_from_market_event` each return early once their
+        // own dimension is already `Healthy`, so neither re-runs the convergence check, and no
+        // event can ever arrive for a dimension the venue does not provide. A strategy gated on
+        // `global` stayed halted for the remainder of the session after a single `warn!` line.
+        for dimension in [
+            ConnectivityDimension::Account,
+            ConnectivityDimension::MarketData,
+        ] {
+            let instruments = split_venue_instruments();
+            let execution_index = instruments.find_exchange_index(EXECUTION).unwrap();
+            let mut states = generate_empty_indexed_connectivity_states(
+                &instruments,
+                Some(&FnvHashSet::from_iter([EXECUTION])),
+            );
+
+            // Converge: each split venue reports the one dimension it actually provides.
+            states.update_from_market_event(&DATA).unwrap();
+            states.update_from_account_event(&execution_index);
+            assert_eq!(states.global, Health::Healthy);
+
+            // Both venues are TRACKED, so neither disconnect is an `UntrackedExchange` -- that
+            // report covers the unknown-venue case, and never fires here.
+            match dimension {
+                // `DATA` is `DataOnly`: it has no account connection to lose.
+                ConnectivityDimension::Account => {
+                    states.update_from_account_reconnecting(&DATA).unwrap()
+                }
+                // `EXECUTION` is `ExecutionOnly`: it has no market data subscription to lose.
+                ConnectivityDimension::MarketData => {
+                    states.update_from_market_reconnecting(&EXECUTION).unwrap()
+                }
+            }
+
+            assert_eq!(
+                states.global,
+                Health::Healthy,
+                "{dimension:?}: a disconnect on a dimension the role does not own must not degrade \
+                 global health"
+            );
+        }
+    }
+
+    #[test]
+    fn a_split_venue_still_degrades_and_restores_global_on_the_dimension_it_does_own() {
+        // The other half of the fix, and what stops the test above from passing vacuously: ignoring
+        // an unowned dimension must not also ignore the one the venue actually provides.
+        let instruments = split_venue_instruments();
+        let execution_index = instruments.find_exchange_index(EXECUTION).unwrap();
+        let mut states = generate_empty_indexed_connectivity_states(
+            &instruments,
+            Some(&FnvHashSet::from_iter([EXECUTION])),
+        );
+        states.update_from_market_event(&DATA).unwrap();
+        states.update_from_account_event(&execution_index);
+        assert_eq!(states.global, Health::Healthy);
+
+        states.update_from_market_reconnecting(&DATA).unwrap();
+        assert_eq!(
+            states.global,
+            Health::Reconnecting,
+            "the data venue's own dimension still counts"
+        );
+
+        states.update_from_market_event(&DATA).unwrap();
+        assert_eq!(states.global, Health::Healthy, "and still recovers");
+    }
+
+    #[test]
     fn reconciling_roles_corrects_a_venue_that_prices_without_executing() {
         // The `backtest` path: the state is built before the execution clients exist, so `DATA` is
         // approximated as `Both` and waits forever on an account. Reconciling against the clients
@@ -1090,7 +1223,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(debug_assertions)] // The guard under test compiles out in release
     #[should_panic(expected = "was not built from")]
     fn reconciling_roles_rejects_a_state_built_from_a_different_collection() {
         // The caller obligation, violated: `states` built from one instrument collection and

--- a/rustrade/src/engine/state/connectivity/mod.rs
+++ b/rustrade/src/engine/state/connectivity/mod.rs
@@ -1,4 +1,5 @@
 use derive_more::Constructor;
+use fnv::FnvHashSet;
 use indexmap::IndexMap;
 use rustrade_instrument::{
     exchange::{ExchangeId, ExchangeIndex},
@@ -314,11 +315,12 @@ impl VenueRole {
             (true, true) => Self::Both,
             (true, false) => Self::DataOnly,
             (false, true) => Self::ExecutionOnly,
-            // Unreachable by construction: an `IndexedInstruments` exchange is only ever registered
-            // as some `Instrument`s execution venue or as its data venue, so every indexed exchange
-            // provides at least one dimension. `Both` is the conservative fallback — it withholds
-            // `Healthy` until there is evidence, rather than declaring a venue with no known
-            // connections healthy.
+            // Reachable only as a misconfiguration, and only once execution venues are declared: a
+            // venue whose every instrument is priced elsewhere, and which was never given an
+            // execution client, provides neither dimension. `Both` is the conservative fallback — it
+            // withholds `Healthy` until there is evidence, rather than declaring a venue with no
+            // known connections healthy. The caller reports it; see
+            // `generate_empty_indexed_connectivity_states`.
             (false, false) => Self::Both,
         }
     }
@@ -383,23 +385,40 @@ impl ConnectivityState {
 /// connections initially set to [`Health::Reconnecting`].
 ///
 /// # Venue roles
-/// Each exchange's [`VenueRole`] is derived one dimension at a time, from the instruments
-/// themselves:
-/// - it has the **market data** dimension iff it is the effective data venue
-///   ([`Instrument::data_exchange`](rustrade_instrument::instrument::Instrument::data_exchange)) of
-///   at least one instrument;
-/// - it has the **account** dimension iff it is the execution venue (`Instrument::exchange`) of at
-///   least one instrument.
+/// Each exchange's [`VenueRole`] is derived one dimension at a time. Deriving them independently is
+/// what makes a split configuration converge. Were the role instead assigned per provider — "this
+/// one is the data venue, so it is `DataOnly`" — the *execution* venue of the same instrument would
+/// keep its market data dimension and wait forever on a subscription that is never made, and
+/// [`ConnectivityStates::global`] would never reach [`Health::Healthy`].
 ///
-/// Deriving both independently is what makes a split configuration converge. Were the role instead
-/// assigned per provider — "this one is the data venue, so it is `DataOnly`" — the *execution* venue
-/// of the same instrument would keep its market data dimension and wait forever on a subscription
-/// that is never made, and [`ConnectivityStates::global`] would never reach [`Health::Healthy`].
+/// The two dimensions have **different** sources of truth, and this asymmetry is the point:
+/// - **Market data** is instrument-derived: a venue has the dimension iff it is the effective data
+///   venue ([`Instrument::data_exchange`](rustrade_instrument::instrument::Instrument::data_exchange))
+///   of at least one instrument. That is exact, because subscriptions are generated from the very
+///   same field.
+/// - **Account** is *execution-derived*: a venue has the dimension iff an execution client is
+///   registered against it, since account events reach the engine only from a registered
+///   `ExecutionManager`. The instrument model cannot answer this — `Instrument::exchange` names the
+///   venue an instrument *would* be executed on, not whether anything is wired up to execute there.
+///
+/// # `execution_venues`, and what happens without it
+/// Pass `Some` set of venues that have a registered execution client whenever it is known;
+/// [`SystemBuilder`](crate::system::builder::SystemBuilder) does this automatically.
+///
+/// `None` falls back to approximating the account dimension as "is the execution venue of at least
+/// one instrument". That is correct for the common configuration where every venue holding
+/// instruments is also traded on, and it is the behaviour that predates this parameter — but it is
+/// **wrong for a venue that prices instruments without executing any**. Such a venue is assigned
+/// [`VenueRole::Both`], its account connection is then waited on forever, and
+/// [`ConnectivityStates::global`] never reaches [`Health::Healthy`]. Declaring the venues closes
+/// that gap; see [`EngineStateBuilder::execution_venues`](crate::engine::state::builder::EngineStateBuilder::execution_venues).
 ///
 /// # Arguments
 /// * `instruments` - Reference to [`IndexedInstruments`] containing what exchanges are being tracked.
+/// * `execution_venues` - Venues with a registered execution client, if known. See above.
 pub fn generate_empty_indexed_connectivity_states(
     instruments: &IndexedInstruments,
+    execution_venues: Option<&FnvHashSet<ExchangeId>>,
 ) -> ConnectivityStates {
     // Scans the instruments once per exchange rather than building a lookup: this runs once at
     // startup, and the exchange count is a handful even for large instrument collections.
@@ -414,13 +433,29 @@ pub fn generate_empty_indexed_connectivity_states(
                 .iter()
                 .any(|instrument| instrument.value.data_exchange().value == exchange);
 
-            let has_account = instruments
-                .instruments()
-                .iter()
-                .any(|instrument| instrument.value.exchange.value == exchange);
+            let has_account = match execution_venues {
+                Some(venues) => venues.contains(&exchange),
+                None => instruments
+                    .instruments()
+                    .iter()
+                    .any(|instrument| instrument.value.exchange.value == exchange),
+            };
 
             let role = VenueRole::from_dimensions(has_market_data, has_account);
-            info!(%exchange, ?role, "EngineState tracking exchange connectivity");
+
+            if has_market_data || has_account {
+                info!(%exchange, ?role, "EngineState tracking exchange connectivity");
+            } else {
+                // Every instrument on this venue is priced elsewhere and nothing executes here, so
+                // there is no connection it could ever report healthy. Said out loud rather than
+                // left to be inferred from a `global` that never leaves `Reconnecting`.
+                warn!(
+                    %exchange,
+                    ?role,
+                    "EngineState tracking an exchange that provides neither market data nor \
+                     execution - global connectivity cannot reach Healthy while it is tracked"
+                );
+            }
 
             (exchange, ConnectivityState::new(role))
         })
@@ -451,7 +486,7 @@ mod tests {
 
     #[test]
     fn a_split_configuration_gives_each_venue_only_the_dimension_it_provides() {
-        let states = generate_empty_indexed_connectivity_states(&split_venue_instruments());
+        let states = generate_empty_indexed_connectivity_states(&split_venue_instruments(), None);
 
         assert_eq!(states.exchanges.len(), 2);
         assert_eq!(states.connectivity(&DATA).role, VenueRole::DataOnly);
@@ -465,7 +500,7 @@ mod tests {
     #[test]
     fn a_single_venue_instrument_leaves_its_venue_providing_both_dimensions() {
         let instruments = IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]);
-        let states = generate_empty_indexed_connectivity_states(&instruments);
+        let states = generate_empty_indexed_connectivity_states(&instruments, None);
 
         assert_eq!(states.exchanges.len(), 1);
         assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::Both);
@@ -477,13 +512,88 @@ mod tests {
             instrument(EXECUTION, "btc", "usdt").with_data_venue(DataVenue::new_same_name(DATA)),
             instrument(DATA, "eth", "usdt"),
         ]);
-        let states = generate_empty_indexed_connectivity_states(&instruments);
+        let states = generate_empty_indexed_connectivity_states(&instruments, None);
 
         assert_eq!(states.connectivity(&DATA).role, VenueRole::Both);
         assert_eq!(
             states.connectivity(&EXECUTION).role,
             VenueRole::ExecutionOnly
         );
+    }
+
+    /// The two-instrument pattern: one instrument priced on `DATA` and never traded, a *different*
+    /// instrument traded on `EXECUTION`. Nothing executes on `DATA`.
+    fn two_instrument_pattern() -> IndexedInstruments {
+        IndexedInstruments::new([
+            instrument(DATA, "xau", "usd"),
+            instrument(EXECUTION, "btc", "usdt"),
+        ])
+    }
+
+    #[test]
+    fn a_venue_that_prices_instruments_without_executing_any_is_data_only() {
+        let instruments = two_instrument_pattern();
+        let states = generate_empty_indexed_connectivity_states(
+            &instruments,
+            Some(&FnvHashSet::from_iter([EXECUTION])),
+        );
+
+        // `DATA` is the `Instrument::exchange` of the priced instrument, so the instrument model
+        // alone claims it holds an account. Only the declared execution venues can say otherwise.
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::DataOnly);
+        assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::Both);
+    }
+
+    #[test]
+    fn without_declared_execution_venues_a_pricing_only_venue_is_approximated_as_both() {
+        // Pins the documented fallback, and is exactly the configuration it gets wrong: `DATA` is
+        // handed an account dimension nothing will ever satisfy. Declaring the execution venues --
+        // as `SystemBuilder` does -- is what closes it, per the test above.
+        let instruments = two_instrument_pattern();
+        let states = generate_empty_indexed_connectivity_states(&instruments, None);
+
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::Both);
+    }
+
+    #[test]
+    fn global_health_reaches_healthy_when_the_pricing_only_venue_never_reports_an_account() {
+        let instruments = two_instrument_pattern();
+        let execution_index = instruments.find_exchange_index(EXECUTION).unwrap();
+        let mut states = generate_empty_indexed_connectivity_states(
+            &instruments,
+            Some(&FnvHashSet::from_iter([EXECUTION])),
+        );
+
+        // Every connection that exists reports in. `DATA` has no account stream and never will.
+        states.update_from_market_event(&DATA).unwrap();
+        states.update_from_market_event(&EXECUTION).unwrap();
+        assert_eq!(
+            states.global,
+            Health::Reconnecting,
+            "the execution venue's account has not reported yet"
+        );
+        states.update_from_account_event(&execution_index);
+
+        assert_eq!(states.global, Health::Healthy);
+        assert_eq!(
+            states.connectivity(&DATA).account,
+            Health::Reconnecting,
+            "the dimension it does not have stays at its default, and is simply not consulted"
+        );
+    }
+
+    #[test]
+    fn a_venue_providing_neither_dimension_conservatively_demands_both() {
+        // Misconfiguration: `EXECUTION` holds an instrument priced elsewhere, and no execution
+        // client was registered for it. Reachable only once execution venues are declared. Health
+        // is withheld rather than granted to a venue with no known connection.
+        let instruments = split_venue_instruments();
+        let states =
+            generate_empty_indexed_connectivity_states(&instruments, Some(&FnvHashSet::default()));
+
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::DataOnly);
+        assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::Both);
+        assert!(!states.connectivity(&EXECUTION).all_healthy());
     }
 
     #[test]
@@ -533,7 +643,7 @@ mod tests {
         for market_data_first in [true, false] {
             let instruments = split_venue_instruments();
             let execution = instruments.find_exchange_index(EXECUTION).unwrap();
-            let mut states = generate_empty_indexed_connectivity_states(&instruments);
+            let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
 
             assert_eq!(states.global, Health::Reconnecting);
 
@@ -566,7 +676,7 @@ mod tests {
         // else was healthy, and only panicked once a reconnect dragged global back down. Reaching
         // `Healthy` first is therefore the whole point of this setup.
         let instruments = IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]);
-        let mut states = generate_empty_indexed_connectivity_states(&instruments);
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
 
         let execution = instruments.find_exchange_index(EXECUTION).unwrap();
         states.update_from_market_event(&EXECUTION).unwrap();
@@ -589,7 +699,7 @@ mod tests {
         // venues it does track -- and could never be repaired, since no later event for it can
         // restore a `ConnectivityState` that does not exist.
         let instruments = IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]);
-        let mut states = generate_empty_indexed_connectivity_states(&instruments);
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
 
         let execution = instruments.find_exchange_index(EXECUTION).unwrap();
         states.update_from_market_event(&EXECUTION).unwrap();
@@ -611,7 +721,7 @@ mod tests {
     #[test]
     fn a_tracked_exchange_disconnect_still_degrades_global_health() {
         let instruments = IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]);
-        let mut states = generate_empty_indexed_connectivity_states(&instruments);
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
 
         let execution = instruments.find_exchange_index(EXECUTION).unwrap();
         states.update_from_market_event(&EXECUTION).unwrap();

--- a/rustrade/src/engine/state/connectivity/mod.rs
+++ b/rustrade/src/engine/state/connectivity/mod.rs
@@ -165,24 +165,113 @@ pub enum Health {
     Reconnecting,
 }
 
+/// Which connection dimensions a venue actually provides.
+///
+/// A venue that only supplies market data has no account connection to establish, and a venue that
+/// is only executed on has no market data subscription — so demanding [`Health::Healthy`] on both
+/// dimensions would leave such a venue, and therefore
+/// [`ConnectivityStates::global`], [`Health::Reconnecting`] forever.
+///
+/// # Roles are per dimension, not per provider
+/// In a configuration where an instrument is priced on one venue and executed on another, **both**
+/// venues are single-dimension. Marking only the data venue as `DataOnly` fixes nothing: the
+/// execution venue would still be waiting on a market data connection that is never made. See
+/// [`generate_empty_indexed_connectivity_states`] for how each dimension is derived independently.
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize,
+)]
+pub enum VenueRole {
+    /// Market data is sourced from this venue, but nothing is executed on it — it has no account.
+    DataOnly,
+
+    /// Instruments are executed on this venue, but their market data comes from elsewhere.
+    ExecutionOnly,
+
+    /// The venue supplies market data *and* holds an account.
+    ///
+    /// The default, and the strictest interpretation: it is the behaviour that predates this type,
+    /// so it is what a `ConnectivityState` deserialised from an older payload assumes.
+    #[default]
+    Both,
+}
+
+impl VenueRole {
+    /// Returns true if market data is sourced from this venue.
+    pub fn has_market_data(self) -> bool {
+        matches!(self, Self::DataOnly | Self::Both)
+    }
+
+    /// Returns true if this venue holds an account and is executed on.
+    pub fn has_account(self) -> bool {
+        matches!(self, Self::ExecutionOnly | Self::Both)
+    }
+
+    /// Derive the role of a venue from the dimensions it was observed to provide.
+    fn from_dimensions(has_market_data: bool, has_account: bool) -> Self {
+        match (has_market_data, has_account) {
+            (true, true) => Self::Both,
+            (true, false) => Self::DataOnly,
+            (false, true) => Self::ExecutionOnly,
+            // Unreachable by construction: an `IndexedInstruments` exchange is only ever registered
+            // as some `Instrument`s execution venue or as its data venue, so every indexed exchange
+            // provides at least one dimension. `Both` is the conservative fallback — it withholds
+            // `Healthy` until there is evidence, rather than declaring a venue with no known
+            // connections healthy.
+            (false, false) => Self::Both,
+        }
+    }
+}
+
 /// Represents the current connection state for both market data and account connections of an
 /// exchange.
 ///
 /// Connection health is monitored separately for market data and account connections since they
-/// often use different endpoints and may have different health states.
+/// often use different endpoints and may have different health states. Which of the two a given
+/// venue actually has is declared by [`Self::role`].
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Deserialize, Serialize)]
 pub struct ConnectivityState {
     /// Status of market data connection.
+    ///
+    /// Only meaningful when [`Self::role`] says market data is sourced from this venue. A
+    /// [`VenueRole::ExecutionOnly`] venue has no market data connection to establish, so this stays
+    /// at its [`Health::Reconnecting`] default indefinitely — read health via [`Self::all_healthy`],
+    /// or consult the role first, rather than this field alone.
     pub market_data: Health,
 
     /// Status of the account and execution connection.
+    ///
+    /// Only meaningful when [`Self::role`] says this venue holds an account — see
+    /// [`Self::market_data`] for the mirror case.
     pub account: Health,
+
+    /// Which connection dimensions this venue provides.
+    ///
+    /// `serde` defaults it to [`VenueRole::Both`] — the semantics that predate the field — so a
+    /// `ConnectivityState` persisted before it existed still deserialises unchanged.
+    #[serde(default)]
+    pub role: VenueRole,
 }
 
 impl ConnectivityState {
-    /// Returns true if both market data and account connections are [`Health::Healthy`].
+    /// Construct a `ConnectivityState` for a venue in the provided [`VenueRole`], with every
+    /// connection [`Health::Reconnecting`].
+    pub fn new(role: VenueRole) -> Self {
+        Self {
+            market_data: Health::Reconnecting,
+            account: Health::Reconnecting,
+            role,
+        }
+    }
+
+    /// Returns true if every connection this venue actually has is [`Health::Healthy`].
+    ///
+    /// Dimensions the venue does not provide are not consulted — a [`VenueRole::DataOnly`] venue is
+    /// healthy on a healthy market data connection alone, since it has no account to connect to.
     pub fn all_healthy(&self) -> bool {
-        self.market_data == Health::Healthy && self.account == Health::Healthy
+        let market_data = !self.role.has_market_data() || self.market_data == Health::Healthy;
+        let account = !self.role.has_account() || self.account == Health::Healthy;
+
+        market_data && account
     }
 }
 
@@ -191,17 +280,189 @@ impl ConnectivityState {
 /// Creates a new connection state tracker for each exchange in the provided instruments, with all
 /// connections initially set to [`Health::Reconnecting`].
 ///
+/// # Venue roles
+/// Each exchange's [`VenueRole`] is derived one dimension at a time, from the instruments
+/// themselves:
+/// - it has the **market data** dimension iff it is the effective data venue
+///   ([`Instrument::data_exchange`](rustrade_instrument::instrument::Instrument::data_exchange)) of
+///   at least one instrument;
+/// - it has the **account** dimension iff it is the execution venue (`Instrument::exchange`) of at
+///   least one instrument.
+///
+/// Deriving both independently is what makes a split configuration converge. Were the role instead
+/// assigned per provider — "this one is the data venue, so it is `DataOnly`" — the *execution* venue
+/// of the same instrument would keep its market data dimension and wait forever on a subscription
+/// that is never made, and [`ConnectivityStates::global`] would never reach [`Health::Healthy`].
+///
 /// # Arguments
 /// * `instruments` - Reference to [`IndexedInstruments`] containing what exchanges are being tracked.
 pub fn generate_empty_indexed_connectivity_states(
     instruments: &IndexedInstruments,
 ) -> ConnectivityStates {
+    // Scans the instruments once per exchange rather than building a lookup: this runs once at
+    // startup, and the exchange count is a handful even for large instrument collections.
+    let exchanges = instruments
+        .exchanges()
+        .iter()
+        .map(|exchange| {
+            let exchange = exchange.value;
+
+            let has_market_data = instruments
+                .instruments()
+                .iter()
+                .any(|instrument| instrument.value.data_exchange().value == exchange);
+
+            let has_account = instruments
+                .instruments()
+                .iter()
+                .any(|instrument| instrument.value.exchange.value == exchange);
+
+            let role = VenueRole::from_dimensions(has_market_data, has_account);
+            info!(%exchange, ?role, "EngineState tracking exchange connectivity");
+
+            (exchange, ConnectivityState::new(role))
+        })
+        .collect();
+
     ConnectivityStates {
         global: Health::Reconnecting,
-        exchanges: instruments
-            .exchanges()
-            .iter()
-            .map(|exchange| (exchange.value, ConnectivityState::default()))
-            .collect(),
+        exchanges,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use rustrade_instrument::{instrument::data_venue::DataVenue, test_utils::instrument};
+
+    const DATA: ExchangeId = ExchangeId::BinanceSpot;
+    const EXECUTION: ExchangeId = ExchangeId::Coinbase;
+
+    /// One instrument priced on `DATA` and executed on `EXECUTION` — the configuration every
+    /// per-dimension derivation exists for.
+    fn split_venue_instruments() -> IndexedInstruments {
+        IndexedInstruments::new([
+            instrument(EXECUTION, "btc", "usdt").with_data_venue(DataVenue::new_same_name(DATA))
+        ])
+    }
+
+    #[test]
+    fn a_split_configuration_gives_each_venue_only_the_dimension_it_provides() {
+        let states = generate_empty_indexed_connectivity_states(&split_venue_instruments());
+
+        assert_eq!(states.exchanges.len(), 2);
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::DataOnly);
+        // The half a per-provider fix misses: the execution venue is single-dimension too.
+        assert_eq!(
+            states.connectivity(&EXECUTION).role,
+            VenueRole::ExecutionOnly
+        );
+    }
+
+    #[test]
+    fn a_single_venue_instrument_leaves_its_venue_providing_both_dimensions() {
+        let instruments = IndexedInstruments::new([instrument(EXECUTION, "btc", "usdt")]);
+        let states = generate_empty_indexed_connectivity_states(&instruments);
+
+        assert_eq!(states.exchanges.len(), 1);
+        assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::Both);
+    }
+
+    #[test]
+    fn a_venue_that_prices_one_instrument_and_executes_another_provides_both_dimensions() {
+        let instruments = IndexedInstruments::new([
+            instrument(EXECUTION, "btc", "usdt").with_data_venue(DataVenue::new_same_name(DATA)),
+            instrument(DATA, "eth", "usdt"),
+        ]);
+        let states = generate_empty_indexed_connectivity_states(&instruments);
+
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::Both);
+        assert_eq!(
+            states.connectivity(&EXECUTION).role,
+            VenueRole::ExecutionOnly
+        );
+    }
+
+    #[test]
+    fn all_healthy_ignores_the_dimension_a_venue_does_not_provide() {
+        assert!(
+            ConnectivityState {
+                market_data: Health::Healthy,
+                account: Health::Reconnecting,
+                role: VenueRole::DataOnly,
+            }
+            .all_healthy()
+        );
+
+        assert!(
+            ConnectivityState {
+                market_data: Health::Reconnecting,
+                account: Health::Healthy,
+                role: VenueRole::ExecutionOnly,
+            }
+            .all_healthy()
+        );
+
+        // ...but the dimension a venue does provide is still required.
+        assert!(
+            !ConnectivityState {
+                market_data: Health::Reconnecting,
+                account: Health::Healthy,
+                role: VenueRole::DataOnly,
+            }
+            .all_healthy()
+        );
+
+        assert!(
+            !ConnectivityState {
+                market_data: Health::Healthy,
+                account: Health::Reconnecting,
+                role: VenueRole::Both,
+            }
+            .all_healthy()
+        );
+    }
+
+    #[test]
+    fn global_health_reaches_healthy_once_each_split_venue_reports_its_own_dimension() {
+        // Both arrival orderings: whichever event lands last is the one that has to observe global
+        // health, so a fix living on only one of the two update paths fails half of this test.
+        for market_data_first in [true, false] {
+            let instruments = split_venue_instruments();
+            let execution = instruments.find_exchange_index(EXECUTION).unwrap();
+            let mut states = generate_empty_indexed_connectivity_states(&instruments);
+
+            assert_eq!(states.global, Health::Reconnecting);
+
+            if market_data_first {
+                states.update_from_market_event(&DATA);
+                assert_eq!(
+                    states.global,
+                    Health::Reconnecting,
+                    "the execution venue has not reported yet"
+                );
+                states.update_from_account_event(&execution);
+            } else {
+                states.update_from_account_event(&execution);
+                assert_eq!(
+                    states.global,
+                    Health::Reconnecting,
+                    "the data venue has not reported yet"
+                );
+                states.update_from_market_event(&DATA);
+            }
+
+            assert_eq!(states.global, Health::Healthy, "{market_data_first}");
+        }
+    }
+
+    #[test]
+    fn a_state_persisted_before_venue_roles_deserialises_demanding_both_dimensions() {
+        let state: ConnectivityState =
+            serde_json::from_str(r#"{"market_data":"Healthy","account":"Reconnecting"}"#).unwrap();
+
+        assert_eq!(state.role, VenueRole::Both);
+        assert!(!state.all_healthy());
     }
 }

--- a/rustrade/src/engine/state/connectivity/mod.rs
+++ b/rustrade/src/engine/state/connectivity/mod.rs
@@ -1,10 +1,10 @@
 use derive_more::Constructor;
 use fnv::FnvHashSet;
-use indexmap::IndexMap;
 use rustrade_instrument::{
     exchange::{ExchangeId, ExchangeIndex},
     index::IndexedInstruments,
 };
+use rustrade_integration::collection::FnvIndexMap;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
@@ -19,7 +19,10 @@ pub struct ConnectivityStates {
     pub global: Health,
 
     /// Connectivity `Health` of market data and account connections by exchange.
-    pub exchanges: IndexMap<ExchangeId, ConnectivityState>,
+    ///
+    /// Fnv-hashed: this is read on every market event, and `ExchangeId` is a fieldless enum — a key
+    /// small enough that SipHash's fixed per-call cost dominates. Insertion-ordered either way.
+    pub exchanges: FnvIndexMap<ExchangeId, ConnectivityState>,
 }
 
 impl ConnectivityStates {
@@ -337,9 +340,13 @@ pub struct ConnectivityState {
     /// Status of market data connection.
     ///
     /// Only meaningful when [`Self::role`] says market data is sourced from this venue. A
-    /// [`VenueRole::ExecutionOnly`] venue has no market data connection to establish, so this stays
-    /// at its [`Health::Reconnecting`] default indefinitely — read health via [`Self::all_healthy`],
-    /// or consult the role first, rather than this field alone.
+    /// [`VenueRole::ExecutionOnly`] venue has no market data connection to establish, so nothing is
+    /// expected to move this off its [`Health::Reconnecting`] default — read health via
+    /// [`Self::all_healthy`], or consult the role first, rather than this field alone.
+    ///
+    /// That is an expectation, not an invariant: [`ConnectivityStates::update_from_market_event`]
+    /// sets this `Healthy` for any *tracked* exchange, role notwithstanding. A market event arriving
+    /// for a venue declared `ExecutionOnly` means the role is wrong, and this field will say so.
     pub market_data: Health,
 
     /// Status of the account and execution connection.

--- a/rustrade/src/engine/state/connectivity/mod.rs
+++ b/rustrade/src/engine/state/connectivity/mod.rs
@@ -39,6 +39,16 @@ impl ConnectivityStates {
         exchange: &ExchangeId,
     ) -> Result<(), UntrackedExchange> {
         let Some(state) = self.exchanges.get_mut(exchange) else {
+            // `warn!` here, unlike the `debug!` on the market *event* path: a disconnect notice
+            // arrives once per disconnect, so there is no volume to bound — and the routine,
+            // tracked-venue case two lines below logs at this same level. Logging the anomaly more
+            // quietly than the routine event it replaces is what this pairing avoids.
+            warn!(
+                %exchange,
+                dimension = ?ConnectivityDimension::Account,
+                "EngineState received AccountStream disconnected event for an exchange it does not \
+                 track - ignoring it"
+            );
             return Err(UntrackedExchange::new(
                 *exchange,
                 ConnectivityDimension::Account,
@@ -92,6 +102,14 @@ impl ConnectivityStates {
         exchange: &ExchangeId,
     ) -> Result<(), UntrackedExchange> {
         let Some(state) = self.exchanges.get_mut(exchange) else {
+            // `warn!` for the same reason as the account twin above: bounded by the disconnect
+            // rate, and level-matched to the tracked-venue line below.
+            warn!(
+                %exchange,
+                dimension = ?ConnectivityDimension::MarketData,
+                "EngineState received MarketStream disconnect event for an exchange it does not \
+                 track - ignoring it"
+            );
             return Err(UntrackedExchange::new(
                 *exchange,
                 ConnectivityDimension::MarketData,
@@ -128,6 +146,19 @@ impl ConnectivityStates {
         // `IndexMap` get per market event and makes the report fire on the first event from that
         // exchange, in every run.
         let Some(state) = self.exchanges.get_mut(exchange) else {
+            // `debug!`, and deliberately not `warn!` like the two disconnect paths: this fires once
+            // per market event from that venue, so a stream wired up for an unconfigured exchange
+            // emits at tick rate. A `warn!` here would bury every other warning in the process
+            // rather than surface this one. The returned `UntrackedExchange` — threaded to
+            // `EngineOutput::UntrackedExchange` — is the observable meant to be counted; this is
+            // the breadcrumb for a consumer on `sync_run`/`async_run`, which discard the audit
+            // stream and would otherwise see nothing at all.
+            debug!(
+                %exchange,
+                dimension = ?ConnectivityDimension::MarketData,
+                "EngineState received MarketStream event for an exchange it does not track - \
+                 dropping it"
+            );
             return Err(UntrackedExchange::new(
                 *exchange,
                 ConnectivityDimension::MarketData,
@@ -243,6 +274,17 @@ pub enum ConnectivityDimension {
 /// Market events additionally stop **before** instrument state is touched. `InstrumentIndex` lookups
 /// are positional, so continuing would either panic on an out-of-range index or, worse, silently
 /// attribute the print to whichever instrument happens to occupy that slot.
+///
+/// # How it is surfaced
+/// The structured observable is `EngineOutput::UntrackedExchange`, carried on the audit stream — but
+/// only the `*_with_audit` runners retain per-event ticks, so a consumer on
+/// [`sync_run`](crate::engine::run::sync_run) / [`async_run`](crate::engine::run::async_run) sees
+/// none of them. Each rejection therefore also logs, at a level chosen by how often that path can
+/// fire: `warn!` on the two disconnect paths, which are bounded by the disconnect rate, and `debug!`
+/// on the market-event path, which fires per event and would otherwise emit at tick rate.
+///
+/// A consumer that must not miss this on a non-audit runner should either enable `debug!` for this
+/// module or run an `*_with_audit` variant and count the output.
 #[derive(
     Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize, Constructor,
 )]
@@ -354,7 +396,13 @@ pub struct ConnectivityState {
     ///
     /// That is an expectation, not an invariant: [`ConnectivityStates::update_from_market_event`]
     /// sets this `Healthy` for any *tracked* exchange, role notwithstanding. A market event arriving
-    /// for a venue declared `ExecutionOnly` means the role is wrong, and this field will say so.
+    /// for a venue declared `ExecutionOnly` means the role is wrong.
+    ///
+    /// This field reports that only while [`ConnectivityStates::global`] has not yet reached
+    /// [`Health::Healthy`]. Once it has, `update_from_market_event` short-circuits on the cached
+    /// aggregate and returns before writing, so a role error that first produces a market event
+    /// after convergence leaves this field `Reconnecting` and is not observable here. Do not treat
+    /// it as a reliable role-mismatch detector.
     pub market_data: Health,
 
     /// Status of the account and execution connection.
@@ -437,7 +485,9 @@ pub fn generate_empty_indexed_connectivity_states(
 ) -> ConnectivityStates {
     // Scans the instruments once per exchange rather than building a lookup: this runs once at
     // startup, and the exchange count is a handful even for large instrument collections.
-    let exchanges = instruments
+    // Annotated because `is_empty()` below is now the first use of this binding — without it the
+    // `collect()` target can no longer be inferred from the struct literal it ends up in.
+    let exchanges: FnvIndexMap<ExchangeId, ConnectivityState> = instruments
         .exchanges()
         .iter()
         .map(|exchange| {
@@ -465,6 +515,17 @@ pub fn generate_empty_indexed_connectivity_states(
             (exchange, ConnectivityState::new(role))
         })
         .collect();
+
+    if exchanges.is_empty() {
+        // Said out loud for the same reason as the neither-dimension case above. `global` cannot
+        // distinguish this from a routine reconnect — both read `Health::Reconnecting` — so a
+        // consumer gating on it would wait indefinitely on a configuration that was simply empty,
+        // with nothing in the state naming why.
+        warn!(
+            "EngineState tracking no exchanges at all - global connectivity cannot reach Healthy, \
+             and no instrument is being tracked"
+        );
+    }
 
     ConnectivityStates {
         global: Health::Reconnecting,
@@ -499,7 +560,7 @@ fn derive_venue_dimensions(
 }
 
 /// Re-derives the [`VenueRole`] of every tracked venue from the venues that have a registered
-/// execution client, leaving connection [`Health`] untouched.
+/// execution client, leaving each venue's connection [`Health`] untouched.
 ///
 /// For callers that must build their [`EngineState`](super::EngineState) *before* their execution
 /// clients exist — [`backtest`](crate::backtest::backtest) does, since it builds one set of clients
@@ -513,6 +574,41 @@ fn derive_venue_dimensions(
 /// is keyed positionally by [`ExchangeIndex`], so inserting one here would renumber every venue
 /// after it and silently re-point the instruments indexed against them.
 ///
+/// # `global` is re-derived, not preserved
+/// Per-venue `Health` is left alone, but the cached [`ConnectivityStates::global`] aggregate is
+/// recomputed from the corrected roles before returning. It has to be:
+/// [`ConnectivityState::all_healthy`] is a *function of* [`ConnectivityState::role`], so changing a
+/// role changes what `global` should already have been — and the event paths that normally maintain
+/// it cannot repair the difference, since each short-circuits once its own dimension is
+/// [`Health::Healthy`]. On a state whose connections had already reported in, a role change would
+/// otherwise strand `global` wrong in whichever direction it moved: stale-`Healthy` when a role
+/// widened (a consumer gating on `global` trades against a link that never came up), or
+/// stuck-`Reconnecting` when one narrowed (every health-gated strategy stays gated for the whole
+/// run, which is the footgun this function exists to remove).
+///
+/// This is a no-op for the ordinary freshly-built state, where every connection is
+/// `Reconnecting` and `global` already is too.
+///
+/// An **empty** `states` re-derives to [`Health::Reconnecting`] regardless of what it arrived with.
+/// Neither variant is honest over zero venues: `all` is vacuously true, which argues for `Healthy`,
+/// while [`Health::Reconnecting`] documents a reconnection in progress that is equally not
+/// happening. `Reconnecting` is chosen because
+/// [`generate_empty_indexed_connectivity_states`] — the only constructor of this type — already
+/// returns it for a zero-exchange collection, and two entry points disagreeing on the same input
+/// would be worse than either answer; and because it leaves the postcondition below total, with no
+/// boundary a caller has to special-case.
+///
+/// That is a convention on a degenerate input, not a safety property. A venue-less state holds no
+/// instruments, so no position exists for either value to protect — do not read `Reconnecting` here
+/// as the library taking a position on what a consumer should do about an empty configuration. The
+/// misconfiguration itself is reported by
+/// [`generate_empty_indexed_connectivity_states`], which `warn!`s on an empty venue set.
+///
+/// # Postcondition
+/// On return, `global` is [`Health::Healthy`] iff `states` is non-empty and every venue in it is
+/// [`ConnectivityState::all_healthy`] under its corrected role. This holds unconditionally — it does
+/// not depend on whether any role actually changed, or on `global`'s incoming value.
+///
 /// # Caller obligation
 /// `instruments` must be the collection `states` was built from. A mismatched pair derives every
 /// dimension against the wrong collection and assigns every venue a plausible but wrong
@@ -522,7 +618,7 @@ fn derive_venue_dimensions(
 /// A `debug_assert!` catches the detectable half of that: `states` holding a different venue set,
 /// or holding it in a different order. It cannot catch a collection carrying the *same* venues
 /// with different instruments, since the venue keys are then identical — but such a pair also
-/// misaligns every [`InstrumentIndex`](rustrade_instrument::index::InstrumentIndex) in the engine,
+/// misaligns every [`InstrumentIndex`](rustrade_instrument::instrument::InstrumentIndex) in the engine,
 /// so venue roles are not the symptom that surfaces first.
 ///
 /// # Arguments
@@ -585,13 +681,33 @@ pub fn reconcile_venue_roles(
         );
         state.role = role;
     }
+
+    // Re-derive the cached aggregate against the corrected roles — see `# global is re-derived, not
+    // preserved`. Unconditional rather than gated on "did any role change", because the incoming
+    // `global` is a caller-supplied value that may disagree with the roles it arrived with. The
+    // empty set is a conjunct rather than an early-out for the same reason: skipping the write there
+    // would leave exactly one input on which this function does not establish its postcondition, and
+    // would answer a zero-venue collection differently from
+    // `generate_empty_indexed_connectivity_states`. Costs one pass over a handful of venues, once
+    // per engine build, off the event path.
+    states.global = if !states.exchanges.is_empty()
+        && states.exchange_states().all(ConnectivityState::all_healthy)
+    {
+        Health::Healthy
+    } else {
+        Health::Reconnecting
+    };
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
-    use rustrade_instrument::{instrument::data_venue::DataVenue, test_utils::instrument};
+    use rustrade_instrument::{
+        asset::Asset,
+        instrument::{Instrument, data_venue::DataVenue},
+        test_utils::instrument,
+    };
 
     const DATA: ExchangeId = ExchangeId::BinanceSpot;
     const EXECUTION: ExchangeId = ExchangeId::Coinbase;
@@ -989,6 +1105,104 @@ mod tests {
             &mut states,
             &two_instrument_pattern(),
             &FnvHashSet::from_iter([EXECUTION]),
+        );
+    }
+
+    #[test]
+    fn reconciling_roles_re_derives_a_global_left_stale_healthy_by_a_widened_role() {
+        // `global` is a cached aggregate over `all_healthy`, which is a function of `role` -- so a
+        // role that WIDENS invalidates a `Healthy` global by making a dimension newly required.
+        // Nothing on the event paths can repair it: both short-circuit while `global == Healthy`,
+        // so without the re-derive below a consumer gating on `global` would trade for the rest of
+        // the run against an account link that never came up.
+        let instruments = two_instrument_pattern();
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
+
+        // Converge under a client set that gives EXECUTION no account: both venues are `DataOnly`,
+        // both satisfied by market data alone, so `global` legitimately reaches `Healthy`.
+        reconcile_venue_roles(&mut states, &instruments, &FnvHashSet::default());
+        assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::DataOnly);
+        states.update_from_market_event(&DATA).unwrap();
+        states.update_from_market_event(&EXECUTION).unwrap();
+        assert_eq!(states.global, Health::Healthy);
+
+        // Now reconcile against a client set that DOES execute on EXECUTION: its role widens to
+        // `Both`, and the account connection it now demands has never reported.
+        reconcile_venue_roles(
+            &mut states,
+            &instruments,
+            &FnvHashSet::from_iter([EXECUTION]),
+        );
+
+        assert_eq!(states.connectivity(&EXECUTION).role, VenueRole::Both);
+        assert!(!states.connectivity(&EXECUTION).all_healthy());
+        assert_eq!(
+            states.global,
+            Health::Reconnecting,
+            "global must follow the role that invalidated it"
+        );
+    }
+
+    #[test]
+    fn reconciling_roles_re_derives_a_global_left_stuck_reconnecting_by_a_narrowed_role() {
+        // The mirror direction, and the one that fails *closed*: a role that NARROWS drops a
+        // dimension that was holding `global` down. This is unrepairable for the opposite reason --
+        // every connection that exists has already reported `Healthy`, so each update path returns
+        // early on its own dimension and never re-runs the convergence check. Without the
+        // re-derive, every health-gated strategy stays gated for the whole run.
+        let instruments = two_instrument_pattern();
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::Both);
+
+        // Every connection that will ever report has reported. `global` is correctly `Reconnecting`
+        // only because `DATA` is still approximated as owning an account.
+        states.update_from_market_event(&DATA).unwrap();
+        states.update_from_market_event(&EXECUTION).unwrap();
+        states.connectivity_mut(&EXECUTION).account = Health::Healthy;
+        states.global = Health::Reconnecting;
+
+        reconcile_venue_roles(
+            &mut states,
+            &instruments,
+            &FnvHashSet::from_iter([EXECUTION]),
+        );
+
+        assert_eq!(states.connectivity(&DATA).role, VenueRole::DataOnly);
+        assert_eq!(
+            states.global,
+            Health::Healthy,
+            "the dimension that was holding global down is no longer demanded"
+        );
+    }
+
+    #[test]
+    fn reconciling_roles_fails_global_closed_when_no_venue_is_tracked() {
+        // `all` is vacuously true over no venues, so an unguarded re-derive would promote an
+        // instrument-less state to `Healthy` -- a claim no connection backs, and one
+        // `generate_empty_indexed_connectivity_states` declines to make.
+        let instruments = IndexedInstruments::new(Vec::<Instrument<ExchangeId, Asset>>::new());
+        let mut states = generate_empty_indexed_connectivity_states(&instruments, None);
+        assert!(states.exchanges.is_empty());
+        assert_eq!(states.global, Health::Reconnecting);
+
+        reconcile_venue_roles(&mut states, &instruments, &FnvHashSet::default());
+
+        assert_eq!(states.global, Health::Reconnecting);
+
+        // The direction that actually distinguishes "fails closed" from "preserves what it was
+        // handed": the assertion above passes under either, since it starts from the answer it
+        // expects. `global` is a `pub` field on a `Deserialize` struct, so a caller-supplied or
+        // deserialised `Healthy` over an empty venue set is reachable -- and is exactly as unbacked
+        // by any connection as the vacuous one the guard exists to reject. Preserving it would
+        // reintroduce, on this boundary, the stale-`Healthy` gap the re-derive was added to close.
+        states.global = Health::Healthy;
+
+        reconcile_venue_roles(&mut states, &instruments, &FnvHashSet::default());
+
+        assert_eq!(
+            states.global,
+            Health::Reconnecting,
+            "an empty venue set must not carry a `Healthy` no connection backs, whatever its source"
         );
     }
 

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -184,8 +184,19 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
     /// correct strike), and that division is otherwise unchecked. A non-standard split touches no
     /// option state, so only the equity positions are pre-computed for it.
     ///
+    /// # Preconditions
+    /// `equity` must already have been established as split-eligible
+    /// ([`InstrumentKind::is_split_eligible`]) by the caller — this function **assumes** it rather
+    /// than checking it, and `debug_assert!`s the assumption. It is a precondition and not a
+    /// returned [`UnsupportedCorporateActionReason::InstrumentKindNotSupported`] because both
+    /// callers must reject an ineligible target *before* the action kind is matched, so that a
+    /// split delivered against an option is attributed to the instrument rather than to the
+    /// action — an ordering this function is called too late to produce.
+    ///
     /// Returns the [`UnsupportedCorporateActionReason`] the caller should surface on the first
     /// failure, or the [`SplitPlan`] to commit when the whole action can be applied.
+    ///
+    /// [`InstrumentKind::is_split_eligible`]: rustrade_instrument::instrument::kind::InstrumentKind::is_split_eligible
     pub(crate) fn prepare_corporate_action_split(
         &self,
         id: &SmolStr,
@@ -195,6 +206,17 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
         adjust_options_in_place: bool,
     ) -> Result<SplitPlan, UnsupportedCorporateActionReason> {
         let equity_state = self.instrument_index(equity);
+
+        // Asserted, not checked: see `# Preconditions`. It earns an assertion because an ineligible
+        // target is not inert here — the underlying identity below is derived FROM the target, so a
+        // derivative reaching this function would have its own positions rescaled through the equity
+        // leg (bypassing the option path's integer-contract check), and an option target would then
+        // match its own scan and be adjusted a second time.
+        debug_assert!(
+            equity_state.instrument.kind.is_split_eligible(),
+            "prepare_corporate_action_split: target is not split-eligible: {:?}",
+            equity_state.instrument.kind
+        );
 
         // The underlying identity every option scan below (and the handler's non-standard signal)
         // resolves against. Derived from the TARGET, so it is only a sound proxy for "this option

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -1119,13 +1119,14 @@ where
             .instruments()
             .iter()
             .map(|instrument| {
-                let exchange_index = instrument.value.exchange.key;
-
                 (
                     instrument.value.name_internal.clone(),
                     InstrumentState {
                         key: instrument.key,
-                        instrument: instrument.value.clone().map_exchange_key(exchange_index),
+                        instrument: instrument
+                            .value
+                            .clone()
+                            .map_exchange_key(|exchange| exchange.key),
                         tear_sheet: TearSheetGenerator::init(time_engine_start),
                         position: position_manager_init(),
                         orders: orders_init(),

--- a/rustrade/src/engine/state/instrument/mod.rs
+++ b/rustrade/src/engine/state/instrument/mod.rs
@@ -85,6 +85,13 @@ pub(crate) struct SplitPlan {
     /// One entry per registered option on the underlying (held OR unheld) for a **standard** split;
     /// empty for a non-standard split (which touches no option state).
     pub(crate) options: Vec<OptionSplitPlan>,
+    /// Registered options on the underlying that already carry this action's `id` in their own
+    /// `corporate_actions_processed` set, and are therefore **excluded** from `options` — this
+    /// action already adjusted them, so re-adjusting would double-divide the strike.
+    ///
+    /// Carried (rather than dropped) purely so the live handler can surface each suppression as an
+    /// observable; the audit replica mirrors state, not outputs, and ignores it.
+    pub(crate) options_already_adjusted: Vec<InstrumentIndex>,
 }
 
 /// The pre-computed standard-split adjustment for a single option instrument on the splitting
@@ -155,12 +162,22 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
     /// Single-sourced so the live handler and the audit replica reach the identical decision — and
     /// the identical pre-computed values — by construction, not by hand-mirrored vigilance. Checks,
     /// in the same order the handler commits:
+    /// - `equity` is the **unique** split-eligible instrument on its `(base, quote, exchange)`
+    ///   underlying identity ⇒ otherwise [`UnsupportedCorporateActionReason::AmbiguousSplitTarget`]
+    ///   (see that variant for why a second eligible instrument makes the option scan unsound);
     /// - every open position on the splitting `equity` rescales without `Decimal` overflow (equity
     ///   quantities may legitimately be fractional, so there is no integer check here);
     /// - iff `adjust_options_in_place` (a standard, whole-number forward split), for every registered
     ///   option on the same underlying (held **or** unheld): its **strike** divides by `ratio`
     ///   without `Decimal` overflow, and — for each **held** position — the contract count is an
     ///   **integer** (a non-integer count is state corruption) and rescales without overflow.
+    ///
+    /// # Per-option idempotency
+    /// An option that already carries `id` in its **own** `corporate_actions_processed` set was
+    /// already adjusted by this action, so it is excluded from [`SplitPlan::options`] (and listed in
+    /// [`SplitPlan::options_already_adjusted`] for the caller to surface) rather than having its
+    /// strike divided a second time. The target's own set is *not* consulted here — the caller
+    /// guards that before calling.
     ///
     /// The strike check is why unheld options are pre-computed here at all: the handler divides the
     /// strike of *every* registered option in place (so a position opened later settles against the
@@ -171,14 +188,36 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
     /// failure, or the [`SplitPlan`] to commit when the whole action can be applied.
     pub(crate) fn prepare_corporate_action_split(
         &self,
+        id: &SmolStr,
         equity: &InstrumentIndex,
         ratio: SplitRatio,
         policy: SplitRoundingPolicy,
         adjust_options_in_place: bool,
     ) -> Result<SplitPlan, UnsupportedCorporateActionReason> {
+        let equity_state = self.instrument_index(equity);
+
+        // The underlying identity every option scan below (and the handler's non-standard signal)
+        // resolves against. Derived from the TARGET, so it is only a sound proxy for "this option
+        // chain" while the target is the sole split-eligible instrument carrying it — which is
+        // exactly what the next guard establishes.
+        let base = equity_state.instrument.underlying.base;
+        let quote = equity_state.instrument.underlying.quote;
+        let exchange = equity_state.instrument.exchange;
+
+        // Guard: the target must be the UNIQUE split-eligible instrument on that identity. A second
+        // one is an equally valid trigger for adjusting the whole option chain, so the same chain
+        // could be adjusted once per eligible instrument — each pass silent for unheld options and
+        // recorded only against its own trigger. Reject the ambiguity instead of picking a winner:
+        // nothing here can tell which instrument the chain is actually written on. Runs FIRST so an
+        // ambiguous target is reported as such even when the arithmetic below would also fail.
+        if self.0.values().any(|state| {
+            state.key != *equity && state.is_split_eligible_on_underlying(&base, &quote, &exchange)
+        }) {
+            return Err(UnsupportedCorporateActionReason::AmbiguousSplitTarget);
+        }
+
         // Equity positions: overflow only. A fractional equity quantity is legitimate (fractional-
         // share brokers), so there is no integer invariant to check here — unlike option contracts.
-        let equity_state = self.instrument_index(equity);
         let mut equity_positions = Vec::with_capacity(equity_state.position.positions.len());
         for (pos_id, position) in &equity_state.position.positions {
             // Match the variant explicitly (not `|_|`): the irrefutable `|SplitError::Overflow|`
@@ -201,6 +240,7 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
             return Ok(SplitPlan {
                 equity_positions,
                 options: Vec::new(),
+                options_already_adjusted: Vec::new(),
             });
         }
 
@@ -208,16 +248,23 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
         // pre-compute, for EVERY registered option on the underlying (held OR unheld), the checked
         // post-split strike (`strike ÷ ratio`) plus the integer-contract invariant + overflow-safe
         // rescale of every HELD option position — all BEFORE the handler mutates any of them.
-        let base = equity_state.instrument.underlying.base;
-        let quote = equity_state.instrument.underlying.quote;
-        let exchange = equity_state.instrument.exchange;
         let ratio_decimal = ratio.get();
         let mut options = Vec::new();
+        let mut options_already_adjusted = Vec::new();
         for option_state in self
             .0
             .values()
             .filter(|state| state.is_option_on_underlying(&base, &quote, &exchange))
         {
+            // Per-option idempotency: this action already adjusted this option (strike, and any
+            // held positions), so re-running it would divide the strike a second time. Exclude it
+            // from the plan and hand the key back for the caller to surface — a deliberate
+            // no-op, not a failure, so it does not reject the action.
+            if option_state.corporate_actions_processed.contains(id) {
+                options_already_adjusted.push(option_state.key);
+                continue;
+            }
+
             // Strike overflow: pre-check the `strike ÷ ratio` the handler applies in place to every
             // registered option, held OR unheld — the fix for the previously unchecked strike
             // `DivAssign` (which could panic on a degenerate-but-positive ratio and was never
@@ -264,6 +311,7 @@ impl<InstrumentData> InstrumentStates<InstrumentData> {
         Ok(SplitPlan {
             equity_positions,
             options,
+            options_already_adjusted,
         })
     }
 
@@ -460,12 +508,26 @@ pub struct InstrumentState<
     /// A `CorporateAction` event carries a caller-assigned unique `id`; the handler records it
     /// here once applied and skips (with a warning) any `id` already present. Scope is
     /// per-instrument — naturally bounded by the number of corporate actions an instrument sees,
-    /// so no global store / LRU is required. This per-instrument-set keyed on `id` alone is
-    /// intentional and sufficient for stock splits (a split event targets a single instrument);
-    /// revisit for future multi-instrument actions (e.g. spin-offs).
+    /// so no global store / LRU is required.
     ///
-    /// Rejected actions (unsupported instrument/action kind) are deliberately **not** recorded,
-    /// so they remain retryable once support is added.
+    /// # Recorded on every instrument the action mutated, not only its target
+    /// A stock split names one target instrument but also adjusts the strike of every registered
+    /// option on that underlying, so the `id` is recorded on the target **and** on each option it
+    /// adjusted. Each option's set is consulted independently before adjusting it, which is what
+    /// makes a second trigger for the same `id` a no-op on the chain rather than a second strike
+    /// division. Two consequences worth knowing:
+    /// - an option carrying an `id` is evidence *that option* was adjusted — not that it was the
+    ///   action's target;
+    /// - a (nonsensical) action re-using that `id` and targeting the option directly is reported as
+    ///   an idempotent skip rather than an unsupported instrument kind, because the option genuinely
+    ///   did process that action.
+    ///
+    /// Revisit for future multi-instrument actions (e.g. spin-offs), which may need to record
+    /// participation more richly than a flat `id` set.
+    ///
+    /// Rejected actions (unsupported instrument/action kind, ambiguous target, failed
+    /// pre-validation) are deliberately **not** recorded, so they remain retryable once the
+    /// blocking condition is resolved.
     ///
     /// A hash set (insertion order is never read — only `contains`/`insert`), consistent with the
     /// sibling `FnvHashMap` routing fields below.
@@ -549,7 +611,45 @@ impl<InstrumentData, ExchangeKey, AssetKey, InstrumentKey>
         ExchangeKey: PartialEq,
     {
         matches!(&self.instrument.kind, InstrumentKind::Option(_))
-            && self.instrument.underlying.base == *base
+            && self.is_on_underlying(base, quote, exchange)
+    }
+
+    /// `true` if this instrument is itself **split-eligible** (the deliverable equity — see
+    /// [`InstrumentKind::is_split_eligible`]) on the underlying `(base, quote)` traded on
+    /// `exchange`.
+    ///
+    /// Used to establish that a corporate action's target is the **only** such instrument on that
+    /// identity. It has to be, because the option chain is resolved by that identity alone: a
+    /// second eligible instrument carrying it would be an equally valid trigger for adjusting the
+    /// same options, with nothing in the state able to say which of the two the chain is written
+    /// on. Shared by the live handler and the audit replica via
+    /// [`InstrumentStates::prepare_corporate_action_split`].
+    pub(crate) fn is_split_eligible_on_underlying(
+        &self,
+        base: &AssetKey,
+        quote: &AssetKey,
+        exchange: &ExchangeKey,
+    ) -> bool
+    where
+        AssetKey: PartialEq,
+        ExchangeKey: PartialEq,
+    {
+        self.instrument.kind.is_split_eligible() && self.is_on_underlying(base, quote, exchange)
+    }
+
+    /// `true` if this instrument's underlying pair is `(base, quote)` **and** it trades on
+    /// `exchange` — the identity match shared by the kind-specific predicates above, with no
+    /// [`InstrumentKind`] constraint of its own.
+    ///
+    /// Both `base` AND `quote` are matched: [`Underlying`](rustrade_instrument::instrument::Underlying)
+    /// is a full pair identity, so without the quote filter a BTC/USDT action would also reach
+    /// BTC/USDC instruments.
+    fn is_on_underlying(&self, base: &AssetKey, quote: &AssetKey, exchange: &ExchangeKey) -> bool
+    where
+        AssetKey: PartialEq,
+        ExchangeKey: PartialEq,
+    {
+        self.instrument.underlying.base == *base
             && self.instrument.underlying.quote == *quote
             && self.instrument.exchange == *exchange
     }

--- a/rustrade/src/engine/state/mod.rs
+++ b/rustrade/src/engine/state/mod.rs
@@ -202,10 +202,9 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
     ///   `pnl_unrealised` and advances `time_exchange_update` from the new market price.
     ///
     /// # Errors
-    /// Returns [`UntrackedExchange`](connectivity::UntrackedExchange) if the event is tagged with an
-    /// exchange the engine was not built against. Nothing is mutated and the event is dropped —
-    /// see that type for why the instrument update is skipped too, rather than merely the
-    /// connectivity one.
+    /// Returns [`UntrackedExchange`] if the event is tagged with an exchange the engine was not
+    /// built against. Nothing is mutated and the event is dropped — see that type for why the
+    /// instrument update is skipped too, rather than merely the connectivity one.
     pub fn update_from_market(
         &mut self,
         event: &MarketEvent<InstrumentIndex, InstrumentData::MarketEventKind>,

--- a/rustrade/src/engine/state/mod.rs
+++ b/rustrade/src/engine/state/mod.rs
@@ -326,6 +326,11 @@ mod tests {
         );
         assert_eq!(snapshots.len(), 1);
 
+        // The property below only bites while the skipped venue sorts FIRST, and `ExchangeId`
+        // orders by declaration position — so assert it rather than assume it. Were the two to
+        // invert, this test would keep passing while guarding nothing.
+        assert!(DATA < EXECUTION, "the skipped venue must sort first");
+
         // Guards the enumerate-before-filter ordering: `DATA` sorts ahead of `EXECUTION`, so
         // numbering the surviving venues instead would hand `EXECUTION` the skipped venue's
         // `ExchangeIndex` and its instrument list would come back empty.

--- a/rustrade/src/engine/state/mod.rs
+++ b/rustrade/src/engine/state/mod.rs
@@ -234,6 +234,19 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
     }
 }
 
+/// Snapshots the account state the engine holds at each exchange that *has* an account.
+///
+/// # Data-only venues are absent, not empty
+/// A [`VenueRole::DataOnly`](connectivity::VenueRole::DataOnly) venue prices instruments but is
+/// executed on by none, so it holds no balances and no positions. It is omitted from the map
+/// entirely rather than mapped to an empty [`UnindexedAccountSnapshot`], because those two claims
+/// are not the same one: an empty snapshot asserts a known, funded-then-drained account, which a
+/// consumer cannot tell apart from a real one that has gone to zero. Seeding a
+/// [`MockExecutionConfig`](rustrade_execution::client::mock::MockExecutionConfig) from an empty
+/// snapshot would stand up a mock account at a venue nothing trades on.
+///
+/// Callers must therefore treat a missing `ExchangeId` as "no account at this venue", and not
+/// assume every exchange the engine tracks appears as a key.
 impl<GlobalData, InstrumentData> From<&EngineState<GlobalData, InstrumentData>>
     for FnvHashMap<ExchangeId, UnindexedAccountSnapshot>
 {
@@ -246,12 +259,21 @@ impl<GlobalData, InstrumentData> From<&EngineState<GlobalData, InstrumentData>>
             instruments,
         } = value;
 
-        // Allocate appropriately
+        // Upper bound: venues without an account are skipped below.
         let mut snapshots =
             FnvHashMap::with_capacity_and_hasher(connectivity.exchanges.len(), Default::default());
 
-        // Insert UnindexedAccountSnapshot for each exchange
-        for (index, exchange) in connectivity.exchange_ids().enumerate() {
+        // Insert UnindexedAccountSnapshot for each exchange that holds an account.
+        //
+        // `enumerate` deliberately runs *before* the role filter. `ExchangeIndex` is positional
+        // into `connectivity.exchanges`, so numbering only the surviving venues would shift every
+        // index past the first skipped one and silently attribute one exchange's instruments to
+        // another.
+        for (index, (exchange, state)) in connectivity.exchanges.iter().enumerate() {
+            if !state.role.has_account() {
+                continue;
+            }
+
             snapshots.insert(
                 *exchange,
                 UnindexedAccountSnapshot {
@@ -273,5 +295,42 @@ impl<GlobalData, InstrumentData> From<&EngineState<GlobalData, InstrumentData>>
         }
 
         snapshots
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::engine::state::EngineState;
+    use rustrade_instrument::{
+        instrument::data_venue::DataVenue, test_utils::instrument as test_instrument,
+    };
+
+    const DATA: ExchangeId = ExchangeId::BinanceSpot;
+    const EXECUTION: ExchangeId = ExchangeId::Coinbase;
+
+    #[test]
+    fn account_snapshots_omit_a_data_only_venue_and_keep_the_execution_venues_instruments() {
+        // Priced on DATA, executed on EXECUTION: DATA is tracked for connectivity but holds no
+        // account at all.
+        let instruments = IndexedInstruments::new([test_instrument(EXECUTION, "btc", "usdt")
+            .with_data_venue(DataVenue::new_same_name(DATA))]);
+        let state: EngineState<(), ()> = EngineState::builder(&instruments, (), |_| ()).build();
+
+        let snapshots = FnvHashMap::<ExchangeId, UnindexedAccountSnapshot>::from(&state);
+
+        assert!(
+            !snapshots.contains_key(&DATA),
+            "a data-only venue has no account, so it must be absent rather than empty"
+        );
+        assert_eq!(snapshots.len(), 1);
+
+        // Guards the enumerate-before-filter ordering: `DATA` sorts ahead of `EXECUTION`, so
+        // numbering the surviving venues instead would hand `EXECUTION` the skipped venue's
+        // `ExchangeIndex` and its instrument list would come back empty.
+        let execution = snapshots.get(&EXECUTION).unwrap();
+        assert_eq!(execution.exchange, EXECUTION);
+        assert_eq!(execution.instruments.len(), 1);
     }
 }

--- a/rustrade/src/engine/state/mod.rs
+++ b/rustrade/src/engine/state/mod.rs
@@ -3,7 +3,7 @@ use crate::engine::{
     state::{
         asset::{AssetStates, filter::AssetFilter},
         builder::EngineStateBuilder,
-        connectivity::ConnectivityStates,
+        connectivity::{ConnectivityStates, UntrackedExchange},
         instrument::{
             InstrumentStates, data::InstrumentDataState, filter::InstrumentFilter,
             generate_unindexed_instrument_account_snapshot,
@@ -200,16 +200,27 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
     ///   [`InstrumentState::update_from_market`](instrument::InstrumentState::update_from_market),
     ///   which updates its [`InstrumentDataState`] and then, for each open position, re-computes
     ///   `pnl_unrealised` and advances `time_exchange_update` from the new market price.
+    ///
+    /// # Errors
+    /// Returns [`UntrackedExchange`](connectivity::UntrackedExchange) if the event is tagged with an
+    /// exchange the engine was not built against. Nothing is mutated and the event is dropped —
+    /// see that type for why the instrument update is skipped too, rather than merely the
+    /// connectivity one.
     pub fn update_from_market(
         &mut self,
         event: &MarketEvent<InstrumentIndex, InstrumentData::MarketEventKind>,
-    ) where
+    ) -> Result<(), UntrackedExchange>
+    where
         GlobalData:
             for<'a> Processor<&'a MarketEvent<InstrumentIndex, InstrumentData::MarketEventKind>>,
         InstrumentData: InstrumentDataState,
     {
-        // Set exchange market data connectivity to Healthy if it was Reconnecting
-        self.connectivity.update_from_market_event(&event.exchange);
+        // Set exchange market data connectivity to Healthy if it was Reconnecting. Resolved first,
+        // and propagated rather than logged: the `InstrumentIndex` on an event from an untracked
+        // exchange is not ours to trust either, and `instrument_index_mut` below is a positional
+        // lookup that would panic on it -- or silently credit the print to another instrument.
+        self.connectivity
+            .update_from_market_event(&event.exchange)?;
 
         let instrument_state = self.instruments.instrument_index_mut(&event.instrument);
 
@@ -218,6 +229,8 @@ impl<GlobalData, InstrumentData> EngineState<GlobalData, InstrumentData> {
         // `pnl_unrealised` + advances `time_exchange_update` — previously only `data.process` ran,
         // leaving `pnl_unrealised` stale between fills despite its documented per-tick contract.
         instrument_state.update_from_market(event);
+
+        Ok(())
     }
 }
 

--- a/rustrade/src/execution/builder.rs
+++ b/rustrade/src/execution/builder.rs
@@ -451,8 +451,8 @@ impl IntoIterator for ExecutionHandles {
 /// why, and for the balances a caller must fund.
 ///
 /// [`MockExchange`]: rustrade_execution::exchange::mock::MockExchange
-#[allow(clippy::unwrap_used)]
 // Invariant: IndexedInstruments - all referenced assets exist; panics for unsupported InstrumentKind
+#[allow(clippy::unwrap_used)]
 fn generate_mock_exchange_instruments(
     instruments: &IndexedInstruments,
     exchange: ExchangeId,

--- a/rustrade/src/execution/builder.rs
+++ b/rustrade/src/execution/builder.rs
@@ -643,11 +643,16 @@ mod tests {
     use rustrade_instrument::{
         asset::Asset,
         index::builder::IndexedInstrumentsBuilder,
-        instrument::{kind::future::FutureContract, quote::InstrumentQuoteAsset},
+        instrument::{
+            data_venue::DataVenue, kind::future::FutureContract, quote::InstrumentQuoteAsset,
+        },
         test_utils::asset,
     };
 
     const EXCHANGE: ExchangeId = ExchangeId::LseCfd;
+
+    /// A venue that only ever prices the fixture instrument.
+    const DATA_VENUE: ExchangeId = ExchangeId::LseEquities;
 
     fn at(raw: &str) -> DateTime<Utc> {
         raw.parse().unwrap()
@@ -655,16 +660,36 @@ mod tests {
 
     /// A single `spx500_usd` instrument of the given kind, registered on [`EXCHANGE`].
     fn instruments(kind: InstrumentKind<Asset>) -> IndexedInstruments {
+        build_instruments(kind, None)
+    }
+
+    /// As [`instruments`], but priced on [`DATA_VENUE`] while still executed on [`EXCHANGE`], so
+    /// the two venues are distinguishable.
+    fn instruments_priced_on_another_venue(kind: InstrumentKind<Asset>) -> IndexedInstruments {
+        build_instruments(kind, Some(DATA_VENUE))
+    }
+
+    fn build_instruments(
+        kind: InstrumentKind<Asset>,
+        data_venue: Option<ExchangeId>,
+    ) -> IndexedInstruments {
+        let instrument = Instrument::new(
+            EXCHANGE,
+            "spx500_usd",
+            "spx500_usd",
+            Underlying::new(asset("spx500"), asset("usd")),
+            InstrumentQuoteAsset::UnderlyingQuote,
+            kind,
+            None,
+        );
+
+        let instrument = match data_venue {
+            Some(exchange) => instrument.with_data_venue(DataVenue::new_same_name(exchange)),
+            None => instrument,
+        };
+
         IndexedInstrumentsBuilder::default()
-            .add_instrument(Instrument::new(
-                EXCHANGE,
-                "spx500_usd",
-                "spx500_usd",
-                Underlying::new(asset("spx500"), asset("usd")),
-                InstrumentQuoteAsset::UnderlyingQuote,
-                kind,
-                None,
-            ))
+            .add_instrument(instrument)
             .build()
     }
 
@@ -800,8 +825,15 @@ mod tests {
             message.contains("future"),
             "the error must name the offending kind, got: {message}"
         );
+        // Asserted on the tail alone, after the "It supports: " marker. `EXCHANGE` renders as
+        // "lse_cfd" and the message leads with it, so a bare `contains("cfd")` over the whole
+        // string passes on the venue name even if the client declared no `Cfd` support at all.
+        let supported = message
+            .split_once("It supports: ")
+            .expect("the error must name the supported kinds")
+            .1;
         assert!(
-            message.contains("spot") && message.contains("cfd"),
+            supported.contains("spot") && supported.contains("cfd"),
             "the error must name the kinds that would work, got: {message}"
         );
     }
@@ -811,14 +843,27 @@ mod tests {
     /// adding a data venue could break an execution setup that trades nothing on it.
     #[test]
     fn validation_ignores_instruments_executed_on_another_exchange() {
-        let instruments = instruments(future());
+        // The instrument is priced on `DATA_VENUE` and executed on `EXCHANGE`, so the two
+        // predicates disagree: filtering on `data_exchange()` instead of `exchange` would reject
+        // this build. A fixture with no `DataVenue` cannot tell them apart, since its
+        // `data_exchange()` IS its execution venue.
+        let instruments = instruments_priced_on_another_venue(future());
 
         validate_supported_instrument_kinds(
             &instruments,
-            ExchangeId::BinanceSpot,
+            DATA_VENUE,
             &[InstrumentKindDiscriminant::Spot],
         )
         .expect("the Future is executed on EXCHANGE, not on the venue being validated");
+
+        // The other half of the same rule: at its execution venue it very much is this client's
+        // concern, so the filter must not be inert.
+        validate_supported_instrument_kinds(
+            &instruments,
+            EXCHANGE,
+            &[InstrumentKindDiscriminant::Spot],
+        )
+        .expect_err("the Future is executed on EXCHANGE, so it must be judged there");
     }
 
     /// Each distinct offending kind is reported once, in a deterministic order, rather than once

--- a/rustrade/src/execution/builder.rs
+++ b/rustrade/src/execution/builder.rs
@@ -460,6 +460,10 @@ fn generate_mock_exchange_instruments(
                     quote,
                     kind,
                     spec,
+                    // Bound explicitly rather than via `..` so a future `Instrument` field forces a
+                    // decision here instead of being silently dropped from the projection. See the
+                    // construction below for why this one is.
+                    data_venue: _,
                 } = instrument;
 
                 let kind = match kind {
@@ -546,6 +550,11 @@ fn generate_mock_exchange_instruments(
                     quote: *quote,
                     kind,
                     spec,
+                    // Deliberately dropped. This projection describes the instrument to the
+                    // `MockExchange`, which fills orders — a `DataVenue` states where *prices* are
+                    // sourced from, which the mock neither reads nor can act on. Carrying it here
+                    // would imply the mock fills against that venue, which it does not.
+                    data_venue: None,
                 };
 
                 Some((instrument.name_exchange.clone(), instrument))

--- a/rustrade/src/execution/builder.rs
+++ b/rustrade/src/execution/builder.rs
@@ -29,13 +29,13 @@ use rustrade_instrument::{
     index::IndexedInstruments,
     instrument::{
         Instrument, InstrumentIndex,
-        kind::{InstrumentKind, cfd::CfdContract},
+        kind::{InstrumentKind, InstrumentKindDiscriminant, cfd::CfdContract},
         name::InstrumentNameExchange,
         spec::{InstrumentSpec, InstrumentSpecQuantity, OrderQuantityUnits},
     },
 };
 use rustrade_integration::channel::{Channel, UnboundedTx, mpsc_unbounded};
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{collections::BTreeSet, pin::Pin, sync::Arc, time::Duration};
 use tokio::{
     sync::{broadcast, mpsc},
     task::{AbortHandle, JoinError, JoinHandle},
@@ -89,21 +89,23 @@ impl<'a> ExecutionBuilder<'a> {
     /// The provided [`MockExecutionConfig`] is used to configure the [`MockExchange`] and provide
     /// the initial account state.
     ///
-    /// # Panics
-    /// Despite returning a `Result`, this **panics** if any indexed instrument on `mocked_exchange`
-    /// has an [`InstrumentKind`] other than `Spot` or `Cfd`. `MockExchange` models no expiry,
-    /// funding or contract chain, so a `Perpetual`, `Future` or `Option` has no faithful
-    /// projection. The panic happens here, at build time, rather than at first order — an
-    /// unbacktestable instrument set is a configuration error, and deferring it would surface as a
-    /// rejected order mid-run.
+    /// # Errors
+    /// Returns [`BarterError::ExecutionBuilder`] if any indexed instrument executed on
+    /// `mocked_exchange` has an [`InstrumentKind`] other than `Spot` or `Cfd`, per
+    /// [`MockExecution::SUPPORTED_KINDS`]. `MockExchange` models no expiry, funding or contract
+    /// chain, so a `Perpetual`, `Future` or `Option` has no faithful projection. This is rejected
+    /// here, at build time, rather than at first order — an unbacktestable instrument set is a
+    /// configuration error, and deferring it would surface as a rejected order mid-run.
     ///
-    /// It also panics if an instrument references a settlement asset absent from the index, which
+    /// # Panics
+    /// Panics if an instrument references a settlement asset absent from the index, which
     /// [`IndexedInstruments`] construction already rules out.
     ///
     /// [`InstrumentKind`]: rustrade_instrument::instrument::kind::InstrumentKind
+    /// [`MockExecution::SUPPORTED_KINDS`]: rustrade_execution::client::ExecutionClient::SUPPORTED_KINDS
     /// [`IndexedInstruments`]: rustrade_instrument::index::IndexedInstruments
     pub fn add_mock<Clock>(
-        mut self,
+        self,
         config: MockExecutionConfig,
         clock: Clock,
     ) -> Result<Self, BarterError>
@@ -123,15 +125,22 @@ impl<'a> ExecutionBuilder<'a> {
             event_rx,
         };
 
-        // Register MockExchange init Future
-        let mock_exchange_future = self.init_mock_exchange(config, request_rx, event_tx);
-        self.mock_exchange_futures.push(mock_exchange_future);
-
-        self.add_execution::<MockExecution<_>>(
+        // `add_execution` runs first so its supported-kind check rejects an unbacktestable
+        // instrument set before `init_mock_exchange` projects it. The projection panics on a kind
+        // the mock cannot model, so building it first would turn a returnable `Err` into an abort.
+        // The two futures are collected into separate queues, so their relative order is
+        // immaterial to the built infrastructure.
+        let mut this = self.add_execution::<MockExecution<_>>(
             mock_execution_client_config.mocked_exchange,
             mock_execution_client_config,
             DUMMY_EXECUTION_REQUEST_TIMEOUT,
-        )
+        )?;
+
+        // Register MockExchange init Future
+        let mock_exchange_future = this.init_mock_exchange(config, request_rx, event_tx);
+        this.mock_exchange_futures.push(mock_exchange_future);
+
+        Ok(this)
     }
 
     fn init_mock_exchange(
@@ -170,6 +179,8 @@ impl<'a> ExecutionBuilder<'a> {
         Client::AccountStream: Send,
         Client::Config: Send,
     {
+        validate_supported_instrument_kinds(self.instruments, exchange, Client::SUPPORTED_KINDS)?;
+
         let instrument_map = generate_execution_instrument_map(self.instruments, exchange)?;
 
         let (execution_tx, execution_rx) = mpsc_unbounded();
@@ -426,6 +437,11 @@ impl IntoIterator for ExecutionHandles {
 /// limit of the mock — it fills at price × quantity with no expiry, settlement or contract chain —
 /// not a statement about which kinds are executable in general.
 ///
+/// The same limit is declared as `MockExecution::SUPPORTED_KINDS`, which
+/// [`ExecutionBuilder::add_mock`] checks first, so through the builder an unsupported kind is a
+/// returned error and this panic is unreachable. Keep the two in step: widening `SUPPORTED_KINDS`
+/// without widening the match below converts that error back into a panic.
+///
 /// `Cfd` is supported because the mock accounts for a cash-settled position directly: it applies
 /// `contract_size` to the notional and the fee, and debits the **quote** asset in both directions.
 /// Without it every CFD-quoted dataset would panic at execution-build time and be unbacktestable.
@@ -435,7 +451,8 @@ impl IntoIterator for ExecutionHandles {
 /// why, and for the balances a caller must fund.
 ///
 /// [`MockExchange`]: rustrade_execution::exchange::mock::MockExchange
-#[allow(clippy::unwrap_used)] // Invariant: IndexedInstruments - all referenced assets exist; panics for unsupported InstrumentKind
+#[allow(clippy::unwrap_used)]
+// Invariant: IndexedInstruments - all referenced assets exist; panics for unsupported InstrumentKind
 fn generate_mock_exchange_instruments(
     instruments: &IndexedInstruments,
     exchange: ExchangeId,
@@ -480,6 +497,12 @@ fn generate_mock_exchange_instruments(
                             .name_exchange
                             .clone(),
                     }),
+                    // Unreachable through `ExecutionBuilder`: `add_execution` rejects a kind
+                    // outside `MockExecution::SUPPORTED_KINDS` before this projection runs. Kept as
+                    // an assertion rather than a silent skip so that a `SUPPORTED_KINDS` widened
+                    // past what this match can project fails loudly here instead of dropping the
+                    // instrument from the mock exchange, which would look like a venue that simply
+                    // never fills it.
                     unsupported => {
                         panic!("MockExchange does not support: {unsupported:?}")
                     }
@@ -561,6 +584,52 @@ fn generate_mock_exchange_instruments(
             },
         )
         .collect()
+}
+
+/// Rejects an instrument set containing a kind the execution client for `exchange` cannot trade.
+///
+/// An [`ExecutionClient`] addresses instruments by [`InstrumentNameExchange`] and never inspects
+/// their [`InstrumentKind`], so an unsupported kind cannot fail at the type level. Left unchecked
+/// it surfaces at the first order, as a venue rejection or — where the wrong contract is nameable
+/// on the venue — as a fill against something the strategy did not intend to trade. Both are worse
+/// than refusing to build.
+///
+/// Only instruments whose **execution** venue is `exchange` are considered. An instrument merely
+/// priced on `exchange` (see [`Instrument::data_exchange`]) is never ordered through this client,
+/// so its kind is not this client's concern.
+///
+/// [`Instrument::data_exchange`]: rustrade_instrument::instrument::Instrument::data_exchange
+fn validate_supported_instrument_kinds(
+    instruments: &IndexedInstruments,
+    exchange: ExchangeId,
+    supported: &[InstrumentKindDiscriminant],
+) -> Result<(), BarterError> {
+    // BTreeSet so a set with many offending instruments reports each distinct kind once, in a
+    // deterministic order.
+    let unsupported = instruments
+        .instruments()
+        .iter()
+        .filter(|keyed| keyed.value.exchange.value == exchange)
+        .map(|keyed| keyed.value.kind.discriminant())
+        .filter(|kind| !supported.contains(kind))
+        .collect::<BTreeSet<_>>();
+
+    if unsupported.is_empty() {
+        return Ok(());
+    }
+
+    Err(BarterError::ExecutionBuilder(format!(
+        "{exchange} execution client cannot trade instrument kind(s): {}. It supports: {}",
+        join_kinds(unsupported.iter().copied()),
+        join_kinds(supported.iter().copied()),
+    )))
+}
+
+fn join_kinds(kinds: impl Iterator<Item = InstrumentKindDiscriminant>) -> String {
+    kinds
+        .map(|kind| kind.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 #[cfg(test)]
@@ -676,16 +745,14 @@ mod tests {
         assert_eq!(instrument.kind, InstrumentKind::Spot);
     }
 
-    /// The capability limit is real, not incidental: kinds the mock cannot fill still panic, so
-    /// adding `Cfd` did not quietly widen the mock to everything.
+    /// The projection's own assertion, reached here by calling it directly. Through
+    /// `ExecutionBuilder` this input is rejected earlier — see
+    /// `add_mock_rejects_an_unsupported_kind_without_panicking` — so this pins the inner guard
+    /// against a future `SUPPORTED_KINDS` that outgrows what the match can project.
     #[test]
     #[should_panic(expected = "MockExchange does not support")]
     fn mock_instruments_panic_on_an_unsupported_kind() {
-        let instruments = instruments(InstrumentKind::Future(FutureContract {
-            contract_size: dec!(1),
-            settlement_asset: asset("usd"),
-            expiry: at("2025-06-27T00:00:00Z"),
-        }));
+        let instruments = instruments(future());
 
         let _ = generate_mock_exchange_instruments(&instruments, EXCHANGE);
     }
@@ -699,5 +766,100 @@ mod tests {
         let mocked = generate_mock_exchange_instruments(&instruments, ExchangeId::BinanceSpot);
 
         assert!(mocked.is_empty());
+    }
+
+    fn future() -> InstrumentKind<Asset> {
+        InstrumentKind::Future(FutureContract {
+            contract_size: dec!(1),
+            settlement_asset: asset("usd"),
+            expiry: at("2025-06-27T00:00:00Z"),
+        })
+    }
+
+    /// The behaviour `SUPPORTED_KINDS` exists to produce: a kind the mock cannot model is a
+    /// returnable configuration error, not an abort. Asserting on `add_mock` rather than the
+    /// validator is deliberate — it pins the ordering against `init_mock_exchange`, whose
+    /// projection still panics on the same input.
+    #[test]
+    fn add_mock_rejects_an_unsupported_kind_without_panicking() {
+        let instruments = instruments(future());
+
+        // `ExecutionBuilder` has no `Debug`, so the success arm cannot be unwrapped via
+        // `expect_err`.
+        let Err(error) = ExecutionBuilder::new(&instruments).add_mock(
+            mock_config(),
+            HistoricalClock::new(at("2025-03-24T22:00:00Z")),
+        ) else {
+            panic!("a Future instrument is not backtestable on MockExchange")
+        };
+
+        let BarterError::ExecutionBuilder(message) = error else {
+            panic!("expected an ExecutionBuilder error, got {error:?}")
+        };
+        assert!(
+            message.contains("future"),
+            "the error must name the offending kind, got: {message}"
+        );
+        assert!(
+            message.contains("spot") && message.contains("cfd"),
+            "the error must name the kinds that would work, got: {message}"
+        );
+    }
+
+    /// Only the *execution* venue's instruments are the client's concern. An instrument executed
+    /// elsewhere but priced here must not be judged against this client's capabilities — otherwise
+    /// adding a data venue could break an execution setup that trades nothing on it.
+    #[test]
+    fn validation_ignores_instruments_executed_on_another_exchange() {
+        let instruments = instruments(future());
+
+        validate_supported_instrument_kinds(
+            &instruments,
+            ExchangeId::BinanceSpot,
+            &[InstrumentKindDiscriminant::Spot],
+        )
+        .expect("the Future is executed on EXCHANGE, not on the venue being validated");
+    }
+
+    /// Each distinct offending kind is reported once, in a deterministic order, rather than once
+    /// per instrument.
+    #[test]
+    fn validation_reports_each_unsupported_kind_once() {
+        let instruments = IndexedInstrumentsBuilder::default()
+            .add_instrument(Instrument::new(
+                EXCHANGE,
+                "a",
+                "a",
+                Underlying::new(asset("spx500"), asset("usd")),
+                InstrumentQuoteAsset::UnderlyingQuote,
+                future(),
+                None,
+            ))
+            .add_instrument(Instrument::new(
+                EXCHANGE,
+                "b",
+                "b",
+                Underlying::new(asset("ftse100"), asset("usd")),
+                InstrumentQuoteAsset::UnderlyingQuote,
+                future(),
+                None,
+            ))
+            .build();
+
+        let error = validate_supported_instrument_kinds(
+            &instruments,
+            EXCHANGE,
+            &[InstrumentKindDiscriminant::Spot],
+        )
+        .expect_err("both instruments are Futures on a spot-only client");
+
+        let BarterError::ExecutionBuilder(message) = error else {
+            panic!("expected an ExecutionBuilder error, got {error:?}")
+        };
+        assert_eq!(
+            message.matches("future").count(),
+            1,
+            "the offending kind must be deduplicated, got: {message}"
+        );
     }
 }

--- a/rustrade/src/lib.rs
+++ b/rustrade/src/lib.rs
@@ -206,7 +206,7 @@ pub enum EngineEvent<
     ///   and **panics on an unknown key** (consistent with the rest of the `EngineEvent` API), so
     ///   validate the key before constructing the event.
     /// - Supply the `policy` (matching the broker's rounding behaviour) and a resolved
-    ///   `effective_time` (see [`split_effective_instant`](rustrade_instrument::corporate_action::split_effective_instant)).
+    ///   `effective_time` (see [`split_effective_instant`]).
     /// - **Inject once**, after the broker has applied the action, before processing new fills on
     ///   the post-split scale.
     /// - A same-day **correction** is expressed as two distinct events with distinct `id`s — a

--- a/rustrade/src/strategy/algo.rs
+++ b/rustrade/src/strategy/algo.rs
@@ -4,6 +4,27 @@ use rustrade_instrument::{exchange::ExchangeIndex, instrument::InstrumentIndex};
 /// Strategy interface for generating algorithmic open and cancel order requests based on the
 /// current `EngineState`.
 ///
+/// # Orders need not name the instrument that motivated them
+/// [`Self::generate_algo_orders`] receives the whole state and returns orders keyed by arbitrary
+/// exchange and instrument keys. Nothing requires an order to name the instrument whose prices
+/// produced the signal, which is what lets a strategy decide on one instrument and trade another —
+/// a CFD or index proxy driving an order on the corresponding future, a spot series driving a
+/// perpetual.
+///
+/// Both instruments are registered as ordinary `Instrument`s and keep **separate** ledgers: the
+/// position and its `pnl_unrealised` live on the instrument the orders name, and the instrument that
+/// was merely priced holds no position. The conversion between them — hedge ratio, contract
+/// multiplier, quantity, basis — is a trading decision this trait cannot make for you, and an
+/// incorrect one produces a plausible-looking position rather than an error.
+///
+/// Register an execution client only for the venues actually traded on. Venues that supply prices
+/// alone have no account to connect to, and declaring them as execution venues would leave global
+/// connectivity permanently degraded — see
+/// [`EngineStateBuilder::execution_venues`](crate::engine::state::builder::EngineStateBuilder::execution_venues).
+///
+/// Contrast [`DataVenue`](rustrade_instrument::instrument::data_venue::DataVenue), which is for the
+/// different case of **one** instrument priced on a venue other than the one it trades on.
+///
 /// # Type Parameters
 /// * `ExchangeKey` - Type used to identify an exchange (defaults to [`ExchangeIndex`]).
 /// * `InstrumentKey` - Type used to identify an instrument (defaults to [`InstrumentIndex`]).

--- a/rustrade/src/system/builder.rs
+++ b/rustrade/src/system/builder.rs
@@ -237,12 +237,10 @@ impl<'a, Clock, Strategy, Risk, MarketStream, GlobalData, FnInstrumentData>
             )?
             .build();
 
-        // Venues that actually have an execution client, which is what decides whether the engine
-        // will ever receive an AccountStream event from them. Read before `execution_tx_map` is
-        // moved into the Engine below.
-        let execution_venues = (&execution.execution_tx_map)
-            .into_iter()
-            .filter_map(|(exchange, tx)| tx.as_ref().map(|_| *exchange))
+        // Read before `execution_tx_map` is moved into the Engine below.
+        let execution_venues = execution
+            .execution_tx_map
+            .execution_venues()
             .collect::<Vec<_>>();
 
         // Build EngineState
@@ -444,5 +442,91 @@ where
             feed_tx,
             audit,
         })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panicking on a bad fixture is acceptable
+mod tests {
+    use super::*;
+    use crate::{
+        EngineEvent,
+        engine::{
+            clock::HistoricalClock,
+            state::{
+                connectivity::VenueRole, global::DefaultGlobalData,
+                instrument::data::DefaultInstrumentMarketData,
+            },
+        },
+        risk::DefaultRiskManager,
+        strategy::DefaultStrategy,
+    };
+    use chrono::{DateTime, Utc};
+    use rustrade_execution::{AccountSnapshot, client::mock::MockExecutionConfig};
+    use rustrade_instrument::test_utils::instrument;
+
+    /// Prices an instrument nothing is traded on, and has no execution client.
+    const DATA: ExchangeId = ExchangeId::BinanceSpot;
+
+    /// Trades a different instrument, via the registered mock client.
+    const EXECUTION: ExchangeId = ExchangeId::Coinbase;
+
+    type TestState = EngineState<DefaultGlobalData, DefaultInstrumentMarketData>;
+
+    fn mock_config(exchange: ExchangeId) -> ExecutionConfig {
+        ExecutionConfig::Mock(MockExecutionConfig {
+            mocked_exchange: exchange,
+            initial_state: AccountSnapshot {
+                exchange,
+                balances: vec![],
+                instruments: vec![],
+            },
+            latency_ms: 0,
+            fee_model: Default::default(),
+            fill_model: Default::default(),
+        })
+    }
+
+    /// `SystemBuilder` derives the account dimension from the execution clients it registers, so a
+    /// venue that prices instruments without being traded on is not given an account connection to
+    /// wait on.
+    ///
+    /// The derivation itself is three lines with no other observer: invert the
+    /// `execution_tx_map` filter and every venue silently reverts to
+    /// [`VenueRole::Both`] — reinstating a run whose global connectivity never leaves
+    /// `Reconnecting`, on the live path.
+    #[test]
+    fn execution_venues_are_derived_from_the_registered_execution_clients() {
+        // Two-instrument pattern: `DATA` prices one instrument that is never traded, `EXECUTION`
+        // trades another. Both are some instrument's `exchange`, so only the registered clients can
+        // tell them apart.
+        let instruments = IndexedInstruments::new([
+            instrument(DATA, "xau", "usd"),
+            instrument(EXECUTION, "btc", "usdt"),
+        ]);
+
+        let args = SystemArgs::new(
+            &instruments,
+            vec![mock_config(EXECUTION)],
+            HistoricalClock::new(DateTime::<Utc>::MIN_UTC),
+            DefaultStrategy::<TestState>::default(),
+            DefaultRiskManager::<TestState>::default(),
+            futures::stream::empty::<EngineEvent>(),
+            DefaultGlobalData,
+            |_| DefaultInstrumentMarketData::default(),
+        );
+
+        let system = SystemBuilder::new(args)
+            .build::<EngineEvent, _>()
+            .expect("a system with one mock execution client must build");
+
+        let connectivity = &system.engine.state.connectivity;
+
+        assert_eq!(
+            connectivity.connectivity(&DATA).role,
+            VenueRole::DataOnly,
+            "no execution client was registered for the pricing venue, so it holds no account"
+        );
+        assert_eq!(connectivity.connectivity(&EXECUTION).role, VenueRole::Both);
     }
 }

--- a/rustrade/src/system/builder.rs
+++ b/rustrade/src/system/builder.rs
@@ -237,10 +237,19 @@ impl<'a, Clock, Strategy, Risk, MarketStream, GlobalData, FnInstrumentData>
             )?
             .build();
 
+        // Venues that actually have an execution client, which is what decides whether the engine
+        // will ever receive an AccountStream event from them. Read before `execution_tx_map` is
+        // moved into the Engine below.
+        let execution_venues = (&execution.execution_tx_map)
+            .into_iter()
+            .filter_map(|(exchange, tx)| tx.as_ref().map(|_| *exchange))
+            .collect::<Vec<_>>();
+
         // Build EngineState
         let state = EngineStateBuilder::new(instruments, global_data, instrument_data_init)
             .time_engine_start(clock.time())
             .trading_state(trading_state)
+            .execution_venues(execution_venues)
             .balances(
                 balances
                     .into_iter()

--- a/rustrade/src/system/config.rs
+++ b/rustrade/src/system/config.rs
@@ -10,6 +10,7 @@ use rustrade_instrument::{
     exchange::ExchangeId,
     instrument::{
         Instrument,
+        data_venue::DataVenue,
         kind::{
             InstrumentKind, cfd::CfdContract, future::FutureContract, option::OptionContract,
             perpetual::PerpetualContract,
@@ -53,6 +54,13 @@ pub struct InstrumentConfig {
 
     /// Optional additional specifications for the instrument.
     pub spec: Option<InstrumentSpec<AssetNameExchange>>,
+
+    /// Optional venue to source this instrument's market data from, when it differs from
+    /// `exchange` — see [`DataVenue`].
+    ///
+    /// Defaulted so every config written before this field existed still deserialises.
+    #[serde(default)]
+    pub data_venue: Option<DataVenue<ExchangeId>>,
 }
 
 /// Configuration for an execution link.
@@ -135,6 +143,7 @@ impl From<InstrumentConfig> for Instrument<ExchangeId, Asset> {
                 },
                 notional: spec.notional,
             }),
+            data_venue: value.data_venue,
         }
     }
 }

--- a/rustrade/tests/test_backtest_connectivity_roles.rs
+++ b/rustrade/tests/test_backtest_connectivity_roles.rs
@@ -1,0 +1,208 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics acceptable
+
+//! Integration coverage for the venue roles a [`backtest`] run derives for itself.
+//!
+//! `backtest` receives a **pre-built** `EngineState` but builds its own execution clients, one set
+//! per run — so it is the only component that knows both which venues hold instruments and which
+//! of them anything actually executes on. It reconciles the two on its own clone of the state.
+//!
+//! The property under test is the one a split configuration depends on: a venue registered purely
+//! so its prices are available must not be given an account connection to wait on. Getting
+//! it wrong errors nowhere — the run completes with global connectivity pinned at `Reconnecting`
+//! and every strategy that gates on it gated for the whole run — which is exactly why it needs a
+//! test rather than a reviewer.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use rustrade::{
+    backtest::{
+        BacktestArgsConstant, BacktestArgsDynamic, aux_events::NoAuxEvents, backtest,
+        market_data::MarketDataInMemory,
+    },
+    engine::state::{
+        EngineState,
+        builder::EngineStateBuilder,
+        connectivity::{Health, VenueRole},
+        global::DefaultGlobalData,
+        instrument::data::DefaultInstrumentMarketData,
+        trading::TradingState,
+    },
+    risk::DefaultRiskManager,
+    statistic::time::Daily,
+    strategy::DefaultStrategy,
+    system::config::ExecutionConfig,
+};
+use rustrade_data::{
+    event::{DataKind, MarketEvent},
+    streams::consumer::MarketStreamEvent,
+    subscription::trade::PublicTrade,
+};
+use rustrade_execution::{AccountSnapshot, client::mock::MockExecutionConfig};
+use rustrade_instrument::{
+    exchange::ExchangeId, index::IndexedInstruments, instrument::InstrumentIndex,
+    test_utils::instrument,
+};
+
+/// Prices the instrument. Nothing is executed here, and no execution client is registered for it.
+const DATA: ExchangeId = ExchangeId::LseEquities;
+
+/// Executes the instrument. No market data subscription is ever made to it.
+const EXECUTION: ExchangeId = ExchangeId::BinanceSpot;
+
+type BacktestState = EngineState<DefaultGlobalData, DefaultInstrumentMarketData>;
+
+fn ts(raw: &str) -> DateTime<Utc> {
+    raw.parse().unwrap()
+}
+
+/// The two-instrument pattern: one instrument priced on [`DATA`] and never traded, driving orders
+/// on a *different* instrument traded on [`EXECUTION`].
+///
+/// This — rather than a single instrument carrying a [`DataVenue`] — is the configuration the
+/// instrument model alone gets wrong. `DATA` is the `Instrument::exchange` of the priced
+/// instrument, so the model claims it holds an account; only the execution clients can say
+/// otherwise. (A dual-venue instrument names `EXECUTION` as its `exchange`, so `DATA` never looks
+/// like an account-holding venue in the first place.)
+fn instruments() -> IndexedInstruments {
+    IndexedInstruments::new([
+        instrument(DATA, "xau", "usd"),
+        instrument(EXECUTION, "btc", "usdt"),
+    ])
+}
+
+/// Trades for the instrument priced on [`DATA`], tagged with that venue.
+fn market_events(
+    instruments: &IndexedInstruments,
+) -> Vec<MarketStreamEvent<InstrumentIndex, DataKind>> {
+    // Resolved rather than hardcoded: `InstrumentIndex` is assigned by sort order, so an
+    // `ExchangeId` declared later would silently re-point a literal index at the other instrument.
+    let priced = instruments
+        .instruments()
+        .iter()
+        .find(|keyed| keyed.value.data_exchange().value == DATA)
+        .expect("the fixture prices one instrument on DATA")
+        .key;
+
+    ["2025-03-24T22:00:00Z", "2025-03-24T22:30:00Z"]
+        .into_iter()
+        .map(|time| {
+            let time = ts(time);
+            MarketStreamEvent::Item(MarketEvent {
+                time_exchange: time,
+                time_received: time,
+                exchange: DATA,
+                instrument: priced,
+                kind: DataKind::Trade(PublicTrade {
+                    id: "trade".into(),
+                    price: dec!(3_000),
+                    amount: dec!(0.01),
+                    side: None,
+                }),
+            })
+        })
+        .collect()
+}
+
+fn mock_config() -> MockExecutionConfig {
+    MockExecutionConfig {
+        mocked_exchange: EXECUTION,
+        initial_state: AccountSnapshot {
+            exchange: EXECUTION,
+            balances: vec![],
+            instruments: vec![],
+        },
+        latency_ms: 0,
+        fee_model: Default::default(),
+        fill_model: Default::default(),
+    }
+}
+
+fn engine_state(instruments: &IndexedInstruments) -> BacktestState {
+    // Deliberately built WITHOUT `execution_venues`: the caller is not required to declare them,
+    // and this is the state shape every pre-existing backtest supplies.
+    EngineStateBuilder::new(instruments, DefaultGlobalData, |_| {
+        DefaultInstrumentMarketData::default()
+    })
+    .time_engine_start(ts("2025-03-24T22:00:00Z"))
+    .trading_state(TradingState::Enabled)
+    .build()
+}
+
+fn args_dynamic(
+    id: &str,
+) -> BacktestArgsDynamic<DefaultStrategy<BacktestState>, DefaultRiskManager<BacktestState>> {
+    BacktestArgsDynamic {
+        id: id.into(),
+        risk_free_return: Decimal::ZERO,
+        strategy: DefaultStrategy::default(),
+        risk: DefaultRiskManager::default(),
+    }
+}
+
+/// The pricing venue is marked [`VenueRole::DataOnly`] from the execution clients the run built,
+/// even though the supplied state could not know that — and the supplied state is left untouched.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn backtest_derives_venue_roles_from_the_execution_clients_it_builds() {
+    let instruments = instruments();
+    let engine_state = engine_state(&instruments);
+
+    // The state alone cannot tell that nothing executes on `DATA`: the instrument model says only
+    // that some instrument is priced there. This is what the run has to correct.
+    assert_eq!(
+        engine_state.connectivity.connectivity(&DATA).role,
+        VenueRole::Both
+    );
+
+    let market_data = MarketDataInMemory::new(Arc::new(market_events(&instruments)));
+
+    let args_constant = Arc::new(BacktestArgsConstant {
+        instruments,
+        executions: vec![ExecutionConfig::Mock(mock_config())],
+        market_data,
+        summary_interval: Daily,
+        engine_state,
+        aux_events: NoAuxEvents,
+    });
+
+    let result = backtest(Arc::clone(&args_constant), args_dynamic("venue-roles"))
+        .await
+        .expect("a backtest with a pricing-only venue must complete");
+
+    let connectivity = &result.engine_state.connectivity;
+
+    assert_eq!(
+        connectivity.connectivity(&DATA).role,
+        VenueRole::DataOnly,
+        "no execution client was registered for the pricing venue, so it holds no account"
+    );
+    assert_eq!(
+        connectivity.connectivity(&EXECUTION).role,
+        VenueRole::Both,
+        "the traded instrument is priced on its own venue, so that venue provides both dimensions"
+    );
+
+    // The consequence, and the whole point: the pricing venue is fully healthy on its market data
+    // connection alone. Approximated as `Both` it would sit at `Reconnecting` forever, since no
+    // account event can arrive from a venue with no execution client.
+    assert_eq!(
+        connectivity.connectivity(&DATA).market_data,
+        Health::Healthy,
+        "the run fed market events tagged with the pricing venue"
+    );
+    assert!(connectivity.connectivity(&DATA).all_healthy());
+
+    // `BacktestArgsConstant` is shared across a whole sweep, so the reconciliation must apply to
+    // the run's own clone.
+    assert_eq!(
+        args_constant
+            .engine_state
+            .connectivity
+            .connectivity(&DATA)
+            .role,
+        VenueRole::Both,
+        "the caller's state must not be modified"
+    );
+}

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -5526,6 +5526,113 @@ fn test_untracked_exchange_market_item_is_reported_without_resolving_its_instrum
     );
 }
 
+/// Live engine vs audit-replica parity across all three `UntrackedExchange` paths.
+///
+/// The replica arm **discards** each `Result` (`let _untracked = …`), on the reasoning that its
+/// `ConnectivityStates` is a clone of the live engine's, so the same lookup against the same map
+/// reaches the same verdict from the event alone — and on `Err` neither side mutates. That holds by
+/// inspection today, but it is the only conditional replica arm in `update_from_event` with no
+/// parity test behind it, and `AuditMode::Enabled` is a live-trading mode `backtest` never
+/// exercises (it hardcodes `Disabled`). Without this, someone threading new `on_disconnect`-adjacent
+/// state through the replica would ship the divergence and discover it in production rather than in
+/// CI.
+#[test]
+fn test_untracked_exchange_replica_parity_across_all_three_paths() {
+    use rustrade::engine::audit::{
+        AuditTick, EngineAudit, context::EngineContext, state_replica::StateReplicaManager,
+    };
+
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine(TradingState::Disabled, execution_tx);
+
+    const UNTRACKED: ExchangeId = ExchangeId::Coinbase;
+
+    // Seed the replica from the engine's own starting state, so the two maps genuinely share a key
+    // set — the premise the discard relies on.
+    let seed_tick: AuditTick<_, EngineContext> = AuditTick {
+        event: engine.state.clone(),
+        context: EngineContext {
+            time: STARTING_TIMESTAMP,
+            sequence: Sequence(0),
+        },
+    };
+    let dummy_updates: DummyAuditUpdates = std::iter::empty();
+    let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
+
+    let drive = |engine: &mut TestEngine,
+                 replica: &mut StateReplicaManager<_, DummyAuditUpdates>,
+                 event: EngineEvent<DataKind>| {
+        let audit_tick = process_with_audit(engine, event.clone());
+        let outputs = match &audit_tick.event {
+            EngineAudit::Process(audit) => audit.outputs.clone(),
+            _ => panic!("expected EngineAudit::Process"),
+        };
+        replica.update_from_event(event, &outputs);
+    };
+
+    // Non-vacuity first: a TRACKED market event moves connectivity off its default on both sides.
+    // Without this the parity assertions below would compare two states neither side ever touched,
+    // and would pass even if `update_from_event` ignored connectivity entirely.
+    drive(
+        &mut engine,
+        &mut replica_manager,
+        market_event_trade(1, 0, dec!(100)),
+    );
+    assert_eq!(
+        engine
+            .state
+            .connectivity
+            .connectivity(&ExchangeId::BinanceSpot)
+            .market_data,
+        Health::Healthy,
+        "the tracked event must actually mutate, or the parity asserts below are vacuous"
+    );
+    assert_eq!(
+        replica_manager.replica_engine_state().connectivity,
+        engine.state.connectivity,
+    );
+
+    let connectivity_before = engine.state.connectivity.clone();
+
+    // All three paths, in the order they appear in `update_from_event`.
+    for event in [
+        EngineEvent::Account(AccountStreamEvent::Reconnecting(UNTRACKED)),
+        EngineEvent::Market(MarketStreamEvent::Reconnecting(UNTRACKED)),
+        // The market `Item` carries an `InstrumentIndex` from a collection neither side shares, so
+        // this also pins that the replica stops before its own positional lookup.
+        EngineEvent::Market(MarketStreamEvent::Item(MarketEvent {
+            time_exchange: time_plus_days(STARTING_TIMESTAMP, 2),
+            time_received: time_plus_days(STARTING_TIMESTAMP, 2),
+            exchange: UNTRACKED,
+            instrument: InstrumentIndex(99),
+            kind: DataKind::Trade(PublicTrade {
+                id: "untracked".into(),
+                price: dec!(10_000),
+                amount: Decimal::ONE,
+                side: Some(Side::Buy),
+            }),
+        })),
+    ] {
+        drive(&mut engine, &mut replica_manager, event);
+    }
+
+    assert_eq!(
+        replica_manager.replica_engine_state().connectivity,
+        engine.state.connectivity,
+        "replica/live connectivity divergence across the untracked paths"
+    );
+    assert_eq!(
+        replica_manager.replica_engine_state().instruments,
+        engine.state.instruments,
+        "replica/live instrument divergence — the out-of-range index must not be dereferenced \
+         on either side"
+    );
+    assert_eq!(
+        engine.state.connectivity, connectivity_before,
+        "and none of the three may have mutated anything at all"
+    );
+}
+
 /// A `Reconnecting` event for an exchange the engine was never built against is **reported**, and
 /// nothing else happens: no `on_disconnect`, no connectivity mutation, no new tracked exchange.
 ///

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -4779,3 +4779,560 @@ fn test_corporate_action_floor_to_zero_prunes_hedging_routing() {
         "the late fill opens a fresh slot under the raw order id (no-mapping fallback)"
     );
 }
+
+/// Engine whose instrument set contains **two** split-eligible (`Spot`) instruments on the *same*
+/// `(exchange, base, quote)` identity, plus one option written on that underlying.
+///
+/// Post-sort indices (instruments on one exchange sort by `name_internal`):
+/// - `0` — the option `BTC-50000-C`
+/// - `1` — spot `BTCUSD`
+/// - `2` — spot `BTCUSD.ALT`, the second deliverable on the identical underlying
+///
+/// This is the registry shape a corporate action cannot be resolved against: either spot is an
+/// equally valid trigger for adjusting index 0, and nothing in the state says which one the option
+/// is written on.
+fn build_ambiguous_underlying_engine(
+    trading_state: TradingState,
+    execution_tx: UnboundedTx<ExecutionRequest>,
+) -> TestEngine {
+    let expiry = chrono::DateTime::parse_from_rfc3339("2030-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let instruments = IndexedInstruments::builder()
+        .add_instrument(Instrument::new(
+            ExchangeId::BinanceSpot,
+            "binance_btc_call_50k",
+            "BTC-50000-C",
+            Underlying::new("btc", "usd"),
+            rustrade_instrument::instrument::quote::InstrumentQuoteAsset::UnderlyingQuote,
+            InstrumentKind::Option(OptionContract {
+                contract_size: dec!(1),
+                settlement_asset: "usd".into(),
+                kind: OptionKind::Call,
+                exercise: OptionExercise::European,
+                expiry,
+                strike: dec!(50_000),
+            }),
+            None,
+        ))
+        .add_instrument(Instrument::spot(
+            ExchangeId::BinanceSpot,
+            "binance_spot_btc_usd",
+            "BTCUSD",
+            Underlying::new("btc", "usd"),
+            None,
+        ))
+        // Same exchange, same underlying pair, different listing — the ambiguity under test.
+        .add_instrument(Instrument::spot(
+            ExchangeId::BinanceSpot,
+            "binance_spot_btc_usd_alt",
+            "BTCUSD.ALT",
+            Underlying::new("btc", "usd"),
+            None,
+        ))
+        .build();
+
+    let clock = HistoricalClock::new(STARTING_TIMESTAMP);
+
+    let state = EngineState::builder(&instruments, DefaultGlobalData, |_| {
+        DefaultInstrumentMarketData::default()
+    })
+    .time_engine_start(STARTING_TIMESTAMP)
+    .trading_state(trading_state)
+    .oms_mode(OmsMode::Netting)
+    .balances([
+        (ExchangeId::BinanceSpot, "usd", STARTING_BALANCE_USDT),
+        (ExchangeId::BinanceSpot, "btc", STARTING_BALANCE_BTC),
+    ])
+    .build();
+
+    let execution_txs =
+        MultiExchangeTxMap::from_iter([(ExchangeId::BinanceSpot, Some(execution_tx))]);
+
+    Engine::new(
+        clock,
+        state,
+        execution_txs,
+        TestBuyAndHoldStrategy { id: strategy_id() },
+        DefaultRiskManager::default(),
+    )
+}
+
+/// Open a position on an arbitrary instrument index (the option helpers above are pinned to idx0).
+fn open_position_on(
+    engine: &mut TestEngine,
+    instrument: usize,
+    side: Side,
+    price: Decimal,
+    quantity: Decimal,
+    tag: &str,
+) {
+    let event = EngineEvent::Account(AccountStreamEvent::Item(AccountEvent {
+        exchange: ExchangeIndex(0),
+        kind: AccountEventKind::Trade(Trade {
+            id: TradeId::new(tag),
+            order_id: OrderId::new(tag),
+            instrument: InstrumentIndex(instrument),
+            strategy: strategy_id(),
+            time_exchange: time_plus_days(STARTING_TIMESTAMP, 1),
+            side,
+            price,
+            quantity,
+            // Quote asset of every instrument in the ambiguous fixture is usd = AssetIndex(1).
+            fees: AssetFees::new(AssetIndex(1), Decimal::ZERO, Some(Decimal::ZERO)),
+        }),
+    }));
+    engine.process(event);
+}
+
+/// A split whose target is **not the unique** split-eligible instrument on its
+/// `(base, quote, exchange)` is rejected with `AmbiguousSplitTarget` before anything is mutated.
+///
+/// The option chain a split must adjust is resolved by that identity alone, so a second deliverable
+/// listing is an equally valid trigger for adjusting the *same* chain — applying either would divide
+/// every strike on it once per trigger, silently for unheld options and recorded only against
+/// whichever instrument happened to be named. Rejecting is the only sound answer: nothing in the
+/// state can say which listing the options are written on.
+#[test]
+fn test_corporate_action_ambiguous_split_target_rejected_without_mutating() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_ambiguous_underlying_engine(TradingState::Disabled, execution_tx);
+
+    // Pin the post-sort layout the assertions below index by.
+    assert!(matches!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(0))
+            .instrument
+            .kind,
+        InstrumentKind::Option(_)
+    ));
+
+    // Marks for the option (idx0) and both spot listings (idx1, idx2).
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+    engine.process(market_event_trade(1, 2, dec!(60_000)));
+
+    // Held positions on the option and on the targeted spot, so a partial application would show.
+    open_position_on(&mut engine, 0, Side::Buy, dec!(1_000), dec!(2), "opt-open");
+    open_position_on(
+        &mut engine,
+        1,
+        Side::Buy,
+        dec!(50_000),
+        dec!(3),
+        "spot-open",
+    );
+
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // Rejected, attributed to the named target, with the ambiguity reason.
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::UnsupportedCorporateAction {
+                instrument,
+                reason: UnsupportedCorporateActionReason::AmbiguousSplitTarget,
+                ..
+            } if *instrument == InstrumentIndex(1)
+        )),
+        "an ambiguous split target must be rejected as AmbiguousSplitTarget"
+    );
+
+    // Nothing was mutated — not the targeted equity's position ...
+    let spot_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(1));
+    let spot_position = spot_state.position.positions.values().next().unwrap();
+    assert_eq!(spot_position.quantity_abs, dec!(3));
+    assert_eq!(spot_position.price_entry_average, dec!(50_000));
+
+    // ... nor the option chain the ambiguity makes unresolvable.
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(50_000));
+    let option_position = option_state.position.positions.values().next().unwrap();
+    assert_eq!(option_position.quantity_abs, dec!(2));
+
+    // The `id` is recorded nowhere, so the action stays retryable once the registry is corrected.
+    for idx in [InstrumentIndex(0), InstrumentIndex(1), InstrumentIndex(2)] {
+        assert!(
+            !engine
+                .state
+                .instruments
+                .instrument_index(&idx)
+                .corporate_actions_processed
+                .contains("BTCUSD-2-1-split"),
+            "a rejected action must record its id nowhere ({idx:?})"
+        );
+    }
+
+    // And no mutation observable was emitted alongside the rejection.
+    assert!(
+        !outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::OptionPositionAdjustedForSplit { .. }
+                | EngineOutput::SplitRemainder { .. }
+                | EngineOutput::OpenOrdersAtSplit { .. }
+                | EngineOutput::OptionPositionsRequireIdentityChange { .. }
+        )),
+        "a rejected split must emit no mutation observable"
+    );
+}
+
+/// A **held** option adjusted by a standard split records that action's `id` in its **own**
+/// `corporate_actions_processed`, and a second delivery of the same `id` therefore leaves it alone.
+///
+/// The target's set is cleared in between to reproduce the door this closes: a same-`id` replay
+/// whose record survived on the options but not on the equity (e.g. state restored from a snapshot
+/// taken before the field existed). Without the per-option record the chain is re-adjusted —
+/// strike divided twice, contracts doubled twice — with the equity's guard powerless to stop it.
+#[test]
+fn test_corporate_action_option_already_carrying_the_id_is_not_readjusted() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+
+    // First delivery: the option is adjusted in place AND records the id itself.
+    process_with_audit(&mut engine, ca_event.clone());
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(25_000));
+    assert!(
+        option_state
+            .corporate_actions_processed
+            .contains("BTCUSD-2-1-split"),
+        "an adjusted option must record the action id on its own set"
+    );
+
+    // Lose the TARGET's record only — its idempotency guard can no longer fire.
+    engine
+        .state
+        .instruments
+        .instrument_index_mut(&InstrumentIndex(1))
+        .corporate_actions_processed
+        .clear();
+
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    // The option is untouched by the second pass: strike NOT halved again, contracts NOT doubled.
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(25_000));
+    let position = option_state.position.positions.values().next().unwrap();
+    assert_eq!(position.quantity_abs, dec!(4));
+    assert_eq!(position.price_entry_average, dec!(500));
+
+    // The suppression is observable, not silent — per skipped option.
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::CorporateActionAlreadyProcessed { instrument, .. }
+                if *instrument == InstrumentIndex(0)
+        )),
+        "a suppressed option re-adjust must be surfaced, not silently dropped"
+    );
+    assert!(
+        !outputs
+            .iter()
+            .any(|o| matches!(o, EngineOutput::OptionPositionAdjustedForSplit { .. })),
+        "a suppressed option must emit no adjustment observable"
+    );
+
+    // The equity leg still ran (its own guard was cleared) — the option protection is independent
+    // of the target's record, which is the whole point of keeping it per-option.
+    assert!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(1))
+            .corporate_actions_processed
+            .contains("BTCUSD-2-1-split")
+    );
+}
+
+/// The same per-option record protects an **unheld** option — the case the original defect made
+/// silent, since an unheld option's strike fix emits no position observable at all. A second
+/// delivery of the same `id` must not divide its strike a second time (50_000 → 25_000, never
+/// → 12_500), or every position opened on it later mis-settles at expiry.
+#[test]
+fn test_corporate_action_unheld_option_strike_not_divided_twice_by_the_same_id() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // No option position is opened — the strike fix is the option's whole adjustment.
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+    };
+
+    process_with_audit(&mut engine, ca_event.clone());
+    assert!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(0))
+            .corporate_actions_processed
+            .contains("BTCUSD-2-1-split"),
+        "an unheld option's silent strike fix must still record the action id"
+    );
+
+    // Lose the target's record, then re-deliver the same action.
+    engine
+        .state
+        .instruments
+        .instrument_index_mut(&InstrumentIndex(1))
+        .corporate_actions_processed
+        .clear();
+    let audit_tick = process_with_audit(&mut engine, ca_event);
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(
+        contract.strike,
+        dec!(25_000),
+        "the unheld option's strike must not be divided a second time"
+    );
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::CorporateActionAlreadyProcessed { instrument, .. }
+                if *instrument == InstrumentIndex(0)
+        )),
+        "the suppressed strike fix must be surfaced"
+    );
+}
+
+/// Live engine vs audit-replica parity for the **rejection** path: an ambiguous split target must
+/// be refused identically by both, or the replica applies a split the live engine never did. Full
+/// `InstrumentState` equality across the whole ambiguous registry.
+#[test]
+fn test_corporate_action_replica_parity_ambiguous_split_target() {
+    use rustrade::engine::audit::{
+        AuditTick, EngineAudit, context::EngineContext, state_replica::StateReplicaManager,
+    };
+
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_ambiguous_underlying_engine(TradingState::Disabled, execution_tx);
+
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+    open_position_on(&mut engine, 0, Side::Buy, dec!(1_000), dec!(2), "opt-open");
+    open_position_on(
+        &mut engine,
+        1,
+        Side::Buy,
+        dec!(50_000),
+        dec!(3),
+        "spot-open",
+    );
+
+    let pre_split_state = engine.state.clone();
+
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+    let audit_tick = process_with_audit(&mut engine, ca_event.clone());
+
+    let seed_tick: AuditTick<_, EngineContext> = AuditTick {
+        event: pre_split_state,
+        context: EngineContext {
+            time: effective_time,
+            sequence: Sequence(0),
+        },
+    };
+    let dummy_updates: DummyAuditUpdates = std::iter::empty();
+    let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
+
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    replica_manager.update_from_event(ca_event, &outputs);
+
+    for idx in [InstrumentIndex(0), InstrumentIndex(1), InstrumentIndex(2)] {
+        let live = engine.state.instruments.instrument_index(&idx);
+        let replica = replica_manager
+            .replica_engine_state()
+            .instruments
+            .instrument_index(&idx);
+        assert_eq!(replica, live, "replica/live divergence at {idx:?}");
+    }
+
+    // Non-vacuous: the live engine really did reject, leaving the option chain at pre-split terms.
+    let InstrumentKind::Option(contract) = &engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0))
+        .instrument
+        .kind
+    else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(50_000));
+}
+
+/// Live engine vs audit-replica parity for the **per-option idempotency** path. The replica records
+/// the action `id` on each option it adjusts, exactly as the live handler does, so a re-delivered
+/// action is suppressed on both sides. A replica missing that record would divide the strike twice
+/// and diverge — which the strike assertion at the end makes non-vacuous.
+#[test]
+fn test_corporate_action_option_replica_parity_suppressed_readjust() {
+    use rustrade::engine::audit::{
+        AuditTick, EngineAudit, context::EngineContext, state_replica::StateReplicaManager,
+    };
+
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+    let pre_split_state = engine.state.clone();
+
+    let effective_time = time_plus_days(STARTING_TIMESTAMP, 10);
+    let ca_event = EngineEvent::CorporateAction {
+        id: "BTCUSD-2-1-split".into(),
+        instrument: InstrumentIndex(1),
+        kind: CorporateActionKind::StockSplit {
+            ratio: SplitRatio::new(dec!(2)).unwrap(),
+        },
+        policy: SplitRoundingPolicy::Floor,
+        effective_time,
+    };
+
+    let seed_tick: AuditTick<_, EngineContext> = AuditTick {
+        event: pre_split_state,
+        context: EngineContext {
+            time: effective_time,
+            sequence: Sequence(0),
+        },
+    };
+    let dummy_updates: DummyAuditUpdates = std::iter::empty();
+    let mut replica_manager = StateReplicaManager::new(seed_tick, dummy_updates);
+
+    // First delivery, driven through both.
+    let first_tick = process_with_audit(&mut engine, ca_event.clone());
+    let first_outputs = match &first_tick.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    replica_manager.update_from_event(ca_event.clone(), &first_outputs);
+
+    // Lose the TARGET's record on both sides, mirroring a snapshot restored without it.
+    engine
+        .state
+        .instruments
+        .instrument_index_mut(&InstrumentIndex(1))
+        .corporate_actions_processed
+        .clear();
+    replica_manager
+        .state_replica
+        .event
+        .instruments
+        .instrument_index_mut(&InstrumentIndex(1))
+        .corporate_actions_processed
+        .clear();
+
+    // Second delivery of the same action.
+    let second_tick = process_with_audit(&mut engine, ca_event.clone());
+    let second_outputs = match &second_tick.event {
+        EngineAudit::Process(audit) => audit.outputs.clone(),
+        _ => panic!("expected EngineAudit::Process"),
+    };
+    replica_manager.update_from_event(ca_event, &second_outputs);
+
+    for idx in [InstrumentIndex(0), InstrumentIndex(1)] {
+        let live = engine.state.instruments.instrument_index(&idx);
+        let replica = replica_manager
+            .replica_engine_state()
+            .instruments
+            .instrument_index(&idx);
+        assert_eq!(replica, live, "replica/live divergence at {idx:?}");
+    }
+
+    // Non-vacuous: one adjustment happened, not two.
+    let InstrumentKind::Option(contract) = &engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0))
+        .instrument
+        .kind
+    else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(25_000));
+}

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -5046,6 +5046,93 @@ fn test_corporate_action_ambiguous_split_target_rejected_without_mutating() {
     assert_eq!(contract.strike, dec!(50_000));
 }
 
+/// A target that is **both** ambiguous and arithmetically un-rescalable is reported as
+/// `AmbiguousSplitTarget`, pinning the order the two guards run in.
+///
+/// `prepare_corporate_action_split` scans for a second split-eligible listing *before* it walks the
+/// equity positions, so the reason a caller receives names the condition it can actually act on:
+/// the instrument registry is ambiguous, and no rescaling arithmetic — overflowing or not — was
+/// ever reachable. Reversed, the same action would be reported as `ArithmeticOverflow`, sending a
+/// caller after a position quantity when the registry is what needs correcting. Every other split
+/// fixture triggers exactly one guard, so nothing else distinguishes the two orderings.
+#[test]
+fn test_corporate_action_ambiguity_is_reported_ahead_of_overflow() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_ambiguous_underlying_engine(TradingState::Disabled, execution_tx);
+
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+    open_position_on(
+        &mut engine,
+        1,
+        Side::Buy,
+        dec!(50_000),
+        dec!(3),
+        "spot-open",
+    );
+
+    // Plant the same adversarial quantity as `test_corporate_action_pre_validation_rejects_
+    // arithmetic_overflow`, so the equity-position pass would overflow if it were ever reached.
+    engine
+        .state
+        .instruments
+        .instrument_index_mut(&InstrumentIndex(1))
+        .position
+        .positions
+        .values_mut()
+        .next()
+        .expect("spot position should exist")
+        .quantity_abs = Decimal::MAX;
+
+    let audit_tick = process_with_audit(
+        &mut engine,
+        EngineEvent::CorporateAction {
+            id: "BTCUSD-2-1-split-ambiguous-and-overflowing".into(),
+            instrument: InstrumentIndex(1),
+            kind: CorporateActionKind::StockSplit {
+                ratio: SplitRatio::new(dec!(2)).unwrap(),
+            },
+            policy: SplitRoundingPolicy::Floor,
+            effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+        },
+    );
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    let rejections: Vec<_> = outputs
+        .iter()
+        .filter_map(|o| match o {
+            EngineOutput::UnsupportedCorporateAction {
+                instrument, reason, ..
+            } => Some((*instrument, *reason)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rejections.len(), 1, "expected exactly one rejection");
+    assert_eq!(rejections[0].0, InstrumentIndex(1));
+    assert_eq!(
+        rejections[0].1,
+        UnsupportedCorporateActionReason::AmbiguousSplitTarget,
+        "the ambiguity guard must run before the position arithmetic"
+    );
+
+    // Atomic on both counts: the planted quantity is left exactly as planted.
+    assert_eq!(
+        engine
+            .state
+            .instruments
+            .instrument_index(&InstrumentIndex(1))
+            .position
+            .positions
+            .values()
+            .next()
+            .unwrap()
+            .quantity_abs,
+        Decimal::MAX
+    );
+}
+
 /// A **held** option adjusted by a standard split records that action's `id` in its **own**
 /// `corporate_actions_processed`, and a second delivery of the same `id` therefore leaves it alone.
 ///

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -21,7 +21,7 @@ use rustrade::{
         state::{
             EngineState,
             asset::AssetStates,
-            connectivity::Health,
+            connectivity::{ConnectivityDimension, Health, UntrackedExchange},
             global::DefaultGlobalData,
             instrument::{
                 data::{DefaultInstrumentMarketData, InstrumentDataState},
@@ -4999,6 +4999,51 @@ fn test_corporate_action_ambiguous_split_target_rejected_without_mutating() {
         )),
         "a rejected split must emit no mutation observable"
     );
+
+    // The attack the per-option `id` record alone does NOT close: a wrapper emitting a DISTINCT id
+    // per held instrument defeats every idempotency guard, because no guard has seen that id before.
+    // Naming the *other* listing with a different id is the same ambiguity wearing a different hat,
+    // and must be rejected on the same grounds -- the uniqueness check reads only
+    // `(base, quote, exchange)`, never the id, which is what makes it immune here.
+    let audit_tick = process_with_audit(
+        &mut engine,
+        EngineEvent::CorporateAction {
+            id: "BTCUSD-2-1-split-listing-2".into(),
+            instrument: InstrumentIndex(2),
+            kind: CorporateActionKind::StockSplit {
+                ratio: SplitRatio::new(dec!(2)).unwrap(),
+            },
+            policy: SplitRoundingPolicy::Floor,
+            effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+        },
+    );
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    assert!(
+        outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::UnsupportedCorporateAction {
+                instrument,
+                reason: UnsupportedCorporateActionReason::AmbiguousSplitTarget,
+                ..
+            } if *instrument == InstrumentIndex(2)
+        )),
+        "a fresh id against the second ambiguous listing must be rejected on the same grounds"
+    );
+
+    // Still untouched -- in particular the option chain, which a second silent pass would have
+    // adjusted a second time.
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(50_000));
 }
 
 /// A **held** option adjusted by a standard split records that action's `id` in its **own**
@@ -5335,4 +5380,65 @@ fn test_corporate_action_option_replica_parity_suppressed_readjust() {
         panic!("instrument 0 must be an option");
     };
     assert_eq!(contract.strike, dec!(25_000));
+}
+
+/// A `Reconnecting` event for an exchange the engine was never built against is **reported**, and
+/// nothing else happens: no `on_disconnect`, no connectivity mutation, no new tracked exchange.
+///
+/// `ConnectivityStates` is unit-tested at its own seam; this pins the two layers above it, which are
+/// where the decision actually lands. `Engine::update_from_{market,account}_stream` matches on the
+/// `Result` to choose between calling `Strategy::on_disconnect` and reporting, and `ProcessAudit`
+/// translates that choice into an `EngineOutput`. Swap those arms — fire `on_disconnect` for a venue
+/// the strategy has no link to, or drop the report instead of emitting it — and every other test in
+/// this suite still passes, because none of them names an exchange the engine does not track.
+#[test]
+fn test_untracked_exchange_reconnecting_is_reported_without_disconnect_or_mutation() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine(TradingState::Disabled, execution_tx);
+
+    // The engine is built from `BinanceSpot` instruments only. Nothing about this event is
+    // malformed — it is the shape a misconfigured subscription or execution client produces.
+    const UNTRACKED: ExchangeId = ExchangeId::Coinbase;
+    let tracked_before = engine.state.connectivity.clone();
+
+    let event = EngineEvent::Market(MarketStreamEvent::Reconnecting(UNTRACKED));
+    let audit = process_with_audit(&mut engine, event.clone());
+
+    assert_eq!(
+        audit.event,
+        EngineAudit::process_with_output(
+            event,
+            EngineOutput::UntrackedExchange(UntrackedExchange::new(
+                UNTRACKED,
+                ConnectivityDimension::MarketData
+            ))
+        ),
+        "the market-data dimension must be named, and no MarketDisconnect emitted"
+    );
+
+    let event = EngineEvent::Account(AccountStreamEvent::Reconnecting(UNTRACKED));
+    let audit = process_with_audit(&mut engine, event.clone());
+
+    assert_eq!(
+        audit.event,
+        EngineAudit::process_with_output(
+            event,
+            EngineOutput::UntrackedExchange(UntrackedExchange::new(
+                UNTRACKED,
+                ConnectivityDimension::Account
+            ))
+        ),
+        "the account dimension must be named, and no AccountDisconnect emitted"
+    );
+
+    // Reporting is the whole effect: an untracked exchange is not silently adopted into the
+    // collection, and the venues the engine does track are left exactly as they were.
+    assert_eq!(
+        engine.state.connectivity, tracked_before,
+        "an untracked exchange must not mutate connectivity state"
+    );
+    assert!(
+        !engine.state.connectivity.exchanges.contains_key(&UNTRACKED),
+        "an untracked exchange must not become tracked by reporting it"
+    );
 }

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -5382,6 +5382,63 @@ fn test_corporate_action_option_replica_parity_suppressed_readjust() {
     assert_eq!(contract.strike, dec!(25_000));
 }
 
+/// A market `Item` from an exchange the engine was never built against is **reported**, and its
+/// `InstrumentIndex` is never dereferenced.
+///
+/// This is the ordering `EngineState::update_from_market` exists to enforce: the exchange is
+/// resolved, and the result propagated, *before* `instrument_index_mut`. An event from an untracked
+/// exchange carries an `InstrumentIndex` from a collection the engine does not share, so the
+/// positional lookup would either panic on an out-of-range index or credit the print to whichever
+/// instrument occupies that slot — a wrong price on a real position, reported nowhere. Move the `?`
+/// below the lookup and only this test fails.
+#[test]
+fn test_untracked_exchange_market_item_is_reported_without_resolving_its_instrument() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_engine(TradingState::Disabled, execution_tx);
+
+    // The engine tracks two `BinanceSpot` instruments, indices 0 and 1.
+    const UNTRACKED: ExchangeId = ExchangeId::Coinbase;
+    let out_of_range = InstrumentIndex(99);
+
+    let connectivity_before = engine.state.connectivity.clone();
+    let instruments_before = engine.state.instruments.clone();
+
+    let event = EngineEvent::Market(MarketStreamEvent::Item(MarketEvent {
+        time_exchange: time_plus_days(STARTING_TIMESTAMP, 1),
+        time_received: time_plus_days(STARTING_TIMESTAMP, 1),
+        exchange: UNTRACKED,
+        instrument: out_of_range,
+        kind: DataKind::Trade(PublicTrade {
+            id: "untracked".into(),
+            price: dec!(10_000),
+            amount: Decimal::ONE,
+            side: Some(Side::Buy),
+        }),
+    }));
+
+    let audit = process_with_audit(&mut engine, event.clone());
+
+    assert_eq!(
+        audit.event,
+        EngineAudit::process_with_output(
+            event,
+            EngineOutput::UntrackedExchange(UntrackedExchange::new(
+                UNTRACKED,
+                ConnectivityDimension::MarketData
+            ))
+        ),
+        "the market-data dimension must be named"
+    );
+    assert_eq!(
+        engine.state.connectivity, connectivity_before,
+        "an untracked exchange must not mutate connectivity state"
+    );
+    assert_eq!(
+        engine.state.instruments, instruments_before,
+        "no instrument state may be read or written for an untrusted InstrumentIndex"
+    );
+}
+
 /// A `Reconnecting` event for an exchange the engine was never built against is **reported**, and
 /// nothing else happens: no `on_disconnect`, no connectivity mutation, no new tracked exchange.
 ///

--- a/rustrade/tests/test_engine_process_engine_event_with_audit.rs
+++ b/rustrade/tests/test_engine_process_engine_event_with_audit.rs
@@ -1306,6 +1306,19 @@ fn build_option_engine_with_oms(
             Underlying::new("btc", "usd"),
             None,
         ))
+        // index 2 (after sort): a second split-eligible Spot on the same base and exchange but a
+        // DIFFERENT quote. Present in every test on this fixture so the split-target uniqueness
+        // guard is continuously exercised against a near-miss, rather than only against instruments
+        // that share a full `(base, quote, exchange)` identity — see
+        // `test_corporate_action_split_is_not_ambiguous_across_a_quote_boundary`. Inert otherwise:
+        // it is never priced, never traded, and carries no position.
+        .add_instrument(Instrument::spot(
+            ExchangeId::BinanceSpot,
+            "binance_spot_btc_usdc",
+            "BTCUSDC",
+            Underlying::new("btc", "usdc"),
+            None,
+        ))
         .build();
 
     let clock = HistoricalClock::new(STARTING_TIMESTAMP);
@@ -5298,6 +5311,87 @@ fn test_corporate_action_unheld_option_strike_not_divided_twice_by_the_same_id()
         )),
         "the suppressed strike fix must be surfaced"
     );
+}
+
+/// A second split-eligible instrument on the same `(base, exchange)` but a **different quote** must
+/// not trip the split-target uniqueness guard.
+///
+/// The guard scans the entire instrument registry, so it is only as narrow as the identity match it
+/// applies. `is_on_underlying`'s own doc warns that "without the quote filter a BTC/USDT action
+/// would also reach BTC/USDC instruments" — drop that filter and a perfectly resolvable action is
+/// rejected as ambiguous, blocking a legitimate corporate action outright. No fixture whose
+/// instruments all share one `Underlying` can detect that, since base and quote agree everywhere;
+/// this one holds `btc/usd` and `btc/usdc` side by side and asserts the `btc/usd` split still
+/// applies in full.
+#[test]
+fn test_corporate_action_split_is_not_ambiguous_across_a_quote_boundary() {
+    let (execution_tx, _execution_rx) = mpsc_unbounded();
+    let mut engine = build_option_engine(TradingState::Disabled, execution_tx); // Netting
+
+    // `BTCUSDC` (index 2) is `Spot`, so split-eligible, and shares the target's base and exchange.
+    // Only its quote differs.
+    let usdc_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(2));
+    assert_eq!(usdc_state.instrument.underlying.quote, AssetIndex(2));
+    assert!(
+        matches!(usdc_state.instrument.kind, InstrumentKind::Spot),
+        "the near-miss instrument must itself be split-eligible, or this proves nothing"
+    );
+
+    engine.process(market_event_trade(1, 0, dec!(1200)));
+    engine.process(market_event_trade(1, 1, dec!(60_000)));
+    open_option_position(&mut engine, dec!(2), dec!(1_000));
+
+    let audit_tick = process_with_audit(
+        &mut engine,
+        EngineEvent::CorporateAction {
+            id: "BTCUSD-2-1-split".into(),
+            instrument: InstrumentIndex(1),
+            kind: CorporateActionKind::StockSplit {
+                ratio: SplitRatio::new(dec!(2)).unwrap(),
+            },
+            policy: SplitRoundingPolicy::Floor,
+            effective_time: time_plus_days(STARTING_TIMESTAMP, 10),
+        },
+    );
+    let outputs = match &audit_tick.event {
+        EngineAudit::Process(audit) => &audit.outputs,
+        _ => panic!("expected EngineAudit::Process"),
+    };
+
+    assert!(
+        !outputs.iter().any(|o| matches!(
+            o,
+            EngineOutput::UnsupportedCorporateAction {
+                reason: UnsupportedCorporateActionReason::AmbiguousSplitTarget,
+                ..
+            }
+        )),
+        "a differing quote is a different underlying - the target is still unique"
+    );
+
+    // The split applied in full, not merely "was not rejected".
+    let option_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(0));
+    let InstrumentKind::Option(contract) = &option_state.instrument.kind else {
+        panic!("instrument 0 must be an option");
+    };
+    assert_eq!(contract.strike, dec!(25_000));
+
+    // ...and the near-miss instrument was left entirely alone by an action on its neighbour.
+    let usdc_state = engine
+        .state
+        .instruments
+        .instrument_index(&InstrumentIndex(2));
+    assert!(
+        usdc_state.corporate_actions_processed.is_empty(),
+        "an instrument on a different quote must not record the action"
+    );
+    assert!(usdc_state.position.positions.is_empty());
 }
 
 /// Live engine vs audit-replica parity for the **rejection** path: an ambiguous split target must


### PR DESCRIPTION
Makes the core model able to express an instrument that is **priced on one venue and executed on another**, and closes the correctness gaps that configuration exposes. No provider integration code is touched — every change here is provider-agnostic, and each commit stands alone.

## What changes

**An instrument can name a separate market-data venue.** `Instrument` gains `data_venue: Option<DataVenue<ExchangeKey>>`. Modelling this as two separate instruments is not equivalent: position and `pnl_unrealised` are strictly `InstrumentIndex`-scoped, so the traded instrument would never receive the price updates landing on the other index and its PnL would sit permanently stale. `DataVenue` carries an optional `name_exchange` alongside the exchange, because two venues routinely spell one instrument differently — a venue-only field would subscribe under the execution venue's symbol and silently receive nothing, or another instrument's prices.

**Venues declare which connection dimensions they provide.** `ConnectivityState` gains `role: VenueRole { DataOnly, ExecutionOnly, Both }`, and the account dimension is derived from **registered execution clients** rather than from the instrument model. The two dimensions have different sources of truth: market data is instrument-derived and exactly so, since subscriptions are generated from the same `data_exchange` field, but account events reach the engine only from a registered `ExecutionManager`, and `Instrument::exchange` names the venue an instrument *would* trade on — not whether anything is wired up to trade there. Without both halves, a venue supplying prices alone waits forever on an account connection nothing will establish, and global connectivity never reaches `Healthy`. Where the state must be built *before* the clients exist — `backtest` builds one set of clients per run from a state supplied once — `connectivity::reconcile_venue_roles` re-derives the roles from the clients that were ultimately registered, rather than obliging a caller to declare venues it cannot yet know.

**An event from an untracked exchange is reported, not panicked on.** The old `panic!` sat behind a `global == Healthy` early-return, making it *intermittent* — a misconfiguration ran clean for hours, then took the engine down on a reconnect. The exchange is now resolved on every market event so the report fires on the first one, in every run. Measured cost: below the noise floor of a ~50,000-market-event backtest bench (127.28 ms → 126.66 ms, within criterion's noise threshold).

**Execution clients declare the instrument kinds they can trade.** There was no kind guard anywhere in `rustrade-execution`, so an instrument of a kind a venue cannot encode reached that venue as a silent wrong-symbol order. `ExecutionBuilder::add_execution` now rejects the build naming the offending client and kind.

**A stock split no longer double-adjusts an option chain.** The split target was never checked for being the unique deliverable instrument on its underlying, and the adjusted options recorded nothing — so a re-delivered action halved an already-halved strike, surfacing months later as mis-settlement at expiry. Both doors are closed, because they are different doors: uniqueness alone leaves a same-id replay unrecorded on the options it mutated, and recording alone is defeated by a distinct id per instrument. Suppressed options are reported rather than silently skipped; dropping them would have reproduced the defect's own signature.

**Account snapshots omit data-only venues instead of reporting them empty.** An empty snapshot asserts a known, drained account, which a caller cannot distinguish from a real one that has gone to zero.

**Docs**: the two-instrument pattern — deciding on one instrument and trading another — is documented on `DataVenue` (which is *not* the tool for it), on `AlgoStrategy` (where the enabling contract lives), and in the live example header.

## Breaking changes

All are listed with migrations in the CHANGELOG. In brief:

- `Instrument` gains a field — struct literals and destructuring patterns need updating. `Instrument::new`/`spot` are unchanged. `system::config::InstrumentConfig` gains the same field and has no constructor, so literals of it need updating too (it is `#[serde(default)]`, so existing configs still deserialise). The field is declared **last** deliberately: `Instrument` derives `Ord` and the builder sorts before assigning `InstrumentIndex`, so appending renumbers no existing configuration.
- `Instrument::map_exchange_key` takes a lookup closure — `(self, exchange: NewExchangeKey)` becomes `(self, find_exchange: impl Fn(&ExchangeKey) -> NewExchangeKey)`, because one key cannot serve two venues. Pass `|_| key.clone()` to reproduce the old behaviour. (`DataVenue::map_exchange_key` takes the same shape, but is new API rather than a change.)
- `ConnectivityState` gains `role: VenueRole` — struct literals and exhaustive destructuring must supply it. Use `ConnectivityState::new(role)`, or `..Default::default()` for the pre-existing `Both` semantics. `#[serde(default)]`, so persisted state is unaffected.
- `ConnectivityStates::exchanges` is now an `FnvIndexMap`, not a SipHash-keyed `IndexMap`: it is looked up on every market event now that resolution precedes the health short-circuit, and this matches every sibling per-event keyed structure. Insertion order is unchanged.
- The `ExchangeId`-keyed `ConnectivityStates` updates and `EngineState::update_from_market` return `Result<_, UntrackedExchange>`. The `ExchangeIndex`-keyed accessors stay panicking deliberately: those keys are structurally valid by construction, so an out-of-range one is a library bug, not a handleable input.
- `UpdateFrom{Market,Account}Output` gain a variant and become `#[non_exhaustive]`.
- `generate_empty_indexed_connectivity_states` takes the execution venues; pass `None` for the previous behaviour.
- `ExecutionClient::SUPPORTED_KINDS` has no default — external implementors must declare it.

## Verification

`cargo check --workspace --all-targets --all-features`; `rustrade --lib` **184**, `rustrade-instrument --lib` **68** (the `ibkr` feature is off by default and adds 3), `rustrade-execution --lib --all-features` **408**, `test_engine_process_engine_event_with_audit` **54**, `test_backtest_connectivity_roles` **1**, `test_backtest_aux_events` **6**, `test_example_configs` **1**. `cargo fmt --all --check` clean; both clippy gates clean apart from one pre-existing complexity warning at `rustrade-execution/src/client/binance/spot.rs:2663`.

## Known limitations, documented rather than silently left

- `index_market_data_subscription_batches` resolves both the assets and the instrument against the execution venue, so it cannot honour a `DataVenue`. The two spellings fail differently and only one fails loudly: naming the **data venue** returns `IndexError`, since that venue registers no assets; naming the **execution venue** returns `Ok`, with the right `InstrumentIndex` on a subscription pointed at the wrong feed, which the function has no way to detect. It has no in-tree callers but is public API, so both cases are spelled out in its rustdoc `# Limitation` and pinned by a test each — the second named as a known gap. Reworking it needs its own design pass.
- `backtest` derives its connectivity roles rather than trusting the state it is handed: each run re-derives every venue's `VenueRole` from the execution clients that run builds, on its own clone of the state. A venue registered purely so its prices are available is therefore marked `DataOnly` and never waited on for an account connection nothing would establish — whether or not the caller declared anything. Declaring upfront with `EngineStateBuilder::execution_venues` remains supported and reconciles to itself, and the caller's own `engine_state` is never modified. **The residual:** a venue that neither prices an instrument nor has an execution client provides no connection that could report healthy, so `global` stays `Reconnecting` for the whole run — reported by a `warn!` naming the venue rather than inferred from a health that never converges. `reconcile_venue_roles`' one caller obligation (the instrument collection must be the one the state was built from) is `debug_assert!`ed as far as venue keys allow; a collection carrying the same venues with different instruments is not detectable that way, but misaligns every `InstrumentIndex` in the engine, so roles are not the symptom that surfaces first. Documented in a `# Connectivity` section on `backtest` itself.


