### PR TITLE
ci: Raise cargo test timeout to 25 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,17 @@ jobs:
     name: cargo test
     needs: [fmt, check]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # This job debug-builds the whole workspace with `--all-features` (ethers, aws-lc-sys, ring and
+    # every exchange SDK) and then runs both `--lib --bins --tests` and the doc-tests against that
+    # one build. Observed wall-clock on a warm cache is 11m35s-14m20s, so a 15-minute budget left
+    # as little as 40 seconds of headroom. Any `Cargo.lock` change invalidates the cache, and a
+    # cold build then runs past the limit: the job is cancelled, and a cancellation reports as a
+    # red required check that is indistinguishable from a genuine test failure at a glance. That
+    # blocks otherwise-good dependency PRs and costs a full re-run to diagnose.
+    #
+    # 25 minutes keeps a real hang bounded while leaving room for a cold cache. Revisit if the
+    # warm-cache figure climbs far enough to erode the margin again.
+    timeout-minutes: 25
     steps:
       - name: Checkout sources
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0


### PR DESCRIPTION
## Problem

The `cargo test` job runs at 78-96% of its own timeout budget. Recent wall-clock on a **warm** cache:

| PR | Duration |
|---|---|
| #267 | 14m20s |
| #265 | 12m47s |
| #263 | 12m08s |
| #236 | 12m02s |
| #213 | 12m01s |
| #204 | 11m35s |

Against `timeout-minutes: 15`, that is as little as **40 seconds of headroom**.

The job debug-builds the entire workspace with `--all-features` — ethers, aws-lc-sys, ring and every exchange SDK — and then runs both the `--lib --bins --tests` step and the doc-tests against that single build. Any `Cargo.lock` change invalidates the build cache, and the resulting cold build runs past the limit.

## Why it matters beyond a slow job

When the timeout fires, GitHub **cancels** the job, and a cancelled required check renders red — indistinguishable at a glance from a genuine test failure. Since `cargo test` is a required check, that silently blocks an otherwise-good PR, and the only way to tell a real failure from a cancellation is to open the job and read the annotation:

```
The job has exceeded the maximum execution time of 15m0s
The operation was canceled.
```

This is not hypothetical. #224 (`http` 1.4.2 → 1.5.0) was cancelled at **15m33s** after its lockfile change cold-started the cache. Nothing was wrong with the bump.

It is also self-reinforcing: a batch of dependency PRs is exactly the situation that invalidates every cache at once, so the failure clusters precisely when the most PRs are in flight.

## Change

`timeout-minutes: 15` → `25` on the `test` job only, with the reasoning recorded inline. No other job is close to its budget (`check`, `clippy` and `docs` each finish in about a minute against 15).

25 minutes still bounds a genuine hang; it just stops treating a cold cache as a failure.

## Considered and rejected

Splitting the doc-tests into a separate job. They are already a separate *step*, deliberately so that a failure is attributable at a glance, and they reuse the first step's build. Promoting them to a job would rebuild the workspace a second time and cost more wall-clock than it saves.

## Verification

`.github/workflows/ci.yml` parses (`yaml.safe_load`), and job timeouts resolve as: fmt 5, check 15, **test 25**, clippy 15, docs 15, audit 5, deny 10.