### PR TITLE
feat(lse): Live WebSocket market data with opt-in reconnect resumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,14 +206,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LseSubscriber` (`LseCredentials`, or `from_env` on `LSE_API_KEY`, whose errors name the variable
   and never its value). Timestamps arrive in three encodings — RFC-3339 with `T`, the same with a
   space separator, and a bare float epoch on replayed ticks — and a decoder accepting only the first
-  would silently drop five of the thirteen dataset families.
+  would silently drop five of the thirteen dataset families. Every spelling is quantised to
+  **microseconds**, the provider's own resolution and the one its replay filter honours: an
+  RFC-3339 string carrying seven fractional digits otherwise decodes to 100 ns while the float
+  spelling of the same instant cannot, and the resume arithmetic compares instants for equality.
   **Pre-subscribe guards, because this surface fails quietly.** An unknown symbol is *confirmed*
   rather than rejected and then never ticks, and the connection-wide 16-subscription cap is reported
   without naming the symbol that breached it. So the whole batch is validated against the symbol
   list the authentication response already carries, before anything is sent: an unoffered symbol or
   an over-cap batch fails loudly and consumes **no** subscription slot. The response's per-symbol
-  category is cross-checked only when present, since it is absent for roughly half the catalog and
-  a missing field is not a contradiction.
+  category is cross-checked only when it is both present *and* a label some dataset is known by,
+  since it is absent for roughly half the catalog: neither a missing field nor a label this
+  integration does not recognise is a contradiction — only one belonging to a *different* dataset
+  is evidence of anything.
   **Opt-in resumption across a reconnect** via `LseSubscriber::with_resume(Arc<LseResumeState>)`.
   A reconnect re-runs the subscribe, so a fixed replay window would re-deliver it in full on every
   attempt; instead the watermark records, per symbol, the newest delivered instant **and how many
@@ -223,11 +228,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to a coarser resolution would re-serve a whole millisecond of already-delivered events on the
   families that carry microseconds. It is **off by default** — a resumed subscription is served its
   entire historical window before a single live tick, and one hour of a busy crypto symbol replayed
-  107,395 ticks. Watermarks are keyed by symbol rather than by symbol and kind, so streams carrying
-  the same symbol need their own state; disjoint sets may share one. The provider retains 24 hours
-  and clamps a longer request **silently**, which is compared against what it says it will replay
-  from and reported rather than swallowed. This covers reconnects, not process restarts: recovering
-  across a restart needs consumer-side acknowledgement of what was durably stored.
+  107,395 ticks. Watermarks are keyed by symbol **and** subscription kind, so one state may be
+  shared by any set of streams: this provider serves both kinds from one data frame, so two streams
+  carrying the same symbol as trades and as top-of-book would otherwise share a watermark and
+  advance it independently, and whichever ran ahead would set the resume point for the one behind.
+  The provider retains 24 hours and clamps a longer request **silently**; the honoured window is
+  announced in a `replay_started` frame that was measured to arrive *after* the subscription
+  confirmation, so the comparison against what was asked for is made on the stream rather than
+  during the handshake, and a clamp is warned about rather than swallowed. This covers reconnects,
+  not process restarts: recovering across a restart needs consumer-side acknowledgement of what was
+  durably stored.
   **⚠️ Known properties of the feed, not of this decoder, that will silently mislead:** the tick is
   a **QUOTE, not a print** — its `price` equalled its `bid` on 3,966 of 3,966 sampled ticks across
   every dataset family — so a `PublicTrade` decoded from it is a bid-side quote wearing a trade's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **microseconds**, the provider's own resolution and the one its replay filter honours: an
   RFC-3339 string carrying seven fractional digits otherwise decodes to 100 ns while the float
   spelling of the same instant cannot, and the resume arithmetic compares instants for equality.
+  Symbols are decoded as owned strings rather than borrowed slices: every symbol on this feed
+  contains a `/`, RFC 8259 permits spelling that `\/`, and a borrowed decode cannot unescape one.
   **Pre-subscribe guards, because this surface fails quietly.** An unknown symbol is *confirmed*
   rather than rejected and then never ticks, and the connection-wide 16-subscription cap is reported
   without naming the symbol that breached it. So the whole batch is validated against the symbol
@@ -218,7 +220,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   category is cross-checked only when it is both present *and* a label some dataset is known by,
   since it is absent for roughly half the catalog: neither a missing field nor a label this
   integration does not recognise is a contradiction — only one belonging to a *different* dataset
-  is evidence of anything.
+  is evidence of anything. A rejection raised *after* the handshake completes — a later
+  `LIMIT_REACHED`, an `INVALID_START` on a resumed symbol, a credential that expired mid-connection
+  — is decoded on the stream and logged rather than discarded: the subscription validator has
+  stopped reading by then, and because the provider names no symbol in a rejection, the only other
+  sign it ever gave would be a subscription that quietly stopped ticking.
   **Opt-in resumption across a reconnect** via `LseSubscriber::with_resume(Arc<LseResumeState>)`.
   A reconnect re-runs the subscribe, so a fixed replay window would re-deliver it in full on every
   attempt; instead the watermark records, per symbol, the newest delivered instant **and how many
@@ -228,10 +234,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to a coarser resolution would re-serve a whole millisecond of already-delivered events on the
   families that carry microseconds. It is **off by default** — a resumed subscription is served its
   entire historical window before a single live tick, and one hour of a busy crypto symbol replayed
-  107,395 ticks. Watermarks are keyed by symbol **and** subscription kind, so one state may be
-  shared by any set of streams: this provider serves both kinds from one data frame, so two streams
-  carrying the same symbol as trades and as top-of-book would otherwise share a watermark and
-  advance it independently, and whichever ran ahead would set the resume point for the one behind.
+  107,395 ticks. Watermarks are keyed by **dataset, symbol and subscription kind**, because two
+  axes collapse onto the provider's wire identifier: both kinds are decodings of one data frame, and
+  the five dataset connectors share one endpoint and one identifier construction — so `AAPL` as
+  trades and as top-of-book, or `AAPL` on `LseEquities` and on `LseFutures`, all resolve to
+  `tick|AAPL`. Sharing a watermark across either axis lets whichever stream ran ahead set the resume
+  point for the one behind, which then resumes past events it never delivered. Both are therefore
+  closed structurally, and one state serves any set of streams differing in any of the three. What
+  no key can separate is two streams duplicating all three, so **each duplicated
+  `(dataset, symbol, kind)` triple needs its own state** — the one obligation the caller carries,
+  and it is documented on `LseResumeState`.
   The provider retains 24 hours and clamps a longer request **silently**; the honoured window is
   announced in a `replay_started` frame that was measured to arrive *after* the subscription
   confirmation, so the comparison against what was asked for is made on the stream rather than
@@ -251,7 +263,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `(ts, price, bid, ask, volume)`, yet removing the repeats destroyed volume that otherwise
   reconciles exactly, so a test pins that both are emitted. Both `OrderBookL1` levels carry a
   **zero size** — the feed publishes prices only — which prices correctly, since the volume-weighted
-  mid falls back to the plain mid, but must not be read as available quantity.
+  mid falls back to the plain mid, but must not be read as available quantity. A zero **price** is
+  the opposite case and decodes to `None` rather than to a level: the provider publishes `0.0` for a
+  side it holds no quote for, and it is exactly the fallback that makes the zero *sizes* harmless
+  which makes a zero price dangerous — `mid_price` requires only that both sides be `Some` and then
+  averages whatever prices they carry, so a real ask of `42001` against a published zero bid would
+  price the instrument at `21000.5`, indistinguishably from a genuine quote.
   Runnable end to end: `lse_market_data` (`rustrade-data`) streams the raw feed, and
   `engine_sync_with_lse_market_data_and_mock_execution` (`rustrade`) prices engine instruments from
   it while routing orders to a different, mocked venue — this provider offers no execution, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **⚠️ Licensing:** as above — the retrieved data is **not redistributable**, whatever this crate's
   own licence says. See <https://londonstrategicedge.com/terms>.
 
+- **London Strategic Edge live market data** (`rustrade-data`, `lse` feature): a WebSocket connector
+  per dataset family — `LseFx`, `LseCrypto`, `LseEquities`, `LseFutures`, `LseCfd` — each serving
+  both `PublicTrades` and `OrderBooksL1`. The provider publishes exactly **one** data frame, a
+  price with a bid, an ask and a size, so the two kinds are two decodings of the same tick rather
+  than two channels; the subscription kind decides what an event becomes, not what is asked for on
+  the wire. There is **no candle channel at all** — this provider's candles are a REST-only product,
+  so no `Candles` support is declared. Authentication is a *message* rather than a header and
+  subscriptions are accepted only after the server answers it, so the integration ships its own
+  `LseSubscriber` (`LseCredentials`, or `from_env` on `LSE_API_KEY`, whose errors name the variable
+  and never its value). Timestamps arrive in three encodings — RFC-3339 with `T`, the same with a
+  space separator, and a bare float epoch on replayed ticks — and a decoder accepting only the first
+  would silently drop five of the thirteen dataset families.
+  **Pre-subscribe guards, because this surface fails quietly.** An unknown symbol is *confirmed*
+  rather than rejected and then never ticks, and the connection-wide 16-subscription cap is reported
+  without naming the symbol that breached it. So the whole batch is validated against the symbol
+  list the authentication response already carries, before anything is sent: an unoffered symbol or
+  an over-cap batch fails loudly and consumes **no** subscription slot. The response's per-symbol
+  category is cross-checked only when present, since it is absent for roughly half the catalog and
+  a missing field is not a contradiction.
+  **Opt-in resumption across a reconnect** via `LseSubscriber::with_resume(Arc<LseResumeState>)`.
+  A reconnect re-runs the subscribe, so a fixed replay window would re-deliver it in full on every
+  attempt; instead the watermark records, per symbol, the newest delivered instant **and how many
+  events already delivered carry it**, and the resumed subscribe skips exactly that prefix. Both
+  halves are load-bearing: `start` is inclusive and filters at microsecond resolution, so resuming
+  one tick later would silently drop every event at that instant not yet consumed, while flooring it
+  to a coarser resolution would re-serve a whole millisecond of already-delivered events on the
+  families that carry microseconds. It is **off by default** — a resumed subscription is served its
+  entire historical window before a single live tick, and one hour of a busy crypto symbol replayed
+  107,395 ticks. Watermarks are keyed by symbol rather than by symbol and kind, so streams carrying
+  the same symbol need their own state; disjoint sets may share one. The provider retains 24 hours
+  and clamps a longer request **silently**, which is compared against what it says it will replay
+  from and reported rather than swallowed. This covers reconnects, not process restarts: recovering
+  across a restart needs consumer-side acknowledgement of what was durably stored.
+  **⚠️ Known properties of the feed, not of this decoder, that will silently mislead:** the tick is
+  a **QUOTE, not a print** — its `price` equalled its `bid` on 3,966 of 3,966 sampled ticks across
+  every dataset family — so a `PublicTrade` decoded from it is a bid-side quote wearing a trade's
+  shape and is not evidence a transaction occurred; it carries no trade identifier and no aggressor
+  side, and neither is inferable. `volume` is **genuine on `LseCrypto` and `LseEquities`** (summing
+  it reproduces the provider's own one-minute candle volume to ratio `1.000`) and a **hard-coded
+  `1.0` on `LseFx` and `LseCfd`**, with no in-band signal separating them — a plausible-looking
+  placeholder that aggregates into a legitimate-looking total, making volume-weighted prices and
+  size filters on those two families meaningless rather than imprecise. Identical consecutive ticks
+  are **genuine and are never de-duplicated**: barely a third of a sampled run was unique on
+  `(ts, price, bid, ask, volume)`, yet removing the repeats destroyed volume that otherwise
+  reconciles exactly, so a test pins that both are emitted. Both `OrderBookL1` levels carry a
+  **zero size** — the feed publishes prices only — which prices correctly, since the volume-weighted
+  mid falls back to the plain mid, but must not be read as available quantity.
+  Runnable end to end: `lse_market_data` (`rustrade-data`) streams the raw feed, and
+  `engine_sync_with_lse_market_data_and_mock_execution` (`rustrade`) prices engine instruments from
+  it while routing orders to a different, mocked venue — this provider offers no execution, so a
+  `DataVenue` is how a live system uses it.
+  **⚠️ Licensing:** as above — the retrieved data is **not redistributable**, whatever this crate's
+  own licence says. See <https://londonstrategicedge.com/terms>.
+
 - **`CandleInterval` gains the sub-minute resolutions `Sec5`, `Sec15` and `Sec30`**
   (`rustrade-data`, `subscription::candle`). `CandleInterval` is the venue-agnostic *union* of
   every resolution any connector serves, and providers exist that publish `5s`/`15s`/`30s` bars

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -143,6 +143,19 @@ databento = { version = "0.54", optional = true, features = ["chrono"] }
 tokio-tungstenite = { version = "0.30", optional = true, features = ["native-tls"] }
 urlencoding = { version = "2.1", optional = true }
 
+# Integration tests whose contents are entirely feature-gated. Without `required-features`, the
+# target still builds with the feature off and libtest reports "0 passed" -- a green run that
+# asserted nothing. Declaring it here makes `cargo test --test <name>` fail with a message naming
+# the missing feature instead.
+
+[[test]]
+name = "lse_ws_handshake"
+required-features = ["lse"]
+
+[[test]]
+name = "lse_ws_canary"
+required-features = ["lse"]
+
 # Examples that depend on optional features. Without `required-features`,
 # `cargo check --all-targets` (default features) fails to compile them.
 

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -55,6 +55,11 @@ tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"
 tempfile = { workspace = true }  # Scratch directories for LSE export download/resume tests; already in the tree
 sha2 = { workspace = true }  # Computes the digest in synthetic LSE export job fixtures
 hex = { workspace = true }  # Encodes that digest as the provider does
+# Speaks the server half of the LSE WebSocket handshake in-process, so the guards that must run
+# *before* the first subscribe leaves the client can be tested by counting what reached the socket.
+# `wiremock` cannot serve this: the flow is a stateful conversation on a long-lived connection, not
+# a request/response exchange. Already in the tree via `rustrade-integration`'s `protocol` feature.
+tokio-tungstenite = { workspace = true }
 
 [dependencies]
 # Rustrade Ecosystem

--- a/rustrade-data/Cargo.toml
+++ b/rustrade-data/Cargo.toml
@@ -171,6 +171,10 @@ name = "lse_export"
 required-features = ["lse-parquet"]
 
 [[example]]
+name = "lse_market_data"
+required-features = ["lse"]
+
+[[example]]
 name = "ibkr_historical"
 required-features = ["ibkr"]
 

--- a/rustrade-data/examples/lse_market_data.rs
+++ b/rustrade-data/examples/lse_market_data.rs
@@ -1,0 +1,206 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
+//! Live ticks from the London Strategic Edge WebSocket.
+//!
+//! # ⚠️ Licensing — the data is NOT redistributable
+//!
+//! This example's **code** is MIT-licensed like the rest of this repository. **The data it
+//! retrieves is not.** London Strategic Edge permits use for your own research, trading and model
+//! training — including commercially — but **prohibits redistributing, reselling, or otherwise
+//! making the data available to third parties**, in bulk or through any competing feed, download
+//! service or interface. Terms: <https://londonstrategicedge.com/terms>
+//!
+//! In practice: do not commit what this prints to a public repository, do not publish it as
+//! fixtures or an example dataset, and do not re-serve it.
+//!
+//! # Running
+//!
+//! Requires a free API key (no account, no card) from <https://londonstrategicedge.com/data>, in
+//! `LSE_API_KEY`:
+//!
+//! ```bash
+//! export LSE_API_KEY=...
+//! cargo run --example lse_market_data --features lse
+//! ```
+//!
+//! Demonstrates:
+//! - **One frame serving two subscription kinds.** The provider publishes a single data frame
+//!   carrying a price, a bid, an ask and a size, so the same tick decodes as a `PublicTrade` or as
+//!   an `OrderBookL1` depending only on which kind was subscribed.
+//! - **Per-dataset provenance.** Each dataset family is its own connector, so `MarketEvent.exchange`
+//!   says which one an event came from — worth having, because two of the five fabricate `volume`.
+//! - **Opt-in resumption across a reconnect**, and the one rule that comes with it.
+//!
+//! # Properties worth knowing before you build on this
+//!
+//! - **The tick is a QUOTE, not a print.** Its `price` equals its `bid` on every sample taken —
+//!   3,966 of 3,966 ticks across every dataset family. A `PublicTrade` decoded from it is a
+//!   bid-side quote wearing a trade's shape, and its arrival is not evidence that a transaction
+//!   occurred.
+//! - **`volume` is real on two venues and fabricated on two others**, with no in-band signal
+//!   separating them. `LseCrypto` and `LseEquities` carry a genuine per-tick size that reconciles
+//!   exactly against the provider's own one-minute candles. **`LseFx` and `LseCfd` carry a
+//!   hard-coded `1.0`** — a placeholder that aggregates into a legitimate-looking total, so
+//!   volume-weighted prices and size filters there are meaningless rather than imprecise. Watch the
+//!   `EUR/USD` line below print `1` forever while `BTC/USD` varies.
+//! - **Identical consecutive ticks are genuine and are never de-duplicated.** Barely a third of a
+//!   sampled run was unique on `(ts, price, bid, ask, volume)`, yet removing the repeats destroyed
+//!   volume that otherwise reconciles exactly. Do not add a filter.
+//! - **Both book levels carry a zero size.** The feed publishes bid and ask *prices* only.
+//! - **Each `subscribe` call opens its own connection, and a connection accepts 16 symbols.** A
+//!   batch that exceeds the cap, or that names a symbol the key cannot subscribe to, is rejected
+//!   before anything reaches the wire — so a typo costs no subscription slot and never presents as
+//!   a symbol that is confirmed and then silently never ticks.
+
+use futures::StreamExt;
+use rustrade_data::{
+    event::DataKind,
+    exchange::lse::{LseCrypto, LseFx, live::LseSubscriber, resume::LseResumeState},
+    streams::{
+        Streams,
+        consumer::MarketStreamResult,
+        reconnect::{Event, stream::ReconnectingStream},
+    },
+    subscription::{book::OrderBooksL1, trade::PublicTrades},
+};
+use rustrade_instrument::instrument::market_data::{
+    MarketDataInstrument, kind::MarketDataInstrumentKind,
+};
+use std::sync::Arc;
+use tracing::{info, warn};
+
+#[tokio::main]
+async fn main() {
+    init_logging();
+
+    let subscriber = LseSubscriber::from_env()
+        .expect("set LSE_API_KEY - get a free key at https://londonstrategicedge.com/data");
+
+    // Resumption is opt-in, and the state is keyed by symbol rather than by symbol and kind. So the
+    // two trade connections below share one state — their symbol sets are disjoint, which is the
+    // ordinary case — while the top-of-book connection carries the *same* crypto symbols as the
+    // crypto trade connection and therefore needs its own. Sharing across those two would let
+    // whichever stream ran ahead set the resume point for both, and the one behind would resume
+    // past events it never delivered.
+    //
+    // On a first connection there is nothing to resume from, so neither state triggers a replay
+    // here. They matter after a drop: the reconnect re-subscribes from the last event each stream
+    // actually delivered instead of leaving a gap.
+    let trades_resume = Arc::new(LseResumeState::new());
+    let quotes_resume = Arc::new(LseResumeState::new());
+
+    let streams: Streams<MarketStreamResult<MarketDataInstrument, DataKind>> =
+        Streams::builder_multi()
+            .add(
+                Streams::<PublicTrades>::builder()
+                    .subscribe(
+                        subscriber.clone().with_resume(Arc::clone(&trades_resume)),
+                        [
+                            (
+                                LseCrypto::default(),
+                                "btc",
+                                "usd",
+                                MarketDataInstrumentKind::Spot,
+                                PublicTrades,
+                            ),
+                            (
+                                LseCrypto::default(),
+                                "eth",
+                                "usd",
+                                MarketDataInstrumentKind::Spot,
+                                PublicTrades,
+                            ),
+                        ],
+                    )
+                    // A second dataset family, on its own connection: same frame, same decoder,
+                    // different `MarketEvent.exchange` — and a `volume` the provider invents.
+                    .subscribe(
+                        subscriber.clone().with_resume(trades_resume),
+                        [(
+                            LseFx::default(),
+                            "eur",
+                            "usd",
+                            MarketDataInstrumentKind::Spot,
+                            PublicTrades,
+                        )],
+                    ),
+            )
+            .add(Streams::<OrderBooksL1>::builder().subscribe(
+                subscriber.with_resume(quotes_resume),
+                [
+                    (
+                        LseCrypto::default(),
+                        "btc",
+                        "usd",
+                        MarketDataInstrumentKind::Spot,
+                        OrderBooksL1,
+                    ),
+                    (
+                        LseCrypto::default(),
+                        "eth",
+                        "usd",
+                        MarketDataInstrumentKind::Spot,
+                        OrderBooksL1,
+                    ),
+                ],
+            ))
+            .init()
+            .await
+            .unwrap();
+
+    let mut joined_stream = streams
+        .select_all()
+        .with_error_handler(|error| warn!(?error, "MarketStream generated error"));
+
+    while let Some(event) = joined_stream.next().await {
+        // A reconnect is reported rather than hidden, so a consumer can tell a quiet market from a
+        // dropped connection. What follows it is a fresh subscription, resumed from the watermark.
+        let event = match event {
+            Event::Reconnecting(exchange) => {
+                warn!(%exchange, "MarketStream reconnecting");
+                continue;
+            }
+            Event::Item(event) => event,
+        };
+
+        match &event.kind {
+            DataKind::Trade(trade) => info!(
+                exchange = %event.exchange,
+                instrument = %event.instrument,
+                time_exchange = %event.time_exchange,
+                price = %trade.price,
+                // Genuine on LseCrypto, a hard-coded 1.0 on LseFx. Same field, same type, no signal.
+                amount = %trade.amount,
+                // Always empty, and always `None`: the feed publishes neither a trade identifier
+                // nor an aggressor side, and neither is inferable from a quote.
+                side = ?trade.side,
+                "tick as trade"
+            ),
+            DataKind::OrderBookL1(l1) => info!(
+                exchange = %event.exchange,
+                instrument = %event.instrument,
+                time_exchange = %event.time_exchange,
+                best_bid = ?l1.best_bid.as_ref().map(|level| level.price),
+                best_ask = ?l1.best_ask.as_ref().map(|level| level.price),
+                // Both zero: the feed publishes no resting size. Do not read them as quantity.
+                "tick as top-of-book"
+            ),
+            // Unreachable: this provider's WebSocket serves no other kind. There is no candle
+            // channel at all — its candles are a REST-only product.
+            other => warn!(kind = other.kind_name(), "unexpected DataKind"),
+        }
+    }
+}
+
+// Initialise an INFO `Subscriber` for `Tracing` Json logs and install it as the global default.
+fn init_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::filter::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_ansi(cfg!(debug_assertions))
+        .json()
+        .init()
+}

--- a/rustrade-data/examples/lse_market_data.rs
+++ b/rustrade-data/examples/lse_market_data.rs
@@ -29,7 +29,7 @@
 //!   an `OrderBookL1` depending only on which kind was subscribed.
 //! - **Per-dataset provenance.** Each dataset family is its own connector, so `MarketEvent.exchange`
 //!   says which one an event came from — worth having, because two of the five fabricate `volume`.
-//! - **Opt-in resumption across a reconnect**, and the one rule that comes with it.
+//! - **Opt-in resumption across a reconnect**, with one state shared across every stream.
 //!
 //! # Properties worth knowing before you build on this
 //!
@@ -76,25 +76,22 @@ async fn main() {
     let subscriber = LseSubscriber::from_env()
         .expect("set LSE_API_KEY - get a free key at https://londonstrategicedge.com/data");
 
-    // Resumption is opt-in, and the state is keyed by symbol rather than by symbol and kind. So the
-    // two trade connections below share one state — their symbol sets are disjoint, which is the
-    // ordinary case — while the top-of-book connection carries the *same* crypto symbols as the
-    // crypto trade connection and therefore needs its own. Sharing across those two would let
-    // whichever stream ran ahead set the resume point for both, and the one behind would resume
-    // past events it never delivered.
+    // Resumption is opt-in, and one state serves every stream below — including the top-of-book
+    // connection, which carries the *same* crypto symbols as the crypto trade connection.
+    // Watermarks are filed per subscription *and* kind, so those two advance independently and
+    // neither can set the other's resume point; nothing about sharing needs thinking about here.
     //
-    // On a first connection there is nothing to resume from, so neither state triggers a replay
-    // here. They matter after a drop: the reconnect re-subscribes from the last event each stream
-    // actually delivered instead of leaving a gap.
-    let trades_resume = Arc::new(LseResumeState::new());
-    let quotes_resume = Arc::new(LseResumeState::new());
+    // On a first connection there is nothing to resume from, so nothing replays here. The state
+    // matters after a drop: the reconnect re-subscribes from the last event each stream actually
+    // delivered instead of leaving a gap.
+    let resume = Arc::new(LseResumeState::new());
 
     let streams: Streams<MarketStreamResult<MarketDataInstrument, DataKind>> =
         Streams::builder_multi()
             .add(
                 Streams::<PublicTrades>::builder()
                     .subscribe(
-                        subscriber.clone().with_resume(Arc::clone(&trades_resume)),
+                        subscriber.clone().with_resume(Arc::clone(&resume)),
                         [
                             (
                                 LseCrypto::default(),
@@ -115,7 +112,7 @@ async fn main() {
                     // A second dataset family, on its own connection: same frame, same decoder,
                     // different `MarketEvent.exchange` — and a `volume` the provider invents.
                     .subscribe(
-                        subscriber.clone().with_resume(trades_resume),
+                        subscriber.clone().with_resume(Arc::clone(&resume)),
                         [(
                             LseFx::default(),
                             "eur",
@@ -126,7 +123,7 @@ async fn main() {
                     ),
             )
             .add(Streams::<OrderBooksL1>::builder().subscribe(
-                subscriber.with_resume(quotes_resume),
+                subscriber.with_resume(resume),
                 [
                     (
                         LseCrypto::default(),

--- a/rustrade-data/src/exchange/lse/channel.rs
+++ b/rustrade-data/src/exchange/lse/channel.rs
@@ -1,0 +1,58 @@
+use super::Lse;
+use crate::{
+    Identifier,
+    subscription::{Subscription, book::OrderBooksL1, trade::PublicTrades},
+};
+
+/// The London Strategic Edge WebSocket channel.
+///
+/// # Why there is only one variant
+/// The provider publishes exactly one data frame — the tick — and it carries the same seven keys
+/// (`type`, `symbol`, `ts`, `price`, `bid`, `ask`, `volume`) on every dataset. There is no
+/// per-channel subscription: a subscribe names a symbol and nothing else
+/// (`{"action":"subscribe","symbol":"EUR/USD"}`), so both supported subscription kinds are decoded
+/// from the same frame.
+///
+/// The variant therefore exists to supply the channel half of a
+/// [`SubscriptionId`](rustrade_integration::subscription::SubscriptionId), not to select anything
+/// on the wire. Both kinds map to it, and each stream carries its own instrument map, so the shared
+/// identifier is unambiguous within a stream.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum LseChannel {
+    /// The tick frame — a price, a bid, an ask and a size for one symbol.
+    Tick,
+}
+
+impl AsRef<str> for LseChannel {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Tick => "tick",
+        }
+    }
+}
+
+impl<Server, Instrument> Identifier<LseChannel>
+    for Subscription<Lse<Server>, Instrument, PublicTrades>
+{
+    fn id(&self) -> LseChannel {
+        LseChannel::Tick
+    }
+}
+
+impl<Server, Instrument> Identifier<LseChannel>
+    for Subscription<Lse<Server>, Instrument, OrderBooksL1>
+{
+    fn id(&self) -> LseChannel {
+        LseChannel::Tick
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_channel_as_ref() {
+        assert_eq!(LseChannel::Tick.as_ref(), "tick");
+    }
+}

--- a/rustrade-data/src/exchange/lse/live.rs
+++ b/rustrade-data/src/exchange/lse/live.rs
@@ -1,0 +1,745 @@
+//! Live WebSocket subscription: authentication, the pre-subscribe guards, and the subscribe flow.
+
+use super::market::LseDataset;
+use crate::{
+    Identifier,
+    exchange::Connector,
+    instrument::InstrumentData,
+    subscriber::{
+        Subscribed, Subscriber,
+        mapper::{SubscriptionMapper, WebSocketSubMapper},
+        validator::SubscriptionValidator,
+    },
+    subscription::{Subscription, SubscriptionKind, SubscriptionMeta},
+};
+use futures::{SinkExt, StreamExt};
+use rustrade_instrument::exchange::ExchangeId;
+use rustrade_integration::{
+    error::SocketError,
+    protocol::websocket::{WebSocket, WsMessage, connect},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use smol_str::SmolStr;
+use std::{collections::HashMap, env, fmt, time::Duration};
+use tracing::{debug, warn};
+
+/// The environment variable [`LseCredentials::from_env`] reads.
+const API_KEY_ENV: &str = "LSE_API_KEY";
+
+/// How long to wait for the `authenticated` frame.
+///
+/// Generous because that frame is not small — it enumerates every symbol the key may subscribe to,
+/// which was over eight thousand entries when measured.
+const AUTH_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// The API key the WebSocket authenticates with.
+///
+/// `Debug` is implemented manually to redact the key: subscribers are routinely logged with `?`,
+/// and a credential that reaches a log line has effectively been disclosed.
+#[derive(Clone)]
+pub struct LseCredentials {
+    api_key: String,
+}
+
+impl fmt::Debug for LseCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LseCredentials")
+            .field("api_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl LseCredentials {
+    /// Construct credentials from an explicit key.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+        }
+    }
+
+    /// Construct credentials from the `LSE_API_KEY` environment variable.
+    ///
+    /// # Errors
+    /// Returns [`SocketError::Subscribe`] if the variable is unset or does not hold valid UTF-8.
+    /// The message names the variable and never its value — `VarError`'s own `Display` embeds the
+    /// raw `OsString` on the non-UTF-8 arm, which would put essentially the whole key into a string
+    /// callers log.
+    pub fn from_env() -> Result<Self, SocketError> {
+        let api_key = env::var(API_KEY_ENV).map_err(|error| {
+            SocketError::Subscribe(match error {
+                env::VarError::NotPresent => format!("{API_KEY_ENV} is not set"),
+                env::VarError::NotUnicode(_) => {
+                    format!("{API_KEY_ENV} is set but is not valid UTF-8")
+                }
+            })
+        })?;
+
+        Ok(Self::new(api_key))
+    }
+}
+
+/// The London Strategic Edge WebSocket subscriber.
+///
+/// # Why this provider needs a subscriber of its own
+/// Authentication is a **message**, not a header, and subscriptions are only accepted after the
+/// server answers it — so [`Connector::requests`] alone cannot express the flow.
+///
+/// The handshake also produces something the guards below need: the `authenticated` frame
+/// enumerates every symbol the key may subscribe to. That list is the only defence against this
+/// surface's quietest failure — see [`Self::subscribe`].
+///
+/// # Example
+/// ```ignore
+/// use rustrade_data::exchange::lse::{LseCrypto, live::LseSubscriber};
+/// use rustrade_data::streams::Streams;
+/// use rustrade_data::subscription::trade::PublicTrades;
+/// use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
+///
+/// let subscriber = LseSubscriber::from_env()?;
+///
+/// let streams = Streams::<PublicTrades>::builder()
+///     .subscribe(subscriber, [(
+///         LseCrypto::default(), "btc", "usd", MarketDataInstrumentKind::Spot, PublicTrades,
+///     )])
+///     .init()
+///     .await?;
+/// ```
+#[derive(Clone, Debug)]
+pub struct LseSubscriber {
+    credentials: LseCredentials,
+}
+
+impl LseSubscriber {
+    /// Construct a subscriber with the provided credentials.
+    pub fn new(credentials: LseCredentials) -> Self {
+        Self { credentials }
+    }
+
+    /// Construct a subscriber from the `LSE_API_KEY` environment variable.
+    ///
+    /// # Errors
+    /// See [`LseCredentials::from_env`].
+    pub fn from_env() -> Result<Self, SocketError> {
+        Ok(Self::new(LseCredentials::from_env()?))
+    }
+}
+
+impl Subscriber for LseSubscriber {
+    type SubMapper = WebSocketSubMapper;
+
+    /// Connect, authenticate, check the batch, then subscribe.
+    ///
+    /// # ⚠️ Every guard runs before the first subscribe leaves the client, deliberately
+    /// This surface confirms a subscription to a symbol it has never heard of: it answers
+    /// `subscribed`, never errors, never ticks, **and permanently consumes one of the connection's
+    /// slots**. A slot spent that way cannot be reclaimed without reconnecting, and the standard
+    /// subscription validator counts the confirmation as a success. So the requested symbols are
+    /// checked against the list the `authenticated` frame supplies *first*, and a batch that fails
+    /// costs nothing.
+    ///
+    /// Two checks run over that list:
+    /// - **Membership is enforced.** A symbol the provider does not offer fails the batch.
+    /// - **The category is only cross-checked when the provider supplies one.** Roughly half the
+    ///   published entries carry no `category` key at all — and some carry neither `category` nor
+    ///   `name` — so absence is normal and can never be treated as a mismatch.
+    ///
+    /// The subscription cap is enforced in the same pass, because an over-cap batch is rejected
+    /// *anonymously*: the provider's rejection does not name the symbol it refused, leaving no
+    /// partial recovery. Failing the whole batch before sending is the only outcome that does not
+    /// leave the caller guessing which subscriptions survived.
+    ///
+    /// # Errors
+    /// Returns [`SocketError::Subscribe`] if the key is rejected, the handshake times out, the
+    /// batch exceeds the connection's subscription cap, or any requested symbol is not offered.
+    async fn subscribe<Exchange, Instrument, Kind>(
+        &self,
+        subscriptions: &[Subscription<Exchange, Instrument, Kind>],
+    ) -> Result<Subscribed<Instrument::Key>, SocketError>
+    where
+        Exchange: Connector + Send + Sync,
+        Kind: SubscriptionKind + Send + Sync,
+        Instrument: InstrumentData,
+        Subscription<Exchange, Instrument, Kind>:
+            Identifier<Exchange::Channel> + Identifier<Exchange::Market>,
+    {
+        let exchange = Exchange::ID;
+        let url = Exchange::url()?;
+        debug!(%exchange, %url, ?subscriptions, "subscribing to London Strategic Edge WebSocket");
+
+        let markets = requested_markets::<Exchange, Instrument, Kind>(subscriptions);
+
+        let mut websocket = connect(url).await?;
+        let authenticated = authenticate(&mut websocket, &self.credentials).await?;
+        debug!(
+            %exchange,
+            tier = ?authenticated.tier,
+            offered = authenticated.symbols.len(),
+            "authenticated to London Strategic Edge WebSocket",
+        );
+
+        check_subscription_cap(exchange, &markets, authenticated.max_subscriptions)?;
+        check_symbols_are_offered(exchange, &markets, &authenticated)?;
+
+        // Only the instrument map is taken from the standard mapper. The subscribe payloads are
+        // built here instead, because this subscriber is where a per-symbol replay window can be
+        // attached -- `Connector::requests` is a static function with no access to it. Both routes
+        // build their payloads with `subscribe_message`, so they cannot drift apart.
+        let SubscriptionMeta {
+            instrument_map,
+            ws_subscriptions: _,
+        } = Self::SubMapper::map::<Exchange, Instrument, Kind>(subscriptions);
+
+        for market in &markets {
+            let message = subscribe_message(market);
+            debug!(%exchange, payload = ?message, "sending London Strategic Edge subscription");
+            websocket
+                .send(message)
+                .await
+                .map_err(|error| SocketError::WebSocket(Box::new(error)))?;
+        }
+
+        let (map, buffered_websocket_events) = Exchange::SubValidator::validate::<
+            Exchange,
+            Instrument::Key,
+            Kind,
+        >(instrument_map, &mut websocket)
+        .await?;
+
+        debug!(%exchange, "London Strategic Edge subscriptions confirmed");
+        Ok(Subscribed {
+            websocket,
+            map,
+            buffered_websocket_events,
+        })
+    }
+}
+
+/// Build the subscribe payload for one symbol.
+///
+/// Shared with [`Connector::requests`] so the two routes into this protocol cannot disagree about
+/// its shape.
+pub(super) fn subscribe_message(symbol: &str) -> WsMessage {
+    WsMessage::text(json!({ "action": "subscribe", "symbol": symbol }).to_string())
+}
+
+/// The distinct symbols a batch will subscribe to, in the order they were requested.
+///
+/// Two subscriptions naming one symbol are one slot and one confirmation, and the instrument map
+/// is keyed the same way — so sending a payload per *subscription* would over-count against the
+/// cap and leave the validator waiting for a confirmation that never comes.
+///
+/// The linear scan is deliberate: the batch is bounded by the connection's subscription cap, which
+/// was sixteen when measured, and at that size it beats building a hash set.
+fn requested_markets<Exchange, Instrument, Kind>(
+    subscriptions: &[Subscription<Exchange, Instrument, Kind>],
+) -> Vec<SmolStr>
+where
+    Exchange: Connector,
+    Subscription<Exchange, Instrument, Kind>: Identifier<Exchange::Market>,
+{
+    let mut markets = Vec::<SmolStr>::with_capacity(subscriptions.len());
+
+    for subscription in subscriptions {
+        let market = Identifier::<Exchange::Market>::id(subscription);
+        let symbol = SmolStr::new(market.as_ref());
+
+        if !markets.contains(&symbol) {
+            markets.push(symbol);
+        }
+    }
+
+    markets
+}
+
+/// Reject a batch larger than the connection may hold.
+///
+/// # Errors
+/// Returns [`SocketError::Subscribe`] if `markets` exceeds `max_subscriptions`.
+fn check_subscription_cap(
+    exchange: ExchangeId,
+    markets: &[SmolStr],
+    max_subscriptions: Option<u32>,
+) -> Result<(), SocketError> {
+    let Some(max) = max_subscriptions else {
+        // Refusing here would break any tier whose cap this integration cannot read, and the
+        // provider still rejects an over-subscription observably. Proceed, but say so.
+        warn!(
+            %exchange,
+            "London Strategic Edge reported no subscription cap; the batch cannot be checked \
+             before it is sent",
+        );
+        return Ok(());
+    };
+
+    let cap = usize::try_from(max).unwrap_or(usize::MAX);
+    if markets.len() > cap {
+        return Err(SocketError::Subscribe(format!(
+            "{} symbols requested on {exchange} but this connection holds at most {cap} - the \
+             provider's rejection does not name the symbols it refuses, so there is no partial \
+             subscription to recover and the batch is rejected before it is sent",
+            markets.len(),
+        )));
+    }
+
+    Ok(())
+}
+
+/// Check every requested symbol against the list the handshake published.
+///
+/// # Errors
+/// Returns [`SocketError::Subscribe`] if a symbol is not offered, or if one is offered under a
+/// category that contradicts the dataset being subscribed on.
+fn check_symbols_are_offered(
+    exchange: ExchangeId,
+    markets: &[SmolStr],
+    authenticated: &LseAuthenticated,
+) -> Result<(), SocketError> {
+    if authenticated.symbols.is_empty() {
+        warn!(
+            %exchange,
+            "London Strategic Edge published no symbol list; a typo'd symbol will be confirmed and \
+             then never tick",
+        );
+        return Ok(());
+    }
+
+    let offered: HashMap<&str, Option<&str>> = authenticated
+        .symbols
+        .iter()
+        .map(|entry| (entry.symbol.as_str(), entry.category.as_deref()))
+        .collect();
+    let expected = expected_categories(exchange);
+
+    let mut unknown = Vec::new();
+    let mut miscategorised = Vec::new();
+
+    for market in markets {
+        match offered.get(market.as_str()) {
+            None => unknown.push(market.as_str()),
+            Some(category) => {
+                if let Some(category) = *category
+                    && !expected.is_empty()
+                    && !expected.contains(&category)
+                {
+                    miscategorised.push(format!("{market} is {category}"));
+                }
+            }
+        }
+    }
+
+    if !unknown.is_empty() {
+        return Err(SocketError::Subscribe(format!(
+            "London Strategic Edge does not offer {unknown:?} on its WebSocket - a symbol may be \
+             reachable through the catalog or the candle store and still be absent here, and \
+             subscribing to one the provider does not offer is CONFIRMED rather than rejected, \
+             then never ticks, while holding a subscription slot for the life of the connection",
+        )));
+    }
+
+    if !miscategorised.is_empty() {
+        return Err(SocketError::Subscribe(format!(
+            "London Strategic Edge categorises {miscategorised:?}, which does not match {exchange} \
+             (expected {expected:?}) - the symbol exists, but on a different dataset than the one \
+             being subscribed",
+        )));
+    }
+
+    Ok(())
+}
+
+/// The categories the handshake may report for symbols belonging to `exchange`.
+///
+/// Empty means this integration has no expectation to check against — the provider publishes no
+/// category for the datasets behind that identifier, so any category it did report would be
+/// unrecognised rather than wrong.
+fn expected_categories(exchange: ExchangeId) -> Vec<&'static str> {
+    LseDataset::ALL
+        .into_iter()
+        .filter(|dataset| dataset.exchange_id() == exchange)
+        .filter_map(|dataset| dataset.ws_category())
+        .collect()
+}
+
+/// Authenticate, and return the frame the provider answers with.
+async fn authenticate(
+    websocket: &mut WebSocket,
+    credentials: &LseCredentials,
+) -> Result<LseAuthenticated, SocketError> {
+    let auth = json!({ "action": "auth", "api_key": credentials.api_key }).to_string();
+
+    websocket
+        .send(WsMessage::text(auth))
+        .await
+        .map_err(|error| SocketError::WebSocket(Box::new(error)))?;
+
+    tokio::time::timeout(AUTH_TIMEOUT, async {
+        loop {
+            match websocket.next().await {
+                Some(Ok(WsMessage::Text(text))) => {
+                    if let Some(result) = read_auth_frame(text.as_str()) {
+                        return result;
+                    }
+                }
+                Some(Ok(WsMessage::Binary(bytes))) => {
+                    if let Ok(text) = std::str::from_utf8(&bytes)
+                        && let Some(result) = read_auth_frame(text)
+                    {
+                        return result;
+                    }
+                }
+                Some(Ok(WsMessage::Close(frame))) => {
+                    return Err(SocketError::Subscribe(format!(
+                        "WebSocket closed during London Strategic Edge authentication: {frame:?}"
+                    )));
+                }
+                Some(Ok(_)) => {}
+                Some(Err(error)) => return Err(SocketError::WebSocket(Box::new(error))),
+                None => {
+                    return Err(SocketError::Subscribe(
+                        "WebSocket closed before London Strategic Edge authentication completed"
+                            .to_owned(),
+                    ));
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|_| {
+        SocketError::Subscribe(format!(
+            "London Strategic Edge authentication timed out after {AUTH_TIMEOUT:?}"
+        ))
+    })?
+}
+
+/// Classify one frame received while awaiting authentication.
+///
+/// `None` means "not an answer to the auth request" — the server opens with a `welcome` frame
+/// before the key is ever sent, so waiting for a specific frame rather than any frame is what
+/// separates being connected from being authenticated.
+fn read_auth_frame(text: &str) -> Option<Result<LseAuthenticated, SocketError>> {
+    match serde_json::from_str::<LseAuthFrame>(text).ok()? {
+        LseAuthFrame::Authenticated(authenticated) => Some(Ok(authenticated)),
+        LseAuthFrame::Error { code, message } => Some(Err(SocketError::Subscribe(format!(
+            "London Strategic Edge rejected authentication ({}): {}",
+            code.as_deref().unwrap_or("unknown"),
+            message.as_deref().unwrap_or("no message"),
+        )))),
+        LseAuthFrame::Other => None,
+    }
+}
+
+/// A frame that may arrive while awaiting authentication.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum LseAuthFrame {
+    Authenticated(LseAuthenticated),
+    Error {
+        #[serde(default)]
+        code: Option<SmolStr>,
+        #[serde(default)]
+        message: Option<SmolStr>,
+    },
+    /// The `welcome` frame, and anything else this integration does not model.
+    #[serde(other)]
+    Other,
+}
+
+/// The provider's answer to a successful `auth`.
+///
+/// Its symbol list is what the pre-subscribe guards check against — see
+/// [`LseSubscriber::subscribe`].
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct LseAuthenticated {
+    /// The key's plan, as the provider names it (`registered` on a free key).
+    #[serde(default)]
+    pub tier: Option<SmolStr>,
+
+    /// Subscriptions this connection may hold, shared between symbols and option underlyings.
+    ///
+    /// `None` if the provider did not report one, in which case the batch cannot be checked before
+    /// it is sent.
+    #[serde(default)]
+    pub max_subscriptions: Option<u32>,
+
+    /// Every symbol the key may subscribe to.
+    ///
+    /// # ⚠️ This is not the same population as the catalog or the candle store
+    /// A symbol reachable on one of the provider's surfaces need not be reachable on all of them —
+    /// at least one series with tens of millions of historical ticks is absent from this list
+    /// entirely. Its length also drifts week to week, so nothing should assert a count.
+    #[serde(default)]
+    pub symbols: Vec<LseSymbol>,
+}
+
+impl fmt::Debug for LseAuthenticated {
+    /// Summarises the symbol list rather than printing it.
+    ///
+    /// The list ran to over eight thousand entries when measured, and this type is reachable from
+    /// tracing fields — deriving `Debug` would put megabytes into a single log line.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LseAuthenticated")
+            .field("tier", &self.tier)
+            .field("max_subscriptions", &self.max_subscriptions)
+            .field("symbols", &format_args!("<{} offered>", self.symbols.len()))
+            .finish()
+    }
+}
+
+/// One entry of the handshake's symbol list.
+///
+/// # ⚠️ Every field but `symbol` may be absent
+/// Entries are not uniform: roughly half carry no `category`, and at least one arrives as
+/// `{"symbol": "ES.F"}` — missing keys rather than null values. This is why the category check can
+/// only reject a *contradiction* and never an absence.
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct LseSymbol {
+    /// The display symbol, exactly as a subscribe must spell it.
+    pub symbol: SmolStr,
+
+    /// The instrument's descriptive name, where the provider publishes one.
+    #[serde(default)]
+    pub name: Option<SmolStr>,
+
+    /// The dataset the provider files this symbol under, where it publishes one.
+    #[serde(default)]
+    pub category: Option<SmolStr>,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::exchange::lse::{LseCrypto, LseEquities, LseFx};
+    use crate::subscription::trade::PublicTrades;
+    use rustrade_instrument::instrument::market_data::MarketDataInstrument;
+    use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
+
+    fn authenticated(symbols: &[(&str, Option<&str>)], max: Option<u32>) -> LseAuthenticated {
+        LseAuthenticated {
+            tier: Some("registered".into()),
+            max_subscriptions: max,
+            symbols: symbols
+                .iter()
+                .map(|(symbol, category)| LseSymbol {
+                    symbol: SmolStr::new(symbol),
+                    name: None,
+                    category: category.map(SmolStr::new),
+                })
+                .collect(),
+        }
+    }
+
+    fn markets(symbols: &[&str]) -> Vec<SmolStr> {
+        symbols.iter().map(SmolStr::new).collect()
+    }
+
+    #[test]
+    fn credentials_do_not_print_the_key() {
+        let printed = format!("{:?}", LseCredentials::new("super-secret-key"));
+
+        assert!(!printed.contains("super-secret-key"), "{printed}");
+        assert!(printed.contains("REDACTED"), "{printed}");
+    }
+
+    #[test]
+    fn a_subscribe_payload_names_the_symbol_and_nothing_else() {
+        let WsMessage::Text(payload) = subscribe_message("EUR/USD") else {
+            panic!("expected a text payload");
+        };
+        let payload: serde_json::Value = serde_json::from_str(payload.as_str()).unwrap();
+
+        assert_eq!(payload, json!({"action": "subscribe", "symbol": "EUR/USD"}));
+    }
+
+    /// Two subscriptions naming one symbol are one slot and one confirmation. Sending two payloads
+    /// would leave the validator waiting for a confirmation that never arrives.
+    #[test]
+    fn repeated_symbols_produce_one_subscribe_each() {
+        let subscription = |base: &str| -> Subscription<LseFx, MarketDataInstrument, PublicTrades> {
+            Subscription::from((
+                LseFx::default(),
+                base,
+                "usd",
+                MarketDataInstrumentKind::Spot,
+                PublicTrades,
+            ))
+        };
+        let subscriptions = [
+            subscription("eur"),
+            subscription("gbp"),
+            subscription("eur"),
+        ];
+
+        assert_eq!(
+            requested_markets(&subscriptions),
+            markets(&["EUR/USD", "GBP/USD"])
+        );
+    }
+
+    #[test]
+    fn a_batch_within_the_cap_is_accepted() {
+        let requested = markets(&["EUR/USD", "GBP/USD"]);
+        assert!(check_subscription_cap(ExchangeId::LseFx, &requested, Some(2)).is_ok());
+    }
+
+    #[test]
+    fn a_batch_over_the_cap_is_rejected_before_it_is_sent() {
+        let requested = markets(&["EUR/USD", "GBP/USD", "XAU/USD"]);
+        let error = check_subscription_cap(ExchangeId::LseFx, &requested, Some(2))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("at most 2"), "{error}");
+    }
+
+    /// Refusing a batch because the cap could not be read would break any tier whose cap this
+    /// integration does not recognise, and the provider still rejects an over-subscription itself.
+    #[test]
+    fn an_unreported_cap_does_not_reject_the_batch() {
+        let requested = markets(&["EUR/USD"]);
+        assert!(check_subscription_cap(ExchangeId::LseFx, &requested, None).is_ok());
+    }
+
+    #[test]
+    fn an_offered_symbol_passes_the_guard() {
+        let frame = authenticated(&[("EUR/USD", Some("Forex"))], Some(16));
+        let requested = markets(&["EUR/USD"]);
+
+        assert!(check_symbols_are_offered(ExchangeId::LseFx, &requested, &frame).is_ok());
+    }
+
+    /// The failure this guard exists for: the provider confirms a symbol it does not offer, never
+    /// ticks it, and holds the slot for the life of the connection.
+    #[test]
+    fn a_symbol_the_provider_does_not_offer_fails_the_batch() {
+        let frame = authenticated(&[("EUR/USD", Some("Forex"))], Some(16));
+        let requested = markets(&["EUR/USD", "NOPE_XYZ"]);
+
+        let error = check_symbols_are_offered(ExchangeId::LseFx, &requested, &frame)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("NOPE_XYZ"), "{error}");
+    }
+
+    #[test]
+    fn a_contradicting_category_fails_the_batch() {
+        let frame = authenticated(&[("AAPL", Some("Stocks"))], Some(16));
+        let requested = markets(&["AAPL"]);
+
+        let error = check_symbols_are_offered(ExchangeId::LseFx, &requested, &frame)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("AAPL is Stocks"), "{error}");
+    }
+
+    /// Roughly half the published entries carry no category, so absence must never be a mismatch.
+    #[test]
+    fn a_missing_category_is_not_a_contradiction() {
+        let frame = authenticated(&[("EUR/USD", None)], Some(16));
+        let requested = markets(&["EUR/USD"]);
+
+        assert!(check_symbols_are_offered(ExchangeId::LseFx, &requested, &frame).is_ok());
+    }
+
+    /// Datasets the provider publishes no category for must not reject the categories it does
+    /// publish — there is nothing to compare against.
+    #[test]
+    fn a_dataset_with_no_published_category_accepts_whatever_is_reported() {
+        assert!(expected_categories(ExchangeId::LseFutures).is_empty());
+
+        let frame = authenticated(&[("ES.F", Some("Anything"))], Some(16));
+        let requested = markets(&["ES.F"]);
+
+        assert!(check_symbols_are_offered(ExchangeId::LseFutures, &requested, &frame).is_ok());
+    }
+
+    /// Equities and ETFs share one identifier, so both categories must satisfy it.
+    #[test]
+    fn stocks_and_etfs_both_satisfy_the_equities_identifier() {
+        let expected = expected_categories(ExchangeId::LseEquities);
+        assert!(expected.contains(&"Stocks"), "{expected:?}");
+        assert!(expected.contains(&"ETFs"), "{expected:?}");
+
+        let frame = authenticated(&[("AAPL", Some("Stocks")), ("SPY", Some("ETFs"))], Some(16));
+        let requested = markets(&["AAPL", "SPY"]);
+
+        assert!(check_symbols_are_offered(ExchangeId::LseEquities, &requested, &frame).is_ok());
+    }
+
+    /// The server opens with a `welcome` frame before the key is ever sent, so treating any frame
+    /// as the answer would report success without authenticating.
+    #[test]
+    fn the_welcome_frame_is_not_mistaken_for_an_auth_response() {
+        let welcome = r#"{"type":"welcome","message":"hello","symbols_available":8516}"#;
+        assert!(read_auth_frame(welcome).is_none());
+    }
+
+    #[test]
+    fn an_auth_response_yields_the_symbol_list_and_the_cap() {
+        let input = r#"{"type":"authenticated","tier":"registered","key_type":"main",
+            "max_subscriptions":16,"symbols":[
+                {"symbol":"BTC/USD","name":"Bitcoin","category":"Crypto"},
+                {"symbol":"ES.F"}
+            ]}"#;
+        let frame = read_auth_frame(input).unwrap().unwrap();
+
+        assert_eq!(frame.tier.as_deref(), Some("registered"));
+        assert_eq!(frame.max_subscriptions, Some(16));
+        assert_eq!(frame.symbols.len(), 2);
+        assert_eq!(frame.symbols[1].symbol, "ES.F");
+        assert!(frame.symbols[1].name.is_none());
+        assert!(frame.symbols[1].category.is_none());
+    }
+
+    #[test]
+    fn a_rejected_key_is_reported_rather_than_awaited() {
+        let input = r#"{"type":"error","code":"INVALID_KEY","message":"invalid api key"}"#;
+        let error = read_auth_frame(input).unwrap().unwrap_err().to_string();
+
+        assert!(error.contains("INVALID_KEY"), "{error}");
+    }
+
+    /// The handshake frame is reachable from tracing fields, and the real list runs to thousands of
+    /// entries.
+    #[test]
+    fn the_auth_frame_summarises_its_symbol_list_when_printed() {
+        let frame = authenticated(&[("BTC/USD", Some("Crypto")), ("ETH/USD", None)], Some(16));
+        let printed = format!("{frame:?}");
+
+        assert!(printed.contains("<2 offered>"), "{printed}");
+        assert!(!printed.contains("BTC/USD"), "{printed}");
+    }
+
+    #[test]
+    fn every_dataset_identifier_expects_only_categories_the_provider_publishes() {
+        // A category expectation that no dataset publishes would reject every symbol on that
+        // identifier, so the two must be derived from one another rather than listed twice.
+        for exchange in [
+            ExchangeId::LseFx,
+            ExchangeId::LseCrypto,
+            ExchangeId::LseEquities,
+            ExchangeId::LseFutures,
+            ExchangeId::LseCfd,
+        ] {
+            for category in expected_categories(exchange) {
+                assert!(
+                    LseDataset::ALL
+                        .into_iter()
+                        .any(|dataset| dataset.ws_category() == Some(category)),
+                    "{exchange} expects an unpublished category {category:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unrelated_datasets_do_not_share_category_expectations() {
+        assert_eq!(expected_categories(ExchangeId::LseFx), vec!["Forex"]);
+        assert_eq!(expected_categories(ExchangeId::LseCrypto), vec!["Crypto"]);
+        assert!(!expected_categories(ExchangeId::LseCfd).contains(&"Forex"));
+
+        // Referenced so the connector aliases stay exercised by this module's tests.
+        let _ = (LseCrypto::default(), LseEquities::default());
+    }
+}

--- a/rustrade-data/src/exchange/lse/live.rs
+++ b/rustrade-data/src/exchange/lse/live.rs
@@ -1,6 +1,10 @@
 //! Live WebSocket subscription: authentication, the pre-subscribe guards, and the subscribe flow.
 
-use super::market::LseDataset;
+use super::{
+    market::LseDataset,
+    resume::{LseResumeState, epoch_seconds, subscription_id},
+    subscription::LseReplayFrame,
+};
 use crate::{
     Identifier,
     exchange::Connector,
@@ -12,6 +16,7 @@ use crate::{
     },
     subscription::{Subscription, SubscriptionKind, SubscriptionMeta},
 };
+use chrono::{DateTime, Utc};
 use futures::{SinkExt, StreamExt};
 use rustrade_instrument::exchange::ExchangeId;
 use rustrade_integration::{
@@ -21,7 +26,7 @@ use rustrade_integration::{
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use smol_str::SmolStr;
-use std::{collections::HashMap, env, fmt, time::Duration};
+use std::{collections::HashMap, env, fmt, sync::Arc, time::Duration};
 use tracing::{debug, warn};
 
 /// The environment variable [`LseCredentials::from_env`] reads.
@@ -108,12 +113,16 @@ impl LseCredentials {
 #[derive(Clone, Debug)]
 pub struct LseSubscriber {
     credentials: LseCredentials,
+    resume: Option<Arc<LseResumeState>>,
 }
 
 impl LseSubscriber {
-    /// Construct a subscriber with the provided credentials.
+    /// Construct a subscriber with the provided credentials, without resumption.
     pub fn new(credentials: LseCredentials) -> Self {
-        Self { credentials }
+        Self {
+            credentials,
+            resume: None,
+        }
     }
 
     /// Construct a subscriber from the `LSE_API_KEY` environment variable.
@@ -122,6 +131,67 @@ impl LseSubscriber {
     /// See [`LseCredentials::from_env`].
     pub fn from_env() -> Result<Self, SocketError> {
         Ok(Self::new(LseCredentials::from_env()?))
+    }
+
+    /// Resume from the last delivered event when a reconnect re-subscribes.
+    ///
+    /// Every stream opened by this subscriber shares `state`, and the same subscriber instance is
+    /// cloned into each reconnect attempt, so the watermark it accumulates survives the
+    /// reconnect that consults it.
+    ///
+    /// # ⚠️ Replay is not free, which is why this is opt-in
+    /// A resumed subscription is served its historical window before a single live tick. That
+    /// window is large: one hour of a single busy crypto symbol replayed **107,395 ticks** before
+    /// going live, and a 24-hour window had not drained after 30 seconds. A consumer that must
+    /// stay current will prefer the gap; a consumer recording a continuous tape will prefer the
+    /// replay. Choosing between those is the caller's business, so the default is off.
+    ///
+    /// # ⚠️ The provider retains only 24 hours, and clamps silently
+    /// A resume point older than that is **moved forward with no error**. This subscriber
+    /// compares what the provider says it will replay from against what was asked for and warns on
+    /// a mismatch, but that check is best-effort — see [`Self::subscribe`].
+    ///
+    /// # ⚠️ Streams carrying the same symbol must not share one state
+    /// Watermarks are keyed by symbol, not by symbol and subscription kind. Two streams carrying
+    /// one symbol — the same instrument subscribed as both trades and top-of-book, say — therefore
+    /// share a single entry and advance it independently: whichever stream is ahead sets the
+    /// resume point for both, and the one behind resumes past events it never delivered. Give each
+    /// such set of streams its own state. Streams over disjoint symbols may share one freely, and
+    /// that is the ordinary case — a batch spanning several symbols is exactly what this is for.
+    ///
+    /// Covers reconnects, not process restarts; see [`LseResumeState`].
+    #[must_use]
+    pub fn with_resume(mut self, state: Arc<LseResumeState>) -> Self {
+        self.resume = Some(state);
+        self
+    }
+
+    /// The resume state this subscriber shares with the streams it opens, if any.
+    pub(super) fn resume_state(&self) -> Option<Arc<LseResumeState>> {
+        self.resume.clone()
+    }
+
+    /// The instant a subscription to `market` should ask the provider to replay from.
+    ///
+    /// `None` — subscribe live, with no replay window — when the caller did not opt in, or when
+    /// nothing has been delivered for this symbol yet. The two are deliberately indistinguishable
+    /// here: a symbol added to a batch after a reconnect has no history to resume from and must
+    /// not be handed one.
+    ///
+    /// # The watermark's instant is sent unmodified, and that is load-bearing
+    /// `start` is **inclusive**, so the provider replays every event carrying it and the
+    /// transformer skips the prefix already delivered. Nudging the instant forward here to exclude
+    /// them instead would drop every event at that instant the previous connection had not yet
+    /// reached — and on a dataset where a single instant carried 141 ticks, that is not a rounding
+    /// error. Rounding it *down* to a coarser resolution would be the mirror failure: the provider
+    /// filters at microsecond resolution, so a millisecond-floored `start` would re-serve a whole
+    /// millisecond of already-delivered, timestamp-distinct events on the datasets that carry
+    /// microseconds.
+    fn resume_start(&self, market: &str) -> Option<DateTime<Utc>> {
+        self.resume
+            .as_ref()
+            .and_then(|state| state.watermark(&subscription_id(market)))
+            .map(|watermark| watermark.time_exchange)
     }
 }
 
@@ -190,8 +260,16 @@ impl Subscriber for LseSubscriber {
             ws_subscriptions: _,
         } = Self::SubMapper::map::<Exchange, Instrument, Kind>(subscriptions);
 
+        let mut requested_replays = Vec::<(SmolStr, DateTime<Utc>)>::new();
+
         for market in &markets {
-            let message = subscribe_message(market);
+            let start = self.resume_start(market);
+
+            if let Some(start) = start {
+                requested_replays.push((market.clone(), start));
+            }
+
+            let message = subscribe_message(market, start);
             debug!(%exchange, payload = ?message, "sending London Strategic Edge subscription");
             websocket
                 .send(message)
@@ -206,6 +284,8 @@ impl Subscriber for LseSubscriber {
         >(instrument_map, &mut websocket)
         .await?;
 
+        warn_on_clamped_replays(exchange, &requested_replays, &buffered_websocket_events);
+
         debug!(%exchange, "London Strategic Edge subscriptions confirmed");
         Ok(Subscribed {
             websocket,
@@ -215,12 +295,96 @@ impl Subscriber for LseSubscriber {
     }
 }
 
-/// Build the subscribe payload for one symbol.
+/// Build the subscribe payload for one symbol, optionally resuming from `start`.
 ///
 /// Shared with [`Connector::requests`] so the two routes into this protocol cannot disagree about
-/// its shape.
-pub(super) fn subscribe_message(symbol: &str) -> WsMessage {
-    WsMessage::text(json!({ "action": "subscribe", "symbol": symbol }).to_string())
+/// its shape. That route never resumes — it has no access to per-symbol state — and passes `None`.
+///
+/// `start` is sent as epoch seconds, the only spelling that can express a sub-second resume point;
+/// see [`epoch_seconds`] for why.
+pub(super) fn subscribe_message(symbol: &str, start: Option<DateTime<Utc>>) -> WsMessage {
+    let payload = match start {
+        Some(start) => json!({
+            "action": "subscribe",
+            "symbol": symbol,
+            "start": epoch_seconds(start),
+        }),
+        None => json!({ "action": "subscribe", "symbol": symbol }),
+    };
+
+    WsMessage::text(payload.to_string())
+}
+
+/// Warn when the provider opened a replay window later than the one asked for.
+///
+/// # ⚠️ Silent clamping is the failure this exists to surface
+/// The provider retains 24 hours. A `start` older than that is **moved forward and served with no
+/// error** — a window requested 48 hours back was answered with one beginning exactly 24 hours
+/// back. The `from` field of the `replay_started` frame is the only signal that it happened, so it
+/// is compared here against what was requested.
+///
+/// # ⚠️ Best-effort by construction
+/// Only frames that arrived *during* subscription validation can be inspected: those are what the
+/// validator hands back after failing to read them as subscription responses. A `replay_started`
+/// that arrives after the last confirmation is never seen here and its clamp goes unreported. The
+/// alternative — holding the connection open to wait for one frame per symbol — would delay every
+/// subscription for a warning, so the check is deliberately opportunistic rather than complete.
+fn warn_on_clamped_replays(
+    exchange: ExchangeId,
+    requested: &[(SmolStr, DateTime<Utc>)],
+    buffered: &[WsMessage],
+) {
+    for (symbol, requested_start, serving_from) in clamped_replays(requested, buffered) {
+        warn!(
+            %exchange,
+            %symbol,
+            requested = %requested_start,
+            serving_from = %serving_from,
+            "London Strategic Edge clamped the requested replay window; events between the two \
+             instants are beyond the provider's retention and are permanently lost",
+        );
+    }
+}
+
+/// The replay windows the provider opened later than asked for, as
+/// `(symbol, requested, serving from)`.
+///
+/// A window opened *at* the requested instant is not a clamp: `start` is inclusive, so that is
+/// precisely the window that was requested. Frames naming a symbol no replay was requested for are
+/// ignored rather than reported — a subscription that asked for no window cannot have had one
+/// clamped, and the buffer also carries frames belonging to other subscriptions entirely.
+fn clamped_replays(
+    requested: &[(SmolStr, DateTime<Utc>)],
+    buffered: &[WsMessage],
+) -> Vec<(SmolStr, DateTime<Utc>, DateTime<Utc>)> {
+    if requested.is_empty() {
+        return Vec::new();
+    }
+
+    let mut clamped = Vec::new();
+
+    for message in buffered {
+        let WsMessage::Text(payload) = message else {
+            continue;
+        };
+
+        let Ok(LseReplayFrame::ReplayStarted { symbol, from }) =
+            serde_json::from_str::<LseReplayFrame>(payload.as_str())
+        else {
+            continue;
+        };
+
+        let Some((_, requested_start)) = requested.iter().find(|(market, _)| *market == symbol)
+        else {
+            continue;
+        };
+
+        if from > *requested_start {
+            clamped.push((symbol, *requested_start, from));
+        }
+    }
+
+    clamped
 }
 
 /// The distinct symbols a batch will subscribe to, in the order they were requested.
@@ -534,6 +698,22 @@ mod tests {
         symbols.iter().map(SmolStr::new).collect()
     }
 
+    fn at(spelling: &str) -> DateTime<Utc> {
+        spelling.parse::<DateTime<Utc>>().unwrap()
+    }
+
+    /// The microsecond count as a float, so the epoch assertions compare in the float domain and
+    /// need no truncating cast of their own.
+    fn micros_as_f64(time: DateTime<Utc>) -> f64 {
+        time.timestamp_micros() as f64
+    }
+
+    fn replay_started(symbol: &str, from: &str) -> WsMessage {
+        WsMessage::text(
+            json!({"type": "replay_started", "symbol": symbol, "from": from}).to_string(),
+        )
+    }
+
     #[test]
     fn credentials_do_not_print_the_key() {
         let printed = format!("{:?}", LseCredentials::new("super-secret-key"));
@@ -544,12 +724,108 @@ mod tests {
 
     #[test]
     fn a_subscribe_payload_names_the_symbol_and_nothing_else() {
-        let WsMessage::Text(payload) = subscribe_message("EUR/USD") else {
+        let WsMessage::Text(payload) = subscribe_message("EUR/USD", None) else {
             panic!("expected a text payload");
         };
         let payload: serde_json::Value = serde_json::from_str(payload.as_str()).unwrap();
 
         assert_eq!(payload, json!({"action": "subscribe", "symbol": "EUR/USD"}));
+    }
+
+    /// The resume point has to survive the trip out as a number the provider can filter on at its
+    /// own resolution: it parses `start` with a float conversion first, and its datetime fallback
+    /// accepts neither a fractional second nor an offset.
+    #[test]
+    fn a_subscribe_payload_carrying_a_resume_point_sends_it_as_epoch_seconds() {
+        let start = at("2026-08-14T10:16:55.161234Z");
+
+        let WsMessage::Text(payload) = subscribe_message("BTC/USD", Some(start)) else {
+            panic!("expected a text payload");
+        };
+        let payload: serde_json::Value = serde_json::from_str(payload.as_str()).unwrap();
+        let payload = payload.as_object().unwrap();
+
+        assert_eq!(payload.len(), 3, "{payload:?}");
+        assert_eq!(payload["action"], json!("subscribe"));
+        assert_eq!(payload["symbol"], json!("BTC/USD"));
+
+        let seconds = payload["start"]
+            .as_f64()
+            .unwrap_or_else(|| panic!("start must be a JSON number, not {:?}", payload["start"]));
+        let drift = seconds * 1_000_000.0 - micros_as_f64(start);
+        assert!(drift.abs() < 0.5, "start drifted {drift} microseconds");
+    }
+
+    /// A subscription that has delivered nothing has nothing to resume from, and must be sent the
+    /// same payload a first-ever subscribe sends.
+    #[test]
+    fn a_subscriber_without_resume_asks_for_no_replay_window() {
+        let subscriber = LseSubscriber::new(LseCredentials::new("key"));
+
+        assert_eq!(subscriber.resume_start("BTC/USD"), None);
+    }
+
+    /// A reconnect re-subscribes every symbol in the batch, including ones added since the last
+    /// connection. Only those with a watermark may carry a window.
+    #[test]
+    fn a_resuming_subscriber_asks_for_a_window_only_where_it_has_delivered() {
+        let state = Arc::new(LseResumeState::new());
+        state.record(
+            &subscription_id("BTC/USD"),
+            at("2026-08-14T10:16:55.161234Z"),
+        );
+
+        let subscriber = LseSubscriber::new(LseCredentials::new("key")).with_resume(state);
+
+        assert_eq!(
+            subscriber.resume_start("BTC/USD"),
+            Some(at("2026-08-14T10:16:55.161234Z")),
+        );
+        assert_eq!(subscriber.resume_start("ETH/USD"), None);
+    }
+
+    /// The provider retains 24 hours and moves an older `start` forward with no error, so the
+    /// `replay_started` frame is the only evidence the requested window was not the served one.
+    #[test]
+    fn a_replay_window_opened_later_than_requested_is_reported() {
+        let requested = vec![("BTC/USD".into(), at("2026-08-12T10:00:00Z"))];
+        let buffered = [replay_started("BTC/USD", "2026-08-13T10:00:00+00:00")];
+
+        assert_eq!(
+            clamped_replays(&requested, &buffered),
+            vec![(
+                SmolStr::new("BTC/USD"),
+                at("2026-08-12T10:00:00Z"),
+                at("2026-08-13T10:00:00Z"),
+            )],
+        );
+    }
+
+    /// `start` is inclusive, so a window opened exactly where it was asked for is the window that
+    /// was asked for — warning on it would make the check noise on every ordinary resume.
+    #[test]
+    fn a_replay_window_opened_where_requested_is_not_a_clamp() {
+        let requested = vec![("BTC/USD".into(), at("2026-08-14T10:16:55.161234Z"))];
+        let buffered = [replay_started(
+            "BTC/USD",
+            "2026-08-14T10:16:55.161234+00:00",
+        )];
+
+        assert!(clamped_replays(&requested, &buffered).is_empty());
+    }
+
+    /// The buffer holds whatever failed to read as a subscription response, which includes frames
+    /// for symbols this batch never asked to resume.
+    #[test]
+    fn a_replay_for_a_symbol_no_window_was_requested_for_is_ignored() {
+        let requested = vec![("BTC/USD".into(), at("2026-08-12T10:00:00Z"))];
+        let buffered = [
+            replay_started("ETH/USD", "2026-08-13T10:00:00+00:00"),
+            WsMessage::text(r#"{"type":"subscribed","symbol":"BTC/USD","count":1,"max":16}"#),
+            WsMessage::text("not json at all"),
+        ];
+
+        assert!(clamped_replays(&requested, &buffered).is_empty());
     }
 
     /// Two subscriptions naming one symbol are one slot and one confirmation. Sending two payloads

--- a/rustrade-data/src/exchange/lse/live.rs
+++ b/rustrade-data/src/exchange/lse/live.rs
@@ -2,8 +2,7 @@
 
 use super::{
     market::LseDataset,
-    resume::{LseResumeState, epoch_seconds, subscription_id},
-    subscription::LseReplayFrame,
+    resume::{LseResumeKey, LseResumeState, epoch_seconds, subscription_id},
 };
 use crate::{
     Identifier,
@@ -147,17 +146,22 @@ impl LseSubscriber {
     /// replay. Choosing between those is the caller's business, so the default is off.
     ///
     /// # ⚠️ The provider retains only 24 hours, and clamps silently
-    /// A resume point older than that is **moved forward with no error**. This subscriber
-    /// compares what the provider says it will replay from against what was asked for and warns on
-    /// a mismatch, but that check is best-effort — see [`Self::subscribe`].
+    /// A resume point older than that is **moved forward with no error**. The stream compares what
+    /// the provider says it will replay from against what was asked for and warns on a mismatch;
+    /// see [`LseMessage::ReplayStarted`](super::tick::LseMessage::ReplayStarted).
     ///
-    /// # ⚠️ Streams carrying the same symbol must not share one state
-    /// Watermarks are keyed by symbol, not by symbol and subscription kind. Two streams carrying
-    /// one symbol — the same instrument subscribed as both trades and top-of-book, say — therefore
-    /// share a single entry and advance it independently: whichever stream is ahead sets the
-    /// resume point for both, and the one behind resumes past events it never delivered. Give each
-    /// such set of streams its own state. Streams over disjoint symbols may share one freely, and
-    /// that is the ordinary case — a batch spanning several symbols is exactly what this is for.
+    /// One state may be shared by any set of streams, including two carrying the same symbol as
+    /// different kinds — watermarks are keyed by subscription *and* kind.
+    ///
+    /// # ⚠️ The replayed prefix is skipped by position, not by the `replay` flag
+    /// The provider re-serves every tick sharing the resume instant, and the ones already delivered
+    /// are dropped by counting rather than by trusting each tick's `replay` stamp — a provider that
+    /// stopped stamping them would otherwise turn every reconnect into a duplicate flood. The cost
+    /// is a narrow one: if the replay under-delivers at that instant, a genuinely *live* tick
+    /// arriving there while the count is still open is dropped as though it were one of the missing
+    /// duplicates. It requires the whole reconnect to land inside one timestamp quantum of the
+    /// resume instant, so it is unlikely rather than impossible, and it is reported by a `warn!`
+    /// naming the subscription and the instant rather than passing silently.
     ///
     /// Covers reconnects, not process restarts; see [`LseResumeState`].
     #[must_use]
@@ -187,10 +191,10 @@ impl LseSubscriber {
     /// filters at microsecond resolution, so a millisecond-floored `start` would re-serve a whole
     /// millisecond of already-delivered, timestamp-distinct events on the datasets that carry
     /// microseconds.
-    fn resume_start(&self, market: &str) -> Option<DateTime<Utc>> {
+    fn resume_start(&self, market: &str, kind: &'static str) -> Option<DateTime<Utc>> {
         self.resume
             .as_ref()
-            .and_then(|state| state.watermark(&subscription_id(market)))
+            .and_then(|state| state.watermark(&LseResumeKey::new(subscription_id(market), kind)))
             .map(|watermark| watermark.time_exchange)
     }
 }
@@ -210,9 +214,11 @@ impl Subscriber for LseSubscriber {
     ///
     /// Two checks run over that list:
     /// - **Membership is enforced.** A symbol the provider does not offer fails the batch.
-    /// - **The category is only cross-checked when the provider supplies one.** Roughly half the
-    ///   published entries carry no `category` key at all — and some carry neither `category` nor
-    ///   `name` — so absence is normal and can never be treated as a mismatch.
+    /// - **The category is only cross-checked when the provider supplies a label this integration
+    ///   recognises.** Roughly half the published entries carry no `category` key at all — and some
+    ///   carry neither `category` nor `name` — so absence is normal and can never be treated as a
+    ///   mismatch. Neither can a label we do not know: only one we recognise as belonging to a
+    ///   *different* dataset is evidence of anything.
     ///
     /// The subscription cap is enforced in the same pass, because an over-cap batch is rejected
     /// *anonymously*: the provider's rejection does not name the symbol it refused, leaving no
@@ -260,15 +266,15 @@ impl Subscriber for LseSubscriber {
             ws_subscriptions: _,
         } = Self::SubMapper::map::<Exchange, Instrument, Kind>(subscriptions);
 
-        let mut requested_replays = Vec::<(SmolStr, DateTime<Utc>)>::new();
+        // Every subscription in a batch shares one `Kind`, and a watermark is filed under the kind
+        // it was delivered for -- see `LseResumeKey`. `markets` is empty when `subscriptions` is,
+        // so the loop below never runs without one.
+        let kind = subscriptions
+            .first()
+            .map(|subscription| subscription.kind.as_str());
 
         for market in &markets {
-            let start = self.resume_start(market);
-
-            if let Some(start) = start {
-                requested_replays.push((market.clone(), start));
-            }
-
+            let start = kind.and_then(|kind| self.resume_start(market, kind));
             let message = subscribe_message(market, start);
             debug!(%exchange, payload = ?message, "sending London Strategic Edge subscription");
             websocket
@@ -283,8 +289,6 @@ impl Subscriber for LseSubscriber {
             Kind,
         >(instrument_map, &mut websocket)
         .await?;
-
-        warn_on_clamped_replays(exchange, &requested_replays, &buffered_websocket_events);
 
         debug!(%exchange, "London Strategic Edge subscriptions confirmed");
         Ok(Subscribed {
@@ -313,78 +317,6 @@ pub(super) fn subscribe_message(symbol: &str, start: Option<DateTime<Utc>>) -> W
     };
 
     WsMessage::text(payload.to_string())
-}
-
-/// Warn when the provider opened a replay window later than the one asked for.
-///
-/// # ⚠️ Silent clamping is the failure this exists to surface
-/// The provider retains 24 hours. A `start` older than that is **moved forward and served with no
-/// error** — a window requested 48 hours back was answered with one beginning exactly 24 hours
-/// back. The `from` field of the `replay_started` frame is the only signal that it happened, so it
-/// is compared here against what was requested.
-///
-/// # ⚠️ Best-effort by construction
-/// Only frames that arrived *during* subscription validation can be inspected: those are what the
-/// validator hands back after failing to read them as subscription responses. A `replay_started`
-/// that arrives after the last confirmation is never seen here and its clamp goes unreported. The
-/// alternative — holding the connection open to wait for one frame per symbol — would delay every
-/// subscription for a warning, so the check is deliberately opportunistic rather than complete.
-fn warn_on_clamped_replays(
-    exchange: ExchangeId,
-    requested: &[(SmolStr, DateTime<Utc>)],
-    buffered: &[WsMessage],
-) {
-    for (symbol, requested_start, serving_from) in clamped_replays(requested, buffered) {
-        warn!(
-            %exchange,
-            %symbol,
-            requested = %requested_start,
-            serving_from = %serving_from,
-            "London Strategic Edge clamped the requested replay window; events between the two \
-             instants are beyond the provider's retention and are permanently lost",
-        );
-    }
-}
-
-/// The replay windows the provider opened later than asked for, as
-/// `(symbol, requested, serving from)`.
-///
-/// A window opened *at* the requested instant is not a clamp: `start` is inclusive, so that is
-/// precisely the window that was requested. Frames naming a symbol no replay was requested for are
-/// ignored rather than reported — a subscription that asked for no window cannot have had one
-/// clamped, and the buffer also carries frames belonging to other subscriptions entirely.
-fn clamped_replays(
-    requested: &[(SmolStr, DateTime<Utc>)],
-    buffered: &[WsMessage],
-) -> Vec<(SmolStr, DateTime<Utc>, DateTime<Utc>)> {
-    if requested.is_empty() {
-        return Vec::new();
-    }
-
-    let mut clamped = Vec::new();
-
-    for message in buffered {
-        let WsMessage::Text(payload) = message else {
-            continue;
-        };
-
-        let Ok(LseReplayFrame::ReplayStarted { symbol, from }) =
-            serde_json::from_str::<LseReplayFrame>(payload.as_str())
-        else {
-            continue;
-        };
-
-        let Some((_, requested_start)) = requested.iter().find(|(market, _)| *market == symbol)
-        else {
-            continue;
-        };
-
-        if from > *requested_start {
-            clamped.push((symbol, *requested_start, from));
-        }
-    }
-
-    clamped
 }
 
 /// The distinct symbols a batch will subscribe to, in the order they were requested.
@@ -485,6 +417,7 @@ fn check_symbols_are_offered(
                 if let Some(category) = *category
                     && !expected.is_empty()
                     && !expected.contains(&category)
+                    && is_published_category(category)
                 {
                     miscategorised.push(format!("{market} is {category}"));
                 }
@@ -523,6 +456,25 @@ fn expected_categories(exchange: ExchangeId) -> Vec<&'static str> {
         .filter(|dataset| dataset.exchange_id() == exchange)
         .filter_map(|dataset| dataset.ws_category())
         .collect()
+}
+
+/// Whether `category` is a label this integration knows some dataset by.
+///
+/// # Why an unrecognised label can never be a contradiction
+/// [`expected_categories`] is only as complete as what the provider publishes *today*, and it is
+/// complete for no better reason than that the provider has not labelled more. Five datasets stand
+/// behind [`ExchangeId::LseCfd`] and only two of them are labelled, so the day the provider begins
+/// publishing a category for one of the other three — its published list moved by hundreds of
+/// entries in a week when measured — a correctly-requested symbol would read as belonging to a
+/// different dataset and fail the whole batch, every other symbol in it included, with no change on
+/// our side.
+///
+/// A label we do not recognise says nothing about which dataset a symbol belongs to. Only one we
+/// recognise as belonging somewhere *else* is evidence, and that is the only case this admits.
+fn is_published_category(category: &str) -> bool {
+    LseDataset::ALL
+        .into_iter()
+        .any(|dataset| dataset.ws_category() == Some(category))
 }
 
 /// Authenticate, and return the frame the provider answers with.
@@ -675,7 +627,9 @@ pub struct LseSymbol {
 mod tests {
     use super::*;
     use crate::exchange::lse::{LseCrypto, LseEquities, LseFx};
-    use crate::subscription::trade::PublicTrades;
+    // `SubscriptionKind` is already in scope through `use super::*`, which is what `as_str` below
+    // resolves through.
+    use crate::subscription::{book::OrderBooksL1, trade::PublicTrades};
     use rustrade_instrument::instrument::market_data::MarketDataInstrument;
     use rustrade_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
 
@@ -706,12 +660,6 @@ mod tests {
     /// need no truncating cast of their own.
     fn micros_as_f64(time: DateTime<Utc>) -> f64 {
         time.timestamp_micros() as f64
-    }
-
-    fn replay_started(symbol: &str, from: &str) -> WsMessage {
-        WsMessage::text(
-            json!({"type": "replay_started", "symbol": symbol, "from": from}).to_string(),
-        )
     }
 
     #[test]
@@ -762,7 +710,10 @@ mod tests {
     fn a_subscriber_without_resume_asks_for_no_replay_window() {
         let subscriber = LseSubscriber::new(LseCredentials::new("key"));
 
-        assert_eq!(subscriber.resume_start("BTC/USD"), None);
+        assert_eq!(
+            subscriber.resume_start("BTC/USD", PublicTrades.as_str()),
+            None
+        );
     }
 
     /// A reconnect re-subscribes every symbol in the batch, including ones added since the last
@@ -771,61 +722,40 @@ mod tests {
     fn a_resuming_subscriber_asks_for_a_window_only_where_it_has_delivered() {
         let state = Arc::new(LseResumeState::new());
         state.record(
-            &subscription_id("BTC/USD"),
+            &LseResumeKey::new(subscription_id("BTC/USD"), PublicTrades.as_str()),
             at("2026-08-14T10:16:55.161234Z"),
         );
 
         let subscriber = LseSubscriber::new(LseCredentials::new("key")).with_resume(state);
 
         assert_eq!(
-            subscriber.resume_start("BTC/USD"),
+            subscriber.resume_start("BTC/USD", PublicTrades.as_str()),
             Some(at("2026-08-14T10:16:55.161234Z")),
         );
-        assert_eq!(subscriber.resume_start("ETH/USD"), None);
-    }
-
-    /// The provider retains 24 hours and moves an older `start` forward with no error, so the
-    /// `replay_started` frame is the only evidence the requested window was not the served one.
-    #[test]
-    fn a_replay_window_opened_later_than_requested_is_reported() {
-        let requested = vec![("BTC/USD".into(), at("2026-08-12T10:00:00Z"))];
-        let buffered = [replay_started("BTC/USD", "2026-08-13T10:00:00+00:00")];
-
         assert_eq!(
-            clamped_replays(&requested, &buffered),
-            vec![(
-                SmolStr::new("BTC/USD"),
-                at("2026-08-12T10:00:00Z"),
-                at("2026-08-13T10:00:00Z"),
-            )],
+            subscriber.resume_start("ETH/USD", PublicTrades.as_str()),
+            None
         );
     }
 
-    /// `start` is inclusive, so a window opened exactly where it was asked for is the window that
-    /// was asked for — warning on it would make the check noise on every ordinary resume.
+    /// The provider has one channel, so both kinds tick under one wire identifier. A window is
+    /// asked for on the strength of what *this* kind delivered, never what another one did — the
+    /// trailing stream would otherwise resume past events it never saw.
     #[test]
-    fn a_replay_window_opened_where_requested_is_not_a_clamp() {
-        let requested = vec![("BTC/USD".into(), at("2026-08-14T10:16:55.161234Z"))];
-        let buffered = [replay_started(
-            "BTC/USD",
-            "2026-08-14T10:16:55.161234+00:00",
-        )];
+    fn a_window_is_asked_for_per_kind_rather_than_per_symbol() {
+        let state = Arc::new(LseResumeState::new());
+        state.record(
+            &LseResumeKey::new(subscription_id("BTC/USD"), PublicTrades.as_str()),
+            at("2026-08-14T10:16:55.161234Z"),
+        );
 
-        assert!(clamped_replays(&requested, &buffered).is_empty());
-    }
+        let subscriber = LseSubscriber::new(LseCredentials::new("key")).with_resume(state);
 
-    /// The buffer holds whatever failed to read as a subscription response, which includes frames
-    /// for symbols this batch never asked to resume.
-    #[test]
-    fn a_replay_for_a_symbol_no_window_was_requested_for_is_ignored() {
-        let requested = vec![("BTC/USD".into(), at("2026-08-12T10:00:00Z"))];
-        let buffered = [
-            replay_started("ETH/USD", "2026-08-13T10:00:00+00:00"),
-            WsMessage::text(r#"{"type":"subscribed","symbol":"BTC/USD","count":1,"max":16}"#),
-            WsMessage::text("not json at all"),
-        ];
-
-        assert!(clamped_replays(&requested, &buffered).is_empty());
+        assert_eq!(
+            subscriber.resume_start("BTC/USD", OrderBooksL1.as_str()),
+            None,
+            "a kind that has delivered nothing must subscribe live, not from another kind's mark",
+        );
     }
 
     /// Two subscriptions naming one symbol are one slot and one confirmation. Sending two payloads
@@ -898,6 +828,22 @@ mod tests {
         assert!(error.contains("NOPE_XYZ"), "{error}");
     }
 
+    /// The same symbol the test above rejects, and the list it was checked against removed. There
+    /// is then nothing to check, so the guard degrades to a warning rather than failing a batch it
+    /// cannot judge — refusing would break every caller the moment the provider stopped publishing
+    /// its catalog in the handshake.
+    ///
+    /// This branch is why the live canary asserts a rejection instead of trusting the guard: pinned
+    /// only by this test, the degradation is silent, and a provider that quietly dropped the list
+    /// would leave the guard passing everything forever.
+    #[test]
+    fn an_absent_symbol_list_degrades_to_a_warning_rather_than_failing_the_batch() {
+        let frame = authenticated(&[], Some(16));
+        let requested = markets(&["NOPE_XYZ"]);
+
+        assert!(check_symbols_are_offered(ExchangeId::LseFx, &requested, &frame).is_ok());
+    }
+
     #[test]
     fn a_contradicting_category_fails_the_batch() {
         let frame = authenticated(&[("AAPL", Some("Stocks"))], Some(16));
@@ -907,6 +853,29 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("AAPL is Stocks"), "{error}");
+    }
+
+    /// The same rule where the labels are *complete*, which is the case a symbol-shaped reading of
+    /// "only cross-check what we recognise" would leave out.
+    ///
+    /// A label is evidence only if some dataset is known by it, whether or not this exchange's own
+    /// expectation has gaps. Restricting the leniency to the partially-labelled exchanges would
+    /// leave the same defect standing here in a slower form: the provider renaming `Forex` makes
+    /// this expectation complete but *stale*, and every correctly-requested `LseFx` batch then
+    /// fails on a label that is simply newer than the table.
+    #[test]
+    fn an_unrecognised_label_is_not_a_contradiction_even_where_the_labels_are_complete() {
+        let expected = expected_categories(ExchangeId::LseFx);
+        assert_eq!(
+            expected,
+            ["Forex"],
+            "this exchange's expectation is complete, which is the point: {expected:?}"
+        );
+
+        let frame = authenticated(&[("EUR/USD", Some("FX Majors"))], Some(16));
+        let requested = markets(&["EUR/USD"]);
+
+        assert!(check_symbols_are_offered(ExchangeId::LseFx, &requested, &frame).is_ok());
     }
 
     /// Roughly half the published entries carry no category, so absence must never be a mismatch.
@@ -928,6 +897,38 @@ mod tests {
         let requested = markets(&["ES.F"]);
 
         assert!(check_symbols_are_offered(ExchangeId::LseFutures, &requested, &frame).is_ok());
+    }
+
+    /// Five datasets stand behind `LseCfd` and the provider labels two of them, so its expectation
+    /// is partial. A label appearing on one of the other three must not read as "this symbol
+    /// belongs to a different dataset" and fail the batch — the published list moved by hundreds of
+    /// entries in a week when measured, and this is what a correct subscription would meet.
+    #[test]
+    fn a_label_no_dataset_is_known_by_is_not_a_contradiction() {
+        let expected = expected_categories(ExchangeId::LseCfd);
+        assert!(expected.contains(&"Indices"), "{expected:?}");
+        assert!(
+            !expected.contains(&"Volatility"),
+            "the expectation is partial by construction: {expected:?}"
+        );
+
+        let frame = authenticated(&[("VIX/USD", Some("Volatility"))], Some(16));
+        let requested = markets(&["VIX/USD"]);
+
+        assert!(check_symbols_are_offered(ExchangeId::LseCfd, &requested, &frame).is_ok());
+    }
+
+    /// The other half of the same rule: a label we recognise as belonging elsewhere still fails,
+    /// because that is evidence the symbol is on a different dataset.
+    #[test]
+    fn a_label_belonging_to_another_dataset_still_fails_the_batch() {
+        let frame = authenticated(&[("AAPL", Some("Stocks"))], Some(16));
+        let requested = markets(&["AAPL"]);
+
+        let error = check_symbols_are_offered(ExchangeId::LseCfd, &requested, &frame)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("AAPL is Stocks"), "{error}");
     }
 
     /// Equities and ETFs share one identifier, so both categories must satisfy it.

--- a/rustrade-data/src/exchange/lse/live.rs
+++ b/rustrade-data/src/exchange/lse/live.rs
@@ -150,8 +150,11 @@ impl LseSubscriber {
     /// the provider says it will replay from against what was asked for and warns on a mismatch;
     /// see [`LseMessage::ReplayStarted`](super::tick::LseMessage::ReplayStarted).
     ///
-    /// One state may be shared by any set of streams, including two carrying the same symbol as
-    /// different kinds — watermarks are keyed by subscription *and* kind.
+    /// # ⚠️ One state per duplicated subscription
+    /// Watermarks are keyed by dataset, subscription **and** subscription kind, so one state serves
+    /// any set of streams that differ in any of those three. Two streams that duplicate all three
+    /// share one watermark and advance it independently, which resumes the trailing one past events
+    /// it never delivered — see [`LseResumeState`] for the obligation in full.
     ///
     /// # ⚠️ The replayed prefix is skipped by position, not by the `replay` flag
     /// The provider re-serves every tick sharing the resume instant, and the ones already delivered
@@ -182,6 +185,11 @@ impl LseSubscriber {
     /// here: a symbol added to a batch after a reconnect has no history to resume from and must
     /// not be handed one.
     ///
+    /// `exchange` and `kind` are the other two axes the watermark is filed under. Reading one
+    /// without them would resume this subscription from whatever another dataset or another kind
+    /// last delivered for the same symbol, which is a window that skips events this stream never
+    /// saw.
+    ///
     /// # The watermark's instant is sent unmodified, and that is load-bearing
     /// `start` is **inclusive**, so the provider replays every event carrying it and the
     /// transformer skips the prefix already delivered. Nudging the instant forward here to exclude
@@ -191,10 +199,17 @@ impl LseSubscriber {
     /// filters at microsecond resolution, so a millisecond-floored `start` would re-serve a whole
     /// millisecond of already-delivered, timestamp-distinct events on the datasets that carry
     /// microseconds.
-    fn resume_start(&self, market: &str, kind: &'static str) -> Option<DateTime<Utc>> {
+    fn resume_start(
+        &self,
+        exchange: ExchangeId,
+        market: &str,
+        kind: &'static str,
+    ) -> Option<DateTime<Utc>> {
         self.resume
             .as_ref()
-            .and_then(|state| state.watermark(&LseResumeKey::new(subscription_id(market), kind)))
+            .and_then(|state| {
+                state.watermark(&LseResumeKey::new(exchange, subscription_id(market), kind))
+            })
             .map(|watermark| watermark.time_exchange)
     }
 }
@@ -266,15 +281,15 @@ impl Subscriber for LseSubscriber {
             ws_subscriptions: _,
         } = Self::SubMapper::map::<Exchange, Instrument, Kind>(subscriptions);
 
-        // Every subscription in a batch shares one `Kind`, and a watermark is filed under the kind
-        // it was delivered for -- see `LseResumeKey`. `markets` is empty when `subscriptions` is,
-        // so the loop below never runs without one.
+        // Every subscription in a batch shares one `Kind`, and a watermark is filed under the
+        // dataset and the kind it was delivered for -- see `LseResumeKey`. `markets` is empty when
+        // `subscriptions` is, so the loop below never runs without one.
         let kind = subscriptions
             .first()
             .map(|subscription| subscription.kind.as_str());
 
         for market in &markets {
-            let start = kind.and_then(|kind| self.resume_start(market, kind));
+            let start = kind.and_then(|kind| self.resume_start(exchange, market, kind));
             let message = subscribe_message(market, start);
             debug!(%exchange, payload = ?message, "sending London Strategic Edge subscription");
             websocket
@@ -626,7 +641,7 @@ pub struct LseSymbol {
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
-    use crate::exchange::lse::{LseCrypto, LseEquities, LseFx};
+    use crate::exchange::lse::LseFx;
     // `SubscriptionKind` is already in scope through `use super::*`, which is what `as_str` below
     // resolves through.
     use crate::subscription::{book::OrderBooksL1, trade::PublicTrades};
@@ -711,7 +726,7 @@ mod tests {
         let subscriber = LseSubscriber::new(LseCredentials::new("key"));
 
         assert_eq!(
-            subscriber.resume_start("BTC/USD", PublicTrades.as_str()),
+            subscriber.resume_start(ExchangeId::LseCrypto, "BTC/USD", PublicTrades.as_str()),
             None
         );
     }
@@ -722,18 +737,22 @@ mod tests {
     fn a_resuming_subscriber_asks_for_a_window_only_where_it_has_delivered() {
         let state = Arc::new(LseResumeState::new());
         state.record(
-            &LseResumeKey::new(subscription_id("BTC/USD"), PublicTrades.as_str()),
+            &LseResumeKey::new(
+                ExchangeId::LseCrypto,
+                subscription_id("BTC/USD"),
+                PublicTrades.as_str(),
+            ),
             at("2026-08-14T10:16:55.161234Z"),
         );
 
         let subscriber = LseSubscriber::new(LseCredentials::new("key")).with_resume(state);
 
         assert_eq!(
-            subscriber.resume_start("BTC/USD", PublicTrades.as_str()),
+            subscriber.resume_start(ExchangeId::LseCrypto, "BTC/USD", PublicTrades.as_str()),
             Some(at("2026-08-14T10:16:55.161234Z")),
         );
         assert_eq!(
-            subscriber.resume_start("ETH/USD", PublicTrades.as_str()),
+            subscriber.resume_start(ExchangeId::LseCrypto, "ETH/USD", PublicTrades.as_str()),
             None
         );
     }
@@ -745,16 +764,49 @@ mod tests {
     fn a_window_is_asked_for_per_kind_rather_than_per_symbol() {
         let state = Arc::new(LseResumeState::new());
         state.record(
-            &LseResumeKey::new(subscription_id("BTC/USD"), PublicTrades.as_str()),
+            &LseResumeKey::new(
+                ExchangeId::LseCrypto,
+                subscription_id("BTC/USD"),
+                PublicTrades.as_str(),
+            ),
             at("2026-08-14T10:16:55.161234Z"),
         );
 
         let subscriber = LseSubscriber::new(LseCredentials::new("key")).with_resume(state);
 
         assert_eq!(
-            subscriber.resume_start("BTC/USD", OrderBooksL1.as_str()),
+            subscriber.resume_start(ExchangeId::LseCrypto, "BTC/USD", OrderBooksL1.as_str()),
             None,
             "a kind that has delivered nothing must subscribe live, not from another kind's mark",
+        );
+    }
+
+    /// The five dataset connectors share one endpoint and one identifier construction, and the
+    /// `Bare` symbol shape rebuilds a symbol from the base asset alone — so one ticker on two of
+    /// them produces one wire identifier. A window read across that boundary would resume this
+    /// dataset from what a different one delivered.
+    #[test]
+    fn a_window_is_asked_for_per_dataset_rather_than_per_symbol() {
+        let state = Arc::new(LseResumeState::new());
+        state.record(
+            &LseResumeKey::new(
+                ExchangeId::LseEquities,
+                subscription_id("AAPL"),
+                PublicTrades.as_str(),
+            ),
+            at("2026-08-14T10:16:55.161234Z"),
+        );
+
+        let subscriber = LseSubscriber::new(LseCredentials::new("key")).with_resume(state);
+
+        assert_eq!(
+            subscriber.resume_start(ExchangeId::LseEquities, "AAPL", PublicTrades.as_str()),
+            Some(at("2026-08-14T10:16:55.161234Z")),
+        );
+        assert_eq!(
+            subscriber.resume_start(ExchangeId::LseFutures, "AAPL", PublicTrades.as_str()),
+            None,
+            "a dataset that has delivered nothing must subscribe live, not from another's mark",
         );
     }
 
@@ -1015,8 +1067,5 @@ mod tests {
         assert_eq!(expected_categories(ExchangeId::LseFx), vec!["Forex"]);
         assert_eq!(expected_categories(ExchangeId::LseCrypto), vec!["Crypto"]);
         assert!(!expected_categories(ExchangeId::LseCfd).contains(&"Forex"));
-
-        // Referenced so the connector aliases stay exercised by this module's tests.
-        let _ = (LseCrypto::default(), LseEquities::default());
     }
 }

--- a/rustrade-data/src/exchange/lse/market.rs
+++ b/rustrade-data/src/exchange/lse/market.rs
@@ -140,6 +140,30 @@ impl LseDataset {
             | Self::Futures => MarketDataInstrumentKind::Cfd,
         }
     }
+
+    /// The category label the WebSocket handshake reports for this dataset's symbols, where it
+    /// reports one at all.
+    ///
+    /// # ⚠️ `None` is the common case, not the exception
+    /// The handshake publishes no category for roughly half the symbols it offers, and some
+    /// entries carry neither a category nor a name. `None` here therefore means *the provider does
+    /// not label this dataset*, not *unknown* — so a symbol arriving without a category can never
+    /// be treated as contradicting the dataset it was requested on.
+    ///
+    /// These labels are the provider's own spelling and are deliberately not derived from
+    /// [`as_catalog_str`](Self::as_catalog_str): the two vocabularies differ (`etf` against
+    /// `ETFs`, `index` against `Indices`) and neither is a transformation of the other.
+    pub fn ws_category(&self) -> Option<&'static str> {
+        match self {
+            Self::Stocks => Some("Stocks"),
+            Self::Etf => Some("ETFs"),
+            Self::Crypto => Some("Crypto"),
+            Self::Fx => Some("Forex"),
+            Self::Index => Some("Indices"),
+            Self::Commodity => Some("Commodities"),
+            Self::InterestRates | Self::CurrencyIndex | Self::Volatility | Self::Futures => None,
+        }
+    }
 }
 
 /// A London Strategic Edge dataset slug — the path key of the provider's dataset-info endpoint.

--- a/rustrade-data/src/exchange/lse/market.rs
+++ b/rustrade-data/src/exchange/lse/market.rs
@@ -564,13 +564,20 @@ where
     }
 }
 
-/// Takes the exchange-side name verbatim, so it needs no per-dataset spelling: the caller has
-/// already supplied the provider's own symbol.
+/// Takes the exchange-side name as given, so it needs no per-dataset shape: the caller has already
+/// supplied the provider's own symbol, and there is nothing to reconstruct.
+///
+/// Case is still normalised, for the same reason the reconstruction path normalises it: the symbol
+/// is the instrument-map key a tick resolves through, and the provider echoes `EUR/USD` on the tick
+/// however the subscribe spelled it. A lowercase `name_exchange` would be *confirmed*, then tick
+/// under a key the map does not hold and deliver nothing — the silent failure the reconstruction
+/// path already avoids, and there is no reason for this path to keep it. On a correctly spelled
+/// exchange name the call is a no-op.
 impl<Server, InstrumentKey, Kind> Identifier<LseMarket>
     for Subscription<Lse<Server>, MarketInstrumentData<InstrumentKey>, Kind>
 {
     fn id(&self) -> LseMarket {
-        LseMarket(self.instrument.name_exchange.name().clone())
+        LseMarket(self.instrument.name_exchange.name().to_uppercase_smolstr())
     }
 }
 
@@ -968,40 +975,77 @@ mod tests {
 
         /// Reconstruction must invert the split the rest of the integration derives assets with,
         /// or the WebSocket and the REST vault would disagree about what one instrument is called.
+        ///
+        /// The shape comes from the dataset's own [`LseServer::SYMBOL_SHAPE`] rather than being
+        /// inferred from the symbol. Inferring it is what [`underlying`] already does, so deriving
+        /// both halves the same way would make the round trip agree with itself no matter what the
+        /// connectors declare — and a connector declaring the wrong shape is precisely the failure
+        /// that produces an unsubscribable symbol, since [`market_symbol`] dispatches on the
+        /// declaration and not on the string.
         #[test]
         fn reconstruction_inverts_the_underlying_split() {
-            for symbol in ["EUR/USD", "BTC/USD", "VIX/USD", "AAPL", "BP.L", "ES.F"] {
+            fn round_trips<Server>(symbol: &str)
+            where
+                Server: LseServer,
+            {
                 let split = underlying(symbol);
-                let shape = if symbol.contains('/') {
-                    LseSymbolShape::Pair
-                } else {
-                    LseSymbolShape::Bare
-                };
 
                 let rebuilt = market_symbol(
-                    shape,
+                    Server::SYMBOL_SHAPE,
                     &AssetNameInternal::new(split.base.name().clone()),
                     &AssetNameInternal::new(split.quote.name().clone()),
                 );
 
-                assert_eq!(rebuilt.as_ref(), symbol);
+                assert_eq!(
+                    rebuilt.as_ref(),
+                    symbol,
+                    "{symbol} does not survive a round trip through {:?}, the shape its dataset \
+                     declares",
+                    Server::SYMBOL_SHAPE,
+                );
             }
+
+            round_trips::<LseServerFx>("EUR/USD");
+            round_trips::<LseServerCrypto>("BTC/USD");
+            round_trips::<LseServerCfd>("VIX/USD");
+            round_trips::<LseServerEquities>("AAPL");
+            round_trips::<LseServerEquities>("BP.L");
+            round_trips::<LseServerFutures>("ES.F");
         }
 
+        /// An exchange-side name is the provider's own symbol, so it is used as given rather than
+        /// rebuilt through the dataset's shape.
         #[test]
         fn an_exchange_named_instrument_is_taken_verbatim() {
+            assert_eq!(
+                market_of_exchange_named("XAU/USD").as_ref(),
+                "XAU/USD",
+                "a correctly spelled exchange name must pass through untouched",
+            );
+        }
+
+        /// The one normalisation that still applies, and why: the symbol is the instrument-map key
+        /// a tick resolves through, and the provider echoes the uppercase spelling on the tick
+        /// whatever the subscribe said. Left alone, a lowercase name would be confirmed and then
+        /// tick under a key the map does not hold.
+        #[test]
+        fn an_exchange_named_instrument_is_uppercased_like_a_reconstructed_one() {
+            assert_eq!(market_of_exchange_named("xau/usd").as_ref(), "XAU/USD");
+            assert_eq!(market_of_exchange_named("bp.l").as_ref(), "BP.L");
+        }
+
+        fn market_of_exchange_named(name_exchange: &str) -> LseMarket {
             let subscription = Subscription {
                 exchange: LseCfd::default(),
                 instrument: MarketInstrumentData {
                     key: 0_usize,
-                    name_exchange: InstrumentNameExchange::new("XAU/USD"),
+                    name_exchange: InstrumentNameExchange::new(name_exchange),
                     kind: MarketDataInstrumentKind::Cfd,
                 },
                 kind: PublicTrades,
             };
-            let market: LseMarket = subscription.id();
 
-            assert_eq!(market.as_ref(), "XAU/USD");
+            subscription.id()
         }
     }
 }

--- a/rustrade-data/src/exchange/lse/market.rs
+++ b/rustrade-data/src/exchange/lse/market.rs
@@ -1,13 +1,17 @@
+use super::Lse;
 use crate::exchange::lse::error::LseError;
 use crate::subscription::candle::CandleInterval;
+use crate::{Identifier, instrument::MarketInstrumentData, subscription::Subscription};
 use rustrade_instrument::asset::name::AssetNameInternal;
 use rustrade_instrument::instrument::name::InstrumentNameExchange;
 use rustrade_instrument::instrument::quote::InstrumentQuoteAsset;
 use rustrade_instrument::{
-    Underlying, asset::name::AssetNameExchange, exchange::ExchangeId, index::IndexedInstruments,
-    instrument::InstrumentIndex, instrument::market_data::kind::MarketDataInstrumentKind,
+    Keyed, Underlying, asset::name::AssetNameExchange, exchange::ExchangeId,
+    index::IndexedInstruments, instrument::InstrumentIndex,
+    instrument::market_data::MarketDataInstrument,
+    instrument::market_data::kind::MarketDataInstrumentKind,
 };
-use smol_str::{SmolStr, StrExt};
+use smol_str::{SmolStr, StrExt, format_smolstr};
 
 /// A London Strategic Edge price dataset.
 ///
@@ -444,6 +448,108 @@ pub fn supports_candle_interval(interval: CandleInterval) -> bool {
     candle_interval_str(interval).is_some()
 }
 
+/// How a dataset spells the display symbol the WebSocket subscribes on.
+///
+/// The provider uses two spellings and each dataset uses exactly one, which is what the per-dataset
+/// [`ExchangeId`] split buys at this boundary: the shape is known statically from the connector
+/// type, so no runtime discriminator is needed to reconstruct a symbol.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum LseSymbolShape {
+    /// `BASE/QUOTE` — FX, crypto and CFDs: `EUR/USD`, `BTC/USD`, `SPX500/USD`, `VIX/USD`.
+    Pair,
+    /// A bare ticker, venue suffix included — equities and futures: `AAPL`, `BP.L`, `ES.F`.
+    Bare,
+}
+
+/// A London Strategic Edge WebSocket server, and the symbol spelling its dataset uses.
+///
+/// Implemented by each `LseServer*` marker type. It exists so the symbol reconstruction below can
+/// be written once per instrument representation rather than once per representation *per server*,
+/// and so each dataset's spelling is declared in exactly one place and cannot drift from it.
+pub trait LseServer: crate::exchange::ExchangeServer {
+    /// The spelling this dataset's display symbols take.
+    const SYMBOL_SHAPE: LseSymbolShape;
+}
+
+/// A London Strategic Edge display symbol, as the WebSocket expects it.
+///
+/// This is the provider's own display symbol — the same key its REST vault serves candles on, not
+/// a slug. See [`slug`] for why the two are not interchangeable.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct LseMarket(pub SmolStr);
+
+impl AsRef<str> for LseMarket {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for LseMarket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Reconstruct a display symbol from a registered instrument's assets.
+///
+/// The provider normalises case server-side (`eur/usd` is confirmed as `EUR/USD`), but the symbol
+/// is also the key of the instrument map a tick is resolved through, so it is uppercased here to
+/// match what the server will echo back on the tick.
+///
+/// The base asset's venue suffix is deliberately *not* stripped — see [`underlying`], which retains
+/// it for the same reason: `BP.L` and `BP` are different instruments in different currencies.
+fn market_symbol(
+    shape: LseSymbolShape,
+    base: &AssetNameInternal,
+    quote: &AssetNameInternal,
+) -> LseMarket {
+    match shape {
+        LseSymbolShape::Pair => LseMarket(format_smolstr!(
+            "{}/{}",
+            base.name().to_uppercase_smolstr(),
+            quote.name().to_uppercase_smolstr()
+        )),
+        LseSymbolShape::Bare => LseMarket(base.name().to_uppercase_smolstr()),
+    }
+}
+
+impl<Server, Kind> Identifier<LseMarket> for Subscription<Lse<Server>, MarketDataInstrument, Kind>
+where
+    Server: LseServer,
+{
+    fn id(&self) -> LseMarket {
+        market_symbol(
+            Server::SYMBOL_SHAPE,
+            &self.instrument.base,
+            &self.instrument.quote,
+        )
+    }
+}
+
+impl<Server, InstrumentKey, Kind> Identifier<LseMarket>
+    for Subscription<Lse<Server>, Keyed<InstrumentKey, MarketDataInstrument>, Kind>
+where
+    Server: LseServer,
+{
+    fn id(&self) -> LseMarket {
+        market_symbol(
+            Server::SYMBOL_SHAPE,
+            &self.instrument.value.base,
+            &self.instrument.value.quote,
+        )
+    }
+}
+
+/// Takes the exchange-side name verbatim, so it needs no per-dataset spelling: the caller has
+/// already supplied the provider's own symbol.
+impl<Server, InstrumentKey, Kind> Identifier<LseMarket>
+    for Subscription<Lse<Server>, MarketInstrumentData<InstrumentKey>, Kind>
+{
+    fn id(&self) -> LseMarket {
+        LseMarket(self.instrument.name_exchange.name().clone())
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
@@ -761,6 +867,117 @@ mod tests {
                 ),
                 "{dataset:?} maps to an unsupported (exchange, kind) pair"
             );
+        }
+    }
+
+    mod market_symbol_reconstruction {
+        use super::*;
+        use crate::exchange::lse::{
+            LseCfd, LseServerCfd, LseServerCrypto, LseServerEquities, LseServerFutures, LseServerFx,
+        };
+        use crate::subscription::trade::PublicTrades;
+
+        /// Build a subscription for `Server` and resolve it to the symbol it would subscribe on.
+        ///
+        /// The return type is what selects `Identifier<LseMarket>` over the `Identifier<LseChannel>`
+        /// impl the same subscription also carries.
+        fn market_of<Server>(base: &str, quote: &str, kind: MarketDataInstrumentKind) -> LseMarket
+        where
+            Server: LseServer,
+        {
+            let subscription: Subscription<Lse<Server>, MarketDataInstrument, PublicTrades> =
+                Subscription::from((Lse::<Server>::default(), base, quote, kind, PublicTrades));
+
+            subscription.id()
+        }
+
+        #[test]
+        fn pair_shaped_datasets_reconstruct_base_slash_quote() {
+            assert_eq!(
+                market_of::<LseServerFx>("eur", "usd", MarketDataInstrumentKind::Spot).as_ref(),
+                "EUR/USD"
+            );
+            assert_eq!(
+                market_of::<LseServerCrypto>("btc", "usd", MarketDataInstrumentKind::Spot).as_ref(),
+                "BTC/USD"
+            );
+            assert_eq!(
+                market_of::<LseServerCfd>("spx500", "usd", MarketDataInstrumentKind::Cfd).as_ref(),
+                "SPX500/USD"
+            );
+        }
+
+        #[test]
+        fn bare_shaped_datasets_reconstruct_the_ticker_alone() {
+            assert_eq!(
+                market_of::<LseServerEquities>("aapl", "usd", MarketDataInstrumentKind::Spot)
+                    .as_ref(),
+                "AAPL"
+            );
+        }
+
+        /// The suffix is part of the base asset, and dropping it would subscribe to the US listing
+        /// while the engine marks the London one — a different instrument in a different currency.
+        #[test]
+        fn a_venue_suffix_survives_symbol_reconstruction() {
+            assert_eq!(
+                market_of::<LseServerEquities>("bp.l", "gbx", MarketDataInstrumentKind::Spot)
+                    .as_ref(),
+                "BP.L"
+            );
+            assert_eq!(
+                market_of::<LseServerFutures>("es.f", "usd", MarketDataInstrumentKind::Cfd)
+                    .as_ref(),
+                "ES.F"
+            );
+        }
+
+        /// The reconstructed symbol is the instrument-map key a tick is resolved through, so it
+        /// must match the casing the provider echoes back rather than the caller's spelling.
+        #[test]
+        fn reconstruction_uppercases_however_the_instrument_was_registered() {
+            assert_eq!(
+                market_of::<LseServerFx>("EuR", "uSd", MarketDataInstrumentKind::Spot).as_ref(),
+                "EUR/USD"
+            );
+        }
+
+        /// Reconstruction must invert the split the rest of the integration derives assets with,
+        /// or the WebSocket and the REST vault would disagree about what one instrument is called.
+        #[test]
+        fn reconstruction_inverts_the_underlying_split() {
+            for symbol in ["EUR/USD", "BTC/USD", "VIX/USD", "AAPL", "BP.L", "ES.F"] {
+                let split = underlying(symbol);
+                let shape = if symbol.contains('/') {
+                    LseSymbolShape::Pair
+                } else {
+                    LseSymbolShape::Bare
+                };
+
+                let rebuilt = market_symbol(
+                    shape,
+                    &AssetNameInternal::new(split.base.name().clone()),
+                    &AssetNameInternal::new(split.quote.name().clone()),
+                );
+
+                assert_eq!(rebuilt.as_ref(), symbol);
+            }
+        }
+
+        #[test]
+        fn an_exchange_named_instrument_is_taken_verbatim() {
+            let subscription = Subscription {
+                exchange: LseCfd::default(),
+                instrument: MarketInstrumentData {
+                    key: 0_usize,
+                    name_exchange: InstrumentNameExchange::new("XAU/USD"),
+                    kind: MarketDataInstrumentKind::Cfd,
+                },
+                kind: PublicTrades,
+            };
+            let market: LseMarket = subscription.id();
+
+            assert_eq!(market.as_ref(), "XAU/USD");
         }
     }
 }

--- a/rustrade-data/src/exchange/lse/mod.rs
+++ b/rustrade-data/src/exchange/lse/mod.rs
@@ -67,6 +67,9 @@ pub mod export;
 
 pub mod historical;
 
+/// The authenticating WebSocket subscriber and its pre-subscribe guards.
+pub mod live;
+
 /// London Strategic Edge symbology: datasets, underlying assets, quote currencies and slugs.
 pub mod market;
 
@@ -83,10 +86,21 @@ pub mod tick;
 
 pub mod vault;
 
-use self::market::{LseServer, LseSymbolShape};
-use crate::exchange::ExchangeServer;
+use self::{
+    channel::LseChannel,
+    live::{LseSubscriber, subscribe_message},
+    market::{LseMarket, LseServer, LseSymbolShape},
+    subscription::LseSubResponse,
+};
+use crate::{
+    exchange::{Connector, ExchangeServer, ExchangeSub},
+    subscriber::validator::WebSocketSubValidator,
+};
 use rustrade_instrument::exchange::ExchangeId;
+use rustrade_integration::protocol::websocket::WsMessage;
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
+use url::Url;
 
 /// The WebSocket endpoint.
 ///
@@ -172,3 +186,64 @@ impl_lse_server!(
     LseSymbolShape::Bare
 );
 impl_lse_server!(LseServerCfd, ExchangeId::LseCfd, LseSymbolShape::Pair);
+
+impl<Server> Connector for Lse<Server>
+where
+    Server: LseServer,
+{
+    const ID: ExchangeId = Server::ID;
+    type Channel = LseChannel;
+    type Market = LseMarket;
+    type Subscriber = LseSubscriber;
+    type SubValidator = WebSocketSubValidator;
+    type SubResponse = LseSubResponse;
+
+    fn url() -> Result<Url, url::ParseError> {
+        Url::parse(Server::websocket_url())
+    }
+
+    /// One payload per symbol — the provider accepts no batched subscribe.
+    ///
+    /// [`LseSubscriber`] builds its payloads with the same helper rather than calling this, because
+    /// a subscription may carry a replay window and this function cannot see one. The two therefore
+    /// agree by construction.
+    fn requests(exchange_subs: Vec<ExchangeSub<Self::Channel, Self::Market>>) -> Vec<WsMessage> {
+        exchange_subs
+            .iter()
+            .map(|exchange_sub| subscribe_message(exchange_sub.market.as_ref()))
+            .collect()
+    }
+}
+
+impl<'de, Server> Deserialize<'de> for Lse<Server>
+where
+    Server: ExchangeServer,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let input = <String as Deserialize>::deserialize(deserializer)?;
+
+        if input.as_str() == Server::ID.as_str() {
+            Ok(Self::default())
+        } else {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(input.as_str()),
+                &Server::ID.as_str(),
+            ))
+        }
+    }
+}
+
+impl<Server> Serialize for Lse<Server>
+where
+    Server: ExchangeServer,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        serializer.serialize_str(Server::ID.as_str())
+    }
+}

--- a/rustrade-data/src/exchange/lse/mod.rs
+++ b/rustrade-data/src/exchange/lse/mod.rs
@@ -76,6 +76,9 @@ pub mod parquet;
 /// The shared streaming + export allowance, as the provider reports it.
 pub mod quota;
 
+/// Subscription-lifecycle frames — confirmations, rejections and replay boundaries.
+pub mod subscription;
+
 pub mod tick;
 
 pub mod vault;

--- a/rustrade-data/src/exchange/lse/mod.rs
+++ b/rustrade-data/src/exchange/lse/mod.rs
@@ -57,6 +57,9 @@
 /// Replay historical candles for N instruments as one time-ordered market stream.
 pub mod backtest;
 
+/// The WebSocket channel a subscription maps to.
+pub mod channel;
+
 /// Errors produced by the London Strategic Edge integration.
 pub mod error;
 
@@ -73,4 +76,96 @@ pub mod parquet;
 /// The shared streaming + export allowance, as the provider reports it.
 pub mod quota;
 
+pub mod tick;
+
 pub mod vault;
+
+use self::market::{LseServer, LseSymbolShape};
+use crate::exchange::ExchangeServer;
+use rustrade_instrument::exchange::ExchangeId;
+use std::marker::PhantomData;
+
+/// The WebSocket endpoint.
+///
+/// One host serves every dataset. The per-dataset connector split below is about provenance in
+/// `MarketEvent.exchange` and per-dataset support declarations, not about distinct endpoints — so
+/// subscribing across datasets opens several connections to this one host. The provider served at
+/// least eight concurrent authenticated connections on one key when measured; the binding
+/// constraint is the per-connection subscription cap, not the connection count.
+pub const WEBSOCKET_URL: &str = "wss://data-ws.londonstrategicedge.com";
+
+/// The London Strategic Edge live market data connector.
+///
+/// Use the per-dataset aliases — [`LseFx`], [`LseCrypto`], [`LseEquities`], [`LseFutures`],
+/// [`LseCfd`] — rather than naming the server type directly.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Lse<Server>(PhantomData<Server>);
+
+/// Spot FX: `EUR/USD`, `GBP/USD`, …
+pub type LseFx = Lse<LseServerFx>;
+
+/// Aggregated spot crypto: `BTC/USD`, `ETH/USD`, …
+pub type LseCrypto = Lse<LseServerCrypto>;
+
+/// Equities and ETFs: `AAPL`, `SPY`, `BP.L`, …
+pub type LseEquities = Lse<LseServerEquities>;
+
+/// Continuous front-month futures proxies: `ES.F`, `FDAX`, …
+pub type LseFutures = Lse<LseServerFutures>;
+
+/// Indices, commodities, interest rates, currency indices and volatility, all as CFDs:
+/// `SPX500/USD`, `XAU/USD`, `USB10Y/USD`, `DXY/USD`, `VIX/USD`.
+pub type LseCfd = Lse<LseServerCfd>;
+
+/// Spot FX server.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct LseServerFx;
+
+/// Aggregated spot crypto server.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct LseServerCrypto;
+
+/// Equities and ETFs server.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct LseServerEquities;
+
+/// Continuous futures-proxy server.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct LseServerFutures;
+
+/// CFD server — indices, commodities, interest rates, currency indices and volatility.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct LseServerCfd;
+
+macro_rules! impl_lse_server {
+    ($server:ty, $id:expr, $shape:expr) => {
+        impl ExchangeServer for $server {
+            const ID: ExchangeId = $id;
+
+            fn websocket_url() -> &'static str {
+                WEBSOCKET_URL
+            }
+        }
+
+        impl LseServer for $server {
+            const SYMBOL_SHAPE: LseSymbolShape = $shape;
+        }
+    };
+}
+
+// The two traits are declared together per server because they answer one question each about the
+// same dataset -- which venue its events are stamped with, and how it spells a symbol -- and a
+// server that implements one without the other is not usable.
+impl_lse_server!(LseServerFx, ExchangeId::LseFx, LseSymbolShape::Pair);
+impl_lse_server!(LseServerCrypto, ExchangeId::LseCrypto, LseSymbolShape::Pair);
+impl_lse_server!(
+    LseServerEquities,
+    ExchangeId::LseEquities,
+    LseSymbolShape::Bare
+);
+impl_lse_server!(
+    LseServerFutures,
+    ExchangeId::LseFutures,
+    LseSymbolShape::Bare
+);
+impl_lse_server!(LseServerCfd, ExchangeId::LseCfd, LseSymbolShape::Pair);

--- a/rustrade-data/src/exchange/lse/mod.rs
+++ b/rustrade-data/src/exchange/lse/mod.rs
@@ -1,4 +1,5 @@
-//! London Strategic Edge market data.
+//! London Strategic Edge market data (behind the `lse` feature) — ⚠️ the retrieved data is **not
+//! redistributable**.
 //!
 //! A free, no-account market-data provider covering FX, equities, ETFs, crypto, commodities,
 //! indices, futures and options, plus reference and macroeconomic series.
@@ -63,9 +64,9 @@
 //!   filter; a test pins that both are emitted.
 //! - **London (`.L`) listings are quoted in PENCE**, and the catalog reports no unit. They are
 //!   quoted in GBX, an asset distinct from GBP; see
-//!   [`market::quote_asset`](crate::exchange::lse::market::quote_asset).
+//!   [`market::quote_asset`].
 //! - **Dataset slugs are not instrument identities** and do not uniquely identify a series; see
-//!   [`market::slug`](crate::exchange::lse::market::slug).
+//!   [`market::slug`].
 
 // A module carries an outer `///` here only when its own file has no `//!` documentation.
 // Supplying both makes rustdoc resolve the file's inner links in THIS module's scope rather than
@@ -84,7 +85,6 @@ pub mod export;
 
 pub mod historical;
 
-/// The authenticating WebSocket subscriber and its pre-subscribe guards.
 pub mod live;
 
 /// London Strategic Edge symbology: datasets, underlying assets, quote currencies and slugs.
@@ -98,12 +98,17 @@ pub mod quota;
 
 pub mod quote;
 
-/// Subscription-lifecycle frames — confirmations, rejections and replay boundaries.
+pub mod resume;
+
+pub mod stream;
+
 pub mod subscription;
 
 pub mod tick;
 
 pub mod trade;
+
+pub mod transformer;
 
 pub mod vault;
 
@@ -111,8 +116,8 @@ use self::{
     channel::LseChannel,
     live::{LseSubscriber, subscribe_message},
     market::{LseMarket, LseServer, LseSymbolShape},
+    stream::LseStream,
     subscription::LseSubResponse,
-    tick::LseMessage,
 };
 use crate::{
     ExchangeWsStream, NoInitialSnapshots,
@@ -120,7 +125,6 @@ use crate::{
     instrument::InstrumentData,
     subscriber::validator::WebSocketSubValidator,
     subscription::{book::OrderBooksL1, trade::PublicTrades},
-    transformer::stateless::StatelessTransformer,
 };
 use rustrade_instrument::exchange::ExchangeId;
 use rustrade_integration::protocol::websocket::{WebSocketSerdeParser, WsMessage};
@@ -137,7 +141,12 @@ use url::Url;
 /// constraint is the per-connection subscription cap, not the connection count.
 pub const WEBSOCKET_URL: &str = "wss://data-ws.londonstrategicedge.com";
 
-/// The WebSocket stream every London Strategic Edge subscription kind is served over.
+/// The stock WebSocket stream, parameterised by transformer.
+///
+/// Published for parity with the other exchange integrations, each of which exposes an alias of
+/// this shape. Subscriptions are **not** served over it: that is [`LseStream`], which is what
+/// carries a caller's resume state into the transformer. A stream assembled through this alias has
+/// no seam to carry it and would replay without skipping.
 pub type LseWsStream<Transformer> = ExchangeWsStream<WebSocketSerdeParser, Transformer>;
 
 /// The London Strategic Edge live market data connector.
@@ -239,7 +248,7 @@ where
     fn requests(exchange_subs: Vec<ExchangeSub<Self::Channel, Self::Market>>) -> Vec<WsMessage> {
         exchange_subs
             .iter()
-            .map(|exchange_sub| subscribe_message(exchange_sub.market.as_ref()))
+            .map(|exchange_sub| subscribe_message(exchange_sub.market.as_ref(), None))
             .collect()
     }
 }
@@ -258,8 +267,7 @@ where
     Server: LseServer + Debug + Send + Sync,
 {
     type SnapFetcher = NoInitialSnapshots;
-    type Stream =
-        LseWsStream<StatelessTransformer<Self, Instrument::Key, PublicTrades, LseMessage>>;
+    type Stream = LseStream<Self, Instrument::Key, PublicTrades>;
 }
 
 impl<Instrument, Server> StreamSelector<Instrument, OrderBooksL1> for Lse<Server>
@@ -268,8 +276,7 @@ where
     Server: LseServer + Debug + Send + Sync,
 {
     type SnapFetcher = NoInitialSnapshots;
-    type Stream =
-        LseWsStream<StatelessTransformer<Self, Instrument::Key, OrderBooksL1, LseMessage>>;
+    type Stream = LseStream<Self, Instrument::Key, OrderBooksL1>;
 }
 
 impl<'de, Server> Deserialize<'de> for Lse<Server>

--- a/rustrade-data/src/exchange/lse/mod.rs
+++ b/rustrade-data/src/exchange/lse/mod.rs
@@ -234,9 +234,16 @@ where
 
     /// One payload per symbol — the provider accepts no batched subscribe.
     ///
-    /// [`LseSubscriber`] builds its payloads with the same helper rather than calling this, because
-    /// a subscription may carry a replay window and this function cannot see one. The two therefore
-    /// agree by construction.
+    /// # ⚠️ Nothing sends what this builds
+    /// [`LseSubscriber`] does not call this: a subscription may carry a replay window and this
+    /// function cannot see one, so the subscriber builds its own payloads and the mapper's output
+    /// is discarded where it does so. This is required by the [`Connector`] contract and is
+    /// implemented faithfully; it is not the route this integration subscribes over.
+    ///
+    /// It shares `subscribe_message` with the live route, so the two cannot disagree about a
+    /// payload's *shape*. They do differ in what they are given: this receives one entry per
+    /// subscription, while the subscriber sends one per *distinct* symbol, because a repeated
+    /// symbol is one slot and one confirmation on this provider.
     fn requests(exchange_subs: Vec<ExchangeSub<Self::Channel, Self::Market>>) -> Vec<WsMessage> {
         exchange_subs
             .iter()

--- a/rustrade-data/src/exchange/lse/mod.rs
+++ b/rustrade-data/src/exchange/lse/mod.rs
@@ -120,14 +120,14 @@ use self::{
     subscription::LseSubResponse,
 };
 use crate::{
-    ExchangeWsStream, NoInitialSnapshots,
+    NoInitialSnapshots,
     exchange::{Connector, ExchangeServer, ExchangeSub, StreamSelector},
     instrument::InstrumentData,
     subscriber::validator::WebSocketSubValidator,
     subscription::{book::OrderBooksL1, trade::PublicTrades},
 };
 use rustrade_instrument::exchange::ExchangeId;
-use rustrade_integration::protocol::websocket::{WebSocketSerdeParser, WsMessage};
+use rustrade_integration::protocol::websocket::WsMessage;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, marker::PhantomData};
 use url::Url;
@@ -140,14 +140,6 @@ use url::Url;
 /// least eight concurrent authenticated connections on one key when measured; the binding
 /// constraint is the per-connection subscription cap, not the connection count.
 pub const WEBSOCKET_URL: &str = "wss://data-ws.londonstrategicedge.com";
-
-/// The stock WebSocket stream, parameterised by transformer.
-///
-/// Published for parity with the other exchange integrations, each of which exposes an alias of
-/// this shape. Subscriptions are **not** served over it: that is [`LseStream`], which is what
-/// carries a caller's resume state into the transformer. A stream assembled through this alias has
-/// no seam to carry it and would replay without skipping.
-pub type LseWsStream<Transformer> = ExchangeWsStream<WebSocketSerdeParser, Transformer>;
 
 /// The London Strategic Edge live market data connector.
 ///
@@ -309,5 +301,34 @@ where
         S: serde::ser::Serializer,
     {
         serializer.serialize_str(Server::ID.as_str())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+
+    /// The connector is hand-serialised rather than derived, so nothing else pins that the two
+    /// halves agree — a `Subscription` carrying one would otherwise fail to round-trip through a
+    /// config file with no compile-time signal.
+    #[test]
+    fn a_connector_round_trips_through_its_exchange_id() {
+        let json = serde_json::to_string(&LseCrypto::default()).unwrap();
+        assert_eq!(json, r#""lse_crypto""#);
+
+        assert_eq!(
+            serde_json::from_str::<LseCrypto>(&json).unwrap(),
+            LseCrypto::default()
+        );
+    }
+
+    /// Every dataset connector is a distinct type over one endpoint, so deserialising a config that
+    /// names a *different* dataset must fail rather than silently produce this one and subscribe
+    /// the wrong venue's symbology.
+    #[test]
+    fn a_connector_rejects_another_datasets_identifier() {
+        let error = serde_json::from_str::<LseCrypto>(r#""lse_fx""#).unwrap_err();
+        assert!(error.to_string().contains("lse_crypto"), "{error}");
     }
 }

--- a/rustrade-data/src/exchange/lse/mod.rs
+++ b/rustrade-data/src/exchange/lse/mod.rs
@@ -44,6 +44,23 @@
 //!   There is no venue attribution anywhere in the feed.
 //! - **Crypto is an aggregated tape**: no funding rates, no liquidations, no venue. It is not a
 //!   substitute for a native exchange connector.
+//! - **The live tick is a QUOTE, not a print.** Its `price` equals its `bid` on every sample taken
+//!   — 3,966 of 3,966 ticks across every dataset family. Both [`PublicTrades`] and [`OrderBooksL1`]
+//!   are served from it, but a trade decoded this way is a bid-side quote wearing a trade's shape
+//!   and is not evidence that a transaction occurred. See [`trade`] for the mapping and its
+//!   reasoning.
+//! - **Live tick `volume` is real on two venues and FABRICATED on two others**, with no in-band
+//!   signal separating them. [`LseCrypto`] and [`LseEquities`] carry a genuine per-tick size, which
+//!   reconciles exactly against the provider's own one-minute candles (ratio `1.000`).
+//!   **[`LseFx`] and [`LseCfd`] carry a hard-coded `1.0`** on every tick of every symbol sampled —
+//!   a placeholder that will aggregate into a legitimate-looking total at any resolution, so
+//!   volume-weighted prices and size filters on those two venues are meaningless rather than merely
+//!   imprecise. Note this differs from the REST vault, which *omits* FX volume entirely; the
+//!   WebSocket invents a value instead.
+//! - **Identical consecutive live ticks are genuine and are never de-duplicated.** Barely a third
+//!   of a sampled run was unique on `(ts, price, bid, ask, volume)`, yet removing the repeats
+//!   destroyed 3–10% of volume that otherwise reconciles exactly. Do not add a de-duplication
+//!   filter; a test pins that both are emitted.
 //! - **London (`.L`) listings are quoted in PENCE**, and the catalog reports no unit. They are
 //!   quoted in GBX, an asset distinct from GBP; see
 //!   [`market::quote_asset`](crate::exchange::lse::market::quote_asset).
@@ -79,10 +96,14 @@ pub mod parquet;
 /// The shared streaming + export allowance, as the provider reports it.
 pub mod quota;
 
+pub mod quote;
+
 /// Subscription-lifecycle frames — confirmations, rejections and replay boundaries.
 pub mod subscription;
 
 pub mod tick;
+
+pub mod trade;
 
 pub mod vault;
 
@@ -91,15 +112,20 @@ use self::{
     live::{LseSubscriber, subscribe_message},
     market::{LseMarket, LseServer, LseSymbolShape},
     subscription::LseSubResponse,
+    tick::LseMessage,
 };
 use crate::{
-    exchange::{Connector, ExchangeServer, ExchangeSub},
+    ExchangeWsStream, NoInitialSnapshots,
+    exchange::{Connector, ExchangeServer, ExchangeSub, StreamSelector},
+    instrument::InstrumentData,
     subscriber::validator::WebSocketSubValidator,
+    subscription::{book::OrderBooksL1, trade::PublicTrades},
+    transformer::stateless::StatelessTransformer,
 };
 use rustrade_instrument::exchange::ExchangeId;
-use rustrade_integration::protocol::websocket::WsMessage;
+use rustrade_integration::protocol::websocket::{WebSocketSerdeParser, WsMessage};
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
+use std::{fmt::Debug, marker::PhantomData};
 use url::Url;
 
 /// The WebSocket endpoint.
@@ -110,6 +136,9 @@ use url::Url;
 /// least eight concurrent authenticated connections on one key when measured; the binding
 /// constraint is the per-connection subscription cap, not the connection count.
 pub const WEBSOCKET_URL: &str = "wss://data-ws.londonstrategicedge.com";
+
+/// The WebSocket stream every London Strategic Edge subscription kind is served over.
+pub type LseWsStream<Transformer> = ExchangeWsStream<WebSocketSerdeParser, Transformer>;
 
 /// The London Strategic Edge live market data connector.
 ///
@@ -213,6 +242,34 @@ where
             .map(|exchange_sub| subscribe_message(exchange_sub.market.as_ref()))
             .collect()
     }
+}
+
+// Both subscription kinds decode the SAME frame -- the provider publishes one data frame and it
+// carries a price, a bid, an ask and a size -- so the two selectors differ only in which decoder
+// the transformer is instantiated with. Neither needs an initial snapshot: the feed is a tick
+// stream with no book to synchronise against.
+//
+// One blanket impl per kind covers all five servers, rather than five impls each. The servers
+// differ in venue and symbol shape, never in framing.
+
+impl<Instrument, Server> StreamSelector<Instrument, PublicTrades> for Lse<Server>
+where
+    Instrument: InstrumentData,
+    Server: LseServer + Debug + Send + Sync,
+{
+    type SnapFetcher = NoInitialSnapshots;
+    type Stream =
+        LseWsStream<StatelessTransformer<Self, Instrument::Key, PublicTrades, LseMessage>>;
+}
+
+impl<Instrument, Server> StreamSelector<Instrument, OrderBooksL1> for Lse<Server>
+where
+    Instrument: InstrumentData,
+    Server: LseServer + Debug + Send + Sync,
+{
+    type SnapFetcher = NoInitialSnapshots;
+    type Stream =
+        LseWsStream<StatelessTransformer<Self, Instrument::Key, OrderBooksL1, LseMessage>>;
 }
 
 impl<'de, Server> Deserialize<'de> for Lse<Server>

--- a/rustrade-data/src/exchange/lse/quote.rs
+++ b/rustrade-data/src/exchange/lse/quote.rs
@@ -28,6 +28,20 @@ use rustrade_instrument::exchange::ExchangeId;
 /// The tick's `volume` is deliberately **not** used for either level: it is a traded size, not
 /// resting bid or ask liquidity, and on two of the five venues it is a fabricated constant. See
 /// [`trade`](super::trade) for that warning in full.
+///
+/// # ⚠️ A zero PRICE is absent, and it is not the same case as a zero size
+/// The provider publishes `0.0` for a side it has no quote for — a venue outside its session, a
+/// symbol quoted on one side only. Published as `Some(Level { price: 0, .. })` that becomes a real
+/// level asserting someone will trade at zero, and the damage is worse than the obvious one: it is
+/// precisely the volume-weighted-mid fallback that makes the zero *sizes* above harmless which
+/// makes a zero price dangerous. `mid_price` requires only that both sides be `Some`, and it
+/// averages whatever prices they carry — so a book quoting a real ask of `42001` against a zero bid
+/// prices at `21000.5`, a number that is neither wrong-looking nor recoverable downstream. The
+/// consumer cannot filter it either, because nothing distinguishes it from a genuine quote.
+///
+/// So a zero price maps to `None`, following the same rule as the Binance L1 decoder. `None` is the
+/// spelling every consumer of this type already handles as "no quote on this side"; a one-sided
+/// book prices as no book at all, which is the honest answer when there is no quote to average.
 impl<InstrumentKey> From<(ExchangeId, InstrumentKey, LseMessage)>
     for MarketIter<InstrumentKey, OrderBookL1>
 {
@@ -48,11 +62,19 @@ impl<InstrumentKey> From<(ExchangeId, InstrumentKey, LseMessage)>
                 // this field rather than on the event's, and a producer that lets the two diverge
                 // gets no error and no log.
                 last_update_time: tick.time_exchange,
-                best_bid: Some(Level::new(tick.bid, Decimal::ZERO)),
-                best_ask: Some(Level::new(tick.ask, Decimal::ZERO)),
+                best_bid: quoted(tick.bid),
+                best_ask: quoted(tick.ask),
             },
         })])
     }
+}
+
+/// One side of the book, or `None` where the provider published no quote for it.
+///
+/// The size is a placeholder rather than a measurement — see the type-level note — so only the
+/// price can say whether the side exists at all.
+fn quoted(price: Decimal) -> Option<Level> {
+    (!price.is_zero()).then(|| Level::new(price, Decimal::ZERO))
 }
 
 #[cfg(test)]
@@ -105,6 +127,52 @@ mod tests {
     fn the_tick_volume_is_not_used_as_a_level_size() {
         let events = decode(TICK);
         assert_ne!(events[0].kind.best_bid.unwrap().amount, dec!(0.00155));
+    }
+
+    fn one_sided(bid: &str, ask: &str) -> String {
+        format!(
+            r#"{{"type":"tick","symbol":"BTC/USD","ts":"2026-01-02T09:37:24.760146+00:00",
+                "price":{bid},"bid":{bid},"ask":{ask},"volume":0.0}}"#
+        )
+    }
+
+    /// The provider publishes `0.0` for a side it holds no quote for. Published as a level it
+    /// asserts someone will trade at zero, which no consumer can distinguish from a genuine quote.
+    #[test]
+    fn a_zero_priced_side_is_absent_rather_than_a_level_at_zero() {
+        let bid_only = decode(&one_sided("42000.5", "0.0"));
+        assert_eq!(bid_only[0].kind.best_bid.unwrap().price, dec!(42000.5));
+        assert_eq!(bid_only[0].kind.best_ask, None);
+
+        let ask_only = decode(&one_sided("0.0", "42001.0"));
+        assert_eq!(ask_only[0].kind.best_bid, None);
+        assert_eq!(ask_only[0].kind.best_ask.unwrap().price, dec!(42001.0));
+
+        let neither = decode(&one_sided("0.0", "0.0"));
+        assert_eq!(neither[0].kind.best_bid, None);
+        assert_eq!(neither[0].kind.best_ask, None);
+    }
+
+    /// Why the zero *price* is the dangerous one while the zero *sizes* are safe: the fallback that
+    /// rescues a size-less book is `mid_price`, which requires only that both sides be `Some` and
+    /// then averages whatever prices they carry. A zero bid published as a level would halve the
+    /// instrument's price, silently and unrecoverably.
+    #[test]
+    fn a_zero_priced_side_would_have_halved_the_mid_had_it_been_published() {
+        let events = decode(&one_sided("0.0", "42001.0"));
+        let book = &events[0].kind;
+
+        assert_eq!(
+            crate::books::mid_price(Decimal::ZERO, dec!(42001.0)),
+            dec!(21000.5),
+            "this is what a published zero bid would have priced the instrument at",
+        );
+
+        // Absent instead, so `mid_price` has nothing to average and no price reaches a consumer
+        // that was never quoted. A missing price is recoverable downstream; a halved one is not.
+        assert!(book.best_bid.is_none());
+        assert_eq!(book.mid_price(), None);
+        assert_eq!(book.volume_weighed_mid_price(), None);
     }
 
     #[test]

--- a/rustrade-data/src/exchange/lse/quote.rs
+++ b/rustrade-data/src/exchange/lse/quote.rs
@@ -1,0 +1,115 @@
+//! Decode a London Strategic Edge tick as an [`OrderBookL1`].
+
+use super::tick::LseMessage;
+use crate::{
+    books::Level,
+    event::{MarketEvent, MarketIter},
+    subscription::book::OrderBookL1,
+};
+use chrono::Utc;
+use rust_decimal::Decimal;
+use rustrade_instrument::exchange::ExchangeId;
+
+/// Decode a tick frame as a top-of-book quote.
+///
+/// This is the mapping the frame fits most honestly: the tick carries a bid and an ask, and its
+/// `price` equals the bid on every sample taken. The trade mapping in
+/// [`trade`](super::trade) exists alongside it and is documented as the approximation it is.
+///
+/// # Both levels carry a ZERO size
+/// The feed publishes no bid or ask size — only prices — so the sizes here are placeholders, not
+/// measurements. This is the same choice the provider's bulk-export decoder makes, for the same
+/// reason: a fabricated size would be indistinguishable downstream from a real one. It is safe
+/// because `DefaultInstrumentMarketData::price` in the `rustrade` crate falls back from the
+/// volume-weighted mid to the plain mid when the sizes are absent, so a zero-size book prices
+/// correctly rather than not at all. Consumers that genuinely need depth must not read these as
+/// available quantity.
+///
+/// The tick's `volume` is deliberately **not** used for either level: it is a traded size, not
+/// resting bid or ask liquidity, and on two of the five venues it is a fabricated constant. See
+/// [`trade`](super::trade) for that warning in full.
+impl<InstrumentKey> From<(ExchangeId, InstrumentKey, LseMessage)>
+    for MarketIter<InstrumentKey, OrderBookL1>
+{
+    fn from((exchange, instrument, message): (ExchangeId, InstrumentKey, LseMessage)) -> Self {
+        let LseMessage::Tick(tick) = message else {
+            // See the matching arm in the trade decoder: unreachable through the transformer, and
+            // an empty result is the only correct answer if it is ever reached anyway.
+            return Self(vec![]);
+        };
+
+        Self(vec![Ok(MarketEvent {
+            time_exchange: tick.time_exchange,
+            time_received: Utc::now(),
+            exchange,
+            instrument,
+            kind: OrderBookL1 {
+                // Must equal the event's `time_exchange` -- downstream state orders L1 updates on
+                // this field rather than on the event's, and a producer that lets the two diverge
+                // gets no error and no log.
+                last_update_time: tick.time_exchange,
+                best_bid: Some(Level::new(tick.bid, Decimal::ZERO)),
+                best_ask: Some(Level::new(tick.ask, Decimal::ZERO)),
+            },
+        })])
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    const TICK: &str = r#"{"type":"tick","symbol":"BTC/USD",
+        "ts":"2026-01-02T09:37:24.760146+00:00","price":42000.5,"bid":42000.5,
+        "ask":42001.0,"volume":0.00155}"#;
+
+    fn decode(json: &str) -> Vec<MarketEvent<u8, OrderBookL1>> {
+        let message: LseMessage = serde_json::from_str(json).unwrap();
+        MarketIter::<u8, OrderBookL1>::from((ExchangeId::LseCrypto, 1_u8, message))
+            .0
+            .into_iter()
+            .map(Result::unwrap)
+            .collect()
+    }
+
+    #[test]
+    fn a_tick_decodes_to_a_two_sided_book() {
+        let events = decode(TICK);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind.best_bid.unwrap().price, dec!(42000.5));
+        assert_eq!(events[0].kind.best_ask.unwrap().price, dec!(42001.0));
+    }
+
+    /// The producer obligation stated on the field: downstream state ranks L1 updates on
+    /// `last_update_time`, so a divergence from the event's own instant silently freezes the book.
+    #[test]
+    fn the_book_instant_equals_the_events_instant() {
+        let events = decode(TICK);
+        assert_eq!(events[0].kind.last_update_time, events[0].time_exchange);
+    }
+
+    /// The feed publishes no sizes. A fabricated one would be indistinguishable from a real one.
+    #[test]
+    fn both_levels_carry_a_zero_size_because_none_is_published() {
+        let events = decode(TICK);
+
+        assert_eq!(events[0].kind.best_bid.unwrap().amount, Decimal::ZERO);
+        assert_eq!(events[0].kind.best_ask.unwrap().amount, Decimal::ZERO);
+    }
+
+    /// The traded size is not resting liquidity, and on two venues it is a fabricated constant.
+    #[test]
+    fn the_tick_volume_is_not_used_as_a_level_size() {
+        let events = decode(TICK);
+        assert_ne!(events[0].kind.best_bid.unwrap().amount, dec!(0.00155));
+    }
+
+    #[test]
+    fn a_control_frame_yields_no_books() {
+        let events = decode(r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41}"#);
+        assert!(events.is_empty());
+    }
+}

--- a/rustrade-data/src/exchange/lse/resume.rs
+++ b/rustrade-data/src/exchange/lse/resume.rs
@@ -9,8 +9,10 @@ use super::channel::LseChannel;
 use crate::{Identifier, exchange::ExchangeSub};
 use chrono::{DateTime, Utc};
 use fnv::FnvHashMap;
+use rustrade_instrument::exchange::ExchangeId;
 use rustrade_integration::subscription::SubscriptionId;
 use std::sync::{Mutex, PoisonError};
+use tracing::warn;
 
 /// The newest instant delivered for one subscription, and how many events already delivered bear
 /// exactly that instant.
@@ -35,33 +37,64 @@ pub(super) struct LseWatermark {
     pub count_at_time: usize,
 }
 
-/// The key a watermark is filed under: the subscription the provider ticks it on, **and** the
-/// subscription kind the stream serves it as.
+/// The key a watermark is filed under: the dataset it was delivered from, the subscription the
+/// provider ticks it on, **and** the subscription kind the stream serves it as.
 ///
-/// # Why the kind is part of the key
-/// The provider publishes one data frame, so a subscribe names a symbol and nothing else and both
-/// supported kinds resolve to the same wire identifier (`tick|BTC/USD`). Keying on that identifier
-/// alone would let two streams carrying one symbol — the same instrument subscribed as trades and
-/// as top-of-book — share a single watermark and advance it independently: whichever stream ran
-/// ahead would set the resume point for both, and the one behind would resume past events it never
-/// delivered. Since this integration is required to serve both kinds from every dataset, that is
-/// the natural way to use the feature rather than an exotic one, so it is closed structurally here
-/// instead of being documented as a caller obligation.
+/// # Why the subscription alone is not enough
+/// The provider publishes one data frame from one host, so a subscribe names a symbol and nothing
+/// else. Every stream therefore files its ticks under a wire identifier — `tick|BTC/USD` — that
+/// says nothing about which stream produced it. Two axes collapse onto it:
 ///
-/// The kind never reaches the wire: it is a partition of this map, not part of the subscription.
+/// - **Kind.** Both supported kinds are decodings of the same frame, so one instrument subscribed
+///   as trades and as top-of-book resolves to one identifier. This integration is required to serve
+///   both kinds from every dataset, so that is the natural way to use the feature rather than an
+///   exotic one.
+/// - **Dataset.** The five `Lse<Server>` connectors share the endpoint and the identifier
+///   construction, and [`LseSymbolShape::Bare`](super::market::LseSymbolShape::Bare) reconstructs a
+///   symbol from the base asset alone — so `AAPL` on [`LseEquities`](super::LseEquities) and `AAPL`
+///   on [`LseFutures`](super::LseFutures) are the same identifier. The pre-subscribe category guard
+///   does not close this: it cross-checks only against datasets the provider labels, and it labels
+///   none of those behind [`LseFutures`](super::LseFutures).
+///
+/// Sharing one watermark across either axis lets two streams advance it independently: whichever
+/// ran ahead sets the resume point for both, and the one behind resumes past events it never
+/// delivered — a silent gap. Both axes are therefore closed structurally here rather than left as a
+/// caller obligation.
+///
+/// # What this key cannot close
+/// Two streams that genuinely duplicate a `(dataset, symbol, kind)` triple — the same subscription
+/// built twice and handed one state — are indistinguishable by construction, and no key can
+/// separate them. That obligation is stated on [`LseResumeState`], which is where a caller meets it.
+///
+/// Neither the dataset nor the kind reaches the wire: both are partitions of this map, not part of
+/// the subscription.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub(super) struct LseResumeKey {
+    exchange: ExchangeId,
     subscription: SubscriptionId,
     kind: &'static str,
 }
 
 impl LseResumeKey {
-    /// File a watermark under `subscription`, as served for `kind`.
+    /// File a watermark under `subscription` on `exchange`, as served for `kind`.
     ///
     /// `kind` is [`SubscriptionKind::as_str`](crate::subscription::SubscriptionKind::as_str) —
     /// taken as a string rather than a type parameter because the map holds every kind at once.
-    pub(super) fn new(subscription: SubscriptionId, kind: &'static str) -> Self {
-        Self { subscription, kind }
+    pub(super) fn new(
+        exchange: ExchangeId,
+        subscription: SubscriptionId,
+        kind: &'static str,
+    ) -> Self {
+        Self {
+            exchange,
+            subscription,
+            kind,
+        }
+    }
+
+    /// The dataset this key partitions on.
+    pub(super) fn exchange(&self) -> ExchangeId {
+        self.exchange
     }
 
     /// The kind this key partitions on.
@@ -90,17 +123,33 @@ impl LseResumeKey {
 /// adding it later against a stated need is a smaller commitment than taking one back.
 ///
 /// # Reconnect, not crash recovery
-/// The watermark advances on **delivered** events and lives in memory. It closes the gap a
-/// reconnect opens; it does not survive the process. Recovering across a restart would require the
-/// consumer to acknowledge what it durably stored, which is consumer policy and deliberately not
-/// modelled here.
+/// The watermark advances on events the stream **emitted**, and lives in memory. It closes the gap
+/// a reconnect opens; it does not survive the process. Recovering across a restart would require
+/// the consumer to acknowledge what it durably stored, which is consumer policy and deliberately
+/// not modelled here.
 ///
-/// # One state may be shared freely
-/// Watermarks are keyed by subscription *and* subscription kind, so one state serves any set of
-/// streams, including two that carry the same symbol as different kinds: this provider serves both
-/// kinds from a single data frame, so keying on the wire identifier alone would let whichever
-/// stream ran ahead set the resume point for both, and the one behind would resume past events it
-/// never delivered. Nothing about sharing needs thinking about at the call site.
+/// "Emitted" is one step short of "consumed": an event is recorded when the transformer produces
+/// it, which is when it enters the stream's own buffer, not when the consumer polls it out. A
+/// reconnect therefore resumes from the newest event the stream *produced*, and anything still
+/// sitting in that buffer when the connection dropped is lost with it. Closing that last step would
+/// mean the consumer acknowledging each event, which is the crash-recovery contract above and is
+/// deliberately not modelled either.
+///
+/// # ⚠️ Sharing one state — the one obligation the caller carries
+/// Watermarks are keyed by dataset, subscription **and** subscription kind, so one state serves any
+/// set of streams that differ in any of those three. Two streams carrying the same symbol as
+/// different kinds, or the same symbol on two datasets, each keep their own watermark and cannot
+/// disturb one another.
+///
+/// **What is not closed, and cannot be:** two streams that duplicate a `(dataset, symbol, kind)`
+/// triple. Nothing distinguishes them, so they share one watermark and advance it independently —
+/// whichever runs ahead sets the resume point for both, and the one behind resumes past events it
+/// never delivered, with no warning. [`StreamBuilder::subscribe`](crate::streams::builder::StreamBuilder::subscribe)
+/// de-duplicates only *within* one batch, so this is reachable by building two `Streams` over the
+/// same subscription and handing both the same state.
+///
+/// So: **give each duplicated triple its own state**, or do not duplicate one. Disjoint sets may
+/// share freely.
 ///
 /// # Opting in
 /// Resumption is **off** unless [`LseSubscriber::with_resume`](super::live::LseSubscriber::with_resume)
@@ -119,11 +168,29 @@ impl LseResumeKey {
 /// ```
 #[derive(Debug, Default)]
 pub struct LseResumeState {
-    // A plain `Mutex` rather than an `RwLock`: there are no concurrent readers to shard. The
-    // reconnect chain polls the outer stream (where the subscriber reads) only once the inner
-    // stream (where the transformer writes) has fully drained, so the two never overlap. The lock
-    // is never held across an `await`.
-    marks: Mutex<FnvHashMap<LseResumeKey, LseWatermark>>,
+    // A plain `Mutex` rather than an `RwLock`. Within one reconnect chain the two accessors never
+    // overlap at all -- the chain polls the outer stream (where the subscriber reads) only once the
+    // inner stream (where the transformer writes) has fully drained. Across chains they do: this
+    // state is documented as shareable between concurrently-spawned per-batch streams, and those
+    // contend. A `Mutex` is still the right choice for that: the critical section is a hash lookup
+    // and a field update with no allocation, which an `RwLock` would only make more expensive to
+    // acquire. The lock is never held across an `await`.
+    marks: Mutex<FnvHashMap<LseResumeKey, MarkState>>,
+}
+
+/// A watermark, plus the per-key bookkeeping that is not part of the resume arithmetic.
+///
+/// Kept beside [`LseWatermark`] rather than inside it so the watermark stays exactly the two values
+/// resumption is computed from, and so equality on it means "the same resume point".
+#[derive(Copy, Clone, Debug)]
+struct MarkState {
+    watermark: LseWatermark,
+
+    /// Whether the out-of-order report has already fired for this key.
+    ///
+    /// A genuinely non-monotonic source would otherwise log once per late tick, which on a busy
+    /// symbol is tens of thousands of identical lines.
+    reported_out_of_order: bool,
 }
 
 impl LseResumeState {
@@ -132,54 +199,102 @@ impl LseResumeState {
         Self::default()
     }
 
-    /// Record that an event bearing `time_exchange` was delivered under `key`.
+    /// Record that an event bearing `time_exchange` was emitted under `key`.
     ///
-    /// Advancing to a newer instant resets the count to one. An instant older than the watermark
-    /// is ignored rather than rolling it back — the watermark is the high-water mark of what was
-    /// delivered, and moving it backwards would re-request events already seen.
+    /// Advancing to a newer instant resets the count to one.
+    ///
+    /// # ⚠️ This assumes the feed is monotonic per subscription, and says so when it is not
+    /// An instant *older* than the watermark is ignored rather than rolling it back: the watermark
+    /// is the high-water mark of what was emitted, and moving it backwards would re-request events
+    /// already seen. That is the right answer for a duplicate, but it is not free if the source is
+    /// genuinely out of order — the resume point stays at the newest instant seen, so a reconnect
+    /// asks for everything after it and the events between the late instant and the watermark are
+    /// never re-requested. The reporting path in the transformer cannot see that either, because
+    /// those frames are never sent.
+    ///
+    /// Every sample taken on this feed arrived in order, and the crypto tape is the one place the
+    /// assumption is least obviously safe — it is an aggregated cross-venue series. So the
+    /// assumption is stated rather than defended, and its first violation per key is logged.
     pub(super) fn record(&self, key: &LseResumeKey, time_exchange: DateTime<Utc>) {
-        let mut marks = self.lock();
+        // The report is emitted *after* the guard is dropped. This state is documented as shareable
+        // between concurrently-spawned per-batch streams, so the lock is contended, and a tracing
+        // subscriber that writes synchronously would otherwise stall every other stream's `record`
+        // for the length of a log write. The critical section stays a hash lookup and a field
+        // update, which is what justifies the plain `Mutex` above.
+        let out_of_order = {
+            let mut marks = self.lock();
 
-        match marks.get_mut(key) {
-            Some(watermark) if time_exchange > watermark.time_exchange => {
-                *watermark = LseWatermark {
-                    time_exchange,
-                    count_at_time: 1,
-                };
-            }
-            Some(watermark) if time_exchange == watermark.time_exchange => {
-                watermark.count_at_time += 1;
-            }
-            Some(_) => {}
-            None => {
-                marks.insert(
-                    key.clone(),
-                    LseWatermark {
+            match marks.get_mut(key) {
+                Some(state) if time_exchange > state.watermark.time_exchange => {
+                    state.watermark = LseWatermark {
                         time_exchange,
                         count_at_time: 1,
-                    },
-                );
+                    };
+
+                    None
+                }
+                Some(state) if time_exchange == state.watermark.time_exchange => {
+                    state.watermark.count_at_time += 1;
+
+                    None
+                }
+                Some(state) if !state.reported_out_of_order => {
+                    state.reported_out_of_order = true;
+
+                    Some(state.watermark.time_exchange)
+                }
+                Some(_) => None,
+                None => {
+                    marks.insert(
+                        key.clone(),
+                        MarkState {
+                            watermark: LseWatermark {
+                                time_exchange,
+                                count_at_time: 1,
+                            },
+                            reported_out_of_order: false,
+                        },
+                    );
+
+                    None
+                }
             }
+        };
+
+        if let Some(watermark) = out_of_order {
+            warn!(
+                exchange = %key.exchange,
+                subscription = %key.subscription,
+                kind = key.kind,
+                instant = %time_exchange,
+                watermark = %watermark,
+                "London Strategic Edge emitted an event older than this subscription's resume \
+                 point, which a monotonic feed cannot do; the resume point is left where it is, so \
+                 a reconnect will not re-request the span between the two",
+            );
         }
     }
 
-    /// The watermark filed under `key`, if anything has been delivered for it.
+    /// The watermark filed under `key`, if anything has been emitted for it.
     pub(super) fn watermark(&self, key: &LseResumeKey) -> Option<LseWatermark> {
-        self.lock().get(key).copied()
+        self.lock().get(key).map(|state| state.watermark)
     }
 
-    /// Every watermark recorded so far, across every kind.
+    /// Every watermark recorded so far, across every dataset and kind.
     ///
     /// Taken as a snapshot so a transformer can carry its own drop counters without holding the
-    /// lock, or consulting it, per tick. The caller filters to its own kind.
+    /// lock, or consulting it, per tick. The caller filters to its own dataset and kind.
     pub(super) fn snapshot(&self) -> FnvHashMap<LseResumeKey, LseWatermark> {
-        self.lock().clone()
+        self.lock()
+            .iter()
+            .map(|(key, state)| (key.clone(), state.watermark))
+            .collect()
     }
 
     // A poisoned lock means some other thread panicked mid-update. The data behind it is a
     // high-water mark whose worst case is a slightly stale resume point, so recovering the inner
     // value is strictly better than propagating the panic and taking the market stream down.
-    fn lock(&self) -> std::sync::MutexGuard<'_, FnvHashMap<LseResumeKey, LseWatermark>> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, FnvHashMap<LseResumeKey, MarkState>> {
         self.marks.lock().unwrap_or_else(PoisonError::into_inner)
     }
 }
@@ -232,11 +347,15 @@ mod tests {
     /// The kind comes from [`SubscriptionKind::as_str`] rather than a spelled-out literal, so
     /// these tests partition on the same string production files watermarks under.
     fn key() -> LseResumeKey {
-        LseResumeKey::new(id(), PublicTrades.as_str())
+        LseResumeKey::new(ExchangeId::LseCrypto, id(), PublicTrades.as_str())
     }
 
     fn key_for(symbol: &str) -> LseResumeKey {
-        LseResumeKey::new(subscription_id(symbol), PublicTrades.as_str())
+        LseResumeKey::new(
+            ExchangeId::LseCrypto,
+            subscription_id(symbol),
+            PublicTrades.as_str(),
+        )
     }
 
     #[test]
@@ -319,8 +438,8 @@ mod tests {
     #[test]
     fn one_symbol_served_as_two_kinds_keeps_two_watermarks() {
         let state = LseResumeState::new();
-        let trades = LseResumeKey::new(id(), PublicTrades.as_str());
-        let books = LseResumeKey::new(id(), OrderBooksL1.as_str());
+        let trades = LseResumeKey::new(ExchangeId::LseCrypto, id(), PublicTrades.as_str());
+        let books = LseResumeKey::new(ExchangeId::LseCrypto, id(), OrderBooksL1.as_str());
 
         state.record(&trades, at("2026-01-02T09:00:00Z"));
         state.record(&trades, at("2026-01-02T10:00:00Z"));
@@ -335,6 +454,49 @@ mod tests {
             at("2026-01-02T09:00:00Z"),
             "the trailing kind must resume from its own last delivery, not the other kind's",
         );
+    }
+
+    /// The five datasets share one endpoint and one identifier construction, and the `Bare` symbol
+    /// shape rebuilds a symbol from the base asset alone — so one ticker subscribed on two of them
+    /// produces one wire identifier. Sharing a watermark across that would let whichever stream ran
+    /// ahead set the resume point for both.
+    #[test]
+    fn one_symbol_served_by_two_datasets_keeps_two_watermarks() {
+        let state = LseResumeState::new();
+        let bare = subscription_id("AAPL");
+        let equities =
+            LseResumeKey::new(ExchangeId::LseEquities, bare.clone(), PublicTrades.as_str());
+        let futures =
+            LseResumeKey::new(ExchangeId::LseFutures, bare.clone(), PublicTrades.as_str());
+
+        assert_eq!(
+            equities.clone().into_subscription(),
+            futures.clone().into_subscription(),
+            "this test is only meaningful while both datasets file under one identifier",
+        );
+
+        state.record(&equities, at("2026-01-02T09:00:00Z"));
+        state.record(&equities, at("2026-01-02T10:00:00Z"));
+        state.record(&futures, at("2026-01-02T09:00:00Z"));
+
+        assert_eq!(
+            state.watermark(&equities).unwrap().time_exchange,
+            at("2026-01-02T10:00:00Z"),
+        );
+        assert_eq!(
+            state.watermark(&futures).unwrap().time_exchange,
+            at("2026-01-02T09:00:00Z"),
+            "the trailing dataset must resume from its own last delivery, not the other dataset's",
+        );
+    }
+
+    /// The kind partition is only a partition while distinct kinds spell themselves distinctly, and
+    /// [`SubscriptionKind`] does not promise that — `Candles::as_str` answers `"candles"` for every
+    /// interval. This provider serves no candles so nothing is reachable today, but the dependency
+    /// is silent, and a collision here is a shared watermark rather than a compile error.
+    #[test]
+    fn the_two_served_kinds_spell_themselves_distinctly() {
+        assert_ne!(PublicTrades.as_str(), OrderBooksL1.as_str());
     }
 
     #[test]

--- a/rustrade-data/src/exchange/lse/resume.rs
+++ b/rustrade-data/src/exchange/lse/resume.rs
@@ -20,7 +20,7 @@ use std::sync::{Mutex, PoisonError};
 /// so they can be skipped by position. Resuming one tick *later* instead would be simpler and
 /// would silently lose every event at that instant not yet consumed.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct LseWatermark {
+pub(super) struct LseWatermark {
     /// The newest `time_exchange` delivered for this subscription.
     pub time_exchange: DateTime<Utc>,
 
@@ -37,6 +37,16 @@ pub struct LseWatermark {
 
 /// Resume state shared between a [`LseSubscriber`](super::live::LseSubscriber) and the transformer
 /// of every stream it opens.
+///
+/// # An opaque handle, deliberately
+/// Construct it, hand it to
+/// [`LseSubscriber::with_resume`](super::live::LseSubscriber::with_resume), and let delivery drive
+/// it; there is no supported way to read or advance a watermark from outside. Reading one means
+/// exposing the key it is filed under, and this provider's ticks are filed under a wire identifier
+/// rather than anything a caller holds — publishing that identifier would freeze its spelling into
+/// this contract and still hand back a map no caller could interpret, because deriving it is
+/// one-way. A read surface keyed on the symbol is the shape to add if a caller ever needs one, and
+/// adding it later against a stated need is a smaller commitment than taking one back.
 ///
 /// # Reconnect, not crash recovery
 /// The watermark advances on **delivered** events and lives in memory. It closes the gap a
@@ -83,7 +93,7 @@ impl LseResumeState {
     /// Advancing to a newer instant resets the count to one. An instant older than the watermark
     /// is ignored rather than rolling it back — the watermark is the high-water mark of what was
     /// delivered, and moving it backwards would re-request events already seen.
-    pub fn record(&self, subscription_id: &SubscriptionId, time_exchange: DateTime<Utc>) {
+    pub(super) fn record(&self, subscription_id: &SubscriptionId, time_exchange: DateTime<Utc>) {
         let mut marks = self.lock();
 
         match marks.get_mut(subscription_id) {
@@ -110,7 +120,7 @@ impl LseResumeState {
     }
 
     /// The watermark for `subscription_id`, if anything has been delivered for it.
-    pub fn watermark(&self, subscription_id: &SubscriptionId) -> Option<LseWatermark> {
+    pub(super) fn watermark(&self, subscription_id: &SubscriptionId) -> Option<LseWatermark> {
         self.lock().get(subscription_id).copied()
     }
 
@@ -118,7 +128,7 @@ impl LseResumeState {
     ///
     /// Taken as a snapshot so a transformer can carry its own drop counters without holding the
     /// lock, or consulting it, per tick.
-    pub fn snapshot(&self) -> FnvHashMap<SubscriptionId, LseWatermark> {
+    pub(super) fn snapshot(&self) -> FnvHashMap<SubscriptionId, LseWatermark> {
         self.lock().clone()
     }
 

--- a/rustrade-data/src/exchange/lse/resume.rs
+++ b/rustrade-data/src/exchange/lse/resume.rs
@@ -35,6 +35,47 @@ pub(super) struct LseWatermark {
     pub count_at_time: usize,
 }
 
+/// The key a watermark is filed under: the subscription the provider ticks it on, **and** the
+/// subscription kind the stream serves it as.
+///
+/// # Why the kind is part of the key
+/// The provider publishes one data frame, so a subscribe names a symbol and nothing else and both
+/// supported kinds resolve to the same wire identifier (`tick|BTC/USD`). Keying on that identifier
+/// alone would let two streams carrying one symbol — the same instrument subscribed as trades and
+/// as top-of-book — share a single watermark and advance it independently: whichever stream ran
+/// ahead would set the resume point for both, and the one behind would resume past events it never
+/// delivered. Since this integration is required to serve both kinds from every dataset, that is
+/// the natural way to use the feature rather than an exotic one, so it is closed structurally here
+/// instead of being documented as a caller obligation.
+///
+/// The kind never reaches the wire: it is a partition of this map, not part of the subscription.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub(super) struct LseResumeKey {
+    subscription: SubscriptionId,
+    kind: &'static str,
+}
+
+impl LseResumeKey {
+    /// File a watermark under `subscription`, as served for `kind`.
+    ///
+    /// `kind` is [`SubscriptionKind::as_str`](crate::subscription::SubscriptionKind::as_str) —
+    /// taken as a string rather than a type parameter because the map holds every kind at once.
+    pub(super) fn new(subscription: SubscriptionId, kind: &'static str) -> Self {
+        Self { subscription, kind }
+    }
+
+    /// The kind this key partitions on.
+    pub(super) fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    /// Consume the key for the subscription half, which is what a transformer keys its own
+    /// per-connection bookkeeping on once it has filtered the snapshot to its own kind.
+    pub(super) fn into_subscription(self) -> SubscriptionId {
+        self.subscription
+    }
+}
+
 /// Resume state shared between a [`LseSubscriber`](super::live::LseSubscriber) and the transformer
 /// of every stream it opens.
 ///
@@ -54,9 +95,12 @@ pub(super) struct LseWatermark {
 /// consumer to acknowledge what it durably stored, which is consumer policy and deliberately not
 /// modelled here.
 ///
-/// # One state per set of streams
-/// Watermarks are keyed by symbol, so streams that carry the same symbol must not share a state;
-/// see [`LseSubscriber::with_resume`](super::live::LseSubscriber::with_resume).
+/// # One state may be shared freely
+/// Watermarks are keyed by subscription *and* subscription kind, so one state serves any set of
+/// streams, including two that carry the same symbol as different kinds: this provider serves both
+/// kinds from a single data frame, so keying on the wire identifier alone would let whichever
+/// stream ran ahead set the resume point for both, and the one behind would resume past events it
+/// never delivered. Nothing about sharing needs thinking about at the call site.
 ///
 /// # Opting in
 /// Resumption is **off** unless [`LseSubscriber::with_resume`](super::live::LseSubscriber::with_resume)
@@ -79,7 +123,7 @@ pub struct LseResumeState {
     // reconnect chain polls the outer stream (where the subscriber reads) only once the inner
     // stream (where the transformer writes) has fully drained, so the two never overlap. The lock
     // is never held across an `await`.
-    marks: Mutex<FnvHashMap<SubscriptionId, LseWatermark>>,
+    marks: Mutex<FnvHashMap<LseResumeKey, LseWatermark>>,
 }
 
 impl LseResumeState {
@@ -88,15 +132,15 @@ impl LseResumeState {
         Self::default()
     }
 
-    /// Record that an event bearing `time_exchange` was delivered for `subscription_id`.
+    /// Record that an event bearing `time_exchange` was delivered under `key`.
     ///
     /// Advancing to a newer instant resets the count to one. An instant older than the watermark
     /// is ignored rather than rolling it back — the watermark is the high-water mark of what was
     /// delivered, and moving it backwards would re-request events already seen.
-    pub(super) fn record(&self, subscription_id: &SubscriptionId, time_exchange: DateTime<Utc>) {
+    pub(super) fn record(&self, key: &LseResumeKey, time_exchange: DateTime<Utc>) {
         let mut marks = self.lock();
 
-        match marks.get_mut(subscription_id) {
+        match marks.get_mut(key) {
             Some(watermark) if time_exchange > watermark.time_exchange => {
                 *watermark = LseWatermark {
                     time_exchange,
@@ -109,7 +153,7 @@ impl LseResumeState {
             Some(_) => {}
             None => {
                 marks.insert(
-                    subscription_id.clone(),
+                    key.clone(),
                     LseWatermark {
                         time_exchange,
                         count_at_time: 1,
@@ -119,23 +163,23 @@ impl LseResumeState {
         }
     }
 
-    /// The watermark for `subscription_id`, if anything has been delivered for it.
-    pub(super) fn watermark(&self, subscription_id: &SubscriptionId) -> Option<LseWatermark> {
-        self.lock().get(subscription_id).copied()
+    /// The watermark filed under `key`, if anything has been delivered for it.
+    pub(super) fn watermark(&self, key: &LseResumeKey) -> Option<LseWatermark> {
+        self.lock().get(key).copied()
     }
 
-    /// Every watermark recorded so far.
+    /// Every watermark recorded so far, across every kind.
     ///
     /// Taken as a snapshot so a transformer can carry its own drop counters without holding the
-    /// lock, or consulting it, per tick.
-    pub(super) fn snapshot(&self) -> FnvHashMap<SubscriptionId, LseWatermark> {
+    /// lock, or consulting it, per tick. The caller filters to its own kind.
+    pub(super) fn snapshot(&self) -> FnvHashMap<LseResumeKey, LseWatermark> {
         self.lock().clone()
     }
 
     // A poisoned lock means some other thread panicked mid-update. The data behind it is a
     // high-water mark whose worst case is a slightly stale resume point, so recovering the inner
     // value is strictly better than propagating the panic and taking the market stream down.
-    fn lock(&self) -> std::sync::MutexGuard<'_, FnvHashMap<SubscriptionId, LseWatermark>> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, FnvHashMap<LseResumeKey, LseWatermark>> {
         self.marks.lock().unwrap_or_else(PoisonError::into_inner)
     }
 }
@@ -173,6 +217,7 @@ pub(super) fn epoch_seconds(time: DateTime<Utc>) -> f64 {
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
     use super::*;
+    use crate::subscription::{SubscriptionKind, book::OrderBooksL1, trade::PublicTrades};
 
     fn at(spelling: &str) -> DateTime<Utc> {
         spelling.parse::<DateTime<Utc>>().unwrap()
@@ -182,13 +227,25 @@ mod tests {
         subscription_id("BTC/USD")
     }
 
+    /// The key one symbol's trades are filed under.
+    ///
+    /// The kind comes from [`SubscriptionKind::as_str`] rather than a spelled-out literal, so
+    /// these tests partition on the same string production files watermarks under.
+    fn key() -> LseResumeKey {
+        LseResumeKey::new(id(), PublicTrades.as_str())
+    }
+
+    fn key_for(symbol: &str) -> LseResumeKey {
+        LseResumeKey::new(subscription_id(symbol), PublicTrades.as_str())
+    }
+
     #[test]
     fn the_first_event_seeds_the_watermark_with_a_count_of_one() {
         let state = LseResumeState::new();
-        state.record(&id(), at("2026-01-02T09:37:24.760146Z"));
+        state.record(&key(), at("2026-01-02T09:37:24.760146Z"));
 
         assert_eq!(
-            state.watermark(&id()),
+            state.watermark(&key()),
             Some(LseWatermark {
                 time_exchange: at("2026-01-02T09:37:24.760146Z"),
                 count_at_time: 1,
@@ -202,21 +259,21 @@ mod tests {
     fn events_sharing_an_instant_accumulate_a_count() {
         let state = LseResumeState::new();
         for _ in 0..141 {
-            state.record(&id(), at("2026-01-02T09:37:24.760Z"));
+            state.record(&key(), at("2026-01-02T09:37:24.760Z"));
         }
 
-        assert_eq!(state.watermark(&id()).unwrap().count_at_time, 141);
+        assert_eq!(state.watermark(&key()).unwrap().count_at_time, 141);
     }
 
     #[test]
     fn a_newer_instant_advances_the_watermark_and_resets_the_count() {
         let state = LseResumeState::new();
-        state.record(&id(), at("2026-01-02T09:37:24.760146Z"));
-        state.record(&id(), at("2026-01-02T09:37:24.760146Z"));
-        state.record(&id(), at("2026-01-02T09:37:24.760147Z"));
+        state.record(&key(), at("2026-01-02T09:37:24.760146Z"));
+        state.record(&key(), at("2026-01-02T09:37:24.760146Z"));
+        state.record(&key(), at("2026-01-02T09:37:24.760147Z"));
 
         assert_eq!(
-            state.watermark(&id()),
+            state.watermark(&key()),
             Some(LseWatermark {
                 time_exchange: at("2026-01-02T09:37:24.760147Z"),
                 count_at_time: 1,
@@ -228,11 +285,11 @@ mod tests {
     #[test]
     fn an_older_instant_leaves_the_watermark_untouched() {
         let state = LseResumeState::new();
-        state.record(&id(), at("2026-01-02T09:37:24.760147Z"));
-        state.record(&id(), at("2026-01-02T09:37:24.760146Z"));
+        state.record(&key(), at("2026-01-02T09:37:24.760147Z"));
+        state.record(&key(), at("2026-01-02T09:37:24.760146Z"));
 
         assert_eq!(
-            state.watermark(&id()),
+            state.watermark(&key()),
             Some(LseWatermark {
                 time_exchange: at("2026-01-02T09:37:24.760147Z"),
                 count_at_time: 1,
@@ -243,28 +300,46 @@ mod tests {
     #[test]
     fn subscriptions_are_tracked_independently() {
         let state = LseResumeState::new();
-        state.record(&subscription_id("BTC/USD"), at("2026-01-02T09:00:00Z"));
-        state.record(&subscription_id("ETH/USD"), at("2026-01-02T10:00:00Z"));
+        state.record(&key_for("BTC/USD"), at("2026-01-02T09:00:00Z"));
+        state.record(&key_for("ETH/USD"), at("2026-01-02T10:00:00Z"));
 
         assert_eq!(
-            state
-                .watermark(&subscription_id("BTC/USD"))
-                .unwrap()
-                .time_exchange,
+            state.watermark(&key_for("BTC/USD")).unwrap().time_exchange,
             at("2026-01-02T09:00:00Z")
         );
         assert_eq!(
-            state
-                .watermark(&subscription_id("ETH/USD"))
-                .unwrap()
-                .time_exchange,
+            state.watermark(&key_for("ETH/USD")).unwrap().time_exchange,
             at("2026-01-02T10:00:00Z")
+        );
+    }
+
+    /// The provider has one channel, so both kinds tick under one wire identifier. Sharing a
+    /// watermark between them would let whichever stream ran ahead set the resume point for both,
+    /// and the one behind would resume past events it never delivered.
+    #[test]
+    fn one_symbol_served_as_two_kinds_keeps_two_watermarks() {
+        let state = LseResumeState::new();
+        let trades = LseResumeKey::new(id(), PublicTrades.as_str());
+        let books = LseResumeKey::new(id(), OrderBooksL1.as_str());
+
+        state.record(&trades, at("2026-01-02T09:00:00Z"));
+        state.record(&trades, at("2026-01-02T10:00:00Z"));
+        state.record(&books, at("2026-01-02T09:00:00Z"));
+
+        assert_eq!(
+            state.watermark(&trades).unwrap().time_exchange,
+            at("2026-01-02T10:00:00Z"),
+        );
+        assert_eq!(
+            state.watermark(&books).unwrap().time_exchange,
+            at("2026-01-02T09:00:00Z"),
+            "the trailing kind must resume from its own last delivery, not the other kind's",
         );
     }
 
     #[test]
     fn an_untracked_subscription_has_no_watermark() {
-        assert_eq!(LseResumeState::new().watermark(&id()), None);
+        assert_eq!(LseResumeState::new().watermark(&key()), None);
     }
 
     /// The resume value must round-trip the stored instant exactly, because the server filters on

--- a/rustrade-data/src/exchange/lse/resume.rs
+++ b/rustrade-data/src/exchange/lse/resume.rs
@@ -1,0 +1,298 @@
+//! Gap-free resumption of a London Strategic Edge subscription across a reconnect.
+//!
+//! The provider serves a historical window before going live when a subscription carries a
+//! `start`, which makes it possible to close the gap a reconnect would otherwise leave. This
+//! module holds the state that survives a reconnect; [`transformer`](super::transformer) applies
+//! it, and [`live`](super::live) sends it.
+
+use super::channel::LseChannel;
+use crate::{Identifier, exchange::ExchangeSub};
+use chrono::{DateTime, Utc};
+use fnv::FnvHashMap;
+use rustrade_integration::subscription::SubscriptionId;
+use std::sync::{Mutex, PoisonError};
+
+/// The newest instant delivered for one subscription, and how many events already delivered bear
+/// exactly that instant.
+///
+/// The count is what makes resumption exact. `start` is **inclusive**, so resuming at the newest
+/// instant re-delivers every event sharing it; the count says how many of those were already seen,
+/// so they can be skipped by position. Resuming one tick *later* instead would be simpler and
+/// would silently lose every event at that instant not yet consumed.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct LseWatermark {
+    /// The newest `time_exchange` delivered for this subscription.
+    pub time_exchange: DateTime<Utc>,
+
+    /// How many events already delivered carry exactly [`time_exchange`](Self::time_exchange).
+    ///
+    /// # This is a real count, not an "almost always 1" optimisation
+    /// Tie density is per-dataset and can be large. Crypto timestamps are quantised to the
+    /// millisecond, and **141 ticks sharing a single instant** were measured on one symbol; FX and
+    /// CFD timestamps carry microseconds and were distinct on every tick sampled, making the count
+    /// `1` there. Both are properties of today's feed rather than contract, which is why the
+    /// arithmetic is written to be correct at any granularity.
+    pub count_at_time: usize,
+}
+
+/// Resume state shared between a [`LseSubscriber`](super::live::LseSubscriber) and the transformer
+/// of every stream it opens.
+///
+/// # Reconnect, not crash recovery
+/// The watermark advances on **delivered** events and lives in memory. It closes the gap a
+/// reconnect opens; it does not survive the process. Recovering across a restart would require the
+/// consumer to acknowledge what it durably stored, which is consumer policy and deliberately not
+/// modelled here.
+///
+/// # One state per set of streams
+/// Watermarks are keyed by symbol, so streams that carry the same symbol must not share a state;
+/// see [`LseSubscriber::with_resume`](super::live::LseSubscriber::with_resume).
+///
+/// # Opting in
+/// Resumption is **off** unless [`LseSubscriber::with_resume`](super::live::LseSubscriber::with_resume)
+/// is called, because the replay it triggers is not free: one hour of a single busy crypto symbol
+/// replayed **107,395 ticks** before the first live tick, and a 24-hour window had not drained
+/// after 30 seconds. A consumer that must stay current is better served by a gap than by a
+/// multi-minute burst of backdated events; a consumer recording a continuous tape wants the
+/// opposite. That is the caller's call to make, so it is not made here.
+///
+/// # Example
+/// ```rust,ignore
+/// use rustrade_data::exchange::lse::{live::LseSubscriber, resume::LseResumeState};
+/// use std::sync::Arc;
+///
+/// let subscriber = LseSubscriber::from_env()?.with_resume(Arc::new(LseResumeState::new()));
+/// ```
+#[derive(Debug, Default)]
+pub struct LseResumeState {
+    // A plain `Mutex` rather than an `RwLock`: there are no concurrent readers to shard. The
+    // reconnect chain polls the outer stream (where the subscriber reads) only once the inner
+    // stream (where the transformer writes) has fully drained, so the two never overlap. The lock
+    // is never held across an `await`.
+    marks: Mutex<FnvHashMap<SubscriptionId, LseWatermark>>,
+}
+
+impl LseResumeState {
+    /// Construct empty resume state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that an event bearing `time_exchange` was delivered for `subscription_id`.
+    ///
+    /// Advancing to a newer instant resets the count to one. An instant older than the watermark
+    /// is ignored rather than rolling it back — the watermark is the high-water mark of what was
+    /// delivered, and moving it backwards would re-request events already seen.
+    pub fn record(&self, subscription_id: &SubscriptionId, time_exchange: DateTime<Utc>) {
+        let mut marks = self.lock();
+
+        match marks.get_mut(subscription_id) {
+            Some(watermark) if time_exchange > watermark.time_exchange => {
+                *watermark = LseWatermark {
+                    time_exchange,
+                    count_at_time: 1,
+                };
+            }
+            Some(watermark) if time_exchange == watermark.time_exchange => {
+                watermark.count_at_time += 1;
+            }
+            Some(_) => {}
+            None => {
+                marks.insert(
+                    subscription_id.clone(),
+                    LseWatermark {
+                        time_exchange,
+                        count_at_time: 1,
+                    },
+                );
+            }
+        }
+    }
+
+    /// The watermark for `subscription_id`, if anything has been delivered for it.
+    pub fn watermark(&self, subscription_id: &SubscriptionId) -> Option<LseWatermark> {
+        self.lock().get(subscription_id).copied()
+    }
+
+    /// Every watermark recorded so far.
+    ///
+    /// Taken as a snapshot so a transformer can carry its own drop counters without holding the
+    /// lock, or consulting it, per tick.
+    pub fn snapshot(&self) -> FnvHashMap<SubscriptionId, LseWatermark> {
+        self.lock().clone()
+    }
+
+    // A poisoned lock means some other thread panicked mid-update. The data behind it is a
+    // high-water mark whose worst case is a slightly stale resume point, so recovering the inner
+    // value is strictly better than propagating the panic and taking the market stream down.
+    fn lock(&self) -> std::sync::MutexGuard<'_, FnvHashMap<SubscriptionId, LseWatermark>> {
+        self.marks.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// The [`SubscriptionId`] the provider's ticks for `symbol` arrive under.
+///
+/// Shared with the tick decoder's own construction of the same identifier so the subscriber and
+/// the stream cannot disagree about which subscription a watermark belongs to.
+pub(super) fn subscription_id(symbol: &str) -> SubscriptionId {
+    ExchangeSub::from((LseChannel::Tick, symbol)).id()
+}
+
+/// Render an instant as the epoch-seconds number the provider's `start` parameter expects.
+///
+/// # Why a float, and why microseconds
+/// The server parses `start` with a float conversion first and only falls back to a datetime
+/// parse, which accepts neither a fractional second nor a UTC offset — so the epoch form is the
+/// only spelling that can express a sub-second resume point at all.
+///
+/// Microseconds are the provider's own resolution and the resolution it filters on: a `start`
+/// placed 400 microseconds past an instant was measured to exclude every tick at that instant,
+/// which neither a millisecond-flooring nor a millisecond-rounding server could do. An `f64`'s
+/// spacing at present-day epochs is roughly a quarter of a microsecond, so this round-trips the
+/// stored instant exactly rather than approximately.
+pub(super) fn epoch_seconds(time: DateTime<Utc>) -> f64 {
+    // The conversion is the point of this function, and its loss is bounded well below the
+    // microsecond the value carries -- see the rustdoc above.
+    #[allow(clippy::cast_precision_loss)]
+    let micros = time.timestamp_micros() as f64;
+
+    micros / 1_000_000.0
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+
+    fn at(spelling: &str) -> DateTime<Utc> {
+        spelling.parse::<DateTime<Utc>>().unwrap()
+    }
+
+    fn id() -> SubscriptionId {
+        subscription_id("BTC/USD")
+    }
+
+    #[test]
+    fn the_first_event_seeds_the_watermark_with_a_count_of_one() {
+        let state = LseResumeState::new();
+        state.record(&id(), at("2026-01-02T09:37:24.760146Z"));
+
+        assert_eq!(
+            state.watermark(&id()),
+            Some(LseWatermark {
+                time_exchange: at("2026-01-02T09:37:24.760146Z"),
+                count_at_time: 1,
+            })
+        );
+    }
+
+    /// The whole point of carrying a count: repeats at one instant are ordinary on this feed, and
+    /// resuming needs to know how many of them were already delivered.
+    #[test]
+    fn events_sharing_an_instant_accumulate_a_count() {
+        let state = LseResumeState::new();
+        for _ in 0..141 {
+            state.record(&id(), at("2026-01-02T09:37:24.760Z"));
+        }
+
+        assert_eq!(state.watermark(&id()).unwrap().count_at_time, 141);
+    }
+
+    #[test]
+    fn a_newer_instant_advances_the_watermark_and_resets_the_count() {
+        let state = LseResumeState::new();
+        state.record(&id(), at("2026-01-02T09:37:24.760146Z"));
+        state.record(&id(), at("2026-01-02T09:37:24.760146Z"));
+        state.record(&id(), at("2026-01-02T09:37:24.760147Z"));
+
+        assert_eq!(
+            state.watermark(&id()),
+            Some(LseWatermark {
+                time_exchange: at("2026-01-02T09:37:24.760147Z"),
+                count_at_time: 1,
+            })
+        );
+    }
+
+    /// Rolling the watermark backwards would re-request events already delivered.
+    #[test]
+    fn an_older_instant_leaves_the_watermark_untouched() {
+        let state = LseResumeState::new();
+        state.record(&id(), at("2026-01-02T09:37:24.760147Z"));
+        state.record(&id(), at("2026-01-02T09:37:24.760146Z"));
+
+        assert_eq!(
+            state.watermark(&id()),
+            Some(LseWatermark {
+                time_exchange: at("2026-01-02T09:37:24.760147Z"),
+                count_at_time: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn subscriptions_are_tracked_independently() {
+        let state = LseResumeState::new();
+        state.record(&subscription_id("BTC/USD"), at("2026-01-02T09:00:00Z"));
+        state.record(&subscription_id("ETH/USD"), at("2026-01-02T10:00:00Z"));
+
+        assert_eq!(
+            state
+                .watermark(&subscription_id("BTC/USD"))
+                .unwrap()
+                .time_exchange,
+            at("2026-01-02T09:00:00Z")
+        );
+        assert_eq!(
+            state
+                .watermark(&subscription_id("ETH/USD"))
+                .unwrap()
+                .time_exchange,
+            at("2026-01-02T10:00:00Z")
+        );
+    }
+
+    #[test]
+    fn an_untracked_subscription_has_no_watermark() {
+        assert_eq!(LseResumeState::new().watermark(&id()), None);
+    }
+
+    /// The resume value must round-trip the stored instant exactly, because the server filters on
+    /// it at microsecond resolution and the drop counter compares instants for equality.
+    #[test]
+    fn the_epoch_form_round_trips_an_instant_to_the_microsecond() {
+        for spelling in [
+            "2026-01-02T09:37:24.760146Z",
+            "2026-08-14T10:16:55.161000Z",
+            "2026-08-14T10:16:55.161999Z",
+            "2026-01-02T09:37:24Z",
+        ] {
+            let instant = at(spelling);
+
+            // Compared in the float domain rather than converting back, so the assertion needs no
+            // truncating cast of its own.
+            #[allow(clippy::cast_precision_loss)] // The bounded loss the function documents
+            let expected = instant.timestamp_micros() as f64;
+            let drift = epoch_seconds(instant) * 1_000_000.0 - expected;
+
+            assert!(drift.abs() < 0.5, "{spelling} drifted {drift} microseconds");
+        }
+    }
+
+    /// The tick decoder builds this identifier independently during deserialisation; if the two
+    /// ever disagreed, every watermark would be filed under a subscription that never reads it.
+    #[test]
+    fn the_subscription_id_matches_the_one_the_tick_decoder_builds() {
+        let tick: super::super::tick::LseMessage = serde_json::from_str(
+            r#"{"type":"tick","symbol":"BTC/USD","ts":"2026-01-02T09:37:24.760146+00:00",
+                "price":42000.5,"bid":42000.5,"ask":42001.0,"volume":0.00155}"#,
+        )
+        .unwrap();
+
+        let super::super::tick::LseMessage::Tick(tick) = tick else {
+            panic!("expected a tick");
+        };
+
+        assert_eq!(tick.subscription_id, subscription_id("BTC/USD"));
+    }
+}

--- a/rustrade-data/src/exchange/lse/stream.rs
+++ b/rustrade-data/src/exchange/lse/stream.rs
@@ -1,0 +1,138 @@
+//! The London Strategic Edge market stream.
+//!
+//! Exists for one reason: to carry the caller's resume state from the subscriber into the
+//! transformer. [`ExchangeTransformer::init`](crate::transformer::ExchangeTransformer::init) is a
+//! static function with no access to the subscriber, so a stream that wants resumption has to
+//! assemble the pieces itself.
+
+use super::{live::LseSubscriber, transformer::LseTransformer};
+use crate::{
+    Identifier, MarketStream, SnapshotFetcher, distribute_messages_to_exchange,
+    error::DataError,
+    event::{MarketEvent, MarketIter},
+    exchange::Connector,
+    instrument::InstrumentData,
+    process_buffered_events, schedule_pings_to_exchange,
+    subscriber::{Subscribed, Subscriber},
+    subscription::{Subscription, SubscriptionKind},
+};
+use futures::{Stream, StreamExt};
+use rustrade_instrument::exchange::ExchangeId;
+use rustrade_integration::{
+    protocol::websocket::{WebSocketSerdeParser, WsStream},
+    stream::ExchangeStream,
+};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::sync::mpsc;
+
+/// The market stream every London Strategic Edge subscription kind is served over.
+///
+/// Behaves exactly as the standard WebSocket stream does; the only difference is that its
+/// initialisation hands the subscriber's resume state to the transformer, which the standard
+/// initialisation has no way to do.
+// The bounds are on the struct rather than only its impls because the inner `ExchangeStream`
+// carries them on its own definition; there is no way to name the field type without them.
+#[derive(Debug)]
+pub struct LseStream<Exchange, InstrumentKey, Kind>
+where
+    Exchange: Connector,
+    InstrumentKey: Clone,
+    Kind: SubscriptionKind,
+    MarketIter<InstrumentKey, Kind::Event>:
+        From<(ExchangeId, InstrumentKey, super::tick::LseMessage)>,
+{
+    inner: ExchangeStream<
+        WebSocketSerdeParser,
+        WsStream,
+        LseTransformer<Exchange, InstrumentKey, Kind>,
+    >,
+}
+
+impl<Exchange, InstrumentKey, Kind> Stream for LseStream<Exchange, InstrumentKey, Kind>
+where
+    Exchange: Connector,
+    InstrumentKey: Clone,
+    Kind: SubscriptionKind,
+    MarketIter<InstrumentKey, Kind::Event>:
+        From<(ExchangeId, InstrumentKey, super::tick::LseMessage)>,
+{
+    type Item = Result<MarketEvent<InstrumentKey, Kind::Event>, DataError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // `WsStream` is `Unpin` and `MarketStream` requires `Unpin` regardless, so the inner
+        // stream can be re-pinned without a projection.
+        Pin::new(&mut self.get_mut().inner).poll_next(cx)
+    }
+}
+
+impl<Exchange, Instrument, Kind> MarketStream<Exchange, Instrument, Kind>
+    for LseStream<Exchange, Instrument::Key, Kind>
+where
+    Exchange: Connector<Subscriber = LseSubscriber> + Send + Sync,
+    Instrument: InstrumentData,
+    Kind: SubscriptionKind + Send + Sync,
+    Kind::Event: Send + Sync,
+    MarketIter<Instrument::Key, Kind::Event>:
+        From<(ExchangeId, Instrument::Key, super::tick::LseMessage)>,
+{
+    /// Connect, subscribe, and assemble the stream around a resume-aware transformer.
+    ///
+    /// This mirrors the standard WebSocket initialisation and calls the same public pieces of it.
+    /// It is not a copy for its own sake: the resume state has to reach the transformer **before**
+    /// any buffered event is processed. Replay ticks can be sitting in that buffer already — they
+    /// fail to deserialise as subscription responses while other symbols are still being
+    /// confirmed, and land there — so attaching the state after the standard initialisation
+    /// returned would let the first replayed ticks past the skip and straight into the stream.
+    async fn init<SnapFetcher>(
+        subscriber: &Exchange::Subscriber,
+        subscriptions: &[Subscription<Exchange, Instrument, Kind>],
+    ) -> Result<Self, DataError>
+    where
+        SnapFetcher: SnapshotFetcher<Exchange, Kind>,
+        Subscription<Exchange, Instrument, Kind>:
+            Identifier<Exchange::Channel> + Identifier<Exchange::Market>,
+    {
+        let Subscribed {
+            websocket,
+            map: instrument_map,
+            buffered_websocket_events,
+        } = subscriber.subscribe(subscriptions).await?;
+
+        // Always empty for this provider -- its streams fetch no initial snapshots -- but taken
+        // through the generic path so a future kind that needs one is not silently ignored.
+        let initial_snapshots = SnapFetcher::fetch_snapshots(subscriptions).await?;
+
+        let (ws_sink, ws_stream) = websocket.split();
+
+        let (ws_sink_tx, ws_sink_rx) = mpsc::unbounded_channel();
+        tokio::spawn(distribute_messages_to_exchange(
+            Exchange::ID,
+            ws_sink,
+            ws_sink_rx,
+        ));
+
+        if let Some(ping_interval) = Exchange::ping_interval() {
+            tokio::spawn(schedule_pings_to_exchange(
+                Exchange::ID,
+                ws_sink_tx.clone(),
+                ping_interval,
+            ));
+        }
+
+        let mut transformer =
+            LseTransformer::new(instrument_map, ws_sink_tx, subscriber.resume_state()).await?;
+
+        let mut processed = process_buffered_events::<WebSocketSerdeParser, _>(
+            &mut transformer,
+            buffered_websocket_events,
+        );
+        processed.extend(initial_snapshots.into_iter().map(Ok));
+
+        Ok(Self {
+            inner: ExchangeStream::new(ws_stream, transformer, processed),
+        })
+    }
+}

--- a/rustrade-data/src/exchange/lse/stream.rs
+++ b/rustrade-data/src/exchange/lse/stream.rs
@@ -122,17 +122,19 @@ where
             ));
         }
 
-        // The resume state is partitioned by subscription kind -- see
-        // [`LseResumeKey`](super::resume::LseResumeKey) -- and every subscription in one batch
-        // shares a `Kind`, so the first names it for all of them. An empty batch has nothing to
-        // resume, which is what the `zip` yields.
+        // The resume state is partitioned by dataset and subscription kind -- see
+        // [`LseResumeKey`](super::resume::LseResumeKey). The dataset is `Exchange::ID` and the
+        // transformer reads it there; the kind has no type-level value to read, and every
+        // subscription in one batch shares a `Kind`, so the first names it for all of them. An
+        // empty batch has nothing to resume, which is what the `zip` yields.
         let resume = subscriber.resume_state().zip(
             subscriptions
                 .first()
                 .map(|subscription| subscription.kind.as_str()),
         );
 
-        let mut transformer = LseTransformer::new(instrument_map, ws_sink_tx, resume).await?;
+        let mut transformer =
+            LseTransformer::new(instrument_map, &initial_snapshots, ws_sink_tx, resume).await?;
 
         let mut processed = process_buffered_events::<WebSocketSerdeParser, _>(
             &mut transformer,

--- a/rustrade-data/src/exchange/lse/stream.rs
+++ b/rustrade-data/src/exchange/lse/stream.rs
@@ -122,8 +122,17 @@ where
             ));
         }
 
-        let mut transformer =
-            LseTransformer::new(instrument_map, ws_sink_tx, subscriber.resume_state()).await?;
+        // The resume state is partitioned by subscription kind -- see
+        // [`LseResumeKey`](super::resume::LseResumeKey) -- and every subscription in one batch
+        // shares a `Kind`, so the first names it for all of them. An empty batch has nothing to
+        // resume, which is what the `zip` yields.
+        let resume = subscriber.resume_state().zip(
+            subscriptions
+                .first()
+                .map(|subscription| subscription.kind.as_str()),
+        );
+
+        let mut transformer = LseTransformer::new(instrument_map, ws_sink_tx, resume).await?;
 
         let mut processed = process_buffered_events::<WebSocketSerdeParser, _>(
             &mut transformer,

--- a/rustrade-data/src/exchange/lse/subscription.rs
+++ b/rustrade-data/src/exchange/lse/subscription.rs
@@ -1,8 +1,10 @@
-//! Subscription-lifecycle frames: what the provider answers a `subscribe` with, and how a replay
-//! window announces its own boundaries.
+//! What the provider answers a `subscribe` with.
+//!
+//! The replay window's own boundary frames are decoded on the stream instead, by
+//! [`LseMessage`](super::tick::LseMessage) — see
+//! [`ReplayStarted`](super::tick::LseMessage::ReplayStarted) for why the handshake is the wrong
+//! place to read them.
 
-use super::tick::de_timestamp;
-use chrono::{DateTime, Utc};
 use rustrade_integration::{Validator, error::SocketError};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
@@ -25,21 +27,29 @@ use smol_str::SmolStr;
 /// # Why replay frames are deliberately not modelled here
 /// The subscription validator counts every frame that deserialises into this type and validates
 /// `Ok` as one more subscription confirmed. A `replay_started` frame modelled as a success would
-/// inflate that count and end validation before the last real confirmation arrived. Replay frames
-/// are [`LseReplayFrame`] instead, and reach the subscriber through the buffered-events path — the
-/// same route ticks that arrive mid-validation take. For the same reason this enum has no
-/// catch-all variant: one would swallow ticks into the success count.
+/// inflate that count and end validation before the last real confirmation arrived. It is decoded
+/// on the stream instead, and reaches the transformer through the buffered-events path — the same
+/// route ticks that arrive mid-validation take. For the same reason this enum has no catch-all
+/// variant: one would swallow ticks into the success count.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LseSubResponse {
     /// A subscription was accepted, and the connection now holds `count` of its `max` slots.
+    ///
+    /// Only `symbol` is required to deserialise. `count` and `max` are reported by the provider and
+    /// modelled for the reader, but nothing acts on them — the cap is enforced before a subscribe
+    /// is sent, against the `authenticated` frame — so requiring them would let a rename or an
+    /// omission upstream turn an arriving confirmation into a ten-second validation timeout
+    /// blaming latency. The same reasoning the [`Error`](Self::Error) variant is built on.
     Subscribed {
         /// The symbol, case-normalised by the provider (`eur/usd` is confirmed as `EUR/USD`).
         symbol: SmolStr,
         /// Slots held on this connection after the subscription.
-        count: u32,
+        #[serde(default)]
+        count: Option<u32>,
         /// Slots this connection may hold in total.
-        max: u32,
+        #[serde(default)]
+        max: Option<u32>,
     },
 
     /// A subscription was rejected.
@@ -81,42 +91,6 @@ impl Validator for LseSubResponse {
     }
 }
 
-/// A replay window's boundary frames.
-///
-/// A subscription carrying a `start` is served the historical window before any live tick, framed
-/// by these two. They are not subscription confirmations — see [`LseSubResponse`] for why keeping
-/// them out of that type is load-bearing rather than tidy.
-#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum LseReplayFrame {
-    /// The replay window the provider actually opened.
-    ///
-    /// # ⚠️ `from` is the only signal that a `start` was clamped
-    /// A `start` further back than the provider's retention is **silently moved forward**, with no
-    /// error: a window requested 48 hours back was answered with one beginning exactly 24 hours
-    /// back, and streamed from there. Comparing `from` against what was asked for is the only way
-    /// to detect it.
-    ReplayStarted {
-        /// The symbol whose replay is beginning.
-        symbol: SmolStr,
-        /// The instant the provider will actually replay from.
-        #[serde(deserialize_with = "de_timestamp")]
-        from: DateTime<Utc>,
-    },
-
-    /// The replay window is drained and the stream is now live for this symbol.
-    ReplayComplete {
-        /// The symbol whose replay has finished.
-        symbol: SmolStr,
-        /// Rows replayed. Trustworthy — it matched the delivered count exactly on every run
-        /// measured.
-        rows: u64,
-        /// Live ticks that arrived during the replay and were held back to preserve ordering.
-        #[serde(default)]
-        buffered_drained: u64,
-    },
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
 mod tests {
@@ -131,8 +105,8 @@ mod tests {
             response,
             LseSubResponse::Subscribed {
                 symbol: "EUR/USD".into(),
-                count: 1,
-                max: 16,
+                count: Some(1),
+                max: Some(16),
             }
         );
         assert!(response.validate().is_ok());
@@ -184,63 +158,23 @@ mod tests {
         }
     }
 
+    /// A confirmation that failed to deserialise would fall through to the buffered-events path and
+    /// leave the validator waiting out its ten-second timeout for a frame that had already arrived
+    /// — a failure that reads as latency. Nothing consumes these two fields, so nothing is worth
+    /// that.
     #[test]
-    fn a_replay_start_deserialises_with_its_window() {
-        let input = r#"{"type":"replay_started","symbol":"BTC/USD","from":"2026-01-02T09:39:31.716622+00:00"}"#;
-        let frame: LseReplayFrame = serde_json::from_str(input).unwrap();
+    fn a_confirmation_missing_the_fields_nothing_reads_still_confirms() {
+        let response: LseSubResponse =
+            serde_json::from_str(r#"{"type":"subscribed","symbol":"EUR/USD"}"#).unwrap();
 
         assert_eq!(
-            frame,
-            LseReplayFrame::ReplayStarted {
-                symbol: "BTC/USD".into(),
-                from: "2026-01-02T09:39:31.716622Z".parse().unwrap(),
+            response,
+            LseSubResponse::Subscribed {
+                symbol: "EUR/USD".into(),
+                count: None,
+                max: None,
             }
         );
-    }
-
-    /// The provider spells timestamps three ways and does not guarantee which one a given frame
-    /// uses, so `from` goes through the same decoder a tick's `ts` does.
-    #[test]
-    fn a_replay_start_accepts_every_timestamp_spelling() {
-        for raw in [
-            r#""2026-01-02 09:39:31.716622+00:00""#,
-            r#""2026-01-02T09:39:31.716622+00:00""#,
-            "1767346771.716622",
-        ] {
-            let input = format!(r#"{{"type":"replay_started","symbol":"BTC/USD","from":{raw}}}"#);
-            let frame: LseReplayFrame = serde_json::from_str(&input).unwrap();
-
-            let LseReplayFrame::ReplayStarted { from, .. } = frame else {
-                panic!("expected a replay start");
-            };
-            assert_eq!(
-                from,
-                "2026-01-02T09:39:31.716622Z"
-                    .parse::<DateTime<Utc>>()
-                    .unwrap()
-            );
-        }
-    }
-
-    #[test]
-    fn a_replay_completion_deserialises_with_its_row_count() {
-        let input = r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41,
-            "buffered_drained":9}"#;
-        let frame: LseReplayFrame = serde_json::from_str(input).unwrap();
-
-        assert_eq!(
-            frame,
-            LseReplayFrame::ReplayComplete {
-                symbol: "BTC/USD".into(),
-                rows: 41,
-                buffered_drained: 9,
-            }
-        );
-    }
-
-    #[test]
-    fn subscription_frames_do_not_deserialise_as_replay_frames() {
-        let input = r#"{"type":"subscribed","symbol":"EUR/USD","count":1,"max":16}"#;
-        assert!(serde_json::from_str::<LseReplayFrame>(input).is_err());
+        assert!(response.validate().is_ok());
     }
 }

--- a/rustrade-data/src/exchange/lse/subscription.rs
+++ b/rustrade-data/src/exchange/lse/subscription.rs
@@ -36,14 +36,18 @@ use smol_str::SmolStr;
 pub enum LseSubResponse {
     /// A subscription was accepted, and the connection now holds `count` of its `max` slots.
     ///
-    /// Only `symbol` is required to deserialise. `count` and `max` are reported by the provider and
-    /// modelled for the reader, but nothing acts on them — the cap is enforced before a subscribe
-    /// is sent, against the `authenticated` frame — so requiring them would let a rename or an
-    /// omission upstream turn an arriving confirmation into a ten-second validation timeout
-    /// blaming latency. The same reasoning the [`Error`](Self::Error) variant is built on.
+    /// **No field is required to deserialise**, `symbol` included. All three are reported by the
+    /// provider and modelled for the reader, but nothing acts on any of them: the validator counts
+    /// confirmations rather than matching them to symbols, and the cap is enforced before a
+    /// subscribe is sent, against the `authenticated` frame. Requiring a field nothing reads would
+    /// let a rename or an omission upstream turn an arriving confirmation into a ten-second
+    /// validation timeout blaming latency — and `symbol` is not privileged here, because a
+    /// confirmation that cannot be matched to a request is worth exactly as much as one that can.
+    /// The same reasoning the [`Error`](Self::Error) variant is built on.
     Subscribed {
         /// The symbol, case-normalised by the provider (`eur/usd` is confirmed as `EUR/USD`).
-        symbol: SmolStr,
+        #[serde(default)]
+        symbol: Option<SmolStr>,
         /// Slots held on this connection after the subscription.
         #[serde(default)]
         count: Option<u32>,
@@ -104,7 +108,7 @@ mod tests {
         assert_eq!(
             response,
             LseSubResponse::Subscribed {
-                symbol: "EUR/USD".into(),
+                symbol: Some("EUR/USD".into()),
                 count: Some(1),
                 max: Some(16),
             }
@@ -160,8 +164,8 @@ mod tests {
 
     /// A confirmation that failed to deserialise would fall through to the buffered-events path and
     /// leave the validator waiting out its ten-second timeout for a frame that had already arrived
-    /// — a failure that reads as latency. Nothing consumes these two fields, so nothing is worth
-    /// that.
+    /// — a failure that reads as latency. Nothing consumes any of these fields, `symbol` included,
+    /// so nothing is worth that.
     #[test]
     fn a_confirmation_missing_the_fields_nothing_reads_still_confirms() {
         let response: LseSubResponse =
@@ -170,11 +174,25 @@ mod tests {
         assert_eq!(
             response,
             LseSubResponse::Subscribed {
-                symbol: "EUR/USD".into(),
+                symbol: Some("EUR/USD".into()),
                 count: None,
                 max: None,
             }
         );
         assert!(response.validate().is_ok());
+
+        // The tag alone is enough. The validator counts confirmations rather than matching them to
+        // requests, so a confirmation naming nothing still confirms one.
+        let bare: LseSubResponse = serde_json::from_str(r#"{"type":"subscribed"}"#).unwrap();
+
+        assert_eq!(
+            bare,
+            LseSubResponse::Subscribed {
+                symbol: None,
+                count: None,
+                max: None,
+            }
+        );
+        assert!(bare.validate().is_ok());
     }
 }

--- a/rustrade-data/src/exchange/lse/subscription.rs
+++ b/rustrade-data/src/exchange/lse/subscription.rs
@@ -1,0 +1,246 @@
+//! Subscription-lifecycle frames: what the provider answers a `subscribe` with, and how a replay
+//! window announces its own boundaries.
+
+use super::tick::de_timestamp;
+use chrono::{DateTime, Utc};
+use rustrade_integration::{Validator, error::SocketError};
+use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+
+/// The provider's answer to a `subscribe` request.
+///
+/// One frame arrives per request — `{"action":"subscribe","symbol":"EUR/USD"}` is answered by
+/// `{"type":"subscribed","symbol":"EUR/USD","count":1,"max":16}` — so the default
+/// [`expected_responses`](crate::exchange::Connector::expected_responses) of one-per-subscription
+/// is correct.
+///
+/// # ⚠️ A confirmation is NOT evidence the symbol exists
+/// Subscribing to a symbol the provider has never heard of is **confirmed, not rejected**: it
+/// answers `subscribed`, never errors, never ticks, and permanently consumes one of the
+/// connection's subscription slots. Validation here therefore cannot catch a typo, and does not
+/// try to. That guard runs in the subscriber, against the symbol list the `authenticated` frame
+/// supplies, *before* any subscribe is sent — which is also what keeps a bad batch from spending
+/// slots it can never get back.
+///
+/// # Why replay frames are deliberately not modelled here
+/// The subscription validator counts every frame that deserialises into this type and validates
+/// `Ok` as one more subscription confirmed. A `replay_started` frame modelled as a success would
+/// inflate that count and end validation before the last real confirmation arrived. Replay frames
+/// are [`LseReplayFrame`] instead, and reach the subscriber through the buffered-events path — the
+/// same route ticks that arrive mid-validation take. For the same reason this enum has no
+/// catch-all variant: one would swallow ticks into the success count.
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LseSubResponse {
+    /// A subscription was accepted, and the connection now holds `count` of its `max` slots.
+    Subscribed {
+        /// The symbol, case-normalised by the provider (`eur/usd` is confirmed as `EUR/USD`).
+        symbol: SmolStr,
+        /// Slots held on this connection after the subscription.
+        count: u32,
+        /// Slots this connection may hold in total.
+        max: u32,
+    },
+
+    /// A subscription was rejected.
+    ///
+    /// Both fields are optional so that a rejection missing one cannot fail to deserialise and be
+    /// silently reclassified as stream data — an error frame must never be the thing that gets
+    /// swallowed.
+    Error {
+        /// The provider's error code. `LIMIT_REACHED` and `INVALID_START` are the two observed;
+        /// the field is kept as text rather than an enum so an unrecognised code reaches the
+        /// caller intact instead of collapsing into a catch-all.
+        #[serde(default)]
+        code: Option<SmolStr>,
+        /// The provider's own diagnostic.
+        #[serde(default)]
+        message: Option<SmolStr>,
+    },
+}
+
+impl Validator for LseSubResponse {
+    type Error = SocketError;
+
+    fn validate(self) -> Result<Self, SocketError> {
+        let Self::Error { code, message } = &self else {
+            return Ok(self);
+        };
+
+        let code = code.as_deref().unwrap_or("unknown");
+        let message = message.as_deref().unwrap_or("no message");
+
+        // The rejection does not name the symbol it rejected -- measured: 20 subscriptions
+        // requested against a cap of 16 produced 16 confirmations and 4 anonymous errors. There is
+        // therefore no partial recovery available, and continuing would leave the caller holding a
+        // subscription set the provider silently truncated.
+        Err(SocketError::Subscribe(format!(
+            "London Strategic Edge rejected a subscription ({code}): {message} - the rejection \
+             does not name the symbol, so the whole batch fails"
+        )))
+    }
+}
+
+/// A replay window's boundary frames.
+///
+/// A subscription carrying a `start` is served the historical window before any live tick, framed
+/// by these two. They are not subscription confirmations — see [`LseSubResponse`] for why keeping
+/// them out of that type is load-bearing rather than tidy.
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LseReplayFrame {
+    /// The replay window the provider actually opened.
+    ///
+    /// # ⚠️ `from` is the only signal that a `start` was clamped
+    /// A `start` further back than the provider's retention is **silently moved forward**, with no
+    /// error: a window requested 48 hours back was answered with one beginning exactly 24 hours
+    /// back, and streamed from there. Comparing `from` against what was asked for is the only way
+    /// to detect it.
+    ReplayStarted {
+        /// The symbol whose replay is beginning.
+        symbol: SmolStr,
+        /// The instant the provider will actually replay from.
+        #[serde(deserialize_with = "de_timestamp")]
+        from: DateTime<Utc>,
+    },
+
+    /// The replay window is drained and the stream is now live for this symbol.
+    ReplayComplete {
+        /// The symbol whose replay has finished.
+        symbol: SmolStr,
+        /// Rows replayed. Trustworthy — it matched the delivered count exactly on every run
+        /// measured.
+        rows: u64,
+        /// Live ticks that arrived during the replay and were held back to preserve ordering.
+        #[serde(default)]
+        buffered_drained: u64,
+    },
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_subscription_confirmation_deserialises_and_validates() {
+        let input = r#"{"type":"subscribed","symbol":"EUR/USD","count":1,"max":16}"#;
+        let response: LseSubResponse = serde_json::from_str(input).unwrap();
+
+        assert_eq!(
+            response,
+            LseSubResponse::Subscribed {
+                symbol: "EUR/USD".into(),
+                count: 1,
+                max: 16,
+            }
+        );
+        assert!(response.validate().is_ok());
+    }
+
+    #[test]
+    fn a_subscription_rejection_fails_validation() {
+        let input = r#"{"type":"error","code":"LIMIT_REACHED",
+            "message":"Max 16 symbols on registered plan"}"#;
+        let response: LseSubResponse = serde_json::from_str(input).unwrap();
+
+        let error = response.validate().unwrap_err().to_string();
+        assert!(error.contains("LIMIT_REACHED"), "{error}");
+        assert!(error.contains("Max 16 symbols"), "{error}");
+    }
+
+    #[test]
+    fn a_rejected_replay_start_fails_validation() {
+        let input = r#"{"type":"error","code":"INVALID_START",
+            "message":"Invalid start: could not convert string to float"}"#;
+        let response: LseSubResponse = serde_json::from_str(input).unwrap();
+
+        assert!(response.validate().is_err());
+    }
+
+    /// An error frame that fails to deserialise would be reclassified as stream data and silently
+    /// dropped, turning a loud rejection into no signal at all.
+    #[test]
+    fn a_rejection_missing_its_fields_still_fails_validation() {
+        let response: LseSubResponse = serde_json::from_str(r#"{"type":"error"}"#).unwrap();
+        assert!(response.validate().is_err());
+    }
+
+    /// The subscription validator counts everything that deserialises into [`LseSubResponse`] as a
+    /// confirmation. Ticks and replay frames must therefore NOT deserialise into it — they take
+    /// the buffered-events path instead.
+    #[test]
+    fn stream_frames_do_not_deserialise_as_subscription_responses() {
+        for input in [
+            r#"{"type":"tick","symbol":"EUR/USD","ts":"2026-01-02T09:37:24.760146+00:00",
+                "price":1.1,"bid":1.1,"ask":1.1001,"volume":1.0}"#,
+            r#"{"type":"replay_started","symbol":"BTC/USD","from":"2026-01-02T09:39:31+00:00"}"#,
+            r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41,"buffered_drained":9}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<LseSubResponse>(input).is_err(),
+                "deserialised as a subscription response: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_replay_start_deserialises_with_its_window() {
+        let input = r#"{"type":"replay_started","symbol":"BTC/USD","from":"2026-01-02T09:39:31.716622+00:00"}"#;
+        let frame: LseReplayFrame = serde_json::from_str(input).unwrap();
+
+        assert_eq!(
+            frame,
+            LseReplayFrame::ReplayStarted {
+                symbol: "BTC/USD".into(),
+                from: "2026-01-02T09:39:31.716622Z".parse().unwrap(),
+            }
+        );
+    }
+
+    /// The provider spells timestamps three ways and does not guarantee which one a given frame
+    /// uses, so `from` goes through the same decoder a tick's `ts` does.
+    #[test]
+    fn a_replay_start_accepts_every_timestamp_spelling() {
+        for raw in [
+            r#""2026-01-02 09:39:31.716622+00:00""#,
+            r#""2026-01-02T09:39:31.716622+00:00""#,
+            "1767346771.716622",
+        ] {
+            let input = format!(r#"{{"type":"replay_started","symbol":"BTC/USD","from":{raw}}}"#);
+            let frame: LseReplayFrame = serde_json::from_str(&input).unwrap();
+
+            let LseReplayFrame::ReplayStarted { from, .. } = frame else {
+                panic!("expected a replay start");
+            };
+            assert_eq!(
+                from,
+                "2026-01-02T09:39:31.716622Z"
+                    .parse::<DateTime<Utc>>()
+                    .unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn a_replay_completion_deserialises_with_its_row_count() {
+        let input = r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41,
+            "buffered_drained":9}"#;
+        let frame: LseReplayFrame = serde_json::from_str(input).unwrap();
+
+        assert_eq!(
+            frame,
+            LseReplayFrame::ReplayComplete {
+                symbol: "BTC/USD".into(),
+                rows: 41,
+                buffered_drained: 9,
+            }
+        );
+    }
+
+    #[test]
+    fn subscription_frames_do_not_deserialise_as_replay_frames() {
+        let input = r#"{"type":"subscribed","symbol":"EUR/USD","count":1,"max":16}"#;
+        assert!(serde_json::from_str::<LseReplayFrame>(input).is_err());
+    }
+}

--- a/rustrade-data/src/exchange/lse/tick.rs
+++ b/rustrade-data/src/exchange/lse/tick.rs
@@ -9,6 +9,7 @@ use serde::{
     Deserialize, Deserializer,
     de::{self, Unexpected, Visitor},
 };
+use smol_str::SmolStr;
 use std::fmt;
 
 /// A tick published on the London Strategic Edge WebSocket.
@@ -43,6 +44,25 @@ use std::fmt;
 /// prints: de-duplicating them destroyed 3–10% of the volume that reconciles exactly against the
 /// provider's candles. This is an aggregated cross-venue tape on which identical-size fills at the
 /// same millisecond are ordinary. Do not add a de-duplication filter.
+///
+/// # The four [`Decimal`] fields carry ~15 significant digits, not arbitrary precision
+/// This feed sends prices as JSON **numbers** rather than as strings — it is the only connector in
+/// this crate that does — so they are parsed as `f64` before reaching [`Decimal`]. The ceiling is
+/// therefore the `f64`'s: 15 significant digits survive exactly, and a 17-digit literal like
+/// `10.123456789012345` lands as `10.123456789012344`. The provider's own tick shapes
+/// (`42000.5`, `0.00155`, `16.9`) are nowhere near that, so no observed value loses a digit.
+///
+/// The same ceiling applies on the bulk-export path for the same reason, where it is pinned by
+/// `an_equity_row_deserializes_float_prices_and_an_integer_volume` in
+/// [`historical`](super::historical).
+///
+/// Reading the provider's digits instead of the `f64` is **not available here**, and that is
+/// structural rather than an omission: [`LseMessage`] is internally tagged, so serde buffers the
+/// frame body into its `Content` type before this struct is deserialised, and `Content` stores a
+/// JSON number as an already-parsed `f64`. A raw-text deserialiser — `serde_json::value::RawValue`
+/// — cannot be driven from that buffer at all, for the same reason a borrowed `&str` symbol cannot
+/// (see `de_tick_subscription_id`). Recovering the digits would mean giving up the derived
+/// tagging for a hand-written dispatch on the crate's central wire enum.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
 pub struct LseTick {
     /// Subscription identifier built from `symbol` during deserialisation.
@@ -94,7 +114,9 @@ pub struct LseTick {
     #[serde(rename = "ts", deserialize_with = "de_timestamp")]
     pub time_exchange: DateTime<Utc>,
 
-    /// The tick price. Equal to [`bid`](Self::bid) on every sample taken; see the type-level note.
+    /// The tick price. Equal to [`bid`](Self::bid) on every sample taken; see the type-level note,
+    /// which also covers the ~15-significant-digit ceiling this and the three fields below decode
+    /// under.
     pub price: Decimal,
 
     /// The bid.
@@ -122,6 +144,11 @@ pub struct LseTick {
 /// this integration does not act on decodes to [`Other`](Self::Other) so a control frame cannot
 /// fail the parse and take the stream down with it; the confirmations that carry meaning to the
 /// *handshake* are decoded by the subscription types instead, where they can be acted on.
+///
+/// Two control frames are modelled rather than collapsed into [`Other`](Self::Other), because both
+/// carry something no other frame does: [`ReplayStarted`](Self::ReplayStarted) is the only evidence
+/// a replay window was clamped, and [`Error`](Self::Error) is the only evidence the provider
+/// rejected something after the handshake stopped reading.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LseMessage {
@@ -153,6 +180,29 @@ pub enum LseMessage {
         from: DateTime<Utc>,
     },
 
+    /// A rejection raised *after* the handshake completed.
+    ///
+    /// # Why the handshake cannot catch these
+    /// The subscription validator stops reading the socket the moment the last confirmation
+    /// arrives, so every rejection the provider raises afterwards lands here instead — a later
+    /// `LIMIT_REACHED`, an `INVALID_START` on a resumed symbol, a credential that expired
+    /// mid-connection. Collapsed into [`Other`](Self::Other) it would be discarded in silence,
+    /// which is the one thing a rejection must never be: the provider does **not** name the symbol
+    /// it rejected, so the only outward sign is a subscription that stops ticking.
+    ///
+    /// Both fields are optional for the same reason they are on the handshake's own rejection: a
+    /// frame missing one must still decode, because failing the parse on an error frame would take
+    /// the whole stream down over the message that was trying to report a problem.
+    Error {
+        /// The provider's error code — `LIMIT_REACHED` and `INVALID_START` are the two observed.
+        #[serde(default)]
+        code: Option<SmolStr>,
+
+        /// The provider's own diagnostic.
+        #[serde(default)]
+        message: Option<SmolStr>,
+    },
+
     /// Any other frame — a control frame, or one this integration does not model.
     #[serde(other)]
     Other,
@@ -169,20 +219,29 @@ impl Identifier<Option<SubscriptionId>> for LseMessage {
         match self {
             Self::Tick(tick) => Some(tick.subscription_id.clone()),
             // A replay boundary names a subscription but describes the stream rather than a market
-            // event. The transformer consumes it before this point; resolving it to an instrument
-            // would only offer it to a decoder that has nothing to build from it.
-            Self::ReplayStarted { .. } | Self::Other => None,
+            // event, and a rejection names no subscription at all. The transformer consumes both
+            // before this point; resolving either to an instrument would only offer it to a decoder
+            // that has nothing to build from it.
+            Self::ReplayStarted { .. } | Self::Error { .. } | Self::Other => None,
         }
     }
 }
 
 /// Deserialise the tick's `symbol` into the [`SubscriptionId`] it was registered under.
+///
+/// # Why this is not typed as `&str`
+/// Every symbol this feed publishes contains a `/`, and a JSON producer is free to spell that as
+/// the escape `\/` — RFC 8259 lists it among the permitted escapes, and escaping it is common
+/// enough that several encoders do it by default. A borrowed `&str` cannot be produced from an
+/// escaped string, because unescaping needs somewhere to write the result, so a decoder typed that
+/// way fails at runtime on a frame that is entirely legal. `SmolStr` accepts either spelling and
+/// keeps a symbol of this length inline, so nothing is allocated for the ordinary case.
 fn de_tick_subscription_id<'de, D>(deserializer: D) -> Result<SubscriptionId, D::Error>
 where
     D: Deserializer<'de>,
 {
-    <&str as Deserialize>::deserialize(deserializer)
-        .map(|symbol| ExchangeSub::from((LseChannel::Tick, symbol)).id())
+    SmolStr::deserialize(deserializer)
+        .map(|symbol| ExchangeSub::from((LseChannel::Tick, symbol.as_str())).id())
 }
 
 /// Deserialise a WebSocket timestamp from any of the three spellings the provider uses.
@@ -488,12 +547,84 @@ mod tests {
         for input in [
             r#"{"type":"subscribed","symbol":"BTC/USD","count":1,"max":16}"#,
             r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41,"buffered_drained":9}"#,
-            r#"{"type":"error","code":"LIMIT_REACHED","message":"Max 16 symbols"}"#,
             r#"{"type":"welcome","message":"hello","symbols_available":1}"#,
         ] {
             let message: LseMessage = serde_json::from_str(input).unwrap();
             assert_eq!(message, LseMessage::Other, "failed on {input}");
         }
+    }
+
+    /// A rejection raised after the handshake stopped reading is the one control frame that must
+    /// not be discarded in silence — the provider names no symbol, so a swallowed rejection leaves
+    /// a subscription that simply stops ticking as the only sign anything went wrong.
+    #[test]
+    fn a_rejection_decodes_as_an_error_rather_than_being_collapsed_into_other() {
+        let message: LseMessage = serde_json::from_str(
+            r#"{"type":"error","code":"LIMIT_REACHED","message":"Max 16 symbols"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            message,
+            LseMessage::Error {
+                code: Some("LIMIT_REACHED".into()),
+                message: Some("Max 16 symbols".into()),
+            }
+        );
+    }
+
+    /// Failing the parse on an error frame would take the stream down over the message that was
+    /// trying to report a problem, so a rejection missing either field must still decode.
+    #[test]
+    fn a_rejection_missing_its_fields_still_decodes_as_an_error() {
+        let message: LseMessage = serde_json::from_str(r#"{"type":"error"}"#).unwrap();
+
+        assert_eq!(
+            message,
+            LseMessage::Error {
+                code: None,
+                message: None,
+            }
+        );
+    }
+
+    /// The rejection names no subscription, so it must resolve to no instrument — the transformer
+    /// consumes it, and no decoder has a market event to build from it.
+    #[test]
+    fn a_rejection_identifies_no_subscription() {
+        let message: LseMessage =
+            serde_json::from_str(r#"{"type":"error","code":"LIMIT_REACHED"}"#).unwrap();
+
+        assert_eq!(message.id(), None);
+    }
+
+    /// `/` is in every symbol this feed publishes and RFC 8259 permits spelling it `\/`, which
+    /// several JSON encoders do by default. A symbol decoded as a borrowed `&str` cannot survive
+    /// that — unescaping needs somewhere to write — so this pins the owned decode.
+    #[test]
+    fn a_symbol_carrying_an_escaped_solidus_decodes_to_the_same_subscription() {
+        let escaped: LseMessage = serde_json::from_str(
+            r#"{"type":"tick","symbol":"BTC\/USD","ts":"2026-01-02T09:37:24.760146+00:00",
+                "price":42000.5,"bid":42000.5,"ask":42001.0,"volume":0.00155}"#,
+        )
+        .unwrap();
+
+        assert_eq!(escaped.id(), Some(SubscriptionId::from("tick|BTC/USD")));
+
+        // The replay boundary decodes its symbol through the same function, and a clamp that went
+        // undetected because the boundary frame failed to parse would be silent.
+        let boundary: LseMessage = serde_json::from_str(
+            r#"{"type":"replay_started","symbol":"BTC\/USD","from":"2026-01-02T09:37:24+00:00"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            boundary,
+            LseMessage::ReplayStarted {
+                subscription_id: SubscriptionId::from("tick|BTC/USD"),
+                from: "2026-01-02T09:37:24Z".parse::<DateTime<Utc>>().unwrap(),
+            }
+        );
     }
 
     /// The replay boundary is the one control frame that is modelled, because its `from` is the

--- a/rustrade-data/src/exchange/lse/tick.rs
+++ b/rustrade-data/src/exchange/lse/tick.rs
@@ -58,9 +58,14 @@ pub struct LseTick {
     /// # The three spellings, all measured on one connection
     /// 1. **RFC 3339** — `2026-01-02T09:37:24.760146+00:00`.
     /// 2. **The same with a space** separating date and time —
-    ///    `2026-01-02 09:37:21.690159+00:00`. [`DateTime::parse_from_rfc3339`] rejects this
-    ///    outright, and it is what five of thirteen sampled dataset families send. A decoder
-    ///    handling only spelling 1 silently loses them.
+    ///    `2026-01-02 09:37:21.690159+00:00`, which is what five of thirteen sampled dataset
+    ///    families send. [`DateTime::parse_from_rfc3339`] **accepts** it: RFC 3339 §5.6 permits a
+    ///    space in place of the `T` by prior agreement, and `chrono` implements that lenience —
+    ///    verified against both 0.4.39, the oldest this workspace admits, and the pinned 0.4.45.
+    ///    It is a lenience rather than a guarantee, so
+    ///    `a_space_separated_timestamp_decodes_to_the_same_instant_as_the_t_form` pins it: a future
+    ///    `chrono` that tightened the grammar would fail the build rather than silently drop five
+    ///    dataset families.
     /// 3. **Epoch seconds as a JSON number** — `1786091921.387`. Replayed ticks use this while
     ///    live ticks on the *same connection* use a string, so the field changes JSON type
     ///    mid-stream. A decoder typed as a string fails the moment replay is enabled.
@@ -68,14 +73,21 @@ pub struct LseTick {
     /// Sub-second precision also varies per symbol within one spelling: microseconds,
     /// milliseconds, and — on at least one symbol — no fractional component at all.
     ///
-    /// # The epoch spelling is quantised to microseconds
+    /// # Every spelling is quantised to microseconds
     /// An `f64` cannot carry nanosecond resolution at epoch scale: near the present its spacing is
-    /// roughly a quarter of a microsecond, so nanoseconds recovered from it are noise. Rounding to
-    /// the nearest microsecond discards that noise and recovers the provider's own precision
-    /// exactly, which matters for more than tidiness — **it is what makes spellings 1 and 3 of one
-    /// instant decode to the same value.** The replay path re-sends ticks the live path already
-    /// delivered, in the other spelling, so anything comparing the two for equality (resume
-    /// arithmetic above all) depends on them agreeing.
+    /// roughly a quarter of a microsecond, so nanoseconds recovered from spelling 3 are noise.
+    /// Rounding to the nearest microsecond discards that noise and recovers the provider's own
+    /// precision exactly, which matters for more than tidiness — **it is what makes the three
+    /// spellings of one instant decode to the same value.** The replay path re-sends ticks the live
+    /// path already delivered, in a different spelling, so anything comparing the two for equality
+    /// (resume arithmetic above all) depends on them agreeing.
+    ///
+    /// The string spellings are quantised to that same resolution rather than passed through at
+    /// whatever they carry, so the agreement is *enforced* rather than observed. Every string
+    /// sampled carried at most six fractional digits, but a seventh would defeat the resume
+    /// comparison silently: the watermark would hold a sub-microsecond instant, `start` would go
+    /// out truncated to the microsecond below it, and every replayed tick at that instant would
+    /// then sort *before* the watermark and be re-emitted as a duplicate.
     ///
     /// A string that is neither spelling, including one carrying no UTC offset, is rejected rather
     /// than guessed at — a mis-parsed timestamp is a silently misdated market event.
@@ -107,14 +119,39 @@ pub struct LseTick {
 ///
 /// The stream carries control frames (subscription confirmations, replay boundaries, errors)
 /// interleaved with ticks, on the same connection and after the handshake has completed. Anything
-/// that is not a tick decodes to [`Other`](Self::Other) so a control frame cannot fail the parse
-/// and take the stream down with it; the frames that carry *meaning* to a subscriber are decoded
-/// by the subscription types instead, during the handshake where they can be acted on.
+/// this integration does not act on decodes to [`Other`](Self::Other) so a control frame cannot
+/// fail the parse and take the stream down with it; the confirmations that carry meaning to the
+/// *handshake* are decoded by the subscription types instead, where they can be acted on.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LseMessage {
     /// A tick.
     Tick(LseTick),
+
+    /// The boundary frame announcing the replay window the provider actually opened.
+    ///
+    /// # ⚠️ `from` is the only signal that a `start` was clamped
+    /// The provider retains 24 hours. A `start` further back is **silently moved forward**, with no
+    /// error: a window requested 48 hours back was answered with one beginning exactly 24 hours
+    /// back, and streamed from there. Comparing `from` against what was asked for is the only way
+    /// to detect it.
+    ///
+    /// # Why it is modelled on the stream rather than caught during the handshake
+    /// The provider answers `subscribe` *before* it announces the window — measured on both a
+    /// crypto and an FX symbol, the order is `subscribed`, then `replay_started`, then the replayed
+    /// ticks. The subscription validator stops reading the socket the moment the last confirmation
+    /// arrives, so a single-symbol resumed subscription never has a `replay_started` to inspect at
+    /// handshake time, and a batch never has one for its last symbol. Reading it here instead makes
+    /// the check independent of frame ordering and of batch size.
+    ReplayStarted {
+        /// The subscription the window belongs to, built from `symbol` exactly as a tick's is.
+        #[serde(rename = "symbol", deserialize_with = "de_tick_subscription_id")]
+        subscription_id: SubscriptionId,
+
+        /// The instant the provider will actually replay from.
+        #[serde(deserialize_with = "de_timestamp")]
+        from: DateTime<Utc>,
+    },
 
     /// Any other frame — a control frame, or one this integration does not model.
     #[serde(other)]
@@ -131,7 +168,10 @@ impl Identifier<Option<SubscriptionId>> for LseMessage {
     fn id(&self) -> Option<SubscriptionId> {
         match self {
             Self::Tick(tick) => Some(tick.subscription_id.clone()),
-            Self::Other => None,
+            // A replay boundary names a subscription but describes the stream rather than a market
+            // event. The transformer consumes it before this point; resolving it to an instrument
+            // would only offer it to a decoder that has nothing to build from it.
+            Self::ReplayStarted { .. } | Self::Other => None,
         }
     }
 }
@@ -151,7 +191,7 @@ where
 /// window's `from` is decoded through it too. The spellings, and why the epoch form is quantised
 /// to microseconds, are documented on [`LseTick::time_exchange`], which is where a reader of the
 /// public API meets them.
-pub(super) fn de_timestamp<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+fn de_timestamp<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -207,24 +247,31 @@ impl Visitor<'_> for TimestampVisitor {
 }
 
 /// Parse spellings 1 and 2 — see [`de_timestamp`].
+///
+/// Both spellings take one code path because `chrono` accepts the space separator itself, as the
+/// RFC 3339 §5.6 lenience it is. There is deliberately no second, laxer grammar behind this: an
+/// offset RFC 3339 rejects is rejected here too, so the spellings cannot drift apart in what they
+/// admit.
 fn parse_timestamp(raw: &str) -> Option<DateTime<Utc>> {
-    if let Ok(parsed) = DateTime::parse_from_rfc3339(raw) {
-        return Some(parsed.with_timezone(&Utc));
-    }
-
-    // The space-separated spelling is the same instant in a form RFC 3339 does not admit. Swapping
-    // the separator and re-parsing reuses the strict parser rather than introducing a second,
-    // laxer grammar -- so an offset RFC 3339 would reject is still rejected here, and the two
-    // spellings cannot drift apart in what they accept.
-    let (date, time) = raw.split_once(' ')?;
-    let mut rfc3339 = String::with_capacity(raw.len());
-    rfc3339.push_str(date);
-    rfc3339.push('T');
-    rfc3339.push_str(time);
-
-    DateTime::parse_from_rfc3339(&rfc3339)
+    DateTime::parse_from_rfc3339(raw)
         .ok()
         .map(|parsed| parsed.with_timezone(&Utc))
+        .and_then(round_to_micros)
+}
+
+/// Round an instant to the nearest microsecond.
+///
+/// The provider is measured never to spell more than six fractional digits, so this is a no-op on
+/// every string sampled. It is applied anyway because the resume arithmetic compares instants
+/// decoded from different spellings for *equality* — see [`LseTick::time_exchange`], which is where
+/// that dependency is documented.
+fn round_to_micros(time: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    // `timestamp_subsec_nanos` measures from the second below, so this rounds half upward. The
+    // epoch spelling's `f64::round` rounds half away from zero, and the two agree on every instant
+    // at or after the epoch -- which is every instant this feed can carry.
+    let round_up = i64::from(time.timestamp_subsec_nanos() % 1_000 >= 500);
+
+    DateTime::from_timestamp_micros(time.timestamp_micros() + round_up)
 }
 
 /// Parse spelling 3 — see [`de_timestamp`] for why this rounds to microseconds.
@@ -284,8 +331,10 @@ mod tests {
         assert_eq!(tick.volume, dec!(0.00155));
     }
 
-    /// The spelling `DateTime::parse_from_rfc3339` rejects. Five of thirteen sampled dataset
-    /// families send it, so an RFC-3339-only decoder loses them silently.
+    /// Five of thirteen sampled dataset families send this spelling. `chrono` accepts the space as
+    /// an RFC 3339 §5.6 lenience rather than a guarantee, so this test is the canary: if a future
+    /// version tightened the grammar, those five families would otherwise start failing to decode
+    /// silently, in production, on a dependency bump.
     #[test]
     fn a_space_separated_timestamp_decodes_to_the_same_instant_as_the_t_form() {
         let tick: LseTick = serde_json::from_str(LIVE_SPACE_SEPARATED).unwrap();
@@ -335,6 +384,27 @@ mod tests {
         let as_float = time_from_epoch_seconds(1_767_346_644.760_146).unwrap();
 
         assert_eq!(as_string, as_float);
+    }
+
+    /// The enforcement half of the same property: a string carrying more precision than the epoch
+    /// spelling can express is quantised to microseconds rather than passed through, so the two
+    /// still decode equal. Without it the watermark would hold an instant `start` cannot name, and
+    /// the replay would re-deliver it as a duplicate.
+    #[test]
+    fn a_sub_microsecond_string_is_quantised_so_it_still_matches_the_float_spelling() {
+        let seven_digits = parse_timestamp("2026-01-02T09:37:24.7601461+00:00").unwrap();
+        let as_float = time_from_epoch_seconds(1_767_346_644.760_146).unwrap();
+
+        assert_eq!(seven_digits, as_float);
+        assert_eq!(seven_digits.timestamp_subsec_nanos() % 1_000, 0);
+
+        // Rounds to nearest rather than truncating, matching what the epoch spelling recovers.
+        assert_eq!(
+            parse_timestamp("2026-01-02T09:37:24.7601465+00:00").unwrap(),
+            "2026-01-02T09:37:24.760147Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
     }
 
     /// A whole-second epoch has no fractional part to print, so JSON carries it as an integer.
@@ -417,7 +487,6 @@ mod tests {
     fn control_frames_decode_as_other_rather_than_failing_the_parse() {
         for input in [
             r#"{"type":"subscribed","symbol":"BTC/USD","count":1,"max":16}"#,
-            r#"{"type":"replay_started","symbol":"BTC/USD","from":"2026-01-02T09:37:24+00:00"}"#,
             r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41,"buffered_drained":9}"#,
             r#"{"type":"error","code":"LIMIT_REACHED","message":"Max 16 symbols"}"#,
             r#"{"type":"welcome","message":"hello","symbols_available":1}"#,
@@ -425,5 +494,42 @@ mod tests {
             let message: LseMessage = serde_json::from_str(input).unwrap();
             assert_eq!(message, LseMessage::Other, "failed on {input}");
         }
+    }
+
+    /// The replay boundary is the one control frame that is modelled, because its `from` is the
+    /// only evidence a requested window was clamped to the provider's retention.
+    #[test]
+    fn a_replay_boundary_decodes_with_its_window_in_every_timestamp_spelling() {
+        for raw in [
+            r#""2026-01-02 09:39:31.716622+00:00""#,
+            r#""2026-01-02T09:39:31.716622+00:00""#,
+            "1767346771.716622",
+        ] {
+            let input = format!(r#"{{"type":"replay_started","symbol":"BTC/USD","from":{raw}}}"#);
+            let message: LseMessage = serde_json::from_str(&input).unwrap();
+
+            assert_eq!(
+                message,
+                LseMessage::ReplayStarted {
+                    subscription_id: SubscriptionId::from("tick|BTC/USD"),
+                    from: "2026-01-02T09:39:31.716622Z"
+                        .parse::<DateTime<Utc>>()
+                        .unwrap(),
+                },
+                "failed on {raw}"
+            );
+        }
+    }
+
+    /// It names a subscription but describes the stream, so it must not resolve to an instrument —
+    /// a decoder handed one has no market event to build from it.
+    #[test]
+    fn a_replay_boundary_identifies_no_subscription() {
+        let message: LseMessage = serde_json::from_str(
+            r#"{"type":"replay_started","symbol":"BTC/USD","from":"2026-01-02T09:37:24+00:00"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(message.id(), None);
     }
 }

--- a/rustrade-data/src/exchange/lse/tick.rs
+++ b/rustrade-data/src/exchange/lse/tick.rs
@@ -1,0 +1,394 @@
+//! The London Strategic Edge WebSocket tick frame, and the three timestamp spellings it arrives in.
+
+use super::channel::LseChannel;
+use crate::{Identifier, exchange::ExchangeSub};
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use rustrade_integration::subscription::SubscriptionId;
+use serde::{
+    Deserialize, Deserializer,
+    de::{self, Unexpected, Visitor},
+};
+use std::fmt;
+
+/// A tick published on the London Strategic Edge WebSocket.
+///
+/// One frame shape serves every dataset — FX, crypto, equities, ETFs, indices, commodities,
+/// futures, volatility, currency indices and interest rates all publish the same seven keys. This
+/// is the opposite of the provider's bulk-export path, where the column set varies per dataset.
+///
+/// ```json
+/// {"type":"tick","symbol":"BTC/USD","ts":"2026-01-02T09:37:24.760146+00:00",
+///  "price":42000.5,"bid":42000.5,"ask":42001.0,"volume":0.00155}
+/// ```
+///
+/// # ⚠️ The tick is a QUOTE, not a print
+/// `price` equals `bid` exactly — measured on 3,966 of 3,966 sampled ticks spanning every dataset
+/// family, plus every sample taken on the provider's other price endpoint. Anything decoded from
+/// this frame as a trade is therefore a bid-side quote wearing a trade's shape, and is not evidence
+/// that a transaction occurred at that price or at all. See the trade transformer for what ships
+/// anyway and why.
+///
+/// # ⚠️ `volume` is real on some datasets and fabricated on others
+/// Crypto and equity ticks carry a genuine per-tick size: summing it over three whole minutes of
+/// one crypto symbol reproduced the provider's own one-minute candle volume to the last decimal,
+/// ratio `1.000`. FX and commodity ticks carry a **hard-coded `1.0`** on every tick of every
+/// symbol sampled — a fabricated size, not a measured one, and it will aggregate into a
+/// legitimate-looking total at any resolution. Note this differs from the provider's REST vault,
+/// which *omits* FX volume entirely; the WebSocket invents a value instead.
+///
+/// # ⚠️ Identical consecutive ticks are REAL and must not be filtered
+/// Ticks routinely repeat a prior `(ts, price, bid, ask, volume)` signature — barely a third of a
+/// sampled run was unique, and one signature recurred 49 times. They are nonetheless distinct
+/// prints: de-duplicating them destroyed 3–10% of the volume that reconciles exactly against the
+/// provider's candles. This is an aggregated cross-venue tape on which identical-size fills at the
+/// same millisecond are ordinary. Do not add a de-duplication filter.
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
+pub struct LseTick {
+    /// Subscription identifier built from `symbol` during deserialisation.
+    ///
+    /// Constructing it here keeps the per-tick `format!` out of the transformer's hot path, and
+    /// mirrors how every other WebSocket integration in this crate resolves a frame to its
+    /// instrument.
+    #[serde(rename = "symbol", deserialize_with = "de_tick_subscription_id")]
+    pub subscription_id: SubscriptionId,
+
+    /// The instant the provider stamped the tick with.
+    ///
+    /// # The three spellings, all measured on one connection
+    /// 1. **RFC 3339** — `2026-01-02T09:37:24.760146+00:00`.
+    /// 2. **The same with a space** separating date and time —
+    ///    `2026-01-02 09:37:21.690159+00:00`. [`DateTime::parse_from_rfc3339`] rejects this
+    ///    outright, and it is what five of thirteen sampled dataset families send. A decoder
+    ///    handling only spelling 1 silently loses them.
+    /// 3. **Epoch seconds as a JSON number** — `1786091921.387`. Replayed ticks use this while
+    ///    live ticks on the *same connection* use a string, so the field changes JSON type
+    ///    mid-stream. A decoder typed as a string fails the moment replay is enabled.
+    ///
+    /// Sub-second precision also varies per symbol within one spelling: microseconds,
+    /// milliseconds, and — on at least one symbol — no fractional component at all.
+    ///
+    /// # The epoch spelling is quantised to microseconds
+    /// An `f64` cannot carry nanosecond resolution at epoch scale: near the present its spacing is
+    /// roughly a quarter of a microsecond, so nanoseconds recovered from it are noise. Rounding to
+    /// the nearest microsecond discards that noise and recovers the provider's own precision
+    /// exactly, which matters for more than tidiness — **it is what makes spellings 1 and 3 of one
+    /// instant decode to the same value.** The replay path re-sends ticks the live path already
+    /// delivered, in the other spelling, so anything comparing the two for equality (resume
+    /// arithmetic above all) depends on them agreeing.
+    ///
+    /// A string that is neither spelling, including one carrying no UTC offset, is rejected rather
+    /// than guessed at — a mis-parsed timestamp is a silently misdated market event.
+    #[serde(rename = "ts", deserialize_with = "de_timestamp")]
+    pub time_exchange: DateTime<Utc>,
+
+    /// The tick price. Equal to [`bid`](Self::bid) on every sample taken; see the type-level note.
+    pub price: Decimal,
+
+    /// The bid.
+    pub bid: Decimal,
+
+    /// The ask.
+    pub ask: Decimal,
+
+    /// The size traded at this tick — genuine on crypto and equities, fabricated on FX and
+    /// commodities. See the type-level note.
+    pub volume: Decimal,
+
+    /// Whether the tick was served from the historical replay buffer rather than live.
+    ///
+    /// The provider sets this only on replayed ticks; live ticks carry no `replay` key at all, so
+    /// absence means live and the default is load-bearing rather than cosmetic.
+    #[serde(default)]
+    pub replay: bool,
+}
+
+/// A frame received on the London Strategic Edge WebSocket data stream.
+///
+/// The stream carries control frames (subscription confirmations, replay boundaries, errors)
+/// interleaved with ticks, on the same connection and after the handshake has completed. Anything
+/// that is not a tick decodes to [`Other`](Self::Other) so a control frame cannot fail the parse
+/// and take the stream down with it; the frames that carry *meaning* to a subscriber are decoded
+/// by the subscription types instead, during the handshake where they can be acted on.
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LseMessage {
+    /// A tick.
+    Tick(LseTick),
+
+    /// Any other frame — a control frame, or one this integration does not model.
+    #[serde(other)]
+    Other,
+}
+
+/// Deserialise the tick's `symbol` into the [`SubscriptionId`] it was registered under.
+fn de_tick_subscription_id<'de, D>(deserializer: D) -> Result<SubscriptionId, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    <&str as Deserialize>::deserialize(deserializer)
+        .map(|symbol| ExchangeSub::from((LseChannel::Tick, symbol)).id())
+}
+
+/// Deserialise a WebSocket timestamp from any of the three spellings the provider uses.
+///
+/// Every timestamp the WebSocket sends shares this problem, not just a tick's `ts` — a replay
+/// window's `from` is decoded through it too. The spellings, and why the epoch form is quantised
+/// to microseconds, are documented on [`LseTick::time_exchange`], which is where a reader of the
+/// public API meets them.
+pub(super) fn de_timestamp<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(TimestampVisitor)
+}
+
+struct TimestampVisitor;
+
+impl Visitor<'_> for TimestampVisitor {
+    type Value = DateTime<Utc>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(
+            "an RFC 3339 timestamp, the same with a space separating date and time, or epoch \
+             seconds as a number",
+        )
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        parse_timestamp(value).ok_or_else(|| E::invalid_value(Unexpected::Str(value), &self))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        time_from_epoch_seconds(value)
+            .ok_or_else(|| E::invalid_value(Unexpected::Float(value), &self))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        // An epoch that lands on a whole second has no fractional part to print, so JSON carries
+        // it as an integer and never reaches `visit_f64`.
+        i64::try_from(value)
+            .ok()
+            .and_then(|seconds| DateTime::from_timestamp(seconds, 0))
+            .ok_or_else(|| E::invalid_value(Unexpected::Unsigned(value), &self))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        DateTime::from_timestamp(value, 0)
+            .ok_or_else(|| E::invalid_value(Unexpected::Signed(value), &self))
+    }
+}
+
+/// Parse spellings 1 and 2 — see [`de_timestamp`].
+fn parse_timestamp(raw: &str) -> Option<DateTime<Utc>> {
+    if let Ok(parsed) = DateTime::parse_from_rfc3339(raw) {
+        return Some(parsed.with_timezone(&Utc));
+    }
+
+    // The space-separated spelling is the same instant in a form RFC 3339 does not admit. Swapping
+    // the separator and re-parsing reuses the strict parser rather than introducing a second,
+    // laxer grammar -- so an offset RFC 3339 would reject is still rejected here, and the two
+    // spellings cannot drift apart in what they accept.
+    let (date, time) = raw.split_once(' ')?;
+    let mut rfc3339 = String::with_capacity(raw.len());
+    rfc3339.push_str(date);
+    rfc3339.push('T');
+    rfc3339.push_str(time);
+
+    DateTime::parse_from_rfc3339(&rfc3339)
+        .ok()
+        .map(|parsed| parsed.with_timezone(&Utc))
+}
+
+/// Parse spelling 3 — see [`de_timestamp`] for why this rounds to microseconds.
+fn time_from_epoch_seconds(epoch: f64) -> Option<DateTime<Utc>> {
+    /// Microseconds in a second, as the multiplier for the epoch conversion.
+    const MICROS_PER_SECOND: f64 = 1_000_000.0;
+
+    if !epoch.is_finite() {
+        return None;
+    }
+
+    // The whole conversion stays inside `f64`'s exactly-representable integer range: epoch
+    // microseconds near the present are ~1.8e15, comfortably under 2^53. Scaling first and
+    // rounding once is therefore exact, where splitting into seconds and a fraction would round
+    // twice for no gain.
+    let micros = (epoch * MICROS_PER_SECOND).round();
+    if micros < i64::MIN as f64 || micros > i64::MAX as f64 {
+        return None;
+    }
+
+    // `micros` is integral (just rounded) and inside `i64`'s range (just checked), so this
+    // conversion is exact -- neither fact is visible to the lint, and `f64` carries no fallible
+    // conversion to `i64` that would express them.
+    #[allow(clippy::cast_possible_truncation)]
+    let micros = micros as i64;
+
+    DateTime::from_timestamp_micros(micros)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    /// A live tick, in the RFC 3339 spelling with a `T` separator.
+    const LIVE_T_SEPARATED: &str = r#"{"type":"tick","symbol":"BTC/USD",
+        "ts":"2026-01-02T09:37:24.760146+00:00","price":42000.5,"bid":42000.5,
+        "ask":42001.0,"volume":0.00155}"#;
+
+    /// A live tick from one of the families that separates date and time with a space.
+    const LIVE_SPACE_SEPARATED: &str = r#"{"type":"tick","symbol":"EUR/USD",
+        "ts":"2026-01-02 09:37:21.690159+00:00","price":1.1,"bid":1.1,"ask":1.1001,
+        "volume":1.0}"#;
+
+    #[test]
+    fn a_t_separated_timestamp_decodes() {
+        let tick: LseTick = serde_json::from_str(LIVE_T_SEPARATED).unwrap();
+
+        assert_eq!(
+            tick.time_exchange,
+            "2026-01-02T09:37:24.760146Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+        assert_eq!(tick.price, dec!(42000.5));
+        assert_eq!(tick.volume, dec!(0.00155));
+    }
+
+    /// The spelling `DateTime::parse_from_rfc3339` rejects. Five of thirteen sampled dataset
+    /// families send it, so an RFC-3339-only decoder loses them silently.
+    #[test]
+    fn a_space_separated_timestamp_decodes_to_the_same_instant_as_the_t_form() {
+        let tick: LseTick = serde_json::from_str(LIVE_SPACE_SEPARATED).unwrap();
+
+        assert_eq!(
+            tick.time_exchange,
+            "2026-01-02T09:37:21.690159Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+    }
+
+    /// At least one symbol publishes no fractional component at all.
+    #[test]
+    fn a_timestamp_without_a_subsecond_component_decodes() {
+        let input = r#"{"type":"tick","symbol":"VIX/USD","ts":"2026-01-02T19:59:46+00:00",
+            "price":16.9,"bid":16.9,"ask":16.93,"volume":0.0}"#;
+        let tick: LseTick = serde_json::from_str(input).unwrap();
+
+        assert_eq!(
+            tick.time_exchange,
+            "2026-01-02T19:59:46Z".parse::<DateTime<Utc>>().unwrap()
+        );
+    }
+
+    /// Replayed ticks send the timestamp as a JSON number while live ticks on the same connection
+    /// send a string, so the field changes JSON type mid-stream.
+    #[test]
+    fn a_float_epoch_timestamp_decodes() {
+        let input = r#"{"type":"tick","symbol":"BTC/USD","ts":1767346644.592,"name":"Bitcoin",
+            "replay":true,"price":42000.5,"bid":42000.5,"ask":42001.0,"volume":0.00155}"#;
+        let tick: LseTick = serde_json::from_str(input).unwrap();
+
+        assert_eq!(
+            tick.time_exchange,
+            DateTime::from_timestamp_micros(1_767_346_644_592_000).unwrap()
+        );
+        assert!(tick.replay);
+    }
+
+    /// The property the resume arithmetic depends on: a replayed tick and the live tick it repeats
+    /// describe the same instant in different spellings, and must decode equal. Nanosecond
+    /// conversion would fail this — `f64` spacing near the present is ~0.24µs.
+    #[test]
+    fn the_string_and_float_spellings_of_one_instant_decode_equal() {
+        let as_string = parse_timestamp("2026-01-02T09:37:24.760146+00:00").unwrap();
+        let as_float = time_from_epoch_seconds(1_767_346_644.760_146).unwrap();
+
+        assert_eq!(as_string, as_float);
+    }
+
+    /// A whole-second epoch has no fractional part to print, so JSON carries it as an integer.
+    #[test]
+    fn an_integer_epoch_timestamp_decodes() {
+        let input = r#"{"type":"tick","symbol":"BTC/USD","ts":1767346644,"replay":true,
+            "price":42000.5,"bid":42000.5,"ask":42001.0,"volume":0.00155}"#;
+        let tick: LseTick = serde_json::from_str(input).unwrap();
+
+        assert_eq!(
+            tick.time_exchange,
+            DateTime::from_timestamp(1_767_346_644, 0).unwrap()
+        );
+    }
+
+    /// Live ticks carry no `replay` key at all, so the default decides whether every live tick is
+    /// mistaken for a replayed one.
+    #[test]
+    fn replay_defaults_to_false_when_the_key_is_absent() {
+        let tick: LseTick = serde_json::from_str(LIVE_T_SEPARATED).unwrap();
+        assert!(!tick.replay);
+    }
+
+    #[test]
+    fn the_subscription_id_is_built_from_the_symbol() {
+        let tick: LseTick = serde_json::from_str(LIVE_T_SEPARATED).unwrap();
+        assert_eq!(tick.subscription_id.as_ref(), "tick|BTC/USD");
+    }
+
+    /// A timestamp carrying no offset is ambiguous, and guessing at it would silently misdate the
+    /// event rather than fail.
+    #[test]
+    fn a_timestamp_without_an_offset_is_rejected() {
+        assert!(parse_timestamp("2026-01-02 09:37:21.690159").is_none());
+        assert!(parse_timestamp("2026-01-02T09:37:21.690159").is_none());
+    }
+
+    #[test]
+    fn a_non_timestamp_string_is_rejected() {
+        assert!(parse_timestamp("").is_none());
+        assert!(parse_timestamp("not a timestamp").is_none());
+    }
+
+    #[test]
+    fn a_non_finite_epoch_is_rejected() {
+        assert!(time_from_epoch_seconds(f64::NAN).is_none());
+        assert!(time_from_epoch_seconds(f64::INFINITY).is_none());
+        assert!(time_from_epoch_seconds(f64::MAX).is_none());
+    }
+
+    #[test]
+    fn a_tick_frame_decodes_as_a_tick() {
+        let message: LseMessage = serde_json::from_str(LIVE_T_SEPARATED).unwrap();
+        assert!(matches!(message, LseMessage::Tick(_)));
+    }
+
+    /// Control frames share the data stream with ticks. Failing the parse on one would take the
+    /// stream down over a message the transformer has no interest in.
+    #[test]
+    fn control_frames_decode_as_other_rather_than_failing_the_parse() {
+        for input in [
+            r#"{"type":"subscribed","symbol":"BTC/USD","count":1,"max":16}"#,
+            r#"{"type":"replay_started","symbol":"BTC/USD","from":"2026-01-02T09:37:24+00:00"}"#,
+            r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41,"buffered_drained":9}"#,
+            r#"{"type":"error","code":"LIMIT_REACHED","message":"Max 16 symbols"}"#,
+            r#"{"type":"welcome","message":"hello","symbols_available":1}"#,
+        ] {
+            let message: LseMessage = serde_json::from_str(input).unwrap();
+            assert_eq!(message, LseMessage::Other, "failed on {input}");
+        }
+    }
+}

--- a/rustrade-data/src/exchange/lse/tick.rs
+++ b/rustrade-data/src/exchange/lse/tick.rs
@@ -121,6 +121,21 @@ pub enum LseMessage {
     Other,
 }
 
+impl Identifier<Option<SubscriptionId>> for LseMessage {
+    /// A tick resolves to the subscription its symbol was registered under; anything else resolves
+    /// to nothing.
+    ///
+    /// The `None` is what keeps control frames out of the market stream: the transformer drops an
+    /// unidentifiable frame rather than attempting to convert it, so the two decoders never have to
+    /// invent an event for a frame that describes none.
+    fn id(&self) -> Option<SubscriptionId> {
+        match self {
+            Self::Tick(tick) => Some(tick.subscription_id.clone()),
+            Self::Other => None,
+        }
+    }
+}
+
 /// Deserialise the tick's `symbol` into the [`SubscriptionId`] it was registered under.
 fn de_tick_subscription_id<'de, D>(deserializer: D) -> Result<SubscriptionId, D::Error>
 where
@@ -374,6 +389,26 @@ mod tests {
     fn a_tick_frame_decodes_as_a_tick() {
         let message: LseMessage = serde_json::from_str(LIVE_T_SEPARATED).unwrap();
         assert!(matches!(message, LseMessage::Tick(_)));
+    }
+
+    #[test]
+    fn a_tick_identifies_itself_by_its_subscription() {
+        let message: LseMessage = serde_json::from_str(LIVE_T_SEPARATED).unwrap();
+        assert_eq!(
+            message.id(),
+            Some(SubscriptionId::from("tick|BTC/USD")),
+            "a tick must resolve to the subscription it was registered under"
+        );
+    }
+
+    /// The transformer drops a frame that identifies no subscription, which is what keeps control
+    /// frames from reaching the decoders at all.
+    #[test]
+    fn a_control_frame_identifies_no_subscription() {
+        let message: LseMessage =
+            serde_json::from_str(r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41}"#)
+                .unwrap();
+        assert_eq!(message.id(), None);
     }
 
     /// Control frames share the data stream with ticks. Failing the parse on one would take the

--- a/rustrade-data/src/exchange/lse/trade.rs
+++ b/rustrade-data/src/exchange/lse/trade.rs
@@ -36,7 +36,9 @@ use smol_str::SmolStr;
 /// # ⚠️ Identical consecutive ticks are REAL and are both emitted
 /// This decoder performs no de-duplication, deliberately. See
 /// [`LseTick`](super::tick::LseTick) for the reconciliation that proves the repeats are distinct
-/// prints, and `identical_consecutive_ticks_are_both_emitted` for the test that pins it.
+/// prints. The property is pinned by `identical_live_ticks_are_never_deduplicated` in
+/// [`transformer`](super::transformer), which is the only place a filter could be added: this
+/// impl is a stateless `From` and has nothing to remember a previous tick with.
 impl<InstrumentKey> From<(ExchangeId, InstrumentKey, LseMessage)>
     for MarketIter<InstrumentKey, PublicTrade>
 {
@@ -116,11 +118,14 @@ mod tests {
         assert_eq!(events[0].kind.side, None);
     }
 
-    /// The feed republishes identical ticks and they are genuine distinct prints: de-duplicating a
-    /// sampled run destroyed 3–10% of volume that otherwise reconciles exactly against the
-    /// provider's own candles. This test exists so the "obvious" filter is not added later.
+    /// Two identical frames decode to two identical events, which is what makes the repeats
+    /// indistinguishable downstream and therefore what a de-duplication filter would key on. The
+    /// filter itself could only live in the transformer, which is stateful — see
+    /// `identical_live_ticks_are_never_deduplicated` there for the property that pins its absence.
+    /// This decoder is a stateless `From`, so what it pins is narrower: the decode carries no
+    /// distinguishing mark that would let one of the two be dropped.
     #[test]
-    fn identical_consecutive_ticks_are_both_emitted() {
+    fn identical_consecutive_ticks_decode_to_identical_events() {
         let json = tick_json("2026-01-02T09:37:24.760146+00:00", "42000.5", "0.00155");
 
         let first = decode(&json);

--- a/rustrade-data/src/exchange/lse/trade.rs
+++ b/rustrade-data/src/exchange/lse/trade.rs
@@ -1,0 +1,159 @@
+//! Decode a London Strategic Edge tick as a [`PublicTrade`].
+
+use super::tick::LseMessage;
+use crate::{
+    event::{MarketEvent, MarketIter},
+    subscription::trade::PublicTrade,
+};
+use chrono::Utc;
+use rustrade_instrument::exchange::ExchangeId;
+use smol_str::SmolStr;
+
+/// Decode a tick frame as a [`PublicTrade`].
+///
+/// # ⚠️ The tick is a QUOTE — a `PublicTrade` from this feed may not be a print
+/// `price` equals `bid` exactly on every sample taken — 3,966 of 3,966 ticks spanning every dataset
+/// family, plus every sample from the provider's separate price endpoint. So the price here is a
+/// bid-side quote wearing a trade's shape, and its arrival is **not** evidence that a transaction
+/// occurred, at that price or at all. The mapping ships regardless, because saying so is more useful
+/// than withholding a feed whose sizes do reconcile; but a strategy that treats these as executions
+/// is reading one side of a quote as a fill.
+///
+/// # ⚠️ `amount` is genuine on some venues and FABRICATED on others
+/// This is per-dataset and there is no in-band signal separating the two:
+///
+/// - [`LseCrypto`](super::LseCrypto) and [`LseEquities`](super::LseEquities) carry a **real**
+///   per-tick size. Summing it across three whole minutes of one crypto symbol reproduced the
+///   provider's own one-minute candle volume to the last decimal, ratio `1.000`.
+/// - [`LseFx`](super::LseFx) and [`LseCfd`](super::LseCfd) carry a **hard-coded `1.0`** — measured
+///   on every tick of every FX and commodity symbol sampled, one distinct value across all of them.
+///   It is a placeholder, not a measurement. Because it is a plausible-looking positive number it
+///   will aggregate into a legitimate-looking total at any resolution, so volume-weighted prices,
+///   participation rates and size filters computed on these two venues are meaningless rather than
+///   merely imprecise. Note this also differs from the provider's REST vault, which *omits* FX
+///   volume entirely — the true absence; the WebSocket invents a value instead.
+///
+/// # ⚠️ Identical consecutive ticks are REAL and are both emitted
+/// This decoder performs no de-duplication, deliberately. See
+/// [`LseTick`](super::tick::LseTick) for the reconciliation that proves the repeats are distinct
+/// prints, and `identical_consecutive_ticks_are_both_emitted` for the test that pins it.
+impl<InstrumentKey> From<(ExchangeId, InstrumentKey, LseMessage)>
+    for MarketIter<InstrumentKey, PublicTrade>
+{
+    fn from((exchange, instrument, message): (ExchangeId, InstrumentKey, LseMessage)) -> Self {
+        let LseMessage::Tick(tick) = message else {
+            // Control frames share the data stream with ticks. The transformer resolves a frame to
+            // its instrument before reaching here and drops anything unidentifiable, so this arm is
+            // unreachable through it -- but the conversion is total, and a control frame yielding
+            // nothing is the only answer that is correct if it ever is reached.
+            return Self(vec![]);
+        };
+
+        Self(vec![Ok(MarketEvent {
+            time_exchange: tick.time_exchange,
+            time_received: Utc::now(),
+            exchange,
+            instrument,
+            kind: PublicTrade {
+                // The feed publishes no trade identifier, and one cannot be synthesised: ticks are
+                // genuinely non-unique in `(ts, price, size)` -- one signature recurred 49 times in
+                // a sampled run -- so anything derived from those fields would collide across
+                // distinct prints. An empty id says "unidentified" rather than asserting a false
+                // one.
+                id: SmolStr::default(),
+                price: tick.price,
+                amount: tick.volume,
+                // No aggressor side is published, and it is not inferable: the price is the bid on
+                // every sample taken, which would make every tick look like a sell.
+                side: None,
+            },
+        })])
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use chrono::DateTime;
+    use rust_decimal_macros::dec;
+
+    fn tick_json(ts: &str, price: &str, volume: &str) -> String {
+        format!(
+            r#"{{"type":"tick","symbol":"BTC/USD","ts":"{ts}","price":{price},
+               "bid":{price},"ask":42001.0,"volume":{volume}}}"#
+        )
+    }
+
+    fn decode(json: &str) -> Vec<MarketEvent<u8, PublicTrade>> {
+        let message: LseMessage = serde_json::from_str(json).unwrap();
+        MarketIter::<u8, PublicTrade>::from((ExchangeId::LseCrypto, 1_u8, message))
+            .0
+            .into_iter()
+            .map(Result::unwrap)
+            .collect()
+    }
+
+    #[test]
+    fn a_tick_decodes_to_one_trade() {
+        let events = decode(&tick_json(
+            "2026-01-02T09:37:24.760146+00:00",
+            "42000.5",
+            "0.00155",
+        ));
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].exchange, ExchangeId::LseCrypto);
+        assert_eq!(events[0].instrument, 1);
+        assert_eq!(
+            events[0].time_exchange,
+            "2026-01-02T09:37:24.760146Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+        assert_eq!(events[0].kind.price, dec!(42000.5));
+        assert_eq!(events[0].kind.amount, dec!(0.00155));
+        assert_eq!(events[0].kind.side, None);
+    }
+
+    /// The feed republishes identical ticks and they are genuine distinct prints: de-duplicating a
+    /// sampled run destroyed 3–10% of volume that otherwise reconciles exactly against the
+    /// provider's own candles. This test exists so the "obvious" filter is not added later.
+    #[test]
+    fn identical_consecutive_ticks_are_both_emitted() {
+        let json = tick_json("2026-01-02T09:37:24.760146+00:00", "42000.5", "0.00155");
+
+        let first = decode(&json);
+        let second = decode(&json);
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+        assert_eq!(first[0].time_exchange, second[0].time_exchange);
+        assert_eq!(first[0].kind, second[0].kind);
+    }
+
+    /// The empty id is forced rather than tidy — see the field comment.
+    #[test]
+    fn the_trade_id_is_empty_because_no_identifier_could_be_synthesised() {
+        let events = decode(&tick_json(
+            "2026-01-02T09:37:24.760146+00:00",
+            "42000.5",
+            "0.00155",
+        ));
+        assert!(events[0].kind.id.is_empty());
+    }
+
+    /// The fabricated FX size is passed through unaltered: rewriting it would replace one invented
+    /// number with another, and the warning belongs in the docs, not in the data.
+    #[test]
+    fn the_fabricated_fx_size_is_passed_through_rather_than_rewritten() {
+        let events = decode(&tick_json("2026-01-02 09:37:21.690159+00:00", "1.1", "1.0"));
+        assert_eq!(events[0].kind.amount, dec!(1.0));
+    }
+
+    #[test]
+    fn a_control_frame_yields_no_trades() {
+        let events = decode(r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41}"#);
+        assert!(events.is_empty());
+    }
+}

--- a/rustrade-data/src/exchange/lse/transformer.rs
+++ b/rustrade-data/src/exchange/lse/transformer.rs
@@ -5,7 +5,7 @@
 //! [`resume`](super::resume): skipping the events a reconnect's replay re-delivers.
 
 use super::{
-    resume::{LseResumeState, LseWatermark},
+    resume::{LseResumeKey, LseResumeState, LseWatermark},
     tick::LseMessage,
 };
 use crate::{
@@ -43,6 +43,14 @@ pub struct LseTransformer<Exchange, InstrumentKey, Kind> {
 #[derive(Debug)]
 struct ResumeTracker {
     state: Arc<LseResumeState>,
+
+    /// The kind this stream serves, which partitions the shared state — see
+    /// [`LseResumeKey`]. Held as a string because the transformer's `Kind` type parameter has no
+    /// value to call [`SubscriptionKind::as_str`] on.
+    kind: &'static str,
+
+    /// Keyed by subscription alone: the snapshot is filtered to this stream's kind on construction,
+    /// so the kind is constant across every entry here.
     pending: FnvHashMap<SubscriptionId, PendingDrop>,
 }
 
@@ -51,6 +59,12 @@ struct ResumeTracker {
 struct PendingDrop {
     time_exchange: DateTime<Utc>,
     remaining: usize,
+
+    /// Whether the out-of-contract-ordering warning has already fired for this subscription.
+    ///
+    /// A provider replaying from *before* the requested instant would otherwise warn once per
+    /// replayed tick, which on a busy symbol is tens of thousands of identical lines.
+    warned_older: bool,
 }
 
 impl<Exchange, InstrumentKey, Kind> LseTransformer<Exchange, InstrumentKey, Kind>
@@ -63,22 +77,28 @@ where
 {
     /// Construct a transformer, optionally resuming from previously delivered events.
     ///
+    /// `resume` carries the kind this stream serves alongside the shared state, because the state
+    /// is partitioned by kind — see [`LseResumeKey`] — and this type's `Kind` parameter has no
+    /// value to derive it from.
+    ///
     /// The drop counters are snapshotted here rather than consulted per tick, so the shared lock
     /// is taken once per connection on this path.
     pub(super) async fn new(
         instrument_map: Map<InstrumentKey>,
         ws_sink_tx: mpsc::UnboundedSender<WsMessage>,
-        resume: Option<Arc<LseResumeState>>,
+        resume: Option<(Arc<LseResumeState>, &'static str)>,
     ) -> Result<Self, DataError> {
         let inner = StatelessTransformer::init(instrument_map, &[], ws_sink_tx).await?;
 
-        let resume = resume.map(|state| ResumeTracker {
+        let resume = resume.map(|(state, kind)| ResumeTracker {
             pending: state
                 .snapshot()
                 .into_iter()
-                .map(|(subscription_id, watermark)| (subscription_id, PendingDrop::from(watermark)))
+                .filter(|(key, _)| key.kind() == kind)
+                .map(|(key, watermark)| (key.into_subscription(), PendingDrop::from(watermark)))
                 .collect(),
             state,
+            kind,
         });
 
         Ok(Self { inner, resume })
@@ -90,6 +110,7 @@ impl From<LseWatermark> for PendingDrop {
         Self {
             time_exchange: watermark.time_exchange,
             remaining: watermark.count_at_time,
+            warned_older: false,
         }
     }
 }
@@ -131,19 +152,39 @@ where
     type OutputIter = Vec<Result<Self::Output, Self::Error>>;
 
     fn transform(&mut self, input: Self::Input) -> Self::OutputIter {
+        // The replay boundary is consumed here rather than forwarded. It is the only evidence that
+        // a requested window was clamped to the provider's retention, and it cannot be caught
+        // during the handshake -- see `LseMessage::ReplayStarted`. No decoder has a market event to
+        // build from it either way.
+        if let LseMessage::ReplayStarted {
+            subscription_id,
+            from,
+        } = &input
+        {
+            if let Some(resume) = self.resume.as_ref() {
+                resume.warn_if_clamped(Exchange::ID, subscription_id, *from);
+            }
+
+            return vec![];
+        }
+
         // Nothing to track when the caller did not opt in, and a control frame carries no instant
         // to track. Both go straight through.
-        let Some((subscription_id, time_exchange)) =
+        let Some((subscription_id, time_exchange, replay)) =
             self.resume.as_ref().and_then(|_| match &input {
-                LseMessage::Tick(tick) => Some((tick.subscription_id.clone(), tick.time_exchange)),
-                LseMessage::Other => None,
+                LseMessage::Tick(tick) => Some((
+                    tick.subscription_id.clone(),
+                    tick.time_exchange,
+                    tick.replay,
+                )),
+                _ => None,
             })
         else {
             return self.inner.transform(input);
         };
 
         if let Some(resume) = self.resume.as_mut()
-            && resume.should_drop(&subscription_id, time_exchange)
+            && resume.should_drop(Exchange::ID, &subscription_id, time_exchange, replay)
         {
             return vec![];
         }
@@ -156,7 +197,7 @@ where
         if let Some(resume) = self.resume.as_ref()
             && output.iter().any(Result::is_ok)
         {
-            resume.state.record(&subscription_id, time_exchange);
+            resume.record(subscription_id, time_exchange);
         }
 
         output
@@ -167,10 +208,12 @@ impl ResumeTracker {
     /// Whether this event was already delivered by the connection this one replaced.
     fn should_drop(
         &mut self,
+        exchange: ExchangeId,
         subscription_id: &SubscriptionId,
         time_exchange: DateTime<Utc>,
+        replay: bool,
     ) -> bool {
-        let Some(pending) = self.pending.get(subscription_id).copied() else {
+        let Some(pending) = self.pending.get_mut(subscription_id) else {
             return false;
         };
 
@@ -179,14 +222,32 @@ impl ResumeTracker {
             // delivered this many events there. `start` is inclusive, so the provider replays them
             // all and they are skipped by position.
             Ordering::Equal if pending.remaining > 0 => {
-                if let Some(pending) = self.pending.get_mut(subscription_id) {
-                    pending.remaining -= 1;
+                pending.remaining -= 1;
+
+                // The skip stays positional and does NOT require `replay`, deliberately: the flag
+                // is absent on live ticks, so a provider that stopped stamping replayed ones would
+                // turn every reconnect into a duplicate flood if the drop depended on it. But a
+                // tick arriving unstamped inside the window is a live event being discarded as a
+                // duplicate, which only happens if the replay under-delivered at this instant, so
+                // it is reported. Bounded by the count the watermark carries.
+                if !replay {
+                    warn!(
+                        %exchange,
+                        subscription = %subscription_id,
+                        instant = %time_exchange,
+                        "London Strategic Edge delivered an unreplayed tick inside the resume \
+                         window and it was skipped as an already-delivered duplicate; a genuinely \
+                         new tick may have been lost",
+                    );
                 }
+
                 true
             }
             // The instant is exhausted; anything further carrying it is genuinely new.
             Ordering::Equal => false,
             Ordering::Greater => {
+                let undelivered = pending.remaining;
+                let instant = pending.time_exchange;
                 self.pending.remove(subscription_id);
 
                 // The replay held fewer events at the watermark's instant than were delivered from
@@ -195,11 +256,12 @@ impl ResumeTracker {
                 // 141 events -- so a shortfall means the provider's history changed underneath the
                 // subscription. No event is lost by it, but the assumption is load-bearing enough
                 // that its failure must be visible rather than inferred from a gap much later.
-                if pending.remaining > 0 {
+                if undelivered > 0 {
                     warn!(
+                        %exchange,
                         subscription = %subscription_id,
-                        instant = %pending.time_exchange,
-                        undelivered = pending.remaining,
+                        instant = %instant,
+                        undelivered,
                         "London Strategic Edge replay held fewer ticks at the resume instant than \
                          were delivered from it; the provider's history changed under the resume",
                     );
@@ -210,8 +272,87 @@ impl ResumeTracker {
             // Older than the watermark. `start` is inclusive, so the provider should never send
             // this; emitting is the safe answer, since dropping would discard a real event on the
             // strength of an assumption that has already been contradicted.
-            Ordering::Less => false,
+            Ordering::Less => {
+                // The mirror image of the shortfall above, and the same load-bearing assumption
+                // contradicted in the other direction -- most plausibly a `start` filter flooring
+                // to a coarser resolution than the microseconds it was given. Its consequence is
+                // worse, because everything between the served instant and the watermark is a
+                // duplicate delivered into consumer state, so it must not be the quiet one. Fired
+                // once per subscription: the condition holds for every replayed tick below the
+                // watermark, and on a busy symbol that is tens of thousands of them.
+                if !pending.warned_older {
+                    pending.warned_older = true;
+
+                    warn!(
+                        %exchange,
+                        subscription = %subscription_id,
+                        instant = %time_exchange,
+                        watermark = %pending.time_exchange,
+                        "London Strategic Edge replayed a tick older than the resume instant, \
+                         which an inclusive `start` should make impossible; it is emitted rather \
+                         than dropped, so expect duplicates back to the instant shown",
+                    );
+                }
+
+                false
+            }
         }
+    }
+
+    /// Warn when the provider opened a replay window later than the one asked for.
+    ///
+    /// # ⚠️ Silent clamping is the failure this exists to surface
+    /// The provider retains 24 hours. A `start` older than that is **moved forward and served with
+    /// no error** — a window requested 48 hours back was answered with one beginning exactly 24
+    /// hours back. The `from` of the [`ReplayStarted`](LseMessage::ReplayStarted) frame is the only
+    /// signal that it happened.
+    ///
+    /// The watermark is what went out as `start`, so it *is* the requested instant and no separate
+    /// record of the request is needed. A window opened exactly at it is not a clamp: `start` is
+    /// inclusive, so that is precisely the window asked for.
+    fn warn_if_clamped(
+        &self,
+        exchange: ExchangeId,
+        subscription_id: &SubscriptionId,
+        from: DateTime<Utc>,
+    ) {
+        if let Some(requested) = self.clamped_from(subscription_id, from) {
+            warn!(
+                %exchange,
+                subscription = %subscription_id,
+                requested = %requested,
+                serving_from = %from,
+                "London Strategic Edge clamped the requested replay window; events between the two \
+                 instants are beyond the provider's retention and are permanently lost",
+            );
+        }
+    }
+
+    /// The instant a window was requested from, if the provider opened it later than that.
+    ///
+    /// `None` for a subscription this stream holds no watermark for — one that asked for no window,
+    /// or whose replay has already passed its watermark. The provider announces the boundary before
+    /// serving the window, measured on both a crypto and an FX symbol, so the second case means the
+    /// frames arrived out of order and the requested instant is no longer known here.
+    fn clamped_from(
+        &self,
+        subscription_id: &SubscriptionId,
+        from: DateTime<Utc>,
+    ) -> Option<DateTime<Utc>> {
+        let requested = self.pending.get(subscription_id)?.time_exchange;
+
+        // A window opened *at* the requested instant is not a clamp: `start` is inclusive, so that
+        // is precisely the window that was asked for, and warning on it would make this fire on
+        // every ordinary resume.
+        (from > requested).then_some(requested)
+    }
+
+    /// Advance the shared watermark for an event this stream delivered.
+    fn record(&self, subscription_id: SubscriptionId, time_exchange: DateTime<Utc>) {
+        self.state.record(
+            &LseResumeKey::new(subscription_id, self.kind),
+            time_exchange,
+        );
     }
 }
 
@@ -231,13 +372,30 @@ mod tests {
 
     type Subject = LseTransformer<LseCrypto, u8, PublicTrades>;
 
+    /// The kind these tests serve, and the partition their watermarks are filed under.
+    const KIND: &str = "public_trades";
+
     fn id() -> SubscriptionId {
         super::super::resume::subscription_id("BTC/USD")
     }
 
+    fn key() -> LseResumeKey {
+        LseResumeKey::new(id(), KIND)
+    }
+
+    /// A live tick, which carries no `replay` key at all.
     fn tick(ts: &str, price: &str) -> LseMessage {
         serde_json::from_str(&format!(
             r#"{{"type":"tick","symbol":"BTC/USD","ts":"{ts}","price":{price},
+                "bid":{price},"ask":42001.0,"volume":0.00155}}"#
+        ))
+        .unwrap()
+    }
+
+    /// A tick served from the provider's replay buffer, which the provider stamps.
+    fn replayed_tick(ts: &str, price: &str) -> LseMessage {
+        serde_json::from_str(&format!(
+            r#"{{"type":"tick","symbol":"BTC/USD","ts":"{ts}","replay":true,"price":{price},
                 "bid":{price},"ask":42001.0,"volume":0.00155}}"#
         ))
         .unwrap()
@@ -249,7 +407,9 @@ mod tests {
             .collect::<FnvHashMap<SubscriptionId, u8>>());
         let (tx, _rx) = mpsc::unbounded_channel();
 
-        Subject::new(map, tx, resume).await.unwrap()
+        Subject::new(map, tx, resume.map(|state| (state, KIND)))
+            .await
+            .unwrap()
     }
 
     #[tokio::test]
@@ -274,7 +434,7 @@ mod tests {
         subject.transform(tick("2026-01-02T09:00:00.000001Z", "1.0"));
         subject.transform(tick("2026-01-02T09:00:00.000001Z", "2.0"));
 
-        let watermark = state.watermark(&id()).unwrap();
+        let watermark = state.watermark(&key()).unwrap();
         assert_eq!(
             watermark.time_exchange,
             "2026-01-02T09:00:00.000001Z"
@@ -295,14 +455,14 @@ mod tests {
         for price in ["1.0", "2.0", "3.0"] {
             first.transform(tick("2026-01-02T09:00:00.000001Z", price));
         }
-        assert_eq!(state.watermark(&id()).unwrap().count_at_time, 3);
+        assert_eq!(state.watermark(&key()).unwrap().count_at_time, 3);
 
         // Reconnect: the provider replays all three, then a fourth that is genuinely new.
         let mut second = subject(Some(Arc::clone(&state))).await;
         for price in ["1.0", "2.0", "3.0"] {
             assert!(
                 second
-                    .transform(tick("2026-01-02T09:00:00.000001Z", price))
+                    .transform(replayed_tick("2026-01-02T09:00:00.000001Z", price))
                     .is_empty(),
                 "an already-delivered tick must not be emitted twice"
             );
@@ -315,7 +475,7 @@ mod tests {
             1,
             "a fourth tick at the same instant is new and must be emitted"
         );
-        assert_eq!(state.watermark(&id()).unwrap().count_at_time, 4);
+        assert_eq!(state.watermark(&key()).unwrap().count_at_time, 4);
     }
 
     /// The gap half of the contract: everything after the resume instant is new, always.
@@ -329,7 +489,7 @@ mod tests {
         let mut second = subject(Some(Arc::clone(&state))).await;
         assert!(
             second
-                .transform(tick("2026-01-02T09:00:00.000001Z", "1.0"))
+                .transform(replayed_tick("2026-01-02T09:00:00.000001Z", "1.0"))
                 .is_empty()
         );
         assert_eq!(
@@ -355,7 +515,7 @@ mod tests {
         // Replay is short by one, then moves past the instant -- the window closes here.
         assert!(
             second
-                .transform(tick("2026-01-02T09:00:00.000001Z", "1.0"))
+                .transform(replayed_tick("2026-01-02T09:00:00.000001Z", "1.0"))
                 .is_empty()
         );
         assert_eq!(
@@ -395,7 +555,7 @@ mod tests {
                 .unwrap();
 
         assert!(subject.transform(frame).is_empty());
-        assert_eq!(state.watermark(&id()), None);
+        assert_eq!(state.watermark(&key()), None);
     }
 
     /// The no-dedupe lock, restated at the transformer: identical repeats are genuine distinct
@@ -410,5 +570,134 @@ mod tests {
 
         assert_eq!(first.len(), 1);
         assert_eq!(second.len(), 1, "an identical repeat is a distinct print");
+    }
+
+    /// An inclusive `start` says this cannot happen, so it means the assumption behind positional
+    /// skipping has been contradicted — most plausibly a `start` filter flooring to a coarser
+    /// resolution. Emitting is the safe answer: dropping would discard a real event on the strength
+    /// of an assumption already known to be wrong. A `warn!` carries the signal.
+    #[tokio::test]
+    async fn a_replayed_tick_older_than_the_resume_instant_is_emitted_rather_than_dropped() {
+        let state = Arc::new(LseResumeState::new());
+
+        let mut first = subject(Some(Arc::clone(&state))).await;
+        first.transform(tick("2026-01-02T09:00:00.000002Z", "1.0"));
+
+        let mut second = subject(Some(Arc::clone(&state))).await;
+        assert_eq!(
+            second
+                .transform(replayed_tick("2026-01-02T09:00:00.000001Z", "0.5"))
+                .len(),
+            1,
+            "a tick below the watermark must be emitted, not silently swallowed"
+        );
+
+        // The window itself is untouched by it: the tick at the watermark is still skipped.
+        assert!(
+            second
+                .transform(replayed_tick("2026-01-02T09:00:00.000002Z", "1.0"))
+                .is_empty()
+        );
+    }
+
+    /// The skip stays positional rather than conditioning on `replay`, because the flag is absent
+    /// on live ticks: a provider that stopped stamping replayed ones would otherwise turn every
+    /// reconnect into a duplicate flood. The cost is this case, which is reported by a `warn!`
+    /// rather than changed.
+    #[tokio::test]
+    async fn an_unstamped_tick_inside_the_resume_window_is_still_skipped() {
+        let state = Arc::new(LseResumeState::new());
+
+        let mut first = subject(Some(Arc::clone(&state))).await;
+        first.transform(tick("2026-01-02T09:00:00.000001Z", "1.0"));
+
+        let mut second = subject(Some(Arc::clone(&state))).await;
+        assert!(
+            second
+                .transform(tick("2026-01-02T09:00:00.000001Z", "1.0"))
+                .is_empty()
+        );
+    }
+
+    /// A resumed subject whose `pending` holds a watermark at `instant`, as a reconnect's would.
+    async fn resumed_at(state: &Arc<LseResumeState>, instant: &str) -> Subject {
+        let mut first = subject(Some(Arc::clone(state))).await;
+        first.transform(tick(instant, "1.0"));
+
+        subject(Some(Arc::clone(state))).await
+    }
+
+    fn at(spelling: &str) -> DateTime<Utc> {
+        spelling.parse::<DateTime<Utc>>().unwrap()
+    }
+
+    /// The provider retains 24 hours and moves an older `start` forward with no error, so the
+    /// boundary frame's `from` is the only evidence the requested window was not the served one.
+    #[tokio::test]
+    async fn a_replay_window_opened_later_than_requested_is_reported() {
+        let state = Arc::new(LseResumeState::new());
+        let subject = resumed_at(&state, "2026-08-12T10:00:00Z").await;
+
+        assert_eq!(
+            subject
+                .resume
+                .as_ref()
+                .unwrap()
+                .clamped_from(&id(), at("2026-08-13T10:00:00Z")),
+            Some(at("2026-08-12T10:00:00Z")),
+        );
+    }
+
+    /// `start` is inclusive, so a window opened exactly where it was asked for is the window that
+    /// was asked for — reporting it would make the check noise on every ordinary resume.
+    #[tokio::test]
+    async fn a_replay_window_opened_where_requested_is_not_a_clamp() {
+        let state = Arc::new(LseResumeState::new());
+        let subject = resumed_at(&state, "2026-08-14T10:16:55.161234Z").await;
+
+        assert_eq!(
+            subject
+                .resume
+                .as_ref()
+                .unwrap()
+                .clamped_from(&id(), at("2026-08-14T10:16:55.161234Z")),
+            None,
+        );
+    }
+
+    /// A subscription that asked for no window cannot have had one clamped.
+    #[tokio::test]
+    async fn a_replay_boundary_for_a_subscription_with_no_watermark_is_ignored() {
+        let state = Arc::new(LseResumeState::new());
+        let subject = subject(Some(state)).await;
+
+        assert_eq!(
+            subject
+                .resume
+                .as_ref()
+                .unwrap()
+                .clamped_from(&id(), at("2026-08-13T10:00:00Z")),
+            None,
+        );
+    }
+
+    /// The frame is the only evidence a requested window was clamped, and it reaches the stream
+    /// rather than the handshake. It must yield no market event of its own.
+    #[tokio::test]
+    async fn a_replay_boundary_is_consumed_without_emitting_an_event() {
+        let state = Arc::new(LseResumeState::new());
+        let mut subject = subject(Some(Arc::clone(&state))).await;
+
+        let boundary: LseMessage = serde_json::from_str(
+            r#"{"type":"replay_started","symbol":"BTC/USD","from":"2026-01-02T09:00:00Z"}"#,
+        )
+        .unwrap();
+
+        assert!(subject.transform(boundary).is_empty());
+        assert_eq!(
+            state.watermark(&key()),
+            None,
+            "a boundary frame must not advance the watermark"
+        );
     }
 }

--- a/rustrade-data/src/exchange/lse/transformer.rs
+++ b/rustrade-data/src/exchange/lse/transformer.rs
@@ -44,13 +44,18 @@ pub struct LseTransformer<Exchange, InstrumentKey, Kind> {
 struct ResumeTracker {
     state: Arc<LseResumeState>,
 
+    /// The dataset this stream serves, which partitions the shared state alongside the kind — see
+    /// [`LseResumeKey`]. Held as a value because the transformer's `Exchange` type parameter is
+    /// only reachable where its bounds are in scope, which the per-tick path is not.
+    exchange: ExchangeId,
+
     /// The kind this stream serves, which partitions the shared state — see
     /// [`LseResumeKey`]. Held as a string because the transformer's `Kind` type parameter has no
     /// value to call [`SubscriptionKind::as_str`] on.
     kind: &'static str,
 
-    /// Keyed by subscription alone: the snapshot is filtered to this stream's kind on construction,
-    /// so the kind is constant across every entry here.
+    /// Keyed by subscription alone: the snapshot is filtered to this stream's dataset and kind on
+    /// construction, so both are constant across every entry here.
     pending: FnvHashMap<SubscriptionId, PendingDrop>,
 }
 
@@ -65,6 +70,19 @@ struct PendingDrop {
     /// A provider replaying from *before* the requested instant would otherwise warn once per
     /// replayed tick, which on a busy symbol is tens of thousands of identical lines.
     warned_older: bool,
+
+    /// Whether the provider announced a replay window opening later than the one requested.
+    ///
+    /// A clamp explains a shortfall at the resume instant completely — the window simply does not
+    /// reach it — so the shortfall must not also be reported as the provider's history changing
+    /// under the subscription. Two reports with different causes for one event is worse than one,
+    /// because only one of them is true.
+    ///
+    /// Set when the boundary frame is read, which the provider was measured to send before the
+    /// window it announces. The suppression is therefore ordered, not absolute: see the
+    /// `Ordering::Greater` arm of [`should_drop`](ResumeTracker::should_drop) for what happens
+    /// under the reverse order, and why it is tolerated.
+    clamped: bool,
 }
 
 impl<Exchange, InstrumentKey, Kind> LseTransformer<Exchange, InstrumentKey, Kind>
@@ -78,26 +96,30 @@ where
     /// Construct a transformer, optionally resuming from previously delivered events.
     ///
     /// `resume` carries the kind this stream serves alongside the shared state, because the state
-    /// is partitioned by kind — see [`LseResumeKey`] — and this type's `Kind` parameter has no
-    /// value to derive it from.
+    /// is partitioned by dataset *and* kind — see [`LseResumeKey`] — and this type's `Kind`
+    /// parameter has no value to derive the latter from. The dataset comes from `Exchange::ID`.
     ///
-    /// The drop counters are snapshotted here rather than consulted per tick, so the shared lock
-    /// is taken once per connection on this path.
+    /// The drop counters are **snapshotted** here rather than consulted per tick, so the shared
+    /// lock is taken once per connection to read them. Recording still takes it once per emitted
+    /// tick; the critical section there is a hash lookup and a field update.
     pub(super) async fn new(
         instrument_map: Map<InstrumentKey>,
+        initial_snapshots: &[MarketEvent<InstrumentKey, Kind::Event>],
         ws_sink_tx: mpsc::UnboundedSender<WsMessage>,
         resume: Option<(Arc<LseResumeState>, &'static str)>,
     ) -> Result<Self, DataError> {
-        let inner = StatelessTransformer::init(instrument_map, &[], ws_sink_tx).await?;
+        let inner =
+            StatelessTransformer::init(instrument_map, initial_snapshots, ws_sink_tx).await?;
 
         let resume = resume.map(|(state, kind)| ResumeTracker {
             pending: state
                 .snapshot()
                 .into_iter()
-                .filter(|(key, _)| key.kind() == kind)
+                .filter(|(key, _)| key.exchange() == Exchange::ID && key.kind() == kind)
                 .map(|(key, watermark)| (key.into_subscription(), PendingDrop::from(watermark)))
                 .collect(),
             state,
+            exchange: Exchange::ID,
             kind,
         });
 
@@ -111,6 +133,7 @@ impl From<LseWatermark> for PendingDrop {
             time_exchange: watermark.time_exchange,
             remaining: watermark.count_at_time,
             warned_older: false,
+            clamped: false,
         }
     }
 }
@@ -128,14 +151,22 @@ where
     ///
     /// This is the trait's only seam and it is a static function, so it cannot carry the caller's
     /// resume state; the stream that wants resumption bypasses it and constructs the transformer
-    /// directly. Initial snapshots are ignored: this provider serves a tick stream with no book to
-    /// synchronise against, so its streams fetch none.
+    /// directly.
+    ///
+    /// Initial snapshots are forwarded rather than dropped here, so this layer stops being the
+    /// place they are lost. That is as far as forwarding reaches: the inner
+    /// [`StatelessTransformer`]'s own `init` discards the argument unconditionally, as every
+    /// stateless connector's does, and this provider's streams fetch no snapshot for it to
+    /// discard. A future LSE kind that does fetch one would
+    /// need a transformer not backed by `StatelessTransformer` before the snapshot reached it —
+    /// forwarding is what makes that a visible gap rather than one hidden behind a `&[]` at the
+    /// call site.
     async fn init(
         instrument_map: Map<InstrumentKey>,
-        _: &[MarketEvent<InstrumentKey, Kind::Event>],
+        initial_snapshots: &[MarketEvent<InstrumentKey, Kind::Event>],
         ws_sink_tx: mpsc::UnboundedSender<WsMessage>,
     ) -> Result<Self, DataError> {
-        Self::new(instrument_map, ws_sink_tx, None).await
+        Self::new(instrument_map, initial_snapshots, ws_sink_tx, None).await
     }
 }
 
@@ -161,9 +192,29 @@ where
             from,
         } = &input
         {
-            if let Some(resume) = self.resume.as_ref() {
-                resume.warn_if_clamped(Exchange::ID, subscription_id, *from);
+            let (subscription_id, from) = (subscription_id.clone(), *from);
+
+            if let Some(resume) = self.resume.as_mut() {
+                resume.warn_if_clamped(&subscription_id, from);
             }
+
+            return vec![];
+        }
+
+        // A rejection raised *after* the handshake completed -- a later `LIMIT_REACHED`, an
+        // `INVALID_START` on a resumed symbol, an expired credential. The handshake validator
+        // cannot see these: it has already stopped reading. Nothing downstream can act on one
+        // either, since the provider does not name the symbol it rejected, so the frame yields no
+        // market event -- but the stream simply stops producing events for whatever was dropped,
+        // and a rejection is the last thing that may reach the consumer as silence.
+        if let LseMessage::Error { code, message } = &input {
+            warn!(
+                exchange = %Exchange::ID,
+                code = code.as_deref().unwrap_or("unknown"),
+                message = message.as_deref().unwrap_or("no message"),
+                "London Strategic Edge rejected something after the handshake completed; the \
+                 rejection does not name a symbol, so check whether a subscription has gone quiet",
+            );
 
             return vec![];
         }
@@ -184,7 +235,7 @@ where
         };
 
         if let Some(resume) = self.resume.as_mut()
-            && resume.should_drop(Exchange::ID, &subscription_id, time_exchange, replay)
+            && resume.should_drop(&subscription_id, time_exchange, replay)
         {
             return vec![];
         }
@@ -208,11 +259,11 @@ impl ResumeTracker {
     /// Whether this event was already delivered by the connection this one replaced.
     fn should_drop(
         &mut self,
-        exchange: ExchangeId,
         subscription_id: &SubscriptionId,
         time_exchange: DateTime<Utc>,
         replay: bool,
     ) -> bool {
+        let exchange = self.exchange;
         let Some(pending) = self.pending.get_mut(subscription_id) else {
             return false;
         };
@@ -248,7 +299,14 @@ impl ResumeTracker {
             Ordering::Greater => {
                 let undelivered = pending.remaining;
                 let instant = pending.time_exchange;
-                self.pending.remove(subscription_id);
+
+                // The window is closed for good, but the entry is KEPT. It carries the instant that
+                // went out as `start`, which is the only record of what was requested, and the
+                // clamp check reads it out of here when the boundary frame arrives -- removing it
+                // would make a clamp undetectable for any subscription whose first replayed tick
+                // beat its own `replay_started`. Zeroing the count closes the drop window just as
+                // removal did: `Ordering::Equal` with nothing remaining emits.
+                pending.remaining = 0;
 
                 // The replay held fewer events at the watermark's instant than were delivered from
                 // it. Positional skipping assumes the replay reproduces what went out live -- an
@@ -256,7 +314,21 @@ impl ResumeTracker {
                 // 141 events -- so a shortfall means the provider's history changed underneath the
                 // subscription. No event is lost by it, but the assumption is load-bearing enough
                 // that its failure must be visible rather than inferred from a gap much later.
-                if undelivered > 0 {
+                //
+                // Unless the window was clamped, which explains the shortfall completely: the
+                // window does not reach the resume instant at all, so of course nothing replayed at
+                // it. The clamp is reported with the right cause by `warn_if_clamped`.
+                //
+                // `clamped` is only set once the boundary frame has been seen, so the suppression
+                // holds for the measured order -- boundary first -- and not for its reverse. Should
+                // a replayed tick beat its own boundary frame, this warning fires before the clamp
+                // is known and BOTH lines appear, of which only the clamp's is true. That is
+                // tolerated rather than closed: the alternative is to defer this warning until
+                // something proves no clamp is coming, and the only frame that could prove it is
+                // `replay_complete`, whose delivery and ordering are unmeasured -- so deferring
+                // would risk losing a true report entirely to avoid an extra false one. A redundant
+                // line is the cheaper failure.
+                if undelivered > 0 && !pending.clamped {
                     warn!(
                         %exchange,
                         subscription = %subscription_id,
@@ -280,6 +352,12 @@ impl ResumeTracker {
                 // duplicate delivered into consumer state, so it must not be the quiet one. Fired
                 // once per subscription: the condition holds for every replayed tick below the
                 // watermark, and on a busy symbol that is tens of thousands of them.
+                //
+                // The entry now outlives the replay window -- it is kept so a late boundary frame
+                // can still be recognised as a clamp -- so this arm is also reachable long after
+                // the replay ended, for a live tick stamped before the resume instant. That is a
+                // different cause with the same consequence, and the wording names neither rather
+                // than asserting the wrong one.
                 if !pending.warned_older {
                     pending.warned_older = true;
 
@@ -288,8 +366,9 @@ impl ResumeTracker {
                         subscription = %subscription_id,
                         instant = %time_exchange,
                         watermark = %pending.time_exchange,
-                        "London Strategic Edge replayed a tick older than the resume instant, \
-                         which an inclusive `start` should make impossible; it is emitted rather \
+                        "London Strategic Edge delivered a tick older than the resume instant, \
+                         which an inclusive `start` should make impossible during the replay and \
+                         a monotonic feed should make impossible after it; it is emitted rather \
                          than dropped, so expect duplicates back to the instant shown",
                     );
                 }
@@ -310,30 +389,37 @@ impl ResumeTracker {
     /// The watermark is what went out as `start`, so it *is* the requested instant and no separate
     /// record of the request is needed. A window opened exactly at it is not a clamp: `start` is
     /// inclusive, so that is precisely the window asked for.
-    fn warn_if_clamped(
-        &self,
-        exchange: ExchangeId,
-        subscription_id: &SubscriptionId,
-        from: DateTime<Utc>,
-    ) {
-        if let Some(requested) = self.clamped_from(subscription_id, from) {
-            warn!(
-                %exchange,
-                subscription = %subscription_id,
-                requested = %requested,
-                serving_from = %from,
-                "London Strategic Edge clamped the requested replay window; events between the two \
-                 instants are beyond the provider's retention and are permanently lost",
-            );
+    ///
+    /// A detected clamp is also recorded against the subscription, because it explains away the
+    /// shortfall [`should_drop`](Self::should_drop) would otherwise report with a different and
+    /// wrong cause.
+    fn warn_if_clamped(&mut self, subscription_id: &SubscriptionId, from: DateTime<Utc>) {
+        let Some(requested) = self.clamped_from(subscription_id, from) else {
+            return;
+        };
+
+        if let Some(pending) = self.pending.get_mut(subscription_id) {
+            pending.clamped = true;
         }
+
+        warn!(
+            exchange = %self.exchange,
+            subscription = %subscription_id,
+            requested = %requested,
+            serving_from = %from,
+            "London Strategic Edge clamped the requested replay window; events between the two \
+             instants are beyond the provider's retention and are permanently lost",
+        );
     }
 
     /// The instant a window was requested from, if the provider opened it later than that.
     ///
-    /// `None` for a subscription this stream holds no watermark for — one that asked for no window,
-    /// or whose replay has already passed its watermark. The provider announces the boundary before
-    /// serving the window, measured on both a crypto and an FX symbol, so the second case means the
-    /// frames arrived out of order and the requested instant is no longer known here.
+    /// `None` for a subscription this stream holds no watermark for — one that asked for no window.
+    /// An entry is never removed once made, so a boundary frame that arrives *after* the replay has
+    /// already passed the watermark is still answered correctly: the provider is measured to
+    /// announce the window first, on both a crypto and an FX symbol, but under a clamp every
+    /// replayed tick sits past the watermark by definition, so a single reordered frame would
+    /// otherwise be enough to lose the only evidence the window was cut short.
     fn clamped_from(
         &self,
         subscription_id: &SubscriptionId,
@@ -347,10 +433,10 @@ impl ResumeTracker {
         (from > requested).then_some(requested)
     }
 
-    /// Advance the shared watermark for an event this stream delivered.
+    /// Advance the shared watermark for an event this stream emitted.
     fn record(&self, subscription_id: SubscriptionId, time_exchange: DateTime<Utc>) {
         self.state.record(
-            &LseResumeKey::new(subscription_id, self.kind),
+            &LseResumeKey::new(self.exchange, subscription_id, self.kind),
             time_exchange,
         );
     }
@@ -380,7 +466,7 @@ mod tests {
     }
 
     fn key() -> LseResumeKey {
-        LseResumeKey::new(id(), KIND)
+        LseResumeKey::new(ExchangeId::LseCrypto, id(), KIND)
     }
 
     /// A live tick, which carries no `replay` key at all.
@@ -407,7 +493,7 @@ mod tests {
             .collect::<FnvHashMap<SubscriptionId, u8>>());
         let (tx, _rx) = mpsc::unbounded_channel();
 
-        Subject::new(map, tx, resume.map(|state| (state, KIND)))
+        Subject::new(map, &[], tx, resume.map(|state| (state, KIND)))
             .await
             .unwrap()
     }
@@ -631,6 +717,25 @@ mod tests {
         spelling.parse::<DateTime<Utc>>().unwrap()
     }
 
+    /// The boundary frame announcing a window opening at `from`.
+    fn boundary(from: &str) -> LseMessage {
+        serde_json::from_str(&format!(
+            r#"{{"type":"replay_started","symbol":"BTC/USD","from":"{from}"}}"#
+        ))
+        .unwrap()
+    }
+
+    /// This subject's per-connection bookkeeping for the one subscription these tests use.
+    fn pending_for(subject: &Subject) -> PendingDrop {
+        *subject
+            .resume
+            .as_ref()
+            .unwrap()
+            .pending
+            .get(&id())
+            .unwrap_or_else(|| panic!("the resumed subject must hold an entry for {}", id()))
+    }
+
     /// The provider retains 24 hours and moves an older `start` forward with no error, so the
     /// boundary frame's `from` is the only evidence the requested window was not the served one.
     #[tokio::test]
@@ -679,6 +784,93 @@ mod tests {
                 .clamped_from(&id(), at("2026-08-13T10:00:00Z")),
             None,
         );
+    }
+
+    /// A clamp explains the shortfall at the resume instant completely — the window does not reach
+    /// it — so the shortfall must not *also* be reported as the provider's history changing under
+    /// the subscription. Two reports with different causes for one event is worse than one, because
+    /// only one of them is true.
+    #[tokio::test]
+    async fn a_clamped_window_is_not_also_reported_as_a_changed_history() {
+        let state = Arc::new(LseResumeState::new());
+        let mut subject = resumed_at(&state, "2026-08-12T10:00:00Z").await;
+
+        // The provider answers with a window opening a day later than asked for.
+        subject.transform(boundary("2026-08-13T10:00:00Z"));
+
+        let pending = pending_for(&subject);
+        assert!(
+            pending.clamped,
+            "the clamp must be recorded, not only logged"
+        );
+        assert_eq!(
+            pending.remaining, 1,
+            "the drop window is still open until a tick passes the resume instant",
+        );
+
+        // Every replayed tick under a clamp sits past the watermark by definition, so the first one
+        // closes the window with the count unspent. That shortfall has one cause and it is the
+        // clamp.
+        assert_eq!(
+            subject
+                .transform(replayed_tick("2026-08-13T10:00:00.000001Z", "1.0"))
+                .len(),
+            1,
+        );
+
+        let pending = pending_for(&subject);
+        assert_eq!(pending.remaining, 0, "the drop window must be closed");
+        assert!(
+            pending.clamped,
+            "the clamp flag is what suppresses the wrong-cause report and must survive the frame \
+             that closes the window",
+        );
+    }
+
+    /// The boundary frame is measured to arrive first, but a single reordered frame must not lose
+    /// the only evidence the window was cut short. The entry is therefore kept rather than removed
+    /// once the replay passes the watermark, so the clamp is still detected when the first replayed
+    /// tick beats its own boundary frame.
+    #[tokio::test]
+    async fn a_clamp_is_still_detected_when_a_replayed_tick_beats_the_boundary_frame() {
+        let state = Arc::new(LseResumeState::new());
+        let mut subject = resumed_at(&state, "2026-08-12T10:00:00Z").await;
+
+        // The tick arrives first and closes the drop window, as every tick under a clamp does.
+        assert_eq!(
+            subject
+                .transform(replayed_tick("2026-08-13T10:00:00.000001Z", "1.0"))
+                .len(),
+            1,
+        );
+
+        // The boundary frame follows. The requested instant must still be readable.
+        assert_eq!(
+            subject
+                .resume
+                .as_ref()
+                .unwrap()
+                .clamped_from(&id(), at("2026-08-13T10:00:00Z")),
+            Some(at("2026-08-12T10:00:00Z")),
+            "the requested instant is the only record of what was asked for and must outlive the \
+             drop window",
+        );
+    }
+
+    /// A rejection raised after the handshake stopped reading carries no instrument and no instant.
+    /// It is consumed for its `warn!` and must not reach a decoder or the watermark.
+    #[tokio::test]
+    async fn a_rejection_yields_no_market_event_and_does_not_advance_the_watermark() {
+        let state = Arc::new(LseResumeState::new());
+        let mut subject = subject(Some(Arc::clone(&state))).await;
+
+        let rejection: LseMessage = serde_json::from_str(
+            r#"{"type":"error","code":"INVALID_START","message":"Invalid start"}"#,
+        )
+        .unwrap();
+
+        assert!(subject.transform(rejection).is_empty());
+        assert_eq!(state.watermark(&key()), None);
     }
 
     /// The frame is the only evidence a requested window was clamped, and it reaches the stream

--- a/rustrade-data/src/exchange/lse/transformer.rs
+++ b/rustrade-data/src/exchange/lse/transformer.rs
@@ -1,0 +1,414 @@
+//! The London Strategic Edge stream transformer.
+//!
+//! Decoding is delegated wholesale to [`StatelessTransformer`] — one provider frame maps to one
+//! event and nothing about it needs state. What this type adds is the consuming half of
+//! [`resume`](super::resume): skipping the events a reconnect's replay re-delivers.
+
+use super::{
+    resume::{LseResumeState, LseWatermark},
+    tick::LseMessage,
+};
+use crate::{
+    Identifier,
+    error::DataError,
+    event::{MarketEvent, MarketIter},
+    exchange::Connector,
+    subscription::{Map, SubscriptionKind},
+    transformer::{ExchangeTransformer, stateless::StatelessTransformer},
+};
+use chrono::{DateTime, Utc};
+use fnv::FnvHashMap;
+use rustrade_instrument::exchange::ExchangeId;
+use rustrade_integration::{
+    Transformer, protocol::websocket::WsMessage, subscription::SubscriptionId,
+};
+use serde::Deserialize;
+use std::{cmp::Ordering, sync::Arc};
+use tokio::sync::mpsc;
+use tracing::warn;
+
+/// Transformer for every London Strategic Edge subscription kind.
+///
+/// Carries no resume state unless the caller opted in via
+/// [`LseSubscriber::with_resume`](super::live::LseSubscriber::with_resume); without it this is a
+/// direct pass-through to [`StatelessTransformer`].
+#[derive(Debug)]
+pub struct LseTransformer<Exchange, InstrumentKey, Kind> {
+    inner: StatelessTransformer<Exchange, InstrumentKey, Kind, LseMessage>,
+    resume: Option<ResumeTracker>,
+}
+
+/// Per-connection resume bookkeeping: the shared watermark, and what this connection still owes
+/// the replay window.
+#[derive(Debug)]
+struct ResumeTracker {
+    state: Arc<LseResumeState>,
+    pending: FnvHashMap<SubscriptionId, PendingDrop>,
+}
+
+/// Events still expected to arrive twice for one subscription, and the instant they carry.
+#[derive(Copy, Clone, Debug)]
+struct PendingDrop {
+    time_exchange: DateTime<Utc>,
+    remaining: usize,
+}
+
+impl<Exchange, InstrumentKey, Kind> LseTransformer<Exchange, InstrumentKey, Kind>
+where
+    Exchange: Connector + Send,
+    InstrumentKey: Clone + Send + Sync,
+    Kind: SubscriptionKind + Send,
+    Kind::Event: Sync,
+    MarketIter<InstrumentKey, Kind::Event>: From<(ExchangeId, InstrumentKey, LseMessage)>,
+{
+    /// Construct a transformer, optionally resuming from previously delivered events.
+    ///
+    /// The drop counters are snapshotted here rather than consulted per tick, so the shared lock
+    /// is taken once per connection on this path.
+    pub(super) async fn new(
+        instrument_map: Map<InstrumentKey>,
+        ws_sink_tx: mpsc::UnboundedSender<WsMessage>,
+        resume: Option<Arc<LseResumeState>>,
+    ) -> Result<Self, DataError> {
+        let inner = StatelessTransformer::init(instrument_map, &[], ws_sink_tx).await?;
+
+        let resume = resume.map(|state| ResumeTracker {
+            pending: state
+                .snapshot()
+                .into_iter()
+                .map(|(subscription_id, watermark)| (subscription_id, PendingDrop::from(watermark)))
+                .collect(),
+            state,
+        });
+
+        Ok(Self { inner, resume })
+    }
+}
+
+impl From<LseWatermark> for PendingDrop {
+    fn from(watermark: LseWatermark) -> Self {
+        Self {
+            time_exchange: watermark.time_exchange,
+            remaining: watermark.count_at_time,
+        }
+    }
+}
+
+impl<Exchange, InstrumentKey, Kind> ExchangeTransformer<Exchange, InstrumentKey, Kind>
+    for LseTransformer<Exchange, InstrumentKey, Kind>
+where
+    Exchange: Connector + Send,
+    InstrumentKey: Clone + Send + Sync,
+    Kind: SubscriptionKind + Send,
+    Kind::Event: Sync,
+    MarketIter<InstrumentKey, Kind::Event>: From<(ExchangeId, InstrumentKey, LseMessage)>,
+{
+    /// Initialise without resumption.
+    ///
+    /// This is the trait's only seam and it is a static function, so it cannot carry the caller's
+    /// resume state; the stream that wants resumption bypasses it and constructs the transformer
+    /// directly. Initial snapshots are ignored: this provider serves a tick stream with no book to
+    /// synchronise against, so its streams fetch none.
+    async fn init(
+        instrument_map: Map<InstrumentKey>,
+        _: &[MarketEvent<InstrumentKey, Kind::Event>],
+        ws_sink_tx: mpsc::UnboundedSender<WsMessage>,
+    ) -> Result<Self, DataError> {
+        Self::new(instrument_map, ws_sink_tx, None).await
+    }
+}
+
+impl<Exchange, InstrumentKey, Kind> Transformer for LseTransformer<Exchange, InstrumentKey, Kind>
+where
+    Exchange: Connector,
+    InstrumentKey: Clone,
+    Kind: SubscriptionKind,
+    MarketIter<InstrumentKey, Kind::Event>: From<(ExchangeId, InstrumentKey, LseMessage)>,
+{
+    type Error = DataError;
+    type Input = LseMessage;
+    type Output = MarketEvent<InstrumentKey, Kind::Event>;
+    type OutputIter = Vec<Result<Self::Output, Self::Error>>;
+
+    fn transform(&mut self, input: Self::Input) -> Self::OutputIter {
+        // Nothing to track when the caller did not opt in, and a control frame carries no instant
+        // to track. Both go straight through.
+        let Some((subscription_id, time_exchange)) =
+            self.resume.as_ref().and_then(|_| match &input {
+                LseMessage::Tick(tick) => Some((tick.subscription_id.clone(), tick.time_exchange)),
+                LseMessage::Other => None,
+            })
+        else {
+            return self.inner.transform(input);
+        };
+
+        if let Some(resume) = self.resume.as_mut()
+            && resume.should_drop(&subscription_id, time_exchange)
+        {
+            return vec![];
+        }
+
+        let output = self.inner.transform(input);
+
+        // Record against what was actually emitted. An unidentifiable instrument yields an error
+        // rather than an event, and a watermark advanced past an event nobody received would
+        // leave a gap on the next reconnect.
+        if let Some(resume) = self.resume.as_ref()
+            && output.iter().any(Result::is_ok)
+        {
+            resume.state.record(&subscription_id, time_exchange);
+        }
+
+        output
+    }
+}
+
+impl ResumeTracker {
+    /// Whether this event was already delivered by the connection this one replaced.
+    fn should_drop(
+        &mut self,
+        subscription_id: &SubscriptionId,
+        time_exchange: DateTime<Utc>,
+    ) -> bool {
+        let Some(pending) = self.pending.get(subscription_id).copied() else {
+            return false;
+        };
+
+        match time_exchange.cmp(&pending.time_exchange) {
+            // Inside the instant the watermark names, and the previous connection is known to have
+            // delivered this many events there. `start` is inclusive, so the provider replays them
+            // all and they are skipped by position.
+            Ordering::Equal if pending.remaining > 0 => {
+                if let Some(pending) = self.pending.get_mut(subscription_id) {
+                    pending.remaining -= 1;
+                }
+                true
+            }
+            // The instant is exhausted; anything further carrying it is genuinely new.
+            Ordering::Equal => false,
+            Ordering::Greater => {
+                self.pending.remove(subscription_id);
+
+                // The replay held fewer events at the watermark's instant than were delivered from
+                // it. Positional skipping assumes the replay reproduces what went out live -- an
+                // assumption that holds on every measurement taken, including one instant carrying
+                // 141 events -- so a shortfall means the provider's history changed underneath the
+                // subscription. No event is lost by it, but the assumption is load-bearing enough
+                // that its failure must be visible rather than inferred from a gap much later.
+                if pending.remaining > 0 {
+                    warn!(
+                        subscription = %subscription_id,
+                        instant = %pending.time_exchange,
+                        undelivered = pending.remaining,
+                        "London Strategic Edge replay held fewer ticks at the resume instant than \
+                         were delivered from it; the provider's history changed under the resume",
+                    );
+                }
+
+                false
+            }
+            // Older than the watermark. `start` is inclusive, so the provider should never send
+            // this; emitting is the safe answer, since dropping would discard a real event on the
+            // strength of an assumption that has already been contradicted.
+            Ordering::Less => false,
+        }
+    }
+}
+
+/// Bound required by [`StatelessTransformer`]'s decode path, restated here so this module's own
+/// bounds stay legible.
+const _: fn() = || {
+    fn assert_identifiable<T: Identifier<Option<SubscriptionId>> + for<'de> Deserialize<'de>>() {}
+    assert_identifiable::<LseMessage>();
+};
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Test code: panics on bad input are acceptable
+mod tests {
+    use super::*;
+    use crate::{exchange::lse::LseCrypto, subscription::trade::PublicTrades};
+    use rustrade_integration::subscription::SubscriptionId;
+
+    type Subject = LseTransformer<LseCrypto, u8, PublicTrades>;
+
+    fn id() -> SubscriptionId {
+        super::super::resume::subscription_id("BTC/USD")
+    }
+
+    fn tick(ts: &str, price: &str) -> LseMessage {
+        serde_json::from_str(&format!(
+            r#"{{"type":"tick","symbol":"BTC/USD","ts":"{ts}","price":{price},
+                "bid":{price},"ask":42001.0,"volume":0.00155}}"#
+        ))
+        .unwrap()
+    }
+
+    async fn subject(resume: Option<Arc<LseResumeState>>) -> Subject {
+        let map = Map([(id(), 1_u8)]
+            .into_iter()
+            .collect::<FnvHashMap<SubscriptionId, u8>>());
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        Subject::new(map, tx, resume).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn without_resume_every_tick_is_emitted() {
+        let mut subject = subject(None).await;
+
+        assert_eq!(
+            subject.transform(tick("2026-01-02T09:00:00Z", "1.0")).len(),
+            1
+        );
+        assert_eq!(
+            subject.transform(tick("2026-01-02T09:00:00Z", "1.0")).len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn with_resume_the_watermark_advances_on_emitted_ticks() {
+        let state = Arc::new(LseResumeState::new());
+        let mut subject = subject(Some(Arc::clone(&state))).await;
+
+        subject.transform(tick("2026-01-02T09:00:00.000001Z", "1.0"));
+        subject.transform(tick("2026-01-02T09:00:00.000001Z", "2.0"));
+
+        let watermark = state.watermark(&id()).unwrap();
+        assert_eq!(
+            watermark.time_exchange,
+            "2026-01-02T09:00:00.000001Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+        assert_eq!(watermark.count_at_time, 2);
+    }
+
+    /// The core of the mechanism: a reconnect replays the whole of the watermark's instant because
+    /// `start` is inclusive, and exactly the already-delivered prefix is skipped.
+    #[tokio::test]
+    async fn a_replay_skips_exactly_the_ticks_already_delivered_at_the_resume_instant() {
+        let state = Arc::new(LseResumeState::new());
+
+        // First connection delivers three ticks sharing one instant.
+        let mut first = subject(Some(Arc::clone(&state))).await;
+        for price in ["1.0", "2.0", "3.0"] {
+            first.transform(tick("2026-01-02T09:00:00.000001Z", price));
+        }
+        assert_eq!(state.watermark(&id()).unwrap().count_at_time, 3);
+
+        // Reconnect: the provider replays all three, then a fourth that is genuinely new.
+        let mut second = subject(Some(Arc::clone(&state))).await;
+        for price in ["1.0", "2.0", "3.0"] {
+            assert!(
+                second
+                    .transform(tick("2026-01-02T09:00:00.000001Z", price))
+                    .is_empty(),
+                "an already-delivered tick must not be emitted twice"
+            );
+        }
+
+        assert_eq!(
+            second
+                .transform(tick("2026-01-02T09:00:00.000001Z", "4.0"))
+                .len(),
+            1,
+            "a fourth tick at the same instant is new and must be emitted"
+        );
+        assert_eq!(state.watermark(&id()).unwrap().count_at_time, 4);
+    }
+
+    /// The gap half of the contract: everything after the resume instant is new, always.
+    #[tokio::test]
+    async fn a_replay_emits_every_tick_past_the_resume_instant() {
+        let state = Arc::new(LseResumeState::new());
+
+        let mut first = subject(Some(Arc::clone(&state))).await;
+        first.transform(tick("2026-01-02T09:00:00.000001Z", "1.0"));
+
+        let mut second = subject(Some(Arc::clone(&state))).await;
+        assert!(
+            second
+                .transform(tick("2026-01-02T09:00:00.000001Z", "1.0"))
+                .is_empty()
+        );
+        assert_eq!(
+            second
+                .transform(tick("2026-01-02T09:00:00.000002Z", "2.0"))
+                .len(),
+            1,
+            "one microsecond later is past the resume instant and must be emitted"
+        );
+    }
+
+    /// The drop window closes for good once the instant is passed, so a later tick that happens to
+    /// carry the resume instant again cannot be swallowed.
+    #[tokio::test]
+    async fn the_drop_window_does_not_reopen_after_the_resume_instant_is_passed() {
+        let state = Arc::new(LseResumeState::new());
+
+        let mut first = subject(Some(Arc::clone(&state))).await;
+        first.transform(tick("2026-01-02T09:00:00.000001Z", "1.0"));
+        first.transform(tick("2026-01-02T09:00:00.000001Z", "2.0"));
+
+        let mut second = subject(Some(Arc::clone(&state))).await;
+        // Replay is short by one, then moves past the instant -- the window closes here.
+        assert!(
+            second
+                .transform(tick("2026-01-02T09:00:00.000001Z", "1.0"))
+                .is_empty()
+        );
+        assert_eq!(
+            second
+                .transform(tick("2026-01-02T09:00:00.000002Z", "2.0"))
+                .len(),
+            1
+        );
+        assert_eq!(
+            second
+                .transform(tick("2026-01-02T09:00:00.000001Z", "3.0"))
+                .len(),
+            1,
+            "the window is closed; a tick at the old instant must be emitted, not dropped"
+        );
+    }
+
+    /// A subscription with no history resumes as a fresh subscription would.
+    #[tokio::test]
+    async fn a_subscription_with_no_watermark_drops_nothing() {
+        let state = Arc::new(LseResumeState::new());
+        let mut subject = subject(Some(state)).await;
+
+        assert_eq!(
+            subject.transform(tick("2026-01-02T09:00:00Z", "1.0")).len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_control_frame_is_neither_emitted_nor_recorded() {
+        let state = Arc::new(LseResumeState::new());
+        let mut subject = subject(Some(Arc::clone(&state))).await;
+
+        let frame: LseMessage =
+            serde_json::from_str(r#"{"type":"replay_complete","symbol":"BTC/USD","rows":41}"#)
+                .unwrap();
+
+        assert!(subject.transform(frame).is_empty());
+        assert_eq!(state.watermark(&id()), None);
+    }
+
+    /// The no-dedupe lock, restated at the transformer: identical repeats are genuine distinct
+    /// prints and only the resume prefix may ever be skipped.
+    #[tokio::test]
+    async fn identical_live_ticks_are_never_deduplicated() {
+        let state = Arc::new(LseResumeState::new());
+        let mut subject = subject(Some(state)).await;
+
+        let first = subject.transform(tick("2026-01-02T09:00:00.000001Z", "1.0"));
+        let second = subject.transform(tick("2026-01-02T09:00:00.000001Z", "1.0"));
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1, "an identical repeat is a distinct print");
+    }
+}

--- a/rustrade-data/src/exchange/mod.rs
+++ b/rustrade-data/src/exchange/mod.rs
@@ -56,9 +56,10 @@ pub mod databento;
 #[cfg(feature = "massive")]
 pub mod massive;
 
-/// `London Strategic Edge` market data (behind `lse` feature).
-///
-/// ⚠️ The retrieved data is **not redistributable** — see the module documentation.
+// No `///` here, unlike its siblings: that file carries its own `//!` documentation, and supplying
+// both makes rustdoc resolve the file's inner links in THIS module's scope rather than the child's,
+// so every one of them renders as dead text. Its summary and the redistribution warning open that
+// file's first paragraph instead.
 #[cfg(feature = "lse")]
 pub mod lse;
 

--- a/rustrade-data/src/lib.rs
+++ b/rustrade-data/src/lib.rs
@@ -141,6 +141,13 @@ use http as _;
 // only when that feature is off.)
 #[cfg(test)]
 use {hex as _, sha2 as _, tempfile as _};
+// tokio_tungstenite is a dev-dependency for the `lse` WebSocket handshake test
+// (tests/lse_ws_handshake.rs), which speaks the server half of the protocol in-process and compiles
+// as a separate unit. It is *also* a non-dev dependency under the `massive` feature, where the lib
+// itself uses it -- so this stub matters only when that feature is off, and the `cfg(test)` gate is
+// load-bearing: an unconditional `use` would fail to resolve in a non-test build without `massive`.
+#[cfg(test)]
+use tokio_tungstenite as _;
 
 use crate::{
     error::DataError,

--- a/rustrade-data/src/subscription/mod.rs
+++ b/rustrade-data/src/subscription/mod.rs
@@ -325,6 +325,33 @@ pub fn exchange_supports_instrument_kind_sub_kind(
         (Okx, Spot | Future { .. } | Perpetual | Option { .. }, PublicTrades) => true,
         (HyperliquidPerp, Perpetual, PublicTrades | OrderBooksL2) => true,
 
+        // London Strategic Edge serves both kinds from ONE frame: its WebSocket publishes a single
+        // tick carrying `price`, `bid`, `ask` and `volume` together, so a dataset that serves one
+        // of these kinds necessarily serves the other. The two arms differ only in instrument kind,
+        // which is fixed per dataset.
+        //
+        // ⚠️ A `PublicTrade` from this feed MAY NOT BE A PRINT. The tick's `price` equals its `bid`
+        // on every sample taken -- 3,966 of 3,966 ticks spanning every dataset family -- so a trade
+        // decoded from it is a bid-side quote wearing a trade's shape, and its arrival is not
+        // evidence that a transaction occurred, at that price or at all.
+        //
+        // ⚠️ And its `amount` is genuine on two of these venues and FABRICATED on the other two,
+        // with no in-band signal separating them. `LseCrypto` and `LseEquities` carry a real
+        // per-tick size, which reconciles against the provider's own one-minute candles to the last
+        // decimal. `LseFx` and `LseCfd` carry a hard-coded `1.0` on every tick of every symbol
+        // sampled -- a placeholder that, being a plausible positive number, aggregates into a
+        // legitimate-looking total at any resolution, leaving volume-weighted prices and size
+        // filters on those two meaningless rather than merely imprecise.
+        //
+        // Support is declared regardless, and uniformly: the frame is identical across datasets, so
+        // withholding the kind would hide the feed rather than the hazard. Saying so is the useful
+        // answer. The full reasoning lives on the trade decoder in the `lse` module.
+        (LseFx | LseCrypto | LseEquities, Spot, PublicTrades | OrderBooksL1) => true,
+        (LseCfd | LseFutures, Cfd, PublicTrades | OrderBooksL1) => true,
+        // No `Candles` arm exists for any London Strategic Edge venue, deliberately: the provider's
+        // WebSocket carries no candle channel at all -- the tick above is its only data frame, so
+        // there is nothing to subscribe to. Its candles are served exclusively over the REST vault,
+        // by a path that never reaches this matrix. The absence is a decision, not an omission.
         (_, _, _) => false,
     }
 }
@@ -439,6 +466,76 @@ mod tests {
                     !exchange_supports_instrument_kind(exchange, &MarketDataInstrumentKind::Cfd),
                     "{exchange:?} should not support Cfd"
                 );
+            }
+        }
+
+        #[test]
+        fn test_lse_supports_both_tick_derived_sub_kinds_for_its_own_kind_only() {
+            // One tick frame carries price, bid, ask and size together, so every dataset serves
+            // both kinds decoded from it -- and serves neither under an instrument kind it does
+            // not model.
+            for (exchange, supported) in LSE {
+                for sub_kind in [SubKind::PublicTrades, SubKind::OrderBooksL1] {
+                    assert!(
+                        exchange_supports_instrument_kind_sub_kind(&exchange, &supported, sub_kind),
+                        "{exchange:?} should support ({supported:?}, {sub_kind})"
+                    );
+
+                    for denied in [
+                        MarketDataInstrumentKind::Spot,
+                        MarketDataInstrumentKind::Cfd,
+                        MarketDataInstrumentKind::Perpetual,
+                    ] {
+                        if denied == supported {
+                            continue;
+                        }
+                        assert!(
+                            !exchange_supports_instrument_kind_sub_kind(
+                                &exchange, &denied, sub_kind
+                            ),
+                            "{exchange:?} should not support ({denied:?}, {sub_kind})"
+                        );
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn test_lse_serves_no_candle_stream_at_any_interval() {
+            // Pins the absent `Candles` arm as a decision: the provider's WebSocket has no candle
+            // channel, and its candles reach users over the REST vault, which never consults this
+            // matrix. A future edit that "completes" the LSE rows fails here.
+            for (exchange, kind) in LSE {
+                for interval in CandleInterval::ALL {
+                    assert!(
+                        !exchange_supports_instrument_kind_sub_kind(
+                            &exchange,
+                            &kind,
+                            SubKind::Candles { interval },
+                        ),
+                        "{exchange:?} serves no candle stream, including {interval:?}"
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn test_lse_denies_sub_kinds_its_tick_cannot_serve() {
+            // The tick is top-of-book, so there is no depth to serve; the feed publishes no
+            // liquidations at all. `Quotes` is denied here as it is for every other venue -- no
+            // exchange declares it in this matrix.
+            for (exchange, kind) in LSE {
+                for sub_kind in [
+                    SubKind::OrderBooksL2,
+                    SubKind::OrderBooksL3,
+                    SubKind::Liquidations,
+                    SubKind::Quotes,
+                ] {
+                    assert!(
+                        !exchange_supports_instrument_kind_sub_kind(&exchange, &kind, sub_kind),
+                        "{exchange:?} should not support ({kind:?}, {sub_kind})"
+                    );
+                }
             }
         }
     }

--- a/rustrade-data/tests/lse_ws_canary.rs
+++ b/rustrade-data/tests/lse_ws_canary.rs
@@ -1,0 +1,310 @@
+//! London Strategic Edge WebSocket shape canary (network + credential gated).
+//!
+//! # Why this exists
+//!
+//! `lse_ws_handshake.rs` drives this integration against a synthetic server, which proves the client
+//! behaves correctly *given* the protocol as this repository understands it. Nothing in it can
+//! notice that the provider's understanding has changed. That is this file's job, and it is the only
+//! test in the crate that ever reaches the real socket — the provider prohibits redistributing its
+//! data (<https://londonstrategicedge.com/terms>), so no recorded frame may be committed here and
+//! every other test is necessarily synthetic.
+//!
+//! # ⚠️ What it deliberately does NOT assert
+//!
+//! **No counts.** The published symbol list moved from 7,940 to 8,516 entries inside a week, and
+//! the subscription cap is a plan attribute the provider may revise. A canary that pinned either
+//! would fail for a reason that is not a defect, and would then be muted — which costs more than it
+//! ever caught. Support is asserted structurally instead: the guards either work against the real
+//! list or they do not.
+//!
+//! # The three signals it does assert
+//!
+//! 1. **Every subscribed symbol actually ticks.** This surface's quietest failure is a subscription
+//!    that is *confirmed and then silent* — the provider answers `subscribed` for a symbol it does
+//!    not serve, never errors, and holds the slot for the life of the connection. A shape check on
+//!    whichever frames happen to arrive cannot see it, because the frames that arrive are fine; it
+//!    is the absent ones that matter. So delivery is required per symbol, not in aggregate.
+//! 2. **A tick's decoded instant is close to now.** The provider spells `ts` three ways and changes
+//!    spelling per dataset and between live and replayed frames. Every one of those spellings
+//!    decodes to *a* `DateTime` — a seconds-vs-milliseconds epoch misread lands in 1970 or in the
+//!    fifty-third century, and a dropped timezone lands hours out — so the decode cannot be checked
+//!    by whether it succeeded, only by whether the answer is plausible.
+//! 3. **A symbol the provider does not offer is rejected before subscribing.** This passes only if
+//!    the `authenticated` frame still carries a usable symbol list: were the list to disappear or be
+//!    renamed, the guard degrades to a warning by design, the provider confirms the bogus symbol,
+//!    and the batch would succeed. That silent degradation is exactly what this catches.
+//!
+//! # Skip vs. fail contract
+//!
+//! - `LSE_API_KEY` **unset** → **SKIP** (logged, test passes), so CI without secrets stays green.
+//! - `LSE_API_KEY` set but unusable → **FAIL**. A skip here would be indistinguishable from "no
+//!   secrets configured", so a mistyped key would report green forever.
+//! - Key present but an assertion fails → **FAIL** (the real signal).
+//!
+//! One test additionally skips on silence, and says so loudly: the venue it covers is the only way
+//! to reach the space-separated timestamp spelling, and it trades outside crypto's hours. A
+//! `CANARY_SKIP` line is never a pass — rerun while that market is open.
+//!
+//! # Running
+//!
+//! ```bash
+//! set -a && . ./.env && set +a
+//! cargo test --test lse_ws_canary --features lse -- --ignored --nocapture
+//! ```
+//!
+//! Marked `#[ignore]` so a default test run never opens a connection or spends the shared
+//! allowance.
+
+#![cfg(feature = "lse")]
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use futures_util::{Stream, StreamExt};
+use rustrade_data::{
+    event::MarketEvent,
+    exchange::lse::{LseCfd, LseCrypto, live::LseSubscriber},
+    streams::{
+        Streams,
+        reconnect::{Event, stream::ReconnectingStream},
+    },
+    subscriber::Subscriber,
+    subscription::{Subscription, trade::PublicTrade, trade::PublicTrades},
+};
+use rustrade_instrument::{
+    exchange::ExchangeId,
+    instrument::market_data::{MarketDataInstrument, kind::MarketDataInstrumentKind},
+};
+use std::time::Duration;
+use tokio::time::Instant;
+
+const KEY_ENV: &str = "LSE_API_KEY";
+
+/// How long to wait for every subscribed symbol to tick.
+///
+/// Generous against the measured rates — one busy crypto symbol replayed six figures of ticks per
+/// hour — so a timeout here means silence, not slowness.
+const DELIVERY_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// How far behind now a live tick may be stamped before the decode is treated as wrong.
+///
+/// Wide enough to absorb clock skew and a quiet minute on a thin symbol, and far narrower than any
+/// epoch or timezone misread: those miss by decades or by whole hours.
+const MAX_TICK_AGE: ChronoDuration = ChronoDuration::minutes(10);
+
+/// How far ahead of now a live tick may be stamped.
+///
+/// Non-zero only for clock skew — the provider stamps in the past by construction.
+const MAX_TICK_LEAD: ChronoDuration = ChronoDuration::minutes(2);
+
+/// Build a subscriber, or `None` when the key is **absent** (skip rather than fail).
+///
+/// Only an unset variable skips. A key that is *set but unusable* — a stray newline from a `.env`
+/// edit, a mis-encoded paste — is a misconfiguration, and reporting it as a skip would let this
+/// canary pass green while never once reaching the provider, which is exactly the state it exists
+/// to detect. The error is safe to print: the credential type redacts the key from every message.
+fn subscriber() -> Option<LseSubscriber> {
+    if std::env::var_os(KEY_ENV).is_none() {
+        println!("CANARY_SKIP: {KEY_ENV} is not set - skipping");
+        return None;
+    }
+
+    Some(
+        LseSubscriber::from_env()
+            .unwrap_or_else(|error| panic!("{KEY_ENV} is set but unusable: {error}")),
+    )
+}
+
+fn spot(base: &str) -> MarketDataInstrument {
+    MarketDataInstrument::from((base, "usd", MarketDataInstrumentKind::Spot))
+}
+
+fn cfd(base: &str) -> MarketDataInstrument {
+    MarketDataInstrument::from((base, "usd", MarketDataInstrumentKind::Cfd))
+}
+
+/// Fail if a tick's decoded instant is not plausibly live.
+///
+/// See signal 2 in the module header: every spelling the provider uses decodes to *some* instant,
+/// so plausibility is the only available check on whether it decoded to the right one.
+fn assert_stamped_near_now(instrument: &MarketDataInstrument, time_exchange: DateTime<Utc>) {
+    let now = Utc::now();
+    let age = now - time_exchange;
+
+    assert!(
+        age <= MAX_TICK_AGE,
+        "{instrument} ticked at {time_exchange}, {age} behind now - a live tick should be recent, \
+         so the timestamp decode has probably misread the provider's spelling",
+    );
+    assert!(
+        -age <= MAX_TICK_LEAD,
+        "{instrument} ticked at {time_exchange}, {} ahead of now - a live tick cannot be stamped in \
+         the future beyond clock skew, so the timestamp decode has probably misread the provider's \
+         spelling",
+        -age,
+    );
+}
+
+/// Drive `stream` until every instrument in `expected` has delivered a tick, or the deadline.
+///
+/// Returns the instruments that never ticked, so the caller decides whether silence is a failure
+/// (a 24/7 venue) or a skip (a venue that closes).
+async fn collect_first_tick_per_instrument<S>(
+    mut stream: S,
+    expected: &[MarketDataInstrument],
+) -> Vec<MarketDataInstrument>
+where
+    S: Stream<Item = Event<ExchangeId, MarketEvent<MarketDataInstrument, PublicTrade>>> + Unpin,
+{
+    let mut pending = expected.to_vec();
+    let deadline = Instant::now() + DELIVERY_TIMEOUT;
+
+    // One deadline governs the whole wait, so there is no per-iteration clock arithmetic and no
+    // chance of spinning once the stream goes quiet.
+    let _ = tokio::time::timeout_at(deadline, async {
+        while !pending.is_empty() {
+            match stream.next().await {
+                Some(Event::Item(event)) => {
+                    // Checked on every tick rather than only the first: the provider changes `ts`
+                    // spelling between datasets, and a stream that begins well can still carry a
+                    // frame this integration reads wrongly.
+                    assert_stamped_near_now(&event.instrument, event.time_exchange);
+
+                    if let Some(index) = pending.iter().position(|i| *i == event.instrument) {
+                        let delivered = pending.swap_remove(index);
+                        println!("CANARY_OK: {delivered} delivered a live tick");
+                    }
+                }
+                // Logged rather than ignored: a reconnect mid-window is the likeliest innocent
+                // cause of a timeout, and distinguishing it from silence matters when reading a
+                // failure.
+                Some(Event::Reconnecting(origin)) => {
+                    println!("CANARY: {origin} is reconnecting mid-test");
+                }
+                // The reconnecting stream should never exhaust; if it has, the consumer task died.
+                None => panic!("the market stream terminated before delivering every symbol"),
+            }
+        }
+    })
+    .await;
+
+    pending
+}
+
+#[tokio::test]
+#[ignore = "opens a live connection and spends the shared provider allowance; run on demand"]
+async fn every_subscribed_crypto_symbol_delivers_a_live_tick() {
+    let Some(subscriber) = subscriber() else {
+        return;
+    };
+
+    // Crypto because it is the one dataset family that trades continuously: on any other, silence
+    // is ambiguous between "closed" and "confirmed but never served", and this test exists to make
+    // that distinction unambiguous.
+    let expected = [spot("btc"), spot("eth")];
+
+    let streams = Streams::<PublicTrades>::builder()
+        .subscribe(
+            subscriber,
+            expected.clone().map(|instrument| {
+                Subscription::<LseCrypto, MarketDataInstrument, PublicTrades>::new(
+                    LseCrypto::default(),
+                    instrument,
+                    PublicTrades,
+                )
+            }),
+        )
+        .init()
+        .await
+        .expect("subscribing to continuously-traded crypto symbols should succeed");
+
+    // Decode failures are reported rather than swallowed: they are themselves a shape-change
+    // signal, and they explain a delivery timeout that would otherwise read as silence.
+    let stream = streams
+        .select_all()
+        .with_error_handler(|error| println!("CANARY: market stream error: {error:?}"));
+    let silent = collect_first_tick_per_instrument(Box::pin(stream), &expected).await;
+
+    assert!(
+        silent.is_empty(),
+        "{silent:?} were confirmed but delivered no tick in {DELIVERY_TIMEOUT:?} - on a \
+         continuously-traded venue that is the confirmed-then-silent failure this integration's \
+         pre-subscribe guard exists to prevent, which means the guard's symbol list no longer \
+         reflects what the provider actually serves",
+    );
+}
+
+/// Covers the space-separated timestamp spelling, which the crypto test above cannot reach: the
+/// provider sends `2026-01-02 09:37:21.690159+00:00` on this venue and the `T`-separated form on
+/// crypto, and [`DateTime::parse_from_rfc3339`] rejects the former outright.
+#[tokio::test]
+#[ignore = "opens a live connection and spends the shared provider allowance; run on demand"]
+async fn a_cfd_tick_decodes_to_a_plausible_instant() {
+    let Some(subscriber) = subscriber() else {
+        return;
+    };
+
+    let expected = [cfd("xau")];
+
+    let streams = Streams::<PublicTrades>::builder()
+        .subscribe(
+            subscriber,
+            expected.clone().map(|instrument| {
+                Subscription::<LseCfd, MarketDataInstrument, PublicTrades>::new(
+                    LseCfd::default(),
+                    instrument,
+                    PublicTrades,
+                )
+            }),
+        )
+        .init()
+        .await
+        .expect("subscribing to a published CFD symbol should succeed");
+
+    // Decode failures are reported rather than swallowed: they are themselves a shape-change
+    // signal, and they explain a delivery timeout that would otherwise read as silence.
+    let stream = streams
+        .select_all()
+        .with_error_handler(|error| println!("CANARY: market stream error: {error:?}"));
+    let silent = collect_first_tick_per_instrument(Box::pin(stream), &expected).await;
+
+    // The assertion that matters ran inside the collector, on every tick that arrived. Silence here
+    // means the venue is closed, which is not a defect -- but it is also not a pass, because the
+    // spelling this test exists to cover was never exercised.
+    if !silent.is_empty() {
+        println!(
+            "CANARY_SKIP: {silent:?} delivered no tick in {DELIVERY_TIMEOUT:?} - this venue keeps \
+             market hours, so this is most likely closed rather than broken. The space-separated \
+             timestamp spelling was NOT exercised; rerun while the market is open.",
+        );
+    }
+}
+
+/// The pre-subscribe guard is only as good as the list it checks against. If the provider stopped
+/// publishing symbols in its `authenticated` frame, the guard would degrade to a warning by design,
+/// the bogus symbol below would be *confirmed*, and this would return `Ok` — so a passing assertion
+/// here is what proves the list is still both present and honoured.
+#[tokio::test]
+#[ignore = "opens a live connection; run on demand"]
+async fn a_symbol_the_provider_does_not_offer_is_rejected_before_subscribing() {
+    let Some(subscriber) = subscriber() else {
+        return;
+    };
+
+    let subscription = Subscription::<LseCrypto, MarketDataInstrument, PublicTrades>::new(
+        LseCrypto::default(),
+        spot("nope-xyz"),
+        PublicTrades,
+    );
+
+    let error = subscriber
+        .subscribe(&[subscription])
+        .await
+        .expect_err(
+            "the provider confirms symbols it does not serve, so a bogus symbol must be rejected \
+             by the pre-subscribe guard rather than by the provider",
+        )
+        .to_string();
+
+    assert!(error.contains("NOPE-XYZ/USD"), "{error}");
+    println!("CANARY_OK: an unoffered symbol was rejected before any subscribe was sent");
+}

--- a/rustrade-data/tests/lse_ws_canary.rs
+++ b/rustrade-data/tests/lse_ws_canary.rs
@@ -17,7 +17,7 @@
 //! ever caught. Support is asserted structurally instead: the guards either work against the real
 //! list or they do not.
 //!
-//! # The three signals it does assert
+//! # The four signals it does assert
 //!
 //! 1. **Every subscribed symbol actually ticks.** This surface's quietest failure is a subscription
 //!    that is *confirmed and then silent* — the provider answers `subscribed` for a symbol it does
@@ -35,6 +35,14 @@
 //!    the `authenticated` frame still carries a usable symbol list: were the list to disappear or be
 //!    renamed, the guard degrades to a warning by design, the provider confirms the bogus symbol,
 //!    and the batch would succeed. That silent degradation is exactly what this catches.
+//! 4. **A resumed reconnect leaves no gap and rolls nothing back.** Resumption is the one part of
+//!    this integration whose correctness rests on the *provider's* half of a bargain — that `start`
+//!    is inclusive, is honoured at the resolution it was sent at, and replays from exactly where it
+//!    is pointed. Every other test asserts that against fixtures this repository wrote, and a
+//!    fixture cannot notice the provider changing its mind. So one test disconnects deliberately,
+//!    stays away long enough that a resubscribe ignoring the watermark would be unmistakable, and
+//!    reconnects: the resumed stream must begin at the watermark rather than at the reconnect, and
+//!    never before it.
 //!
 //! # Skip vs. fail contract
 //!
@@ -72,8 +80,12 @@
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use futures_util::{Stream, StreamExt};
 use rustrade_data::{
+    MarketStream, NoInitialSnapshots,
+    error::DataError,
     event::MarketEvent,
-    exchange::lse::{LseCfd, LseCrypto, live::LseSubscriber},
+    exchange::lse::{
+        LseCfd, LseCrypto, live::LseSubscriber, resume::LseResumeState, stream::LseStream,
+    },
     streams::{
         Streams,
         reconnect::{Event, stream::ReconnectingStream},
@@ -85,7 +97,7 @@ use rustrade_instrument::{
     exchange::ExchangeId,
     instrument::market_data::{MarketDataInstrument, kind::MarketDataInstrumentKind},
 };
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tokio::time::Instant;
 
 const KEY_ENV: &str = "LSE_API_KEY";
@@ -116,6 +128,28 @@ const MAX_CLOSED_VENUE_TICK_AGE: ChronoDuration = ChronoDuration::days(7);
 ///
 /// Non-zero only for clock skew — the provider stamps in the past by construction.
 const MAX_TICK_LEAD: ChronoDuration = ChronoDuration::minutes(2);
+
+/// How long the resume canary's two connections stay apart.
+///
+/// This is the whole measurement: a reconnect that ignores the watermark begins at *now*, this far
+/// past it, while a resumed one begins *at* it. The two are only distinguishable if the pause is
+/// comfortably wider than the tick spacing, and it is — a busy crypto symbol prints roughly thirty
+/// ticks a second, so this is hundreds of ticks of separation. It is also short enough that the
+/// replay it triggers drains in a second or two rather than the minutes a whole-window resume takes.
+const RESUME_PAUSE: Duration = Duration::from_secs(20);
+
+/// How far past the watermark the resumed stream's earliest event may be stamped.
+///
+/// A correct resume begins *at* the watermark, so this is slack for a quiet stretch at that instant
+/// — not for the reconnect. It has to stay well under [`RESUME_PAUSE`] or it stops distinguishing a
+/// replay from a fresh live subscription, which is the only thing this bound is for.
+const RESUME_GAP_TOLERANCE: ChronoDuration = ChronoDuration::seconds(5);
+
+/// How many events the resume canary's first connection takes before disconnecting.
+///
+/// Only has to be enough to seed a watermark. The arithmetic being exercised is per instant, not
+/// per batch, so a larger sample would buy nothing but wall-clock.
+const TICKS_BEFORE_DISCONNECT: usize = 25;
 
 /// Build a subscriber, or `None` when the key is **absent** (skip rather than fail).
 ///
@@ -357,4 +391,192 @@ async fn a_symbol_the_provider_does_not_offer_is_rejected_before_subscribing() {
 
     assert!(error.contains("NOPE-XYZ/USD"), "{error}");
     println!("CANARY_OK: an unoffered symbol was rejected before any subscribe was sent");
+}
+
+/// One connection to the provider, resume state and all, with nothing wrapped around it.
+///
+/// The reconnecting stream the other tests build is deliberately avoided here: it decides for itself
+/// when to reconnect, and this test's entire signal is *what a reconnect does*, which means owning
+/// both connections explicitly. What is driven is still production code — this is the same
+/// [`LseStream`] that [`StreamSelector`](rustrade_data::exchange::StreamSelector) resolves to.
+async fn connection(
+    subscriber: &LseSubscriber,
+    subscriptions: &[Subscription<LseCrypto, MarketDataInstrument, PublicTrades>],
+) -> LseStream<LseCrypto, MarketDataInstrument, PublicTrades> {
+    <LseStream<_, _, _> as MarketStream<LseCrypto, MarketDataInstrument, PublicTrades>>::init::<
+        NoInitialSnapshots,
+    >(subscriber, subscriptions)
+    .await
+    .expect("subscribing to a continuously-traded crypto symbol should succeed")
+}
+
+/// Drive `stream` until `is_last` accepts an event or the deadline passes, returning what arrived.
+///
+/// A decode failure fails the test rather than being skipped: on this file's surface it is itself a
+/// shape-change signal, and silently dropping it would let a resumed stream that delivers nothing
+/// *readable* look the same as one that delivers nothing at all.
+async fn collect_until<S, F>(
+    stream: &mut S,
+    deadline: Instant,
+    mut is_last: F,
+) -> Vec<MarketEvent<MarketDataInstrument, PublicTrade>>
+where
+    S: Stream<Item = Result<MarketEvent<MarketDataInstrument, PublicTrade>, DataError>> + Unpin,
+    F: FnMut(&MarketEvent<MarketDataInstrument, PublicTrade>) -> bool,
+{
+    let mut collected = Vec::new();
+
+    let _ = tokio::time::timeout_at(deadline, async {
+        while let Some(item) = stream.next().await {
+            let event = item.expect("the market stream yielded an error instead of an event");
+            let last = is_last(&event);
+            collected.push(event);
+
+            if last {
+                break;
+            }
+        }
+    })
+    .await;
+
+    collected
+}
+
+/// Resumption, end to end against the real provider: disconnect, wait, reconnect, and check the
+/// seam.
+///
+/// # Why this cannot be a synthetic test
+///
+/// Every other resume test in this repository asserts the *client* half of the contract — that the
+/// watermark advances on delivery, that `start` carries the stored instant to the microsecond, that
+/// the replayed prefix is skipped by position. All of them are checked against frames this
+/// repository wrote, so all of them would keep passing if the provider changed the *server* half:
+/// if `start` stopped being inclusive, stopped being honoured at microsecond resolution, or began
+/// replaying from somewhere other than where it was pointed. That half has only ever been verified
+/// by hand. This makes it repeatable.
+///
+/// # What the two bounds actually separate
+///
+/// After the pause, a stream that consulted the watermark and one that ignored it look identical in
+/// every respect but one: where their first event is *stamped*. A live-only resubscribe begins at
+/// the reconnect — a whole [`RESUME_PAUSE`] past the watermark. A resumed one begins at the
+/// watermark itself. So the earliest resumed instant is required to sit **at or after** the
+/// watermark (nothing already delivered is served a second time, which is what a mis-scaled or
+/// timezone-shifted `start` would cause) and **no later than** a small tolerance past it (the
+/// window was really replayed). Reaching a live instant afterwards is required too, so the check
+/// covers the whole pause rather than only its first tick.
+///
+/// # ⚠️ What it deliberately does NOT decide
+///
+/// **The tie-group prefix.** `start` is inclusive, so the provider re-serves every tick sharing the
+/// watermark instant and the transformer drops the ones already delivered by position. Deciding
+/// whether it dropped *exactly* the right number needs the provider's own total at that instant,
+/// which is not observable — and inferring it from the tick signatures is not available either,
+/// because identical consecutive ticks are genuine on this feed and are never de-duplicated, so a
+/// legitimate repeat and a re-delivered duplicate are the same bytes. The counts on both sides of
+/// the seam are therefore printed rather than asserted; the positional arithmetic itself is covered
+/// exactly, against known totals, by the transformer's unit tests. Crypto also quantises to the
+/// millisecond, which is why a rounding error in `start` cannot be caught here — that is what
+/// `the_epoch_form_round_trips_an_instant_to_the_microsecond` is for.
+#[tokio::test]
+#[ignore = "opens two live connections and pauses between them; run on demand"]
+async fn a_resumed_reconnect_replays_from_the_watermark_rather_than_from_now() {
+    let Some(subscriber) = subscriber() else {
+        return;
+    };
+
+    // Crypto for the same reason the delivery test uses it: it never closes, so a pause of a known
+    // length is a window of known content rather than possibly a shut market.
+    let state = Arc::new(LseResumeState::new());
+    let subscriber = subscriber.with_resume(Arc::clone(&state));
+    let subscriptions = [
+        Subscription::<LseCrypto, MarketDataInstrument, PublicTrades>::new(
+            LseCrypto::default(),
+            spot("btc"),
+            PublicTrades,
+        ),
+    ];
+
+    // First connection: take enough ticks to seed a watermark, then hang up.
+    let mut opened = connection(&subscriber, &subscriptions).await;
+    let mut taken = 0;
+    let delivered = collect_until(&mut opened, Instant::now() + DELIVERY_TIMEOUT, |_| {
+        taken += 1;
+        taken >= TICKS_BEFORE_DISCONNECT
+    })
+    .await;
+    drop(opened);
+
+    let watermark = delivered
+        .last()
+        .map(|event| event.time_exchange)
+        .expect("a continuously-traded symbol delivered no tick to resume from");
+    for event in &delivered {
+        assert_stamped_plausibly(&event.instrument, event.time_exchange, MAX_TICK_AGE);
+    }
+    println!(
+        "CANARY: {} tick(s) taken, watermark {watermark}",
+        delivered.len()
+    );
+
+    tokio::time::sleep(RESUME_PAUSE).await;
+
+    // Second connection: the same subscriber, so the same resume state, which is exactly what the
+    // reconnecting stream does when it re-runs the subscribe.
+    let mut resumed_stream = connection(&subscriber, &subscriptions).await;
+    let reopened_at = Utc::now();
+    let resumed = collect_until(
+        &mut resumed_stream,
+        Instant::now() + DELIVERY_TIMEOUT,
+        |event| event.time_exchange >= reopened_at,
+    )
+    .await;
+
+    for event in &resumed {
+        assert_stamped_plausibly(&event.instrument, event.time_exchange, MAX_TICK_AGE);
+    }
+
+    let earliest = resumed
+        .iter()
+        .map(|event| event.time_exchange)
+        .min()
+        .expect("the resumed subscription delivered no tick at all");
+
+    assert!(
+        earliest >= watermark,
+        "the resumed stream served {earliest}, which is before the watermark {watermark} - the \
+         provider replayed further back than it was asked to, or `start` no longer means what this \
+         integration sends it as, and events already delivered are being served again",
+    );
+    assert!(
+        earliest - watermark <= RESUME_GAP_TOLERANCE,
+        "the resumed stream began at {earliest}, {} past the watermark {watermark} after a \
+         {RESUME_PAUSE:?} pause - the historical window was not replayed, so the reconnect left \
+         the gap resumption exists to close",
+        earliest - watermark,
+    );
+    assert!(
+        resumed
+            .last()
+            .is_some_and(|event| event.time_exchange >= reopened_at),
+        "the resumed stream never reached a live instant within {DELIVERY_TIMEOUT:?} - it began at \
+         the watermark but did not deliver the whole pause, so the window is covered at its start \
+         and not at its end",
+    );
+
+    // Reported, not asserted -- see the note on the tie-group prefix above.
+    println!(
+        "CANARY_OK: resumed at {earliest} from watermark {watermark} after a {RESUME_PAUSE:?} \
+         pause, {} tick(s) replayed to catch up ({} delivered at the watermark instant before the \
+         disconnect, {} served at it after)",
+        resumed.len(),
+        delivered
+            .iter()
+            .filter(|event| event.time_exchange == watermark)
+            .count(),
+        resumed
+            .iter()
+            .filter(|event| event.time_exchange == watermark)
+            .count(),
+    );
 }

--- a/rustrade-data/tests/lse_ws_canary.rs
+++ b/rustrade-data/tests/lse_ws_canary.rs
@@ -24,11 +24,13 @@
 //!    not serve, never errors, and holds the slot for the life of the connection. A shape check on
 //!    whichever frames happen to arrive cannot see it, because the frames that arrive are fine; it
 //!    is the absent ones that matter. So delivery is required per symbol, not in aggregate.
-//! 2. **A tick's decoded instant is close to now.** The provider spells `ts` three ways and changes
-//!    spelling per dataset and between live and replayed frames. Every one of those spellings
-//!    decodes to *a* `DateTime` — a seconds-vs-milliseconds epoch misread lands in 1970 or in the
-//!    fifty-third century, and a dropped timezone lands hours out — so the decode cannot be checked
-//!    by whether it succeeded, only by whether the answer is plausible.
+//! 2. **A tick's decoded instant is plausible — and on a 24/7 venue, recent.** The provider spells
+//!    `ts` three ways and changes spelling per dataset and between live and replayed frames. Every
+//!    one of those spellings decodes to *a* `DateTime` — a seconds-vs-milliseconds epoch misread
+//!    lands in 1970 or in the fifty-third century, and a dropped timezone lands hours out — so the
+//!    decode cannot be checked by whether it succeeded, only by whether the answer is plausible.
+//!    The *tight* recency window is held only against continuously-traded crypto, because a venue
+//!    that keeps market hours serves a stale instant legitimately; see the note below.
 //! 3. **A symbol the provider does not offer is rejected before subscribing.** This passes only if
 //!    the `authenticated` frame still carries a usable symbol list: were the list to disappear or be
 //!    renamed, the guard degrades to a warning by design, the provider confirms the bogus symbol,
@@ -41,9 +43,18 @@
 //!   secrets configured", so a mistyped key would report green forever.
 //! - Key present but an assertion fails → **FAIL** (the real signal).
 //!
-//! One test additionally skips on silence, and says so loudly: the venue it covers is the only way
-//! to reach the space-separated timestamp spelling, and it trades outside crypto's hours. A
-//! `CANARY_SKIP` line is never a pass — rerun while that market is open.
+//! # ⚠️ A closed venue is not a silent one — measured
+//!
+//! One test covers the only venue that reaches the space-separated timestamp spelling, and that
+//! venue keeps market hours. It was first written to **skip on silence**, on the assumption that a
+//! closed market delivers nothing. That assumption is false: subscribing on a Saturday delivered a
+//! tick stamped at the previous session's close — well-formed, correctly decoded, and five hours
+//! old. Holding it to a ten-minute window failed the canary for a market simply being shut, which
+//! is the failure-for-a-non-defect this file's own reasoning rules out.
+//!
+//! So that test holds the wide plausibility band unconditionally and reports whether the tight
+//! recency signal was reached at all. A stale-but-plausible instant and a `CANARY_SKIP` line mean
+//! the same thing — rerun while that market is open. Neither is a pass for the signal it names.
 //!
 //! # Running
 //!
@@ -85,11 +96,21 @@ const KEY_ENV: &str = "LSE_API_KEY";
 /// hour — so a timeout here means silence, not slowness.
 const DELIVERY_TIMEOUT: Duration = Duration::from_secs(45);
 
-/// How far behind now a live tick may be stamped before the decode is treated as wrong.
+/// How far behind now a tick may be stamped on a **continuously-traded** venue.
 ///
 /// Wide enough to absorb clock skew and a quiet minute on a thin symbol, and far narrower than any
-/// epoch or timezone misread: those miss by decades or by whole hours.
+/// epoch or timezone misread: those miss by decades or by whole hours. Only crypto is held to this,
+/// because only crypto never closes — see the module header.
 const MAX_TICK_AGE: ChronoDuration = ChronoDuration::minutes(10);
+
+/// How far behind now a tick may be stamped on a venue that **keeps market hours**.
+///
+/// A closed venue serves its last session print rather than going silent, so the age of a perfectly
+/// decoded instant there is bounded by the closure, not by the feed: a Friday-evening close read on
+/// a Sunday is two days old and entirely correct. This band contains any weekend or holiday closure
+/// while still being narrower than an epoch-scale misread by decades, so it keeps the signal that
+/// survives a closed market and drops the one that cannot.
+const MAX_CLOSED_VENUE_TICK_AGE: ChronoDuration = ChronoDuration::days(7);
 
 /// How far ahead of now a live tick may be stamped.
 ///
@@ -122,18 +143,25 @@ fn cfd(base: &str) -> MarketDataInstrument {
     MarketDataInstrument::from((base, "usd", MarketDataInstrumentKind::Cfd))
 }
 
-/// Fail if a tick's decoded instant is not plausibly live.
+/// Fail if a tick's decoded instant is not plausible, where `max_age` is what "plausible" means for
+/// the venue under test.
 ///
 /// See signal 2 in the module header: every spelling the provider uses decodes to *some* instant,
-/// so plausibility is the only available check on whether it decoded to the right one.
-fn assert_stamped_near_now(instrument: &MarketDataInstrument, time_exchange: DateTime<Utc>) {
+/// so plausibility is the only available check on whether it decoded to the right one. How much
+/// staleness is plausible is a property of the venue's trading hours, not of the decoder, which is
+/// why the bound is a parameter rather than a constant.
+fn assert_stamped_plausibly(
+    instrument: &MarketDataInstrument,
+    time_exchange: DateTime<Utc>,
+    max_age: ChronoDuration,
+) {
     let now = Utc::now();
     let age = now - time_exchange;
 
     assert!(
-        age <= MAX_TICK_AGE,
-        "{instrument} ticked at {time_exchange}, {age} behind now - a live tick should be recent, \
-         so the timestamp decode has probably misread the provider's spelling",
+        age <= max_age,
+        "{instrument} ticked at {time_exchange}, {age} behind now (limit {max_age}) - the timestamp \
+         decode has probably misread the provider's spelling",
     );
     assert!(
         -age <= MAX_TICK_LEAD,
@@ -146,16 +174,19 @@ fn assert_stamped_near_now(instrument: &MarketDataInstrument, time_exchange: Dat
 
 /// Drive `stream` until every instrument in `expected` has delivered a tick, or the deadline.
 ///
-/// Returns the instruments that never ticked, so the caller decides whether silence is a failure
-/// (a 24/7 venue) or a skip (a venue that closes).
+/// Returns the instruments that never ticked **and** the newest instant seen. The caller decides
+/// what both mean for its venue: whether silence is a failure (a 24/7 venue) or a skip (a venue that
+/// closes), and whether the newest instant was recent enough to have exercised the tight window.
 async fn collect_first_tick_per_instrument<S>(
     mut stream: S,
     expected: &[MarketDataInstrument],
-) -> Vec<MarketDataInstrument>
+    max_age: ChronoDuration,
+) -> (Vec<MarketDataInstrument>, Option<DateTime<Utc>>)
 where
     S: Stream<Item = Event<ExchangeId, MarketEvent<MarketDataInstrument, PublicTrade>>> + Unpin,
 {
     let mut pending = expected.to_vec();
+    let mut newest: Option<DateTime<Utc>> = None;
     let deadline = Instant::now() + DELIVERY_TIMEOUT;
 
     // One deadline governs the whole wait, so there is no per-iteration clock arithmetic and no
@@ -167,7 +198,9 @@ where
                     // Checked on every tick rather than only the first: the provider changes `ts`
                     // spelling between datasets, and a stream that begins well can still carry a
                     // frame this integration reads wrongly.
-                    assert_stamped_near_now(&event.instrument, event.time_exchange);
+                    assert_stamped_plausibly(&event.instrument, event.time_exchange, max_age);
+
+                    newest = newest.max(Some(event.time_exchange));
 
                     if let Some(index) = pending.iter().position(|i| *i == event.instrument) {
                         let delivered = pending.swap_remove(index);
@@ -187,7 +220,7 @@ where
     })
     .await;
 
-    pending
+    (pending, newest)
 }
 
 #[tokio::test]
@@ -222,7 +255,10 @@ async fn every_subscribed_crypto_symbol_delivers_a_live_tick() {
     let stream = streams
         .select_all()
         .with_error_handler(|error| println!("CANARY: market stream error: {error:?}"));
-    let silent = collect_first_tick_per_instrument(Box::pin(stream), &expected).await;
+
+    // Crypto is the one venue whose staleness is unambiguous, so it carries the tight window.
+    let (silent, _newest) =
+        collect_first_tick_per_instrument(Box::pin(stream), &expected, MAX_TICK_AGE).await;
 
     assert!(
         silent.is_empty(),
@@ -265,17 +301,31 @@ async fn a_cfd_tick_decodes_to_a_plausible_instant() {
     let stream = streams
         .select_all()
         .with_error_handler(|error| println!("CANARY: market stream error: {error:?}"));
-    let silent = collect_first_tick_per_instrument(Box::pin(stream), &expected).await;
 
-    // The assertion that matters ran inside the collector, on every tick that arrived. Silence here
-    // means the venue is closed, which is not a defect -- but it is also not a pass, because the
-    // spelling this test exists to cover was never exercised.
-    if !silent.is_empty() {
-        println!(
+    // The wide band, because this venue closes. A tick arriving here is not evidence the market is
+    // open: a closed session serves its last print, correctly stamped hours or days ago.
+    let (silent, newest) =
+        collect_first_tick_per_instrument(Box::pin(stream), &expected, MAX_CLOSED_VENUE_TICK_AGE)
+            .await;
+
+    // The plausibility assertion already ran inside the collector, on every tick that arrived. What
+    // is left is to say which signal was actually reached, because neither outcome below is a pass
+    // for the recency check, and a silent green here would be the muted canary this file warns
+    // about.
+    match newest {
+        None => println!(
             "CANARY_SKIP: {silent:?} delivered no tick in {DELIVERY_TIMEOUT:?} - this venue keeps \
              market hours, so this is most likely closed rather than broken. The space-separated \
              timestamp spelling was NOT exercised; rerun while the market is open.",
-        );
+        ),
+        Some(newest) if Utc::now() - newest > MAX_TICK_AGE => println!(
+            "CANARY_SKIP: the newest tick is stamped {newest}, older than {MAX_TICK_AGE} - the \
+             session has closed and the provider is serving its last print. The spelling decoded \
+             plausibly, but recency was NOT exercised; rerun while the market is open.",
+        ),
+        Some(newest) => println!(
+            "CANARY_OK: the space-separated timestamp spelling decoded to {newest}, live and recent",
+        ),
     }
 }
 

--- a/rustrade-data/tests/lse_ws_canary.rs
+++ b/rustrade-data/tests/lse_ws_canary.rs
@@ -51,6 +51,14 @@
 //!   secrets configured", so a mistyped key would report green forever.
 //! - Key present but an assertion fails → **FAIL** (the real signal).
 //!
+//! ## ⚠️ The contract above is invisible without `--nocapture`
+//!
+//! Every skip and every `CANARY_OK` is a `println!`, and libtest **discards stdout for a passing
+//! test**. Run without `--nocapture` — as the command in *Running* below does not — and a skip is
+//! reported as `ok`, identical to a run that exercised every signal. That is why `--nocapture` is
+//! part of the invocation rather than a debugging nicety, and why nothing this file *decides* is
+//! left to a printed line: what must not pass silently is asserted.
+//!
 //! # ⚠️ A closed venue is not a silent one — measured
 //!
 //! One test covers the only venue that reaches the space-separated timestamp spelling, and that
@@ -63,6 +71,18 @@
 //! So that test holds the wide plausibility band unconditionally and reports whether the tight
 //! recency signal was reached at all. A stale-but-plausible instant and a `CANARY_SKIP` line mean
 //! the same thing — rerun while that market is open. Neither is a pass for the signal it names.
+//!
+//! ## ⚠️ Silence must be proved innocent before it is read as a closure
+//!
+//! Tolerating silence opens a hole, and it is the one this whole file is built to close. The error
+//! handler these tests install is a `filter_map`: an item it is called for is **removed** from the
+//! stream. A connection on which every frame failed to decode therefore looks, from below the
+//! handler, exactly like a connection that delivered nothing — so a shape change that broke the
+//! decoder outright would be read as "the market is shut" and reported as a *pass*.
+//!
+//! So decode failures are counted, and the count is asserted zero **before** any silence is
+//! interpreted. Silence is only allowed to mean a closed venue once it is known that nothing
+//! arrived and failed to be read.
 //!
 //! # Running
 //!
@@ -97,7 +117,13 @@ use rustrade_instrument::{
     exchange::ExchangeId,
     instrument::market_data::{MarketDataInstrument, kind::MarketDataInstrumentKind},
 };
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 use tokio::time::Instant;
 
 const KEY_ENV: &str = "LSE_API_KEY";
@@ -206,6 +232,45 @@ fn assert_stamped_plausibly(
     );
 }
 
+/// A decode-failure counter, and the error handler that feeds it.
+///
+/// # ⚠️ Printing a decode failure is not reporting it
+/// [`with_error_handler`](ReconnectingStream::with_error_handler) is a `filter_map`: the item it is
+/// called for is **removed** from the stream. So a connection on which every frame failed to decode
+/// looks, from below the handler, exactly like a connection that delivered nothing — and a test
+/// that reads silence as "the market is closed" would report `CANARY_SKIP` and pass, on precisely
+/// the shape change this file exists to catch. A `println!` cannot close that: libtest discards
+/// stdout for a passing test, so the evidence would only exist in a run that already knew to look.
+///
+/// The counter turns it into an assertion. The handler still prints, because the message names
+/// *what* changed and the count only says that something did.
+fn decode_failures() -> (Arc<AtomicUsize>, impl Fn(DataError)) {
+    let failures = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&failures);
+
+    let handler = move |error: DataError| {
+        counter.fetch_add(1, Ordering::Relaxed);
+        println!("CANARY: market stream error: {error:?}");
+    };
+
+    (failures, handler)
+}
+
+/// Fail if any frame failed to decode, whatever else the stream did.
+///
+/// Called **before** any silence is interpreted: a decode failure explains silence, and reading it
+/// as a closed market instead is how this canary would go quiet on a real shape change.
+fn assert_every_frame_decoded(failures: &Arc<AtomicUsize>) {
+    let failed = failures.load(Ordering::Relaxed);
+
+    assert_eq!(
+        failed, 0,
+        "{failed} frame(s) failed to decode - the error handler filters them out of the stream, so \
+         this would otherwise present as silence rather than as a failure. The provider's frame \
+         shape has changed; see the CANARY lines above for what it now sends",
+    );
+}
+
 /// Drive `stream` until every instrument in `expected` has delivered a tick, or the deadline.
 ///
 /// Returns the instruments that never ticked **and** the newest instant seen. The caller decides
@@ -284,22 +349,26 @@ async fn every_subscribed_crypto_symbol_delivers_a_live_tick() {
         .await
         .expect("subscribing to continuously-traded crypto symbols should succeed");
 
-    // Decode failures are reported rather than swallowed: they are themselves a shape-change
-    // signal, and they explain a delivery timeout that would otherwise read as silence.
-    let stream = streams
-        .select_all()
-        .with_error_handler(|error| println!("CANARY: market stream error: {error:?}"));
+    // Decode failures are counted as well as printed: the handler filters them out of the stream,
+    // so an undecodable frame arrives below as nothing at all.
+    let (failures, on_error) = decode_failures();
+    let stream = streams.select_all().with_error_handler(on_error);
 
     // Crypto is the one venue whose staleness is unambiguous, so it carries the tight window.
     let (silent, _newest) =
         collect_first_tick_per_instrument(Box::pin(stream), &expected, MAX_TICK_AGE).await;
 
+    // Before the silence below is read as a missing subscription: a frame that failed to decode
+    // produces the same silence and has a different cause, so diagnosing it as the other would send
+    // a reader after the pre-subscribe guard for a problem in the decoder.
+    assert_every_frame_decoded(&failures);
+
     assert!(
         silent.is_empty(),
-        "{silent:?} were confirmed but delivered no tick in {DELIVERY_TIMEOUT:?} - on a \
-         continuously-traded venue that is the confirmed-then-silent failure this integration's \
-         pre-subscribe guard exists to prevent, which means the guard's symbol list no longer \
-         reflects what the provider actually serves",
+        "{silent:?} were confirmed but delivered no tick in {DELIVERY_TIMEOUT:?}, and every frame \
+         that did arrive decoded - on a continuously-traded venue that is the confirmed-then-silent \
+         failure this integration's pre-subscribe guard exists to prevent, which means the guard's \
+         symbol list no longer reflects what the provider actually serves",
     );
 }
 
@@ -330,17 +399,22 @@ async fn a_cfd_tick_decodes_to_a_plausible_instant() {
         .await
         .expect("subscribing to a published CFD symbol should succeed");
 
-    // Decode failures are reported rather than swallowed: they are themselves a shape-change
-    // signal, and they explain a delivery timeout that would otherwise read as silence.
-    let stream = streams
-        .select_all()
-        .with_error_handler(|error| println!("CANARY: market stream error: {error:?}"));
+    // Decode failures are counted as well as printed: the handler filters them out of the stream,
+    // so an undecodable frame arrives below as nothing at all.
+    let (failures, on_error) = decode_failures();
+    let stream = streams.select_all().with_error_handler(on_error);
 
     // The wide band, because this venue closes. A tick arriving here is not evidence the market is
     // open: a closed session serves its last print, correctly stamped hours or days ago.
     let (silent, newest) =
         collect_first_tick_per_instrument(Box::pin(stream), &expected, MAX_CLOSED_VENUE_TICK_AGE)
             .await;
+
+    // ⚠️ BEFORE the match below, and that ordering is the whole point. This is the one test whose
+    // silence is a legitimate SKIP, so it is the one place where a total decode failure -- the exact
+    // shape change this file exists to catch -- would otherwise be read as "the market is shut" and
+    // reported as a pass.
+    assert_every_frame_decoded(&failures);
 
     // The plausibility assertion already ran inside the collector, on every tick that arrived. What
     // is left is to say which signal was actually reached, because neither outcome below is a pass

--- a/rustrade-data/tests/lse_ws_handshake.rs
+++ b/rustrade-data/tests/lse_ws_handshake.rs
@@ -57,7 +57,6 @@ use rustrade_data::{
             channel::LseChannel,
             live::{LseCredentials, LseSubscriber},
             market::{LseMarket, LseServer, LseSymbolShape},
-            resume::LseResumeState,
         },
         subscription::ExchangeSub,
     },
@@ -361,43 +360,6 @@ async fn a_subscriber_without_resume_opens_no_replay_window_on_the_wire() {
         sent[0],
         json!({"action": "subscribe", "symbol": "BTC/USD"}),
         "a subscriber with no resume state must send the plain payload",
-    );
-}
-
-/// The resume point has to survive the trip out as a number the provider filters on at microsecond
-/// resolution. Asserting it at the socket is what proves the watermark reached the payload, rather
-/// than only that the payload builder can encode one.
-#[tokio::test]
-#[serial]
-async fn a_resuming_subscriber_puts_its_watermark_on_the_wire() {
-    let harness = Harness::start(Script::default()).await;
-
-    let watermark = "2026-08-14T10:16:55.161234Z".parse().unwrap();
-    let state = Arc::new(LseResumeState::new());
-    state.record(&subscription_id("btc"), watermark);
-
-    let subscriptions = [subscription("btc"), subscription("eth")];
-    subscriber()
-        .with_resume(state)
-        .subscribe(&subscriptions)
-        .await
-        .unwrap();
-
-    let sent = harness.subscribes();
-    assert_eq!(symbols(&sent), vec!["BTC/USD", "ETH/USD"]);
-
-    let start = sent[0]["start"]
-        .as_f64()
-        .unwrap_or_else(|| panic!("BTC/USD should carry a resume point: {:?}", sent[0]));
-    let drift = start * 1_000_000.0 - watermark.timestamp_micros() as f64;
-    assert!(drift.abs() < 0.5, "the resume point drifted {drift} micros");
-
-    // A symbol the stream has delivered nothing for has nothing to resume from, and must be sent
-    // the payload a first-ever subscribe sends -- not the other symbol's window.
-    assert!(
-        sent[1].get("start").is_none(),
-        "ETH/USD has no watermark and must open no window: {:?}",
-        sent[1],
     );
 }
 

--- a/rustrade-data/tests/lse_ws_handshake.rs
+++ b/rustrade-data/tests/lse_ws_handshake.rs
@@ -201,29 +201,41 @@ impl Harness {
         Self { subscribes, served }
     }
 
-    /// The subscribe payloads that reached the socket, in the order they arrived.
+    /// A sample of the subscribe payloads recorded so far, in the order they arrived.
     ///
-    /// Sound only once every payload the client intends to send has been answered — on the success
-    /// path, where `subscribe` returns after the last confirmation, which the server sends *after*
-    /// recording. On a rejection path use [`Self::drained`] instead: a payload written to the
-    /// socket and not yet read by the server is indistinguishable here from one never sent, so
-    /// sampling would report a guard as running before the first send when it ran after it.
+    /// # ⚠️ Sound for content assertions only, never for counts
+    /// The server task is still running and still writing to this vector. What is safe to conclude
+    /// from a sample is that a payload *present* in it was really sent, and what it contained —
+    /// so this is the right tool for asserting the shape of a payload already known to exist,
+    /// which is what the confirmation the client just returned on establishes.
+    ///
+    /// It cannot say how many were sent, or that none was. A payload written to the socket and not
+    /// yet read by the server is indistinguishable here from one never sent, so an assertion on
+    /// `len()` would report a guard as running before the first send when it ran after it, and a
+    /// duplicate subscribe as absent when it was merely late. Those need [`Self::drained`], which
+    /// waits for the server to finish reading rather than sampling it mid-write.
     fn subscribes(&self) -> Vec<Value> {
         self.subscribes.lock().unwrap().clone()
     }
 
     /// Everything that reached the socket, read after the connection has closed.
     ///
-    /// A rejected batch drops the client's connection as it returns, which ends the server's read
-    /// loop — so awaiting that loop is what makes "nothing was sent" an observation rather than a
-    /// guess about timing. Never call this while the connection is still held open: on the success
-    /// path the client keeps it, and there would be nothing to await.
+    /// The server's read loop ends when the client's end of the connection goes away, so awaiting
+    /// that loop is what turns "nothing more was sent" from a guess about timing into an
+    /// observation. This is the only sound basis for a count.
+    ///
+    /// The connection must already be closing when this is called:
+    /// - on a **rejection** path, `subscribe` drops it as it returns, so nothing more is needed;
+    /// - on a **success** path the client keeps it, so drop the [`Subscribed`] first — and read
+    ///   anything wanted from it beforehand, since dropping it takes the buffered events with it.
+    ///
+    /// [`Subscribed`]: rustrade_data::subscriber::Subscribed
     async fn drained(self) -> Vec<Value> {
         let Self { subscribes, served } = self;
 
         tokio::time::timeout(std::time::Duration::from_secs(5), served)
             .await
-            .expect("the connection should have closed once the client rejected the batch")
+            .expect("the connection should have closed once the client released it")
             .expect("the harness server panicked");
 
         subscribes.lock().unwrap().clone()
@@ -361,10 +373,23 @@ async fn a_full_handshake_subscribes_each_distinct_symbol_exactly_once() {
     ];
     let subscribed = subscriber().subscribe(&subscriptions).await.unwrap();
 
-    assert_eq!(symbols(&harness.subscribes()), vec!["BTC/USD", "ETH/USD"]);
-    assert_eq!(subscribed.map.0.len(), 2);
-    assert!(subscribed.map.0.contains_key(&subscription_id("btc")));
-    assert!(subscribed.buffered_websocket_events.is_empty());
+    // Read the client's side before releasing the connection: dropping `Subscribed` takes the
+    // buffered events with it.
+    let instruments = subscribed.map.0.len();
+    let maps_btc = subscribed.map.0.contains_key(&subscription_id("btc"));
+    let buffered = subscribed.buffered_websocket_events.len();
+
+    // "Exactly once" is a count, so it needs the server to have finished reading rather than a
+    // sample of it mid-write -- a duplicate subscribe still in flight would otherwise read as
+    // absent, which is the very thing this test is here to rule out. Dropping the connection ends
+    // the server's read loop, and `drained` waits for it.
+    drop(subscribed);
+    let sent = harness.drained().await;
+
+    assert_eq!(symbols(&sent), vec!["BTC/USD", "ETH/USD"]);
+    assert_eq!(instruments, 2);
+    assert!(maps_btc);
+    assert_eq!(buffered, 0);
 }
 
 /// A live subscribe carries the symbol and nothing else — no replay window is opened for a
@@ -374,12 +399,16 @@ async fn a_full_handshake_subscribes_each_distinct_symbol_exactly_once() {
 async fn a_subscriber_without_resume_opens_no_replay_window_on_the_wire() {
     let harness = Harness::start(Script::default()).await;
 
-    subscriber()
+    let subscribed = subscriber()
         .subscribe(&[subscription("btc")])
         .await
         .unwrap();
 
-    let sent = harness.subscribes();
+    // The claim is that *no* payload carried a window, which is a statement about every payload
+    // sent and so needs the drained view rather than a sample of it.
+    drop(subscribed);
+    let sent = harness.drained().await;
+
     assert_eq!(sent.len(), 1);
     assert_eq!(
         sent[0],
@@ -519,8 +548,8 @@ async fn frames_arriving_during_validation_are_buffered_rather_than_dropped() {
         .await
         .unwrap();
 
-    assert_eq!(symbols(&harness.subscribes()), vec!["BTC/USD"]);
-
+    // Collected before the connection is released, because dropping `Subscribed` takes the
+    // buffered events with it.
     let buffered = subscribed
         .buffered_websocket_events
         .iter()
@@ -531,6 +560,9 @@ async fn frames_arriving_during_validation_are_buffered_rather_than_dropped() {
             other => panic!("unexpected buffered frame: {other:?}"),
         })
         .collect::<Vec<_>>();
+
+    drop(subscribed);
+    assert_eq!(symbols(&harness.drained().await), vec!["BTC/USD"]);
 
     assert_eq!(
         buffered.len(),

--- a/rustrade-data/tests/lse_ws_handshake.rs
+++ b/rustrade-data/tests/lse_ws_handshake.rs
@@ -1,0 +1,555 @@
+//! London Strategic Edge WebSocket handshake, driven against a synthetic in-process server.
+//!
+//! # Why this exists
+//!
+//! The unit tests beside the subscriber call its guards directly, which proves what each guard
+//! *decides* but not what the client *does*. The contract this surface actually rests on is about
+//! the wire:
+//!
+//! > every guard runs before the first subscribe leaves the client
+//!
+//! That is not a stylistic preference. Subscribing to a symbol the provider does not offer is
+//! **confirmed rather than rejected** — it answers `subscribed`, never errors, never ticks, and
+//! permanently consumes one of the connection's few subscription slots. A guard that rejected the
+//! batch *after* sending would be indistinguishable from one that rejected it before, in every
+//! assertion a unit test can make, while quietly spending slots that cannot be reclaimed without
+//! reconnecting. Only a server that counts what arrived can tell the two apart, so these tests
+//! assert **zero subscribe payloads reached the socket** on every rejection path.
+//!
+//! The same applies to what the handshake *reads*: a client that treated the first frame as the
+//! answer to its `auth` would appear to work, because the server opens with an unsolicited
+//! `welcome`. Here the server sends one, and the rejection that follows it is what proves the
+//! client waited.
+//!
+//! # No provider data is involved
+//!
+//! Every frame below is hand-written to the shapes documented on the types that decode them. The
+//! provider prohibits redistributing its data (<https://londonstrategicedge.com/terms>), so no
+//! recorded response may be committed to this repository — which is precisely why a synthetic
+//! server is worth building rather than replaying a capture. Live shape verification is the
+//! separate, credential-gated job of `lse_ws_canary.rs`.
+//!
+//! # Why the server is real rather than mocked
+//!
+//! The subscriber's flow is inseparable from the socket: it connects, sends, waits for a specific
+//! frame, sends again, then hands the still-open connection to the subscription validator. A mock
+//! of that would be a re-implementation of it. `tokio-tungstenite` speaks the same protocol the
+//! client does, so the only thing swapped out is the endpoint.
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo test --test lse_ws_handshake --features lse
+//! ```
+//!
+//! No network, no credentials, no provider allowance spent — these run on every ordinary test run.
+
+#![cfg(feature = "lse")]
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
+
+use futures_util::{SinkExt, StreamExt};
+use rustrade_data::{
+    Identifier,
+    exchange::{
+        ExchangeServer,
+        lse::{
+            Lse,
+            channel::LseChannel,
+            live::{LseCredentials, LseSubscriber},
+            market::{LseMarket, LseServer, LseSymbolShape},
+            resume::LseResumeState,
+        },
+        subscription::ExchangeSub,
+    },
+    subscriber::Subscriber,
+    subscription::{Subscription, trade::PublicTrades},
+};
+use rustrade_instrument::{
+    exchange::ExchangeId,
+    instrument::market_data::{MarketDataInstrument, kind::MarketDataInstrumentKind},
+};
+use rustrade_integration::subscription::SubscriptionId;
+use serde_json::{Value, json};
+use serial_test::serial;
+use std::sync::{Arc, Mutex};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::Message;
+
+/// The endpoint the connector under test resolves to, set by whichever harness is running.
+///
+/// [`ExchangeServer::websocket_url`] answers with a `&'static str` and takes no arguments, so the
+/// port a freshly-bound listener was assigned has nowhere else to live. Every test therefore holds
+/// this for its duration and runs `#[serial]` — which is also what lets one connector type serve
+/// every scenario, so the tests exercise the real `Connector` implementation with nothing swapped
+/// out but the endpoint.
+static HARNESS_URL: Mutex<Option<&'static str>> = Mutex::new(None);
+
+/// A connector identical to the shipped ones except for where it points.
+///
+/// Declaring a server rather than a whole connector is deliberate: `Lse<Server>` carries the real
+/// [`Connector`](rustrade_data::exchange::Connector) implementation, the real `Identifier` impls
+/// and the real symbol spelling, so what these tests drive is production code. A bespoke connector
+/// would only be a look-alike, and could drift from the thing it stands in for.
+#[derive(Copy, Clone, Debug, Default)]
+struct HarnessServer;
+
+impl ExchangeServer for HarnessServer {
+    // Crypto because its symbols are pair-shaped and its published category is a single known
+    // value, so the category cross-check has something definite to agree with.
+    const ID: ExchangeId = ExchangeId::LseCrypto;
+
+    fn websocket_url() -> &'static str {
+        HARNESS_URL
+            .lock()
+            .unwrap()
+            .expect("a harness must be started before the connector resolves its endpoint")
+    }
+}
+
+impl LseServer for HarnessServer {
+    const SYMBOL_SHAPE: LseSymbolShape = LseSymbolShape::Pair;
+}
+
+type HarnessLse = Lse<HarnessServer>;
+
+/// How the synthetic server answers.
+struct Script {
+    /// The frame sent in reply to `auth`.
+    auth_reply: Value,
+    /// Close the connection instead of ever answering `auth`.
+    close_without_answering: bool,
+    /// Frames to send ahead of each subscription confirmation.
+    ///
+    /// These are what the subscription validator cannot read as a response and hands back as
+    /// buffered events — the path a replayed tick takes when it arrives while other symbols are
+    /// still being confirmed.
+    frames_before_confirmation: Vec<Value>,
+}
+
+impl Default for Script {
+    fn default() -> Self {
+        Self {
+            auth_reply: authenticated(&[("BTC/USD", Some("Crypto")), ("ETH/USD", None)], 16),
+            close_without_answering: false,
+            frames_before_confirmation: Vec::new(),
+        }
+    }
+}
+
+/// A successful `auth` answer offering `symbols`.
+fn authenticated(symbols: &[(&str, Option<&str>)], max_subscriptions: u32) -> Value {
+    let symbols = symbols
+        .iter()
+        .map(|(symbol, category)| match category {
+            Some(category) => json!({"symbol": symbol, "category": category}),
+            // Roughly half the real entries carry no category key at all, so the harness offers
+            // both shapes rather than the tidy one only.
+            None => json!({"symbol": symbol}),
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "type": "authenticated",
+        "tier": "registered",
+        "max_subscriptions": max_subscriptions,
+        "symbols": symbols,
+    })
+}
+
+/// A running synthetic server, and the subscribe payloads it has been sent.
+struct Harness {
+    subscribes: Arc<Mutex<Vec<Value>>>,
+    served: tokio::task::JoinHandle<()>,
+}
+
+impl Harness {
+    /// Bind an ephemeral port, publish it to the connector, and serve one connection.
+    async fn start(script: Script) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        // Leaked so the endpoint can satisfy `websocket_url`'s `&'static str`. One short string per
+        // test, in a test binary that exits immediately afterwards, is a bounded cost; the
+        // alternative is threading a lifetime through a public trait to serve a test.
+        let url: &'static str = Box::leak(format!("ws://{address}").into_boxed_str());
+        *HARNESS_URL.lock().unwrap() = Some(url);
+
+        let subscribes = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&subscribes);
+
+        let served = tokio::spawn(async move {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            serve(stream, script, recorded).await;
+        });
+
+        Self { subscribes, served }
+    }
+
+    /// The subscribe payloads that reached the socket, in the order they arrived.
+    ///
+    /// Sound only once every payload the client intends to send has been answered — on the success
+    /// path, where `subscribe` returns after the last confirmation, which the server sends *after*
+    /// recording. On a rejection path use [`Self::drained`] instead: a payload written to the
+    /// socket and not yet read by the server is indistinguishable here from one never sent, so
+    /// sampling would report a guard as running before the first send when it ran after it.
+    fn subscribes(&self) -> Vec<Value> {
+        self.subscribes.lock().unwrap().clone()
+    }
+
+    /// Everything that reached the socket, read after the connection has closed.
+    ///
+    /// A rejected batch drops the client's connection as it returns, which ends the server's read
+    /// loop — so awaiting that loop is what makes "nothing was sent" an observation rather than a
+    /// guess about timing. Never call this while the connection is still held open: on the success
+    /// path the client keeps it, and there would be nothing to await.
+    async fn drained(self) -> Vec<Value> {
+        let Self { subscribes, served } = self;
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), served)
+            .await
+            .expect("the connection should have closed once the client rejected the batch")
+            .expect("the harness server panicked");
+
+        subscribes.lock().unwrap().clone()
+    }
+}
+
+/// Speak the provider's side of the protocol for one connection.
+async fn serve(stream: TcpStream, script: Script, subscribes: Arc<Mutex<Vec<Value>>>) {
+    let Ok(mut websocket) = tokio_tungstenite::accept_async(stream).await else {
+        return;
+    };
+
+    // The real server greets before it is asked anything. Sending it here is what makes the
+    // "waited for the right frame" assertions meaningful rather than vacuous.
+    let welcome = json!({"type": "welcome", "message": "connected", "symbols_available": 8516});
+    if websocket
+        .send(Message::text(welcome.to_string()))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    while let Some(Ok(message)) = websocket.next().await {
+        let Message::Text(text) = message else {
+            continue;
+        };
+        let Ok(payload) = serde_json::from_str::<Value>(text.as_str()) else {
+            continue;
+        };
+
+        match payload["action"].as_str() {
+            Some("auth") => {
+                if script.close_without_answering {
+                    let _ = websocket.close(None).await;
+                    return;
+                }
+                if websocket
+                    .send(Message::text(script.auth_reply.to_string()))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Some("subscribe") => {
+                let symbol = payload["symbol"].as_str().unwrap_or_default().to_owned();
+                let count = {
+                    let mut recorded = subscribes.lock().unwrap();
+                    recorded.push(payload.clone());
+                    recorded.len()
+                };
+
+                for frame in &script.frames_before_confirmation {
+                    if websocket
+                        .send(Message::text(frame.to_string()))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+
+                let confirmation = json!({
+                    "type": "subscribed", "symbol": symbol, "count": count, "max": 16,
+                });
+                if websocket
+                    .send(Message::text(confirmation.to_string()))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            // The client sends nothing else during a handshake; anything here would be a change in
+            // the flow under test, and ignoring it lets the assertion below report that as silence
+            // rather than as a protocol error from the harness.
+            _ => {}
+        }
+    }
+}
+
+fn subscription(base: &str) -> Subscription<HarnessLse, MarketDataInstrument, PublicTrades> {
+    Subscription::from((
+        HarnessLse::default(),
+        base,
+        "usd",
+        MarketDataInstrumentKind::Spot,
+        PublicTrades,
+    ))
+}
+
+/// The identifier a subscription's watermark is filed under.
+///
+/// Derived the way the connector derives it, rather than spelled out, so this pins the resume
+/// behaviour and not the identifier's format.
+fn subscription_id(base: &str) -> SubscriptionId {
+    ExchangeSub::<LseChannel, LseMarket>::new(&subscription(base)).id()
+}
+
+fn subscriber() -> LseSubscriber {
+    LseSubscriber::new(LseCredentials::new("harness-key"))
+}
+
+/// The symbols named by the subscribe payloads that reached the socket.
+fn symbols(subscribes: &[Value]) -> Vec<&str> {
+    subscribes
+        .iter()
+        .map(|payload| payload["symbol"].as_str().unwrap())
+        .collect()
+}
+
+#[tokio::test]
+#[serial]
+async fn a_full_handshake_subscribes_each_distinct_symbol_exactly_once() {
+    let harness = Harness::start(Script::default()).await;
+
+    // The batch names one symbol twice. Two subscriptions over one symbol are one slot and one
+    // confirmation, so a second payload would leave the validator waiting on a confirmation the
+    // provider will never send -- a hang, not an error.
+    let subscriptions = [
+        subscription("btc"),
+        subscription("eth"),
+        subscription("btc"),
+    ];
+    let subscribed = subscriber().subscribe(&subscriptions).await.unwrap();
+
+    assert_eq!(symbols(&harness.subscribes()), vec!["BTC/USD", "ETH/USD"]);
+    assert_eq!(subscribed.map.0.len(), 2);
+    assert!(subscribed.map.0.contains_key(&subscription_id("btc")));
+    assert!(subscribed.buffered_websocket_events.is_empty());
+}
+
+/// A live subscribe carries the symbol and nothing else — no replay window is opened for a
+/// subscriber that was never asked to resume.
+#[tokio::test]
+#[serial]
+async fn a_subscriber_without_resume_opens_no_replay_window_on_the_wire() {
+    let harness = Harness::start(Script::default()).await;
+
+    subscriber()
+        .subscribe(&[subscription("btc")])
+        .await
+        .unwrap();
+
+    let sent = harness.subscribes();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(
+        sent[0],
+        json!({"action": "subscribe", "symbol": "BTC/USD"}),
+        "a subscriber with no resume state must send the plain payload",
+    );
+}
+
+/// The resume point has to survive the trip out as a number the provider filters on at microsecond
+/// resolution. Asserting it at the socket is what proves the watermark reached the payload, rather
+/// than only that the payload builder can encode one.
+#[tokio::test]
+#[serial]
+async fn a_resuming_subscriber_puts_its_watermark_on_the_wire() {
+    let harness = Harness::start(Script::default()).await;
+
+    let watermark = "2026-08-14T10:16:55.161234Z".parse().unwrap();
+    let state = Arc::new(LseResumeState::new());
+    state.record(&subscription_id("btc"), watermark);
+
+    let subscriptions = [subscription("btc"), subscription("eth")];
+    subscriber()
+        .with_resume(state)
+        .subscribe(&subscriptions)
+        .await
+        .unwrap();
+
+    let sent = harness.subscribes();
+    assert_eq!(symbols(&sent), vec!["BTC/USD", "ETH/USD"]);
+
+    let start = sent[0]["start"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("BTC/USD should carry a resume point: {:?}", sent[0]));
+    let drift = start * 1_000_000.0 - watermark.timestamp_micros() as f64;
+    assert!(drift.abs() < 0.5, "the resume point drifted {drift} micros");
+
+    // A symbol the stream has delivered nothing for has nothing to resume from, and must be sent
+    // the payload a first-ever subscribe sends -- not the other symbol's window.
+    assert!(
+        sent[1].get("start").is_none(),
+        "ETH/USD has no watermark and must open no window: {:?}",
+        sent[1],
+    );
+}
+
+/// The failure this whole guard exists for. The provider confirms a symbol it does not offer, never
+/// ticks it, and holds the slot until the connection is torn down — so rejecting after sending
+/// would cost exactly what rejecting is meant to save.
+#[tokio::test]
+#[serial]
+async fn a_symbol_the_provider_does_not_offer_costs_no_subscription_slot() {
+    let harness = Harness::start(Script::default()).await;
+
+    // BTC/USD is offered; the batch is rejected for the company it keeps, and neither is sent.
+    let subscriptions = [subscription("btc"), subscription("nope")];
+    let error = subscriber()
+        .subscribe(&subscriptions)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("NOPE/USD"), "{error}");
+
+    let sent = harness.drained().await;
+    assert!(
+        sent.is_empty(),
+        "the batch was rejected only after spending slots: {sent:?}",
+    );
+}
+
+/// An over-cap batch is rejected *anonymously* by the provider — its error does not name the symbol
+/// it refused — so there is no partial subscription to recover. Failing before sending is the only
+/// outcome that leaves the caller with a connection in a state they can reason about.
+#[tokio::test]
+#[serial]
+async fn an_over_cap_batch_costs_no_subscription_slot() {
+    let script = Script {
+        auth_reply: authenticated(&[("BTC/USD", Some("Crypto")), ("ETH/USD", None)], 1),
+        ..Script::default()
+    };
+    let harness = Harness::start(script).await;
+
+    let subscriptions = [subscription("btc"), subscription("eth")];
+    let error = subscriber()
+        .subscribe(&subscriptions)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("at most 1"), "{error}");
+
+    let sent = harness.drained().await;
+    assert!(
+        sent.is_empty(),
+        "an over-cap batch reached the socket: {sent:?}"
+    );
+}
+
+/// The server greets with an unsolicited `welcome` before the key is ever sent. A client that took
+/// the first frame for the answer would authenticate against that greeting and sail past a
+/// rejected key — so the rejection here arrives *after* a welcome, and the client must still report
+/// it rather than proceed.
+#[tokio::test]
+#[serial]
+async fn a_rejected_key_is_reported_rather_than_read_past() {
+    let script = Script {
+        auth_reply: json!({
+            "type": "error", "code": "INVALID_KEY", "message": "invalid api key",
+        }),
+        ..Script::default()
+    };
+    let harness = Harness::start(script).await;
+
+    let error = subscriber()
+        .subscribe(&[subscription("btc")])
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("INVALID_KEY"), "{error}");
+
+    let sent = harness.drained().await;
+    assert!(
+        sent.is_empty(),
+        "subscribed on an unauthenticated connection: {sent:?}",
+    );
+}
+
+/// A connection dropped mid-handshake must be reported, not waited out: the client is otherwise
+/// blocked until its authentication timeout for a connection it already knows is gone.
+#[tokio::test]
+#[serial]
+async fn a_connection_closed_during_authentication_is_reported() {
+    let script = Script {
+        close_without_answering: true,
+        ..Script::default()
+    };
+    let harness = Harness::start(script).await;
+
+    let error = subscriber()
+        .subscribe(&[subscription("btc")])
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        error.contains("closed"),
+        "a closed connection should say so: {error}",
+    );
+    assert!(harness.drained().await.is_empty());
+}
+
+/// Ticks and replay boundaries arrive while *other* symbols in the batch are still being confirmed,
+/// and neither deserialises as a subscription response. They must survive as buffered events: the
+/// clamp check reads the replay boundary out of that buffer, and the stream replays the ticks from
+/// it. A frame dropped here is market data lost before the stream ever starts.
+#[tokio::test]
+#[serial]
+async fn frames_arriving_during_validation_are_buffered_rather_than_dropped() {
+    let script = Script {
+        frames_before_confirmation: vec![
+            json!({"type": "replay_started", "symbol": "BTC/USD",
+                   "from": "2026-08-14T10:16:55.161234+00:00"}),
+            json!({"type": "tick", "symbol": "BTC/USD",
+                   "ts": "2026-08-14T10:16:55.161234+00:00",
+                   "price": 42000.5, "bid": 42000.5, "ask": 42001.0, "volume": 0.00155}),
+        ],
+        ..Script::default()
+    };
+    let harness = Harness::start(script).await;
+
+    let subscribed = subscriber()
+        .subscribe(&[subscription("btc")])
+        .await
+        .unwrap();
+
+    assert_eq!(symbols(&harness.subscribes()), vec!["BTC/USD"]);
+
+    let buffered = subscribed
+        .buffered_websocket_events
+        .iter()
+        .map(|message| match message {
+            rustrade_integration::protocol::websocket::WsMessage::Text(text) => {
+                serde_json::from_str::<Value>(text.as_str()).unwrap()
+            }
+            other => panic!("unexpected buffered frame: {other:?}"),
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        buffered.len(),
+        2,
+        "both frames should have been buffered: {buffered:?}",
+    );
+    assert_eq!(buffered[0]["type"], "replay_started");
+    assert_eq!(buffered[1]["type"], "tick");
+}

--- a/rustrade-data/tests/lse_ws_handshake.rs
+++ b/rustrade-data/tests/lse_ws_handshake.rs
@@ -47,9 +47,12 @@
 #![cfg(feature = "lse")]
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Test code: panics on bad input are acceptable
 
+use chrono::{DateTime, Utc};
 use futures_util::{SinkExt, StreamExt};
 use rustrade_data::{
-    Identifier,
+    Identifier, MarketStream, NoInitialSnapshots,
+    error::DataError,
+    event::MarketEvent,
     exchange::{
         ExchangeServer,
         lse::{
@@ -57,11 +60,16 @@ use rustrade_data::{
             channel::LseChannel,
             live::{LseCredentials, LseSubscriber},
             market::{LseMarket, LseServer, LseSymbolShape},
+            resume::LseResumeState,
+            stream::LseStream,
         },
         subscription::ExchangeSub,
     },
     subscriber::Subscriber,
-    subscription::{Subscription, trade::PublicTrades},
+    subscription::{
+        Subscription,
+        trade::{PublicTrade, PublicTrades},
+    },
 };
 use rustrade_instrument::{
     exchange::ExchangeId,
@@ -123,6 +131,12 @@ struct Script {
     /// buffered events — the path a replayed tick takes when it arrives while other symbols are
     /// still being confirmed.
     frames_before_confirmation: Vec<Value>,
+
+    /// Frames to send after each subscription confirmation.
+    ///
+    /// These reach the stream itself rather than the handshake, which is what lets a test drive a
+    /// market event out of the far end instead of stopping at `subscribe`.
+    frames_after_confirmation: Vec<Value>,
 }
 
 impl Default for Script {
@@ -131,6 +145,7 @@ impl Default for Script {
             auth_reply: authenticated(&[("BTC/USD", Some("Crypto")), ("ETH/USD", None)], 16),
             close_without_answering: false,
             frames_before_confirmation: Vec::new(),
+            frames_after_confirmation: Vec::new(),
         }
     }
 }
@@ -281,6 +296,16 @@ async fn serve(stream: TcpStream, script: Script, subscribes: Arc<Mutex<Vec<Valu
                     .is_err()
                 {
                     return;
+                }
+
+                for frame in &script.frames_after_confirmation {
+                    if websocket
+                        .send(Message::text(frame.to_string()))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
                 }
             }
             // The client sends nothing else during a handshake; anything here would be a change in
@@ -514,4 +539,112 @@ async fn frames_arriving_during_validation_are_buffered_rather_than_dropped() {
     );
     assert_eq!(buffered[0]["type"], "replay_started");
     assert_eq!(buffered[1]["type"], "tick");
+}
+
+/// A tick frame as the provider spells it, live or replayed.
+fn tick_frame(symbol: &str, ts: &str, price: f64, replay: bool) -> Value {
+    let mut frame = json!({
+        "type": "tick", "symbol": symbol, "ts": ts,
+        "price": price, "bid": price, "ask": price + 0.5, "volume": 0.00155,
+    });
+
+    // Live ticks carry no `replay` key at all; only replayed ones are stamped.
+    if replay {
+        frame["replay"] = json!(true);
+    }
+
+    frame
+}
+
+/// Assemble the market stream the connector actually serves, resume state and all.
+async fn stream(
+    subscriber: &LseSubscriber,
+    subscriptions: &[Subscription<HarnessLse, MarketDataInstrument, PublicTrades>],
+) -> LseStream<HarnessLse, MarketDataInstrument, PublicTrades> {
+    <LseStream<_, _, _> as MarketStream<HarnessLse, MarketDataInstrument, PublicTrades>>::init::<
+        NoInitialSnapshots,
+    >(subscriber, subscriptions)
+    .await
+    .unwrap()
+}
+
+/// The next market event, or a failure naming which of the three ways it did not arrive.
+async fn next_event<S>(stream: &mut S) -> MarketEvent<MarketDataInstrument, PublicTrade>
+where
+    S: futures_util::Stream<
+            Item = Result<MarketEvent<MarketDataInstrument, PublicTrade>, DataError>,
+        > + Unpin,
+{
+    tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+        .await
+        .expect("the stream produced no event before the timeout")
+        .expect("the stream ended instead of producing an event")
+        .expect("the stream yielded an error instead of an event")
+}
+
+/// The invariant [`LseStream`] exists for, end to end.
+///
+/// A replayed tick can already be sitting in the handshake's buffered events: it fails to
+/// deserialise as a subscription response while other symbols are still confirming, and lands
+/// there. The resume state must therefore reach the transformer **before** those buffered events
+/// are processed, which is the only reason this connector does not use the blanket WebSocket
+/// stream.
+///
+/// The pieces are covered in isolation elsewhere — the transformer's skip logic in its own unit
+/// tests, the buffering in `frames_arriving_during_validation_are_buffered_rather_than_dropped`.
+/// This is what joins them: reorder the two statements in `LseStream::init` and every other test in
+/// this repository still passes, while every reconnect of a resumed subscription starts delivering
+/// duplicates.
+#[tokio::test]
+#[serial]
+async fn a_replayed_tick_buffered_during_validation_is_skipped_on_a_resumed_reconnect() {
+    const INSTANT: &str = "2026-08-14T10:16:55.161234+00:00";
+    const LATER: &str = "2026-08-14T10:16:55.161235+00:00";
+
+    let state = Arc::new(LseResumeState::new());
+    let subscriber = subscriber().with_resume(Arc::clone(&state));
+    let subscriptions = [subscription("btc")];
+
+    // The first connection delivers one tick, which becomes the watermark.
+    let first = Harness::start(Script {
+        frames_after_confirmation: vec![tick_frame("BTC/USD", INSTANT, 42000.5, false)],
+        ..Script::default()
+    })
+    .await;
+
+    let mut opened = stream(&subscriber, &subscriptions).await;
+    assert_eq!(
+        next_event(&mut opened).await.time_exchange,
+        INSTANT.parse::<DateTime<Utc>>().unwrap(),
+    );
+    assert_eq!(
+        first.subscribes()[0].get("start"),
+        None,
+        "the first subscribe has nothing to resume from and must open no window",
+    );
+    drop(opened);
+
+    // The reconnect: the provider replays that same tick, and it arrives *before* the confirmation
+    // -- so the stream meets it in the buffered events, not on the socket.
+    let second = Harness::start(Script {
+        frames_before_confirmation: vec![tick_frame("BTC/USD", INSTANT, 42000.5, true)],
+        frames_after_confirmation: vec![tick_frame("BTC/USD", LATER, 42001.0, false)],
+        ..Script::default()
+    })
+    .await;
+
+    let mut resumed = stream(&subscriber, &subscriptions).await;
+
+    assert!(
+        second.subscribes()[0]["start"].is_number(),
+        "the reconnect must carry the resume window: {:?}",
+        second.subscribes()[0],
+    );
+
+    assert_eq!(
+        next_event(&mut resumed).await.time_exchange,
+        LATER.parse::<DateTime<Utc>>().unwrap(),
+        "the first event out of a resumed stream was the replayed duplicate, so the resume state \
+         did not reach the transformer before the buffered events were processed",
+    );
 }

--- a/rustrade/Cargo.toml
+++ b/rustrade/Cargo.toml
@@ -25,6 +25,10 @@ lse = ["rustrade-data/lse"]
 name = "engine_backtest_with_lse_candles"
 required-features = ["lse"]
 
+[[example]]
+name = "engine_sync_with_lse_market_data_and_mock_execution"
+required-features = ["lse"]
+
 [[bench]]
 name = "backtest"
 path = "benches/backtest/mod.rs"

--- a/rustrade/examples/config/lse_live_config.json
+++ b/rustrade/examples/config/lse_live_config.json
@@ -1,0 +1,81 @@
+{
+  "risk_free_return": 0.05,
+  "system": {
+    "executions": [
+      {
+        "mocked_exchange": "coinbase",
+        "latency_ms": 100,
+        "fee_model": { "Percentage": { "rate": "0.05" } },
+        "initial_state": {
+          "exchange": "coinbase",
+          "balances": [
+            {
+              "asset": "usd",
+              "balance": {
+                "total": 100000,
+                "free": 100000
+              },
+              "time_exchange": "2026-01-01T00:00:00Z"
+            },
+            {
+              "asset": "btc",
+              "balance": {
+                "total": 0,
+                "free": 0
+              },
+              "time_exchange": "2026-01-01T00:00:00Z"
+            },
+            {
+              "asset": "eth",
+              "balance": {
+                "total": 0,
+                "free": 0
+              },
+              "time_exchange": "2026-01-01T00:00:00Z"
+            }
+          ],
+          "instruments": [
+            {
+              "instrument": "BTC-USD",
+              "orders": []
+            },
+            {
+              "instrument": "ETH-USD",
+              "orders": []
+            }
+          ]
+        }
+      }
+    ],
+    "instruments": [
+      {
+        "exchange": "coinbase",
+        "name_exchange": "BTC-USD",
+        "underlying": {
+          "base": "btc",
+          "quote": "usd"
+        },
+        "quote": "underlying_quote",
+        "kind": "spot",
+        "data_venue": {
+          "exchange": "lse_crypto",
+          "name_exchange": "BTC/USD"
+        }
+      },
+      {
+        "exchange": "coinbase",
+        "name_exchange": "ETH-USD",
+        "underlying": {
+          "base": "eth",
+          "quote": "usd"
+        },
+        "quote": "underlying_quote",
+        "kind": "spot",
+        "data_venue": {
+          "exchange": "lse_crypto",
+          "name_exchange": "ETH/USD"
+        }
+      }
+    ]
+  }
+}

--- a/rustrade/examples/engine_sync_with_lse_market_data_and_mock_execution.rs
+++ b/rustrade/examples/engine_sync_with_lse_market_data_and_mock_execution.rs
@@ -1,0 +1,264 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Example code: panics acceptable for demonstration
+
+//! Live London Strategic Edge ticks pricing instruments that are executed somewhere else.
+//!
+//! # ⚠️ Licensing — the data is NOT redistributable
+//!
+//! This example's **code** is MIT-licensed like the rest of this repository. **The data it
+//! retrieves is not.** London Strategic Edge permits use for your own research, trading and model
+//! training — including commercially — but **prohibits redistributing, reselling, or otherwise
+//! making the data available to third parties**, in bulk or through any competing feed, download
+//! service or interface. Terms: <https://londonstrategicedge.com/terms>
+//!
+//! In practice: do not commit what this consumes to a public repository, do not publish it as
+//! fixtures or an example dataset, and do not re-serve it.
+//!
+//! # Running
+//!
+//! Requires a free API key (no account, no card) from <https://londonstrategicedge.com/data>, in
+//! `LSE_API_KEY`:
+//!
+//! ```bash
+//! export LSE_API_KEY=...
+//! cargo run --example engine_sync_with_lse_market_data_and_mock_execution --features lse
+//! ```
+//!
+//! # What this demonstrates
+//!
+//! 1. **A data venue that is not the execution venue.** This provider publishes prices and offers
+//!    no execution at all, so every live use of it is necessarily "priced here, traded there". Each
+//!    instrument in the config carries a `data_venue`, which keeps both roles on **one**
+//!    `Instrument` — and so on one position and one `pnl_unrealised`. Registering the two roles as
+//!    two instruments instead would leave the traded one's PnL permanently stale, because price
+//!    updates would land on the other index.
+//! 2. **The data venue spells symbols differently, and that is not cosmetic.** The provider quotes
+//!    `BTC/USD` where the execution venue lists `BTC-USD`, so the `data_venue` carries its own
+//!    `name_exchange`. Subscribing under the execution venue's spelling would silently receive
+//!    nothing.
+//! 3. **Execution clients are registered only for the venue actually traded.** A venue that only
+//!    supplies prices has no account to connect to, and connectivity is derived from the registered
+//!    execution clients — so a data-only venue does not hold global connectivity at `Reconnecting`.
+//! 4. **Subscriptions are built from the registry, not from literals.** The subscription list below
+//!    is derived from `IndexedInstruments`, so each event arrives already tagged with the
+//!    `InstrumentIndex` the engine keys its state on. A hand-written index would silently attribute
+//!    one symbol's prices to a different instrument.
+//!
+//! # What a working run looks like
+//!
+//! Three lines are worth watching for, because they are the whole point of the wiring:
+//!
+//! ```text
+//! EngineState tracking exchange connectivity exchange=coinbase role=ExecutionOnly
+//! EngineState tracking exchange connectivity exchange=lse_crypto role=DataOnly
+//! EngineState updating global connectivity previous=Reconnecting global=Healthy
+//! ```
+//!
+//! Each venue is tracked in the role it actually plays, and global connectivity reaches `Healthy`
+//! without waiting on an account the data venue does not have. The subscription log alongside them
+//! names the **data** venue's symbols (`BTC/USD`, `ETH/USD`) against the engine's own instrument
+//! indices, which is the `data_venue` `name_exchange` doing its job.
+//!
+//! # ⚠️ Suitability — the decision price is not the fill price
+//!
+//! Prices come from an aggregated tape with no venue attribution, and fills come from
+//! `MockExchange`. Those are two different markets, and the basis between them is real. That is
+//! sound for research and paper trading; before risking capital it is a property to opt into
+//! knowingly, because nothing in the library can detect it.
+//!
+//! # ⚠️ The tick is a QUOTE, not a print
+//!
+//! The provider publishes one data frame, and its `price` equals its `bid` on every sample taken —
+//! 3,966 of 3,966 ticks across every dataset family. This example subscribes to **both** kinds the
+//! frame serves, so `DefaultInstrumentMarketData` prices from the top-of-book mid and also records
+//! a last-traded price; the trade-shaped events are bid-side quotes, not evidence that a
+//! transaction occurred. Both book levels carry a **zero size** — the feed publishes prices only —
+//! which prices correctly because the volume-weighted mid falls back to the plain mid, but must not
+//! be read as available quantity. See the `rustrade_data::exchange::lse` module documentation.
+//!
+//! Resumption across a reconnect is available and deliberately **not** enabled here: a resumed
+//! subscription is served its whole historical window before a single live tick, and one hour of a
+//! busy crypto symbol replays over a hundred thousand ticks. A live engine wants to be current, so
+//! it takes the gap. See `LseSubscriber::with_resume` for the other choice.
+
+use futures::Stream;
+use rust_decimal::Decimal;
+use rustrade::{
+    engine::{
+        clock::LiveClock,
+        state::{
+            global::DefaultGlobalData,
+            instrument::{data::DefaultInstrumentMarketData, filter::InstrumentFilter},
+            trading::TradingState,
+        },
+    },
+    logging::init_logging,
+    risk::DefaultRiskManager,
+    statistic::time::Daily,
+    strategy::DefaultStrategy,
+    system::{
+        builder::{EngineFeedMode, SystemArgs, SystemBuilder},
+        config::SystemConfig,
+    },
+};
+use rustrade_data::{
+    error::DataError,
+    event::DataKind,
+    exchange::lse::{LseCrypto, live::LseSubscriber},
+    instrument::MarketInstrumentData,
+    streams::{
+        Streams,
+        consumer::{MarketStreamEvent, MarketStreamResult},
+        reconnect::stream::ReconnectingStream,
+    },
+    subscription::{Subscription, book::OrderBooksL1, trade::PublicTrades},
+};
+use rustrade_instrument::{
+    exchange::ExchangeId, index::IndexedInstruments, instrument::InstrumentIndex,
+};
+use serde::Deserialize;
+use std::{fs::File, io::BufReader, time::Duration};
+use tracing::warn;
+
+const CONFIG_PATH: &str = "rustrade/examples/config/lse_live_config.json";
+
+/// The dataset family the config prices its instruments from.
+///
+/// One `ExchangeId` per dataset family, so this both selects the instruments to subscribe for and
+/// names the connector that serves them. An instrument priced by a different family — equities, FX,
+/// futures or CFDs — needs its own connector and its own subscription batch, because each family
+/// spells symbols its own way.
+const DATA_VENUE: ExchangeId = ExchangeId::LseCrypto;
+
+/// How long to let the live system run before shutting down and summarising.
+const RUN_DURATION: Duration = Duration::from_secs(30);
+
+#[derive(Deserialize)]
+pub struct Config {
+    pub risk_free_return: Decimal,
+    pub system: SystemConfig,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_logging();
+
+    let Config {
+        risk_free_return,
+        system: SystemConfig {
+            instruments,
+            executions,
+        },
+    } = load_config();
+
+    // Indices are assigned here, in config order, and every market event below is tagged with the
+    // index of the instrument it prices rather than with a symbol.
+    let instruments = IndexedInstruments::new(instruments);
+
+    let market_stream = init_lse_market_stream(&instruments).await?;
+
+    let args = SystemArgs::new(
+        &instruments,
+        executions,
+        LiveClock,
+        DefaultStrategy::default(),
+        DefaultRiskManager::default(),
+        market_stream,
+        DefaultGlobalData,
+        // No custom state needed: `DefaultInstrumentMarketData` consumes both kinds this feed
+        // serves, pricing from the top-of-book mid and falling back to the last traded price.
+        |_| DefaultInstrumentMarketData::default(),
+    );
+
+    let system = SystemBuilder::new(args)
+        .engine_feed_mode(EngineFeedMode::Iterator)
+        .trading_state(TradingState::Disabled)
+        .build()?
+        .init_with_runtime(tokio::runtime::Handle::current())
+        .await?;
+
+    system.trading_state(TradingState::Enabled);
+
+    tokio::time::sleep(RUN_DURATION).await;
+
+    // `DefaultStrategy` and `DefaultRiskManager` are no-ops — this example demonstrates the live
+    // market-data wiring, not a strategy — so there is nothing outstanding to cancel or close. Both
+    // calls are made anyway, because that is the shutdown order a real system needs.
+    system.cancel_orders(InstrumentFilter::None);
+    system.close_positions(InstrumentFilter::None);
+
+    let (engine, _shutdown_audit) = system.shutdown().await?;
+
+    engine
+        .trading_summary_generator(risk_free_return)
+        .generate(Daily)
+        .print_summary();
+
+    Ok(())
+}
+
+/// Subscribe every registered instrument that this provider prices, for both kinds its tick serves.
+///
+/// The instrument list is read from the registry rather than written out again, so the two cannot
+/// drift: an instrument added to the config is subscribed by adding nothing here.
+async fn init_lse_market_stream(
+    instruments: &IndexedInstruments,
+) -> Result<impl Stream<Item = MarketStreamEvent<InstrumentIndex, DataKind>> + use<>, DataError> {
+    // The subscriber holds the credential and performs the authenticating handshake. It is cloned
+    // into each connection, and again into every reconnect attempt, so one instance serves all of
+    // them.
+    let subscriber = LseSubscriber::from_env()
+        .expect("set LSE_API_KEY - get a free key at https://londonstrategicedge.com/data");
+
+    // `data_exchange()` falls back to the execution venue when an instrument carries no
+    // `DataVenue`, so this reads correctly for both kinds of instrument and selects exactly those
+    // this provider prices. `MarketInstrumentData::from` takes the *data* venue's symbol for the
+    // same reason.
+    let subscribed = || {
+        instruments
+            .instruments()
+            .iter()
+            .filter(|keyed| keyed.value.data_exchange().value == DATA_VENUE)
+            .map(MarketInstrumentData::from)
+    };
+
+    // The instrument type is named explicitly: `Subscription::new` accepts anything convertible
+    // into it, and three instrument shapes can address this provider's symbols, so the conversion
+    // is ambiguous without it.
+    let trades = subscribed()
+        .map(|instrument| {
+            Subscription::<LseCrypto, MarketInstrumentData<InstrumentIndex>, PublicTrades>::new(
+                LseCrypto::default(),
+                instrument,
+                PublicTrades,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let quotes = subscribed()
+        .map(|instrument| {
+            Subscription::<LseCrypto, MarketInstrumentData<InstrumentIndex>, OrderBooksL1>::new(
+                LseCrypto::default(),
+                instrument,
+                OrderBooksL1,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    // One connection per kind, each capped at 16 symbols by the provider. Both decode the same tick
+    // frame — the kind decides what it becomes, not what is asked for on the wire.
+    let streams: Streams<MarketStreamResult<InstrumentIndex, DataKind>> = Streams::builder_multi()
+        .add(Streams::<PublicTrades>::builder().subscribe(subscriber.clone(), trades))
+        .add(Streams::<OrderBooksL1>::builder().subscribe(subscriber, quotes))
+        .init()
+        .await?;
+
+    Ok(streams
+        .select_all()
+        .with_error_handler(|error| warn!(?error, "MarketStream generated error")))
+}
+
+pub fn load_config() -> Config {
+    let file = File::open(CONFIG_PATH).expect("Failed to open config file");
+    let reader = BufReader::new(file);
+    serde_json::from_reader(reader).expect("Failed to parse config file")
+}


### PR DESCRIPTION
## Summary

Adds the London Strategic Edge live WebSocket connector behind the existing `lse` feature: one
connector per dataset family — `LseFx`, `LseCrypto`, `LseEquities`, `LseFutures`, `LseCfd` — each
serving **both** `PublicTrades` and `OrderBooksL1`, with opt-in resumption across a reconnect.

This is also the first provider to exercise the venue-role model from #238. The provider publishes
prices and offers **no execution at all**, so every live system built on it is necessarily "priced
here, traded there" — which is exactly what a `DataVenue` is for, and until now nothing in the tree
used it.

## One frame, two kinds, no candles

The provider publishes exactly one data frame — a price with a bid, an ask and a size — so the two
subscription kinds are two decodings of the same tick rather than two channels. The subscription
kind decides what an event becomes; nothing changes on the wire. There is **no candle channel at
all**, so no `Candles` support is declared and the matrix records that absence as a decision rather
than an omission. This provider's candles are a REST-only product, already shipped.

Timestamps arrive in three encodings — RFC-3339 with `T`, the same with a space separator, and a
bare float epoch on replayed ticks. A decoder accepting only the first silently drops five of the
thirteen dataset families.

Symbols are decoded as **owned** strings rather than borrowed slices. Every symbol on this feed
contains a `/`, RFC 8259 permits spelling that `\/`, and a borrowed decode cannot unescape one — so
a provider that started emitting the escaped form would fail every frame outright, at a place with
nothing to do with symbols.

## The guards exist because this surface fails quietly

Authentication is a *message*, not a header, and subscriptions are accepted only after the server
answers it, so the integration ships its own `Subscriber`. That handshake also returns the only
defence against this surface's quietest failure: an unknown symbol is **confirmed rather than
rejected**, then never ticks, while holding one of the connection's sixteen slots until teardown.
The connection-wide cap is likewise reported without naming the symbol that breached it.

So the whole batch is validated against the symbol list the authentication response already carries,
**before anything is sent**: an unoffered symbol or an over-cap batch fails loudly and consumes zero
slots. The per-symbol category is cross-checked only when it is both present *and* a label this
integration already knows some dataset by. It is absent for roughly half the catalog, and an
unrecognised label is no more a contradiction than a missing one: five datasets stand behind
`LseCfd` and only two of them are labelled, so on the day the provider labels a third, a
correctly-requested symbol would otherwise read as belonging elsewhere and fail the whole batch —
every other symbol in it included — with no change on our side.

That validator has stopped reading by the time the handshake completes, so a rejection raised
*afterwards* — a later `LIMIT_REACHED`, an `INVALID_START` on a resumed symbol, a credential that
expires mid-connection — is decoded on the stream and logged rather than discarded. The provider
names no symbol in a rejection, so without that the only other sign it ever gave would be a
subscription that quietly stopped ticking. It is logged, not surfaced as a stream error: the frame
says nothing about which subscription it condemns, so there is no honest way to fail one.

## Resumption carries a count, and is off by default

A reconnect re-runs the subscribe, so a fixed replay window would re-deliver it in full on every
attempt. Instead the watermark records, per symbol, the newest delivered instant **and how many
delivered events carry it**; the resumed subscribe skips exactly that prefix.

Both halves are load-bearing. `start` is inclusive and filters at **microsecond** resolution
(measured), so resuming one tick later would silently drop every event at that instant not yet
consumed — and one dataset carried 141 ticks at a single instant. Flooring it to a coarser
resolution is the mirror failure: it would re-serve a whole millisecond of already-delivered events
on the families that carry microseconds.

It is **opt-in**, because a resumed subscription is served its entire historical window before a
single live tick — one hour of a busy crypto symbol replayed 107,395 ticks, and a 24-hour window had
not drained after 30 seconds.

Watermarks are keyed by **dataset, symbol and subscription kind**, because two axes collapse onto
the provider's wire identifier: both kinds are decodings of one data frame, and the five dataset
connectors share one endpoint and one identifier construction — so `AAPL` as trades and as
top-of-book, or `AAPL` on `LseEquities` and on `LseFutures`, all resolve to `tick|AAPL`. Sharing a
watermark across either axis lets whichever stream ran ahead set the resume point for the one
behind, which then resumes past events it never delivered. Both are closed structurally, so one
state serves any set of streams differing in any of the three. What no key can separate is two
streams duplicating all three, so **each duplicated `(dataset, symbol, kind)` triple needs its own
state** — the one obligation the caller carries, and it is documented on `LseResumeState`.

The provider retains 24 hours and clamps a longer request **silently**, so what it says it will
replay from is compared against what was asked and reported rather than swallowed. This covers
reconnects, not process restarts — that would need consumer-side acknowledgement of what was durably
stored.

## ⚠️ Properties of the feed that will silently mislead

All measured, all documented at the site, in the module docs and in the changelog:

- **The tick is a QUOTE, not a print.** `price` equalled `bid` on 3,966 of 3,966 sampled ticks
  across every dataset family. A `PublicTrade` decoded from it is a bid-side quote wearing a trade's
  shape. It carries no trade id and no aggressor side, and neither is inferable.
- **`volume` is genuine on two families and fabricated on two others**, with no in-band signal
  separating them. `LseCrypto`/`LseEquities` sizes reproduce the provider's own one-minute candle
  volume to ratio `1.000`; `LseFx`/`LseCfd` carry a hard-coded `1.0`. A plausible positive
  placeholder aggregates into a legitimate-looking total, so size filters and volume-weighted prices
  there are meaningless rather than imprecise.
- **Identical consecutive ticks are genuine and are never de-duplicated.** Barely a third of a
  sampled run was unique on `(ts, price, bid, ask, volume)`, yet removing the repeats destroyed
  volume that otherwise reconciles exactly. A test pins that both are emitted.
- **Both `OrderBookL1` levels carry a zero size** — the feed publishes prices only. This prices
  correctly (the volume-weighted mid falls back to the plain mid) but is not depth.
- **A zero *price* is a missing quote, and it is the opposite case** — it decodes to `None` rather
  than to a level at zero. It is exactly the fallback that makes the zero *sizes* harmless which
  makes a zero price dangerous: `mid_price` requires only that both sides be `Some` and then
  averages whatever prices they carry, so a published zero bid against a real ask of `42001` would
  price the instrument at `21000.5`, indistinguishably from a genuine quote.

## Testing

- **An offline handshake harness** (8 tests, runs on every ordinary test run). An in-process server
  speaks the provider's side of the protocol, swapping the endpoint and nothing else — the tests
  drive the shipped connector, its real subscription identifiers and its real symbol spelling, so
  they cannot drift from what they stand for. Every frame is hand-written from the documented
  shapes; no recorded response may be committed here.

  Its central assertion is "zero subscribe payloads reached the socket", which was verified by
  reversing the guard and the send loop in the connector: the first version of the test **still
  passed**, because reading the recorded payloads immediately after the client errors samples a
  socket the server has not drained. The harness now awaits the connection's close before reading,
  which turns "nothing was sent" into an observation rather than a statement about timing.

  That same hazard reached the **success**-path tests, where the connection stays open and so was
  never awaited: `exactly once`, `no replay window on the wire` and the buffered-frame count were
  all sampling a vector the server task was still writing to, and a duplicate or late payload would
  have read as absent — the very thing those tests exist to rule out. Every count now drops the
  `Subscribed` first and awaits the drained view; sampling is documented as sound for asserting the
  *content* of a payload already known to exist, and never for a count.
- **A live canary** (4 tests, `#[ignore]`, gated on the credential). Asserts no counts — the
  published symbol list moved by hundreds of entries in a week, and a canary that fails for a
  non-defect gets muted. It asserts that *every* subscribed symbol delivers a tick, that a decoded
  instant is plausible, that a resumed reconnect replays from the watermark rather than from now,
  and that an unoffered symbol is still rejected. Unset credential skips; set-but-unusable fails.

  Each canary that reads the stream now also **counts decode failures and asserts zero before it
  asserts anything about a missing tick**. A frame the decoder rejects and a market that is closed
  are the same observation — "no tick" — and the tests reported the second, so a decoder regression
  on a live dataset would have surfaced as a reassuring "the venue is shut". Silence has to be
  proved innocent before it is read as a closure.

  Running it on a Saturday caught the canary failing on itself, which is worth recording: the gold
  CFD test fired on a tick stamped five hours old, and nothing was wrong — the session had closed on
  Friday and the timestamp decoded exactly right. The test assumed a closed venue goes **silent**,
  so silence carried the "not a defect" case; measured, this provider serves the session's last
  print on connect instead, so that path was unreachable on the one venue written for it. Two
  signals were riding on one bound. *Plausibility* catches a seconds-for-milliseconds epoch misread
  (which lands in 1970 or the fifty-third century) and survives a closure, since a weekend is days
  and a scale error is decades; *recency* catches a dropped timezone and cannot survive one, since a
  closed session and a few hours of offset are the same size. The tight window now applies only to
  continuously-traded crypto — where the delivery check already lived, for the same reason — and the
  closing venue reports which signal it actually reached rather than passing quietly.
- **Both new test targets declare `required-features = ["lse"]`.** Their contents are entirely
  feature-gated, so without it `cargo test --test lse_ws_handshake` builds green and reports
  `0 passed` — a run that asserted nothing, indistinguishable from one that asserted everything. It
  now fails naming the missing feature. The five pre-existing LSE test targets (`lse_export`,
  `lse_export_canary`, `lse_parquet`, `lse_vault`, `lse_vault_canary`) have the same gap; they are
  left alone here rather than widening this diff, and are worth a follow-up.
- **Both examples were run against the live feed.** In one 40-second run the raw stream printed a
  single distinct size across every FX tick and 185 distinct sizes across the crypto ticks arriving
  beside them — the documented warning demonstrating itself. The engine example exited cleanly
  having logged `coinbase role=ExecutionOnly`, `lse_crypto role=DataOnly`, and
  `global connectivity previous=Reconnecting global=Healthy`.

## Examples

- `rustrade-data/examples/lse_market_data.rs` — the raw stream, over both kinds and two dataset
  families, so the fabricated size sits next to a real one in the same output.
- `rustrade/examples/engine_sync_with_lse_market_data_and_mock_execution.rs` — engine instruments
  priced by this provider and ordered on a different, mocked venue. The two venues spell the same
  pair differently on purpose (`BTC/USD` against `BTC-USD`), which is what the data venue's own
  symbol field exists for.

## ⚠️ Licensing

This repository is MIT. **The data this integration retrieves is not redistributable.** London
Strategic Edge permits use for your own research, trading and model training — including
commercially — but prohibits redistributing, reselling or otherwise making the data available to
third parties. No provider-sourced data is committed anywhere in this PR: every test fixture is
synthetic and the offline harness is a hand-written server, not a capture.

Terms: https://londonstrategicedge.com/terms

## Verification

| Check | Result |
|---|---|
| `cargo test -p rustrade-data --features lse --lib` | 352 passed |
| `cargo test -p rustrade-data --features lse --test lse_ws_handshake` | 8 passed |
| `cargo test -p rustrade-data --features lse --test lse_ws_canary -- --ignored` | 4 passed against the live surface; 4 skipped cleanly with the credential unset |
| `cargo test -p rustrade-data --test lse_ws_handshake` (feature off) | errors naming `lse`, rather than reporting 0 tests |
| `cargo clippy --workspace --all-targets --all-features` (repo gate) | clean but for one pre-existing warning in `rustrade-execution` |
| Rustdoc CI gate | clean |
| Both examples, live | ran end to end |

## Notes for review

`LseResumeState`'s `record`, `watermark` and `snapshot` were `pub` and keyed on a `SubscriptionId`
whose builder was not — reachable methods whose argument no caller could construct. Publishing the
builder was the obvious repair and the wrong one: deriving that identifier is one-way, so
`snapshot()` would still return a map no caller could attribute to a symbol, and the identifier's
spelling — a wire detail — would have been frozen into the contract. Since the provider carries
exactly one channel, that identifier is a pure function of the symbol and holds nothing the symbol
does not, so a read surface worth publishing would be keyed on the symbol and would be a different
surface. Nothing needs one yet, so the three methods went internal while the feature is unreleased
and narrowing is still free — widening later is not a breaking change, and narrowing later is.
`LseResumeState` is now the opaque handle its own docs already described: construct it, hand it to
`with_resume`, and let delivery drive it.
